### PR TITLE
PC-88: Connect self-hosted runners

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ matrix.os == 'arc-runner-set' }}  # Run this step only on Ubuntu
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential gcc g++ cmake pkg-config libcairo2-dev python3-dev
+          sudo apt-get install -y build-essential gcc g++ cmake pkg-config libcairo2-dev python3-dev libpango1.0-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -40,9 +40,10 @@ jobs:
         with:
           cmake-version: '3.17.x'
       - name: Install Dependencies
+        if: ${{ matrix.os == 'arc-runner-set' }}  # Run this step only on Ubuntu
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential gcc g++ cmake pkg-config
+          sudo apt-get install -y build-essential gcc g++ cmake pkg-config libcairo2-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.16.x'
+          cmake-version: '3.17.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,6 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
+      - name: Install C/C++ Compiler
+        id: install_cc
+        uses: rlalik/setup-cpp-compiler@master
+        with:
+          compiler: latest  # You can specify 'gcc', 'clang', or specific versions like 'gcc-10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,7 +1,6 @@
 name: CI on Linux, MacOS and Windows
 
 on:
-  workflow_dispatch:
   push:
     branches: ["main", "devel"]
   pull_request:
@@ -40,6 +39,10 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.17.x'
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gcc g++ cmake pkg-config
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,11 +31,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - name: Install C/C++ Compiler
+        if: ${{ matrix.os == 'arc-runner-set' }}  # Run this step only on Ubuntu
         id: install_cc
         uses: rlalik/setup-cpp-compiler@master
         with:
           compiler: latest  # You can specify 'gcc', 'clang', or specific versions like 'gcc-10'
       - name: Setup CMake
+        if: ${{ matrix.os == 'arc-runner-set' }}  # Run this step only on Ubuntu
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.17.x'
@@ -43,7 +45,7 @@ jobs:
         if: ${{ matrix.os == 'arc-runner-set' }}  # Run this step only on Ubuntu
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential gcc g++ cmake pkg-config libcairo2-dev
+          sudo apt-get install -y build-essential gcc g++ cmake pkg-config libcairo2-dev python3-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ matrix.os == 'arc-runner-set' }}  # Run this step only on Ubuntu
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential gcc g++ cmake pkg-config libcairo2-dev python3-dev libpango1.0-dev
+          sudo apt-get install -y build-essential gcc g++ cmake pkg-config libcairo2-dev python3-dev python-dev libpango1.0-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13] # macos-latest has an issue with nlopt
+      # "ubuntu-latest" replaced with "arc-runner-set"
+        os: [arc-runner-set, windows-latest, macos-13] # macos-latest has an issue with nlopt
         # os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         python-version: ["3.10", "3.11", "3.12"]
         exclude:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -36,6 +36,10 @@ jobs:
         uses: rlalik/setup-cpp-compiler@master
         with:
           compiler: latest  # You can specify 'gcc', 'clang', or specific versions like 'gcc-10'
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.16.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,6 +1,7 @@
 name: CI on Linux, MacOS and Windows
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main", "devel"]
   pull_request:


### PR DESCRIPTION
# Copilot Summary

This pull request includes updates to the GitHub Actions workflow configuration for running tests on different operating systems. The most important changes are the addition of a manual trigger for the workflow and the replacement of an operating system in the test matrix.

Workflow configuration updates:

* [`.github/workflows/python-test.yml`](diffhunk://#diff-0165ee7fe5057e5c6e9f2ae4ae3d87d21324f691385cbf51b220a4abe79ce492R4): Added `workflow_dispatch` to allow manual triggering of the workflow.
* [`.github/workflows/python-test.yml`](diffhunk://#diff-0165ee7fe5057e5c6e9f2ae4ae3d87d21324f691385cbf51b220a4abe79ce492L17-R19): Replaced `ubuntu-latest` with `arc-runner-set` in the `os` matrix for the test strategy.