### PR TITLE
refactor(CI): Implement new gh action for test result upload

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -1,0 +1,49 @@
+name: Upload Test Results & Coverage Reports
+
+description: Upload test results and coverage reports to GitHub and Codecov
+
+inputs:
+  name:
+    description: Name of the artifact to upload to GitHub.
+    required: true
+    default: test-results
+  path:
+    description: Path to the test results to upload to GitHub.
+    required: true
+  status:
+    description: The status of the job.
+    required: true
+  retention-days:
+    description: Number of days to retain the artifact on GitHub.
+    required: false
+    default: "7"
+  codecov-files:
+    description: Path to the test results file to upload to Codecov.
+    required: true
+  coverage-report:
+    description: Path to the coverage reports to upload to Codecov.
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload test results to GitHub
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        retention-days: ${{ inputs.retention-days }}
+
+    - name: Upload coverage reports to Codecov
+      if: ${{ inputs.status }} != 'cancelled'
+      uses: codecov/codecov-action@v5
+      with:
+        files: ${{ inputs.coverage-report }}
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload test results to Codecov
+      if: ${{ inputs.status }} != 'cancelled'
+      uses: codecov/test-results-action@v1
+      with:
+        files: ${{ inputs.codecov-files }}
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -23,6 +23,9 @@ inputs:
   coverage-report:
     description: Path to the coverage reports to upload to Codecov.
     required: true
+  token:
+    description: Codecov token.
+    required: true
 
 runs:
   using: 'composite'
@@ -39,11 +42,11 @@ runs:
       uses: codecov/codecov-action@v5
       with:
         files: ${{ inputs.coverage-report }}
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ inputs.token }}
 
     - name: Upload test results to Codecov
       if: ${{ inputs.status }} != 'cancelled'
       uses: codecov/test-results-action@v1
       with:
         files: ${{ inputs.codecov-files }}
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ inputs.token }}

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -123,16 +123,16 @@ jobs:
             mkdir -pv test-results
             poetry --no-ansi --no-interaction run pytest --verbose --color=no
 
-      # TODO: Create .github/workflows/upload-test-results.yml
-      # TODO: Move the common upload steps there
-      # TODO: Reference it from both pytest and behave jobs
-      - name: Upload test results
+      - name: Upload test results & coverage reports to github and codecov
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results
           path: test-results/
           retention-days: 7
+          status: ${{ job.status }}
+          codecov-files: test-results/junit.xml
+          coverage-report: test-results/coverage.xml
 
       - name: Generate Allure Report
         if: always()
@@ -157,19 +157,6 @@ jobs:
           path: allure-report/
           retention-days: 7
 
-      - name: Upload coverage reports to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          files: test-results/coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          files: test-results/junit.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit:
     name: "Run: pre-commit"
@@ -251,13 +238,16 @@ jobs:
             mkdir -pv test-results
             poetry --no-ansi --no-interaction run behave
 
-      - name: Upload test results
+      - name: Upload test results & coverage reports to github and codecov
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/upload-test-results
         with:
           name: test-results
           path: test-results/
           retention-days: 7
+          status: ${{ job.status }}
+          codecov-files: test-results/junit.xml
+          coverage-report: test-results/coverage.xml
 
       - name: Generate Allure Report
         if: always()
@@ -281,17 +271,3 @@ jobs:
           name: behave-allure-report
           path: allure-report/
           retention-days: 7
-
-      - name: Upload coverage reports to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
-        with:
-          files: test-results/coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          files: test-results/junit.xml
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -131,6 +131,7 @@ jobs:
           path: test-results/
           retention-days: 7
           status: ${{ job.status }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           codecov-files: test-results/junit.xml
           coverage-report: test-results/coverage.xml
 
@@ -246,6 +247,7 @@ jobs:
           path: test-results/
           retention-days: 7
           status: ${{ job.status }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           codecov-files: test-results/junit.xml
           coverage-report: test-results/coverage.xml
 


### PR DESCRIPTION
Created a new action `upload-test-results` to consolidate test result upload logic. Moved test result upload steps from `dev-container.yml` to the new action. Centralized upload of test results and coverage reports to GitHub and Codecov. Updated workflows to use the new action.
Added inputs for control over upload paths and retention. Added status input for better conditional handling. Removed redundant upload steps in workflows.
Refactored actions for better modularity and maintainability. Improved conditional logic for enhanced reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new GitHub Actions workflow for uploading test results and coverage reports to GitHub and Codecov.
  - Added new input parameters to enhance the upload process.

- **Improvements**
  - Consolidated test result and coverage report uploads into a single step for better efficiency.
  - Updated the workflow to ensure consistent handling of test results across different testing phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->