### PR TITLE
feat(partcad-cli): show package info in cli

### DIFF
--- a/features/info.feature
+++ b/features/info.feature
@@ -1,10 +1,11 @@
-@cli @add-assembly
+@cli @pc-info @add-assembly
 Feature: `pc info` command
 
   Background: Initialize sandbox
     Given I am in "/tmp/sandbox/behave" directory
     And I have temporary $HOME in "/tmp/sandbox/home"
 
+  @pc-info @add-assembly
   Scenario: Add assembly from `logo.assy` file
     When I run command:
       """
@@ -90,6 +91,39 @@ Feature: `pc info` command
       partcad info -a primitive
       """
     Then the command should exit with a status code of "0"
+
+  @success @pc-info
+  Scenario: Show 'Url' & 'Path' as package info for remote imports(git/tar)
+    Given a file named "partcad.yaml" with content:
+      """
+      import:
+        rob:
+          type: git
+          relPath: robotics/parts
+          url: https://github.com/partcad/partcad-index.git
+      """
+    When I run "pc info /rob/dfrobot:motion/rubber_wheel_136_24"
+    Then the command should exit with a status code of "0"
+    And STDOUT should contain "github.com"
+    And STDOUT should contain "Url: 'https://github.com/"
+    And STDOUT should contain "Path: '/rob/dfrobot'"
+
+  @success @pc-info
+  Scenario: Show 'Path' as package info for local imports
+    When I run command:
+      """
+      echo "translate (v= [0,0,0])  cube (size = 10);" > test.scad
+      """
+    Then the command should exit with a status code of "0"
+    Given a file named "partcad.yaml" with content:
+      """
+        parts:
+          test:
+            type: scad
+      """
+    When I run "pc info test"
+    Then the command should exit with a status code of "0"
+    And STDOUT should contain "Path: '/'"
 # And STDOUT should contain "cube" in the parts list
 # And STDOUT should contain "cylinder" in the parts list
 # And STDOUT should contain valid location coordinates

--- a/partcad/src/partcad/project_factory.py
+++ b/partcad/src/partcad/project_factory.py
@@ -26,6 +26,7 @@ class ImportConfiguration:
                 raise ValueError("Import configuration type is not set")
         self.import_config_type = config_obj.get("type")
         self.import_config_is_root = config_obj.get("isRoot", False)
+        self.import_config_url = config_obj.get("url")
         self.include_paths = self.config_obj.get("includePaths", [])
         self.inherited_config = config_obj.get("inheritedConfig", {})
         if parent and not self.inherited_config:
@@ -59,6 +60,7 @@ class ProjectFactory(ImportConfiguration):
         # Make the project config inherit some properties of the import config
         self.project.config_obj["type"] = self.import_config_type
         self.project.config_obj["isRoot"] = self.import_config_is_root
+        self.project.config_obj["url"] = self.import_config_url
 
     def _save(self):
         self.ctx.projects[self.name] = self.project

--- a/partcad/src/partcad/shape_factory.py
+++ b/partcad/src/partcad/shape_factory.py
@@ -35,4 +35,8 @@ class ShapeFactory(factory.Factory):
 
     def info(self, shape):
         """This is the default implementation of the get_info method for factories."""
-        return shape.shape_info()
+        info: dict = shape.shape_info()
+        if 'url' in self.project.config_obj and self.project.config_obj["url"] is not None:
+            info["Url"] = self.project.config_obj["url"]
+        info["Path"] = self.project.name
+        return info


### PR DESCRIPTION
- Updated the "info" method for all "shape" objects to return package path and Git URL (if applicable).
- Inherited the "url" field from ImportConfiguration to Configuration in _create() method within project_factory.py.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a URL attribute in the import configuration, enhancing project configuration handling.
	- Updated shape information retrieval to include URL and project path details.
	- Added new scenarios for displaying package information in the CLI, focusing on remote and local imports.

- **Bug Fixes**
	- Improved the `info` method to ensure comprehensive shape information is returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->