### PR TITLE
feat(cli): add long versions to all pc commands

### DIFF
--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -29,8 +29,8 @@ pc.plugins.export_png = pc.PluginExportPngReportlab()
 
 
 @click.command(cls=Loader)
-@click.option("-v", is_flag=True, help="Increase verbosity level")
-@click.option("-q", is_flag=True, help="Decrease verbosity level")
+@click.option("-v", "--verbose", is_flag=True, help="Increase verbosity level")
+@click.option("-q", "--quiet", is_flag=True, help="Decrease verbosity level")
 @click.option(
     "--no-ansi",
     is_flag=True,
@@ -38,6 +38,7 @@ pc.plugins.export_png = pc.PluginExportPngReportlab()
 )
 @click.option(
     "-p",
+    "--package",
     type=click.Path(exists=True),
     help="Specify the package path (YAML file or directory with 'partcad.yaml')",
 )
@@ -49,7 +50,7 @@ pc.plugins.export_png = pc.PluginExportPngReportlab()
     show_envvar=True,
 )
 @click.pass_context
-def cli(ctx, v, q, no_ansi, p, format):
+def cli(ctx, verbose, quiet, no_ansi, package, format):
     """
     \b
     ██████╗  █████╗ ██████╗ ████████╗ ██████╗ █████╗ ██████╗
@@ -94,10 +95,10 @@ def cli(ctx, v, q, no_ansi, p, format):
 
         logging_ansi_terminal_init()
 
-    if q:
+    if quiet:
         pc.logging.setLevel(logging.CRITICAL + 1)
     else:
-        if v:
+        if verbose:
             pc.logging.setLevel(logging.DEBUG)
         else:
             pc.logging.setLevel(logging.INFO)
@@ -130,9 +131,9 @@ def cli(ctx, v, q, no_ansi, p, format):
         from partcad.globals import init
 
         try:
-            ctx.obj = init(p)
+            ctx.obj = init(package)
         except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
-            exc = click.BadParameter("Invalid configuration file", ctx=ctx, param=p, param_hint=None)
+            exc = click.BadParameter("Invalid configuration file", ctx=ctx, param=package, param_hint=None)
             exc.exit_code = 2
             raise exc from e
         except Exception as e:
@@ -160,7 +161,7 @@ cli.context_settings = {
 
 
 @cli.result_callback()
-def process_result(result, v, q, no_ansi, p, format):
+def process_result(result, verbose, quiet, no_ansi, package, format):
     # TODO-89: @alexanderilyin: What is this for?
     if not no_ansi:
         pc.logging_ansi_terminal_fini()

--- a/partcad-cli/src/partcad_cli/click/commands/info.py
+++ b/partcad-cli/src/partcad_cli/click/commands/info.py
@@ -13,10 +13,10 @@ import partcad.logging as logging
     help="Package to retrieve the object from",
     default=None,
 )
-@click.option("-i", "interface", is_flag=True, help="The object is an interface")
-@click.option("-a", "assembly", is_flag=True, help="The object is an assembly")
-@click.option("-s", "sketch", is_flag=True, help="The object is a sketch")
-@click.option("-S", "scene", is_flag=True, help="The object is a scene")
+@click.option("-i", "--interface", "interface", is_flag=True, help="The object is an interface")
+@click.option("-a", "--assembly", "assembly", is_flag=True, help="The object is an assembly")
+@click.option("-s", "--sketch", "sketch", is_flag=True, help="The object is a sketch")
+@click.option("-S", "--scene", "scene", is_flag=True, help="The object is a scene")
 @click.option(
     "-p",
     "--param",

--- a/partcad-cli/src/partcad_cli/click/commands/init.py
+++ b/partcad-cli/src/partcad_cli/click/commands/init.py
@@ -14,19 +14,19 @@ from partcad.globals import create_package
 
 @click.command(help="Create a new PartCAD package in the current directory")
 # TODO-95: All long options everywhere
-@click.option("-p", is_flag=True, help="Initialize this package as private")
+@click.option("-p", "--private", is_flag=True, help="Initialize this package as private")
 @click.pass_context
-def cli(ctx: click.rich_context.RichContext, p):
+def cli(ctx: click.rich_context.RichContext, private):
     # TODO-96: @alexanderilyin: Deal with noise like "PartCAD configuration file is not found"
     logging.had_errors = False
-    if not ctx.parent.params.get("p") is None:
-        if os.path.isdir(ctx.parent.params.get("p")):
+    if not ctx.parent.params.get("package") is None:
+        if os.path.isdir(ctx.parent.params.get("package")):
             # TODO-97: Move filename to constant somewhere.
-            dst_path = os.path.join(ctx.parent.params.get("p"), "partcad.yaml")
+            dst_path = os.path.join(ctx.parent.params.get("package"), "partcad.yaml")
         else:
-            dst_path = ctx.parent.params.get("p")
+            dst_path = ctx.parent.params.get("package")
     else:
         dst_path = "partcad.yaml"
 
-    if not create_package(dst_path, p):
+    if not create_package(dst_path, private):
         logging.error("Failed creating '%s'!" % dst_path)

--- a/partcad-cli/src/partcad_cli/click/commands/list/parts.py
+++ b/partcad-cli/src/partcad_cli/click/commands/list/parts.py
@@ -7,6 +7,7 @@ from partcad.logging import Process
 @click.command(help="List available parts")
 @click.option(
     "-u",
+    "--used_by",
     "used_by",
     help="Only process objects used by the given assembly or scene.",
     type=str,
@@ -14,6 +15,7 @@ from partcad.logging import Process
 )
 @click.option(
     "-r",
+    "--recursive",
     "recursive",
     is_flag=True,
     help="Recursively process all imported packages",


### PR DESCRIPTION
Add `--verbose`, `--quiet`, `--package` options to the CLI.
Added equivalent longer options to commands (`cli_ai_regenerate`, `cli_info`, `cli_init`, `cli_inspect`, `cli_list`, `cli_render`, `cli_test`). Added `--recursive` for listing and rendering subcommands. 
Added `--used_by` for listing subcommands to only process objects used by the given assembly or scene. 
Added `--prepare`, `--output`, and `--type` options for render arguments.

![image](https://github.com/user-attachments/assets/225bee51-4387-4def-9d9e-572f0061c117)

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced CLI with more descriptive long-form options for verbosity, package path, and initialization.
  - Added new filtering options for listing parts, including `--used_by` and `--recursive`.

- **Improvements**
  - Improved command-line interface usability by adding long-form options.
  - Maintained backward compatibility with existing short options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->