### PR TITLE
feat(partcad): Allow user to configure git clone protocol in settings

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -24,6 +24,44 @@ possibility to enforce the use of a specific provider for corresponding parts
 (for example, for parts that are using a patented design).
 
 
+=======================
+Installing Dependencies
+=======================
+
+Cloning over SSH is faster and more reliable because it uses an efficient
+protocol with lower overhead, supports compression, and maintains stable
+connections via key-based authentication. SSH avoids HTTPS rate limits,
+handles firewalls better, and eliminates credential prompts, making it
+ideal for large repositories or frequent interactions.
+
+If you have SSH keys configured then you can add the following
+to the ~/.partcad/config.yaml:
+
+  .. code-block:: yaml
+
+    # ~/.partcad/config.yaml
+    import:
+      overrides:
+        url:
+          "git@github.com:": "https://github.com/"
+
+===========================
+Git Configuration Overrides
+===========================
+
+By default, PartCAD uses the system's Git configuration when importing packages
+using git. If you want to override these configurations, you can add your
+overrides in ``~/.partcad/config.yaml`` as shown below:
+
+  .. code-block:: yaml
+
+    # ~/.partcad/config.yaml
+    git:
+      config:
+        "user.name": "John Doe"
+        "user.email": "johndoe@example.com"
+        ...
+
 =============
 Generative AI
 =============

--- a/features/install.feature
+++ b/features/install.feature
@@ -37,6 +37,55 @@ Feature: `pc install` command
     Then STDERR should contain "DONE: Install: this:"
     Then the command should exit with a status code of "0"
 
+  @wip @success @pc-init @pc-install @pc-ansi
+  Scenario: Install packages with ssh
+    Given a file named "partcad.yaml" with content:
+      """
+      import:
+        raspberrypi:
+          desc: Raspberry Pi
+          type: git
+          url: https://github.com/partcad/partcad-electronics-sbcs-raspberrypi
+      """
+    And a user configuration file named "config.yaml" with content:
+      """
+      import:
+        overrides:
+          url:
+            "git@github.com:": "https://github.com/"
+      """
+    When I run "partcad install"
+    Then STDOUT should contain "Cloning the GIT repo:"
+    Then STDOUT should contain "git@github.com:"
+    Then STDOUT should contain "DONE: Install: this:"
+    Then the command should exit with a status code of "0"
+
+  @success @pc-init @pc-install @pc-ansi
+  Scenario: Override git configuration
+    Given a file named "partcad.yaml" with content:
+      """
+      import:
+        raspberrypi:
+          desc: Raspberry Pi
+          type: git
+          url: https://github.com/partcad/partcad-electronics-sbcs-raspberrypi
+      """
+    And a user configuration file named "config.yaml" with content:
+      """
+      git:
+        config:
+          "user.name": "John Doe"
+          "user.email": "johndoe@example.com"
+      """
+    When I run "partcad install"
+    Then STDOUT should contain "Cloning the GIT repo:"
+    Then STDOUT should contain "DONE: Install: this:"
+    Then the command should exit with a status code of "0"
+    When I run "git -C ~/.partcad/git/*/ config --get user.name"
+    Then STDOUT should contain "John Doe"
+    When I run "git -C ~/.partcad/git/*/ config --get user.email"
+    Then STDOUT should contain "johndoe@example.com"
+
   @wip @failure @pc-install
   Scenario: Install non-existent package
     Given I am in "/tmp/sandbox/behave" directory

--- a/features/steps/partcad-cli/commands/add/assembly.py
+++ b/features/steps/partcad-cli/commands/add/assembly.py
@@ -15,6 +15,14 @@ def step_impl(context, filename):
         logging.debug(f"Creating file: {filename}")
         file.write(content)
 
+@given('a user configuration file named "{filename}" with content')
+def step_impl(context, filename):
+    content = context.text
+    filename = expandvars(filename, context)
+    filename = os.path.join(context.user_config_dir, filename)
+    with open(filename, "w") as file:
+        logging.debug(f"Creating file: {filename}")
+        file.write(content)
 
 @then('a file named "{file_path}" should have YAML content')
 def step_impl(context, file_path):

--- a/features/steps/partcad-cli/commands/list/packages.py
+++ b/features/steps/partcad-cli/commands/list/packages.py
@@ -16,6 +16,10 @@ def step_impl(context: Context, directory: str) -> None:
     )
     logging.info("Created temporary home: %s", context.home_dir)
 
+    context.user_config_dir = os.path.join(context.home_dir, ".partcad")
+    os.makedirs(context.user_config_dir, exist_ok=True)
+    logging.info("Created temporary partcad configuration directory: %s", context.user_config_dir)
+
     # TODO-71: @alexanderilyin: mention in docs
     # Clean up after the test
     if os.environ.get("BEHAVE_NO_CLEANUP", "0") != "1":

--- a/partcad/src/partcad/user_config.py
+++ b/partcad/src/partcad/user_config.py
@@ -128,6 +128,21 @@ class UserConfig:
         else:
             self.max_script_correction = None
 
+        # option: git.config
+        # description: git configuration for git
+        # values: <dict>
+        # default: {}
+        self.git_config = self.config_obj.get("git", {}).get("config", {})
+        if self.git_config is None:
+            self.git_config = {}
+
+        # option: import.overrides
+        # description: overrides for import settings
+        # values: <dict>
+        # default: {}
+        self.import_overrides = self.config_obj.get("import", {}).get("overrides", {})
+        if self.import_overrides is None:
+            self.import_overrides = {}
         # option: import.git.retry
         # description: retry settings for git clone
         # values: <dict>


### PR DESCRIPTION
Add support for runtime git configuration override for cloning and update. User will be able to specify git protocol to be used for cloning and update. specified at ~/.partcad/config.yaml

![image](https://github.com/user-attachments/assets/a60da800-b16d-4107-96ed-8d3b228ddcd4)

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for SSH URL overrides in package installation.
  - Introduced Git configuration customization options.
  - Enhanced user configuration capabilities for dependency management.

- **Documentation**
  - Updated documentation with detailed guides on installing dependencies and Git configuration overrides.
  - Added examples for configuring package installation settings.

- **Testing**
  - Implemented new test scenarios for SSH and Git configuration installations.
  - Added functionality to create user configuration files and directories during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->