### PR TITLE
feat(docs): Add reset feature & git operation stats

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -87,6 +87,15 @@ Now the part can be exported:
 
     pc render -t stl :test
 
+Reset partcad
+---------------------
+
+PartCAD maintains an internal state to keep track of dependencies of a project. This state can be reset using the command below.
+
+  .. code-block:: shell
+
+    pc reset
+
 =================
 VS Code Extension
 =================

--- a/features/test.feature
+++ b/features/test.feature
@@ -1,10 +1,11 @@
-@wip @cli @pc-test
+@cli @pc-test
 Feature: `pc test` command
 
   Background: Create temporary $HOME and working directory
     Given I am in "/tmp/sandbox/behave" directory
     And I have temporary $HOME in "/tmp/sandbox/home"
 
+  @wip
   Scenario: `pc test -s /pub/std/metric/m:m3`
     Given I have a valid PartCAD configuration
     When I execute "pc test -s /pub/std/metric/m:m3"
@@ -12,12 +13,29 @@ Feature: `pc test` command
     And the output should contain "Test completed successfully"
     And no errors should be reported
 
+  @success
+  Scenario: `Recursively test all imported packages`
+    Given a file named "partcad.yaml" with content:
+      """
+      import:
+        raspberrypi:
+          desc: Raspberry Pi
+          type: git
+          url: https://github.com/partcad/partcad-robotics-part-vendor-dfrobot
+      """
+    When I run "pc test -r"
+    Then the command should exit with a status code of "0"
+    Then STDOUT should contain "Git operations: 1"
+    Then STDOUT should contain "DONE: Test: this:"
+
+  @wip
   Scenario: Test with invalid configuration
     Given I have an invalid PartCAD configuration
     When I execute "pc test -s /pub/std/metric/m:m3"
     Then the command should exit with non-zero code
     And the output should contain "Configuration error"
 
+  @wip
   Scenario: Test with non-existent part
     Given I have a valid PartCAD configuration
     When I execute "pc test -s /pub/non/existent/part"

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -125,6 +125,7 @@ def cli(ctx, verbose, quiet, no_ansi, package, format):
         "supply",  # Actually context is needed for "quote" but for now it it is what it is
         "test",
         "update",
+        "reset"
     ]
 
     if ctx.invoked_subcommand in commands_with_context:

--- a/partcad-cli/src/partcad_cli/click/commands/install.py
+++ b/partcad-cli/src/partcad_cli/click/commands/install.py
@@ -1,5 +1,5 @@
 import rich_click as click
-from partcad.logging import Process
+from partcad.logging import Process, info
 from partcad.context import Context
 from partcad.user_config import user_config
 
@@ -11,3 +11,5 @@ def cli(ctx: Context) -> None:
     with Process("Install", "this"):
         user_config.force_update = True
         ctx.get_all_packages()
+        if ctx.stats_git_ops:
+            info(f"Git operations: {ctx.stats_git_ops}")

--- a/partcad-cli/src/partcad_cli/click/commands/reset.py
+++ b/partcad-cli/src/partcad_cli/click/commands/reset.py
@@ -1,0 +1,23 @@
+import os
+import shutil
+import rich_click as click
+from partcad.logging import Process, info
+from partcad.context import Context
+from partcad.user_config import user_config
+
+
+@click.command(help="Reset all internal states maintained by PartCAD")
+@click.pass_obj
+def cli(ctx: Context) -> None:
+    with Process("Reset", "this"):
+        for _, package_info in ctx.config_obj.get("import", {}).items():
+            import_type = package_info["type"]
+            cache_dir = os.path.join(user_config.internal_state_dir, import_type)
+            if os.path.exists(cache_dir):
+                info(f"Removing cached {import_type} imports: '{cache_dir}'")
+                shutil.rmtree(cache_dir)
+
+        runtime_dir = os.path.join(user_config.internal_state_dir, "runtime")
+        if os.path.exists(runtime_dir):
+            info(f"Removing runtime: '{runtime_dir}'")
+            shutil.rmtree(runtime_dir)

--- a/partcad-cli/src/partcad_cli/click/commands/test.py
+++ b/partcad-cli/src/partcad_cli/click/commands/test.py
@@ -62,6 +62,8 @@ def cli(ctx, package, recursive, sketch, interface, assembly, scene, object):
         if recursive:
             start_package = ctx.get_project_abs_path(package)
             all_packages = ctx.get_all_packages(start_package)
+            if ctx.stats_git_ops:
+                logging.info(f"Git operations: {ctx.stats_git_ops}")
             packages = [p["name"] for p in all_packages]
         else:
             packages = [package]

--- a/partcad-cli/src/partcad_cli/click/commands/update.py
+++ b/partcad-cli/src/partcad_cli/click/commands/update.py
@@ -1,7 +1,6 @@
 import rich_click as click
 from partcad.context import Context
 from partcad.user_config import user_config
-from partcad.user_config import user_config
 from partcad import logging as logging
 
 
@@ -15,6 +14,8 @@ def cli(ctx: Context):
     user_config.force_update = True
     try:
         packages = ctx.get_all_packages()
+        if ctx.stats_git_ops:
+            logging.info(f"Git operations: {ctx.stats_git_ops}")
         logging.info(f"Successfully updated {len(packages)} packages")
     except Exception as e:
         logging.error(f"Error updating packages: {str(e)}")

--- a/partcad/src/partcad/context.py
+++ b/partcad/src/partcad/context.py
@@ -42,6 +42,7 @@ class Context(project_config.Configuration):
     stats_providers: int
     stats_provider_queries: int
     stats_memory: int
+    stats_git_ops: int
 
     # name is the package path (not a filesystem path) of the root package
     # in case it's configured to be something other than '/' (default)
@@ -119,6 +120,7 @@ class Context(project_config.Configuration):
         self.stats_providers = 0
         self.stats_provider_queries = 0
         self.stats_memory = 0
+        self.stats_git_ops = 0
 
         self.mates = {}
         # self.projects contains all projects known to this context

--- a/partcad/src/partcad/project_factory_git.py
+++ b/partcad/src/partcad/project_factory_git.py
@@ -108,6 +108,7 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
                             short_branch_name = branch_name[branch_name.find("/") + 1 :]
                             pc_logging.debug("Refreshing the GIT branch: %s" % short_branch_name)
                             origin.pull(short_branch_name)
+                            self.ctx.stats_git_ops += 1
                             os.utime(guard_path, (now, now))
                     else:
                         # Import a specific revision
@@ -127,6 +128,7 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
                             origin.fetch()
                             repo.git.checkout(self.import_revision, force=True)
                             origin.pull(force=True, rebase=True)
+                            self.ctx.stats_git_ops += 1
                             os.utime(guard_path, (now, now))
                         else:
                             # No update was performed
@@ -151,6 +153,7 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
                 try:
                     pc_logging.info("Cloning the GIT repo: %s" % self.import_config_url)
                     repo = Repo.clone_from(repo_url, cache_path)
+                    self.ctx.stats_git_ops += 1
                     if not self.import_revision is None:
                         repo.git.checkout(self.import_revision, force=True)
                         after = self.import_revision


### PR DESCRIPTION
- Added a new command to reset internal states.
- Added documentation for the `pc reset` command.
- Add recursive pc test and validate git operation count
- Add git operation stats to context
- logged count of git operations during install, updates and test commands.

Working Example

![image](https://github.com/user-attachments/assets/bf960011-ad0f-47fa-99b8-b75351e30880)

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `pc reset` command to clear internal project state and dependencies.
	- Introduced a new scenario for recursively testing all imported packages.

- **Documentation**
	- Updated tutorial with a new section explaining the reset functionality.

- **Tests**
	- Added new test scenarios for recursive package testing, marked as work in progress.

- **Chores**
	- Enhanced logging to track Git operations during package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->