### PR TITLE
fixed pip dependencies to enable partcad to be built with python-3.12

### DIFF
--- a/partcad-cli/pyproject.toml
+++ b/partcad-cli/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.7.40"
 description = "Command-line interface to PartCAD"
 readme = "README.md"
 keywords = ["cadquery", "build123d", "cad", "design", "openscad", "step", "stl"]
-requires-python = ">=3.10"
+requires-python = "==3.12"
 license = {file = "LICENSE.txt"}
 authors = [
   {name = "PartCAD", email = "support@partcad.org" }

--- a/partcad/pyproject.toml
+++ b/partcad/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.7.40"
 description = "Package manager for CAD models and a modelling framework"
 readme = "README.md"
 keywords = ["cadquery", "build123d", "cad", "design", "openscad", "step", "stl"]
-requires-python = ">=3.10"
+requires-python = "==3.12"
 license = {file = "LICENSE.txt"}
 authors = [
   {name = "PartCAD", email = "support@partcad.org" }

--- a/partcad/requirements.txt
+++ b/partcad/requirements.txt
@@ -1,10 +1,10 @@
 ocp_tessellate==3.0.8
-cadquery==2.4.0
-numpy==1.26.4
-numpy-quaternion==2023.0.4
+cadquery
+numpy
+numpy-quaternion
 nptyping==2.0.1
 typing_extensions==4.12.2
-build123d==0.7.0
+build123d
 scipy>=1.11.1
 pyyaml>=6.0.1
 GitPython>=3.1.40
@@ -15,6 +15,14 @@ jinja2
 requests
 aiofiles
 aiohttp
+
+allure-pytest
+click
+coloredlogs
+pytest-cov
+pytest-durations
+pytest-html
+rich-click
 
 # Google AI
 google.generativeai


### PR DESCRIPTION
…3.12

## Copilot Summary

<!-- Use GitHub Copilot to generate a summary of your changes here. -->

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->

fixes dependencies to allow partcad to work with python 3.12 with latest versions of build123d and cadquery at the same time

fixes #253 and #256 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Python Version**
  - Updated project Python version requirement to 3.12

- **Dependencies**
  - Removed specific version constraints for several packages
  - Added new testing and utility dependencies, including:
    - Allure pytest
    - Click
    - Pytest coverage and HTML reporting tools
    - Logging enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->