### PR TITLE
feat(list): Fixed the CLI list commands

### DIFF
--- a/features/add/package.feature
+++ b/features/add/package.feature
@@ -46,7 +46,7 @@ Feature: `pc add package` command
     # And the directory "OpenVMP-robots/.git" should exist
     # And STDOUT should contain "Successfully installed OpenVMP-robots"
 
-    When I run "partcad list packages"
+    When I run "partcad list packages -r"
     Then the command should exit with a status code of "0"
     And STDOUT should contain "PartCAD packages:"
     And STDOUT should contain "OpenVMP-robots"

--- a/features/list/assemblies.feature
+++ b/features/list/assemblies.feature
@@ -84,7 +84,7 @@ Feature: `pc list assemblies` command
     Then STDOUT should contain "PartCAD assemblies:"
     Then STDOUT should contain "primitive"
     Then STDOUT should contain "Total: 1"
-    Then STDOUT should contain "DONE: ListAssy: this:"
+    Then STDOUT should contain "DONE: ListAssy: /:"
 
 #   @ai-openscad @failure
 #   Scenario: Fail to add assembly with missing referenced parts

--- a/features/list/interfaces.feature
+++ b/features/list/interfaces.feature
@@ -35,7 +35,7 @@ Feature: `pc list interfaces` command
     Then STDOUT should contain "m3"
     Then STDOUT should contain "Abstract 3mm circular interface"
     Then STDOUT should contain "Total: 1"
-    Then STDOUT should contain "DONE: ListInterfaces: this:"
+    Then STDOUT should contain "DONE: ListInterfaces: /:"
 
 # Feature: List Interfaces Command
 #   As a PartCAD user

--- a/features/list/parts.feature
+++ b/features/list/parts.feature
@@ -26,7 +26,7 @@ Feature: `pc list parts` command
     When I run "partcad list parts"
     Then the command should exit with a status code of "0"
     And STDOUT should contain "PartCAD parts:"
-    And STDOUT should contain "Total:"
+    And STDOUT should not contain "Total:"
     And STDOUT should contain "<none>"
 
   @success @pc-list @pc-list-parts @pc-list-parts-recursively

--- a/features/list/parts.feature
+++ b/features/list/parts.feature
@@ -27,7 +27,7 @@ Feature: `pc list parts` command
     Then the command should exit with a status code of "0"
     And STDOUT should contain "PartCAD parts:"
     And STDOUT should contain "Total:"
-    And STDOUT should not contain "<none>"
+    And STDOUT should contain "<none>"
 
   @success @pc-list @pc-list-parts @pc-list-parts-recursively
   Scenario: List parts recursively

--- a/features/list/sketches.feature
+++ b/features/list/sketches.feature
@@ -32,7 +32,7 @@ Feature: `pc list assemblies` command
     Then STDOUT should contain "circle_01"
     Then STDOUT should contain "The shortest way to create a basic circle in PartCAD"
     Then STDOUT should contain "Total: 1"
-    Then STDOUT should contain "DONE: ListSketches: this:"
+    Then STDOUT should contain "DONE: ListSketches: /:"
 
 # Feature: List sketches recursively
 #   As a PartCAD user

--- a/partcad-cli/src/partcad_cli/click/commands/list/all.py
+++ b/partcad-cli/src/partcad_cli/click/commands/list/all.py
@@ -22,7 +22,7 @@ from partcad_cli.click.commands.list.sketches import cli as list_sketches
     is_flag=True,
     help="Recursively process all imported packages",
 )
-@click.argument("package", type=str, required=False)
+@click.argument("package", type=str, required=False, default=".")
 @click.command(help="List all available parts, assemblies and scenes")
 @click.pass_obj
 def cli(ctx, used_by, recursive, package) -> None:
@@ -39,10 +39,10 @@ def cli(ctx, used_by, recursive, package) -> None:
 
     catch_exceptions = False
 
-    runner.invoke(list_assemblies, options, catch_exceptions=catch_exceptions, obj=ctx)
+    runner.invoke(list_packages, catch_exceptions=catch_exceptions, obj=ctx)
+    runner.invoke(list_sketches, options, catch_exceptions=catch_exceptions, obj=ctx)
     runner.invoke(list_interfaces, options, catch_exceptions=catch_exceptions, obj=ctx)
+    runner.invoke(list_parts, options, catch_exceptions=catch_exceptions, obj=ctx)
+    runner.invoke(list_assemblies, options, catch_exceptions=catch_exceptions, obj=ctx)
     # TODO: @alexanderilyin: TypeError: startswith first arg must be str or a tuple of str, not Project
     # runner.invoke(list_mates, options, catch_exceptions=catch_exceptions, obj=ctx)
-    runner.invoke(list_packages, catch_exceptions=catch_exceptions, obj=ctx)
-    runner.invoke(list_parts, options, catch_exceptions=catch_exceptions, obj=ctx)
-    runner.invoke(list_sketches, options, catch_exceptions=catch_exceptions, obj=ctx)

--- a/partcad-cli/src/partcad_cli/click/commands/list/assemblies.py
+++ b/partcad-cli/src/partcad_cli/click/commands/list/assemblies.py
@@ -8,10 +8,12 @@ from partcad.logging import Process
 @click.option(
     "-u", "--used_by", type=str, required=False, help="Only process objects used by the given assembly or scene."
 )
-@click.argument("package", type=str, required=False)  # help="Package to retrieve the object from"
+@click.argument("package", type=str, required=False, default=".")  # help="Package to retrieve the object from"
 @click.pass_obj
 def cli(ctx, recursive, used_by, package):
-    with Process("ListAssy", "this"):
+    package = ctx.get_project(package).name
+
+    with Process("ListAssy", package):
         assy_count = 0
         assy_kinds = 0
 
@@ -24,16 +26,10 @@ def cli(ctx, recursive, used_by, package):
 
         output = "PartCAD assemblies:\n"
         for project_name in ctx.projects:
-            if not recursive and package is not None and package != project_name:
+            if not recursive and package != project_name:
                 continue
 
-            if not recursive and project_name != ctx.get_current_project_path():
-                continue
-
-            if recursive and package is not None and not project_name.startswith(package):
-                continue
-
-            if recursive and package is None and not project_name.startswith(ctx.get_current_project_path()):
+            if recursive and not project_name.startswith(package):
                 continue
 
             project = ctx.projects[project_name]

--- a/partcad-cli/src/partcad_cli/click/commands/list/interfaces.py
+++ b/partcad-cli/src/partcad_cli/click/commands/list/interfaces.py
@@ -8,10 +8,12 @@ from partcad.logging import Process
 @click.option(
     "-u", "--used_by", type=str, required=False, help="Only process objects used by the given assembly or scene."
 )
-@click.argument("package", type=str, required=False)  # help="Package to retrieve the object from"
+@click.argument("package", type=str, required=False, default=".")  # help="Package to retrieve the object from"
 @click.pass_obj
 def cli(ctx, recursive, used_by, package):
-    with Process("ListInterfaces", "this"):
+    package = ctx.get_project(package).name
+
+    with Process("ListInterfaces", package):
         interface_count = 0
         interface_kinds = 0
 
@@ -23,16 +25,10 @@ def cli(ctx, recursive, used_by, package):
 
         output = "PartCAD interfaces:\n"
         for project_name in ctx.projects:
-            if not recursive and package is not None and package != project_name:
+            if not recursive and package != project_name:
                 continue
 
-            if not recursive and project_name != ctx.get_current_project_path():
-                continue
-
-            if recursive and package is not None and not project_name.startswith(package):
-                continue
-
-            if recursive and package is None and not project_name.startswith(ctx.get_current_project_path()):
+            if recursive and not project_name.startswith(package):
                 continue
 
             project = ctx.projects[project_name]

--- a/partcad-cli/src/partcad_cli/click/commands/list/packages.py
+++ b/partcad-cli/src/partcad_cli/click/commands/list/packages.py
@@ -4,9 +4,13 @@ from partcad.logging import Process
 
 
 @click.command(help="List imported packages")
+@click.option("-r", "--recursive", is_flag=True, help="Recursively process all imported packages")
+@click.argument("package", type=str, required=False, default=".")  # help="Package to retrieve the object from"
 @click.pass_obj
-def cli(ctx):
-    with Process("ListPackages", "this"):
+def cli(ctx, recursive, package):
+    package = ctx.get_project(package).name
+
+    with Process("ListPackages", package):
         # TODO-103: Show source (URL, PATH) of the package, probably use prettytable as well
         pkg_count = 0
 
@@ -16,6 +20,12 @@ def cli(ctx):
         output = "PartCAD packages:\n"
         for project in projects:
             project_name = project["name"]
+
+            if not recursive and package != project_name:
+                continue
+
+            if recursive and not project_name.startswith(package):
+                continue
 
             line = "\t%s" % project_name
             padding_size = 60 - len(project_name)

--- a/partcad-cli/src/partcad_cli/click/commands/list/parts.py
+++ b/partcad-cli/src/partcad_cli/click/commands/list/parts.py
@@ -20,10 +20,12 @@ from partcad.logging import Process
     is_flag=True,
     help="Recursively process all imported packages",
 )
-@click.argument("package", type=str, required=False)  # help='Package to retrieve the object from'
+@click.argument("package", type=str, required=False, default=".")  # help='Package to retrieve the object from'
 @click.pass_obj
 def cli(ctx, used_by, recursive, package):
-    with Process("ListParts", "this"):
+    package = ctx.get_project(package).name
+
+    with Process("ListParts", package):
         part_count = 0
         part_kinds = 0
 
@@ -33,19 +35,12 @@ def cli(ctx, used_by, recursive, package):
         else:
             ctx.get_all_packages()
 
-        # TODO-104: @openvmp: remove the following workaround after replacing 'print'
-        # with corresponding logging calls
-        time.sleep(2)
-
         output = "PartCAD parts:\n"
         for project_name in ctx.projects:
-            if not recursive and package is not None and package != project_name:
+            if not recursive and package != project_name:
                 continue
 
-            if recursive and package is not None and not project_name.startswith(package):
-                continue
-
-            if recursive and package is None and not project_name.startswith(ctx.get_current_project_path()):
+            if recursive and not project_name.startswith(package):
                 continue
 
             project = ctx.projects[project_name]

--- a/partcad-cli/src/partcad_cli/click/commands/list/sketches.py
+++ b/partcad-cli/src/partcad_cli/click/commands/list/sketches.py
@@ -17,10 +17,12 @@ from partcad import logging
     required=False,
     help="Only process objects used by the given assembly or scene.",
 )
-@click.argument("package", type=str, required=False)  # help="Package to retrieve the object from"
+@click.argument("package", type=str, required=False, default=".")  # help="Package to retrieve the object from"
 @click.pass_obj
 def cli(ctx, recursive, used_by, package):
-    with Process("ListSketches", "this"):
+    package = ctx.get_project(package).name
+
+    with Process("ListSketches", package):
         sketch_count = 0
         sketch_kinds = 0
 
@@ -32,16 +34,10 @@ def cli(ctx, recursive, used_by, package):
 
         output = "PartCAD sketches:\n"
         for project_name in ctx.projects:
-            if not recursive and package is not None and package != project_name:
+            if not recursive and package != project_name:
                 continue
 
-            if not recursive and project_name != ctx.get_current_project_path():
-                continue
-
-            if recursive and package is not None and not project_name.startswith(package):
-                continue
-
-            if recursive and package is None and not project_name.startswith(ctx.get_current_project_path()):
+            if recursive and not project_name.startswith(package):
                 continue
 
             project = ctx.projects[project_name]


### PR DESCRIPTION
Add default value of '.' to package argument for all list commands.
The list commands are now working for the current packages by default as expected.
The recursive commands are now working starting from the current package by default as expected.


## Copilot Summary

<!-- Use GitHub Copilot to generate a summary of your changes here. -->

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added optional `package` argument with default value of current directory (`.`) to list commands.
	- Introduced `--recursive` flag for package listing to enable recursive package processing.

- **Improvements**
	- Simplified command logic for processing projects.
	- Enhanced flexibility in specifying package context for CLI commands.
	- Streamlined project filtering based on package and recursive flags.

- **Changes**
	- Updated CLI command signatures across multiple list subcommands.
	- Refined control flow for package, part, assembly, sketch, interface, and mate listing.
	- Adjusted expected output for various list commands to align with new logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->