### PR TITLE
fix(deploy): use sudo for apt install

### DIFF
--- a/.github/workflows/python-deploy.yml
+++ b/.github/workflows/python-deploy.yml
@@ -47,7 +47,7 @@ jobs:
           (. .venv/build-cli/${{ env.BIN_DIR }}/activate && python -m pip install --upgrade pip build && deactivate)
           python -m venv .venv/install
           (. .venv/install/${{ env.BIN_DIR }}/activate && python -m pip install --upgrade pip build && deactivate)
-          apt install --yes libcairo2-dev python3-dev
+          sudo apt install --yes libcairo2-dev python3-dev
       - name: Test building and packaging
         run: |
           (. .venv/build/${{ env.BIN_DIR }}/activate && cd partcad && python -m build && cd .. && deactivate)


### PR DESCRIPTION
## Copilot Summary

This pull request includes a small but important change to the `jobs:` section in the `.github/workflows/python-deploy.yml` file. The change ensures that the `apt install` command is run with `sudo` to avoid permission issues during the installation of dependencies.

* [`.github/workflows/python-deploy.yml`](diffhunk://#diff-c10475b5f950338107c15d3b79c7ec33b5f6b2a4bb95fc41338f694bc0f9aef5L50-R50): Added `sudo` to the `apt install` command to ensure proper installation permissions.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use `sudo` for system dependency installation during deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->