### PR TITLE
PC-214: fix bump-my-version config

### DIFF
--- a/.devcontainer/.bumpversion.toml
+++ b/.devcontainer/.bumpversion.toml
@@ -33,10 +33,10 @@ replace = "__version__: str = \"{new_version}\""
 
 [[tool.bumpversion.files]]
 filename = "docs/mkdocs/docs/development/quick-start.md"
-search = "__version__: str = \"{current_version}\""
-replace = "__version__: str = \"{new_version}\""
+search = "Installing the current project: partcad-dev ({current_version})"
+replace = "Installing the current project: partcad-dev ({new_version})"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = "__version__: str = \"{current_version}\""
-replace = "__version__: str = \"{new_version}\""
+search = "version = \"{current_version}\""
+replace = "version = \"{new_version}\""

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -34,4 +34,6 @@ jobs:
 
       - run: pip install mkdocs-material
 
-      - run: mkdocs gh-deploy --force
+      - run: |
+          cd docs/mkdocs
+          mkdocs gh-deploy --force


### PR DESCRIPTION
## Copilot Summary

This pull request includes changes to update version information in documentation and improve the GitHub Actions workflow for deploying MkDocs. The most important changes are listed below:

Version information updates:

* [`.devcontainer/.bumpversion.toml`](diffhunk://#diff-5d682d9dce2eda31a9bb67e2539047f9fefc61bbd13727ec214ac62663b3a719L36-R42): Updated the `search` and `replace` patterns to reflect the new format for version information in `quick-start.md` and `pyproject.toml` files.

GitHub Actions workflow improvement:

* [`.github/workflows/mkdocs.yml`](diffhunk://#diff-ac5175ca62288ff3d3d57d7f315390766083f9a99e21f56d709026e10114a551L37-R39): Modified the workflow to change the directory to `docs/mkdocs` before running the `mkdocs gh-deploy` command.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version configuration for `bumpversion` tool
  - Modified MkDocs deployment workflow to change working directory before site deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->