### PR TITLE
feat(deploy): Rename artifact name for CLI distributions

### DIFF
--- a/.github/workflows/python-deploy.yml
+++ b/.github/workflows/python-deploy.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Download cli dists
         uses: actions/download-artifact@v4
         with:
-          name: python-package-distributions
+          name: python-package-distributions-cli
           path: dist
 
       - name: Determine the release tag

--- a/.github/workflows/python-deploy.yml
+++ b/.github/workflows/python-deploy.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.11' }}
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-distributions
+          name: python-package-distributions-cli
           path: partcad-cli/dist/
 
   publish-to-pypi:
@@ -89,7 +89,13 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Download all the dists
+      - name: Download lib dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Download cli dists
         uses: actions/download-artifact@v4
         with:
           name: python-package-distributions


### PR DESCRIPTION
- Refactor artifact name for CLI distributions to python-package-distributions-cli.
- Download lib dists artifact before downloading CLI distributions.

## Copilot Summary

This pull request includes changes to the GitHub Actions workflow for Python deployment to update artifact naming and downloading steps. The most important changes are as follows:

Workflow updates:

* [`.github/workflows/python-deploy.yml`](diffhunk://#diff-c10475b5f950338107c15d3b79c7ec33b5f6b2a4bb95fc41338f694bc0f9aef5L75-R75): Renamed the artifact from `python-package-distributions` to `python-package-distributions-cli` to better reflect its contents.
* [`.github/workflows/python-deploy.yml`](diffhunk://#diff-c10475b5f950338107c15d3b79c7ec33b5f6b2a4bb95fc41338f694bc0f9aef5L92-R98): Added a new step to download the library distributions separately from the CLI distributions, improving the clarity and organization of the deployment process.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for PyPI deployment.
	- Modified artifact handling for package and CLI distributions.
	- Refined artifact download and upload steps in deployment workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->