### PR TITLE
feat(vscode): enhance devcontainer and settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -82,7 +82,7 @@
         // Docker Support
         "ms-azuretools.vscode-docker",
         // YAML Support
-        // "redhat.vscode-yaml", # TODO-20:command 'jumpToSchema' already exists
+        "redhat.vscode-yaml", // TODO-20:command 'jumpToSchema' already exists
         // SVG Support
         "jock.svg",
         // Jinja Support

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -275,6 +275,6 @@
     "devel"
   ],
   "yaml.schemas": {
-    "docs/mkdocs/docs/schema/partcad.json": "*/partcad.yaml"
+    "partcad/src/partcad/schema/partcad.json": "*/partcad.yaml"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,6 +56,7 @@
     "devel",
     "eamodio",
     "ensurepip",
+    "gcode",
     "ggshield",
     "Gruntfuggly",
     "hadolint",
@@ -68,6 +69,7 @@
     "mkdocs",
     "mktemp",
     "mypy",
+    "nema",
     "njpwerner",
     "nlopt",
     "NOCOMMIT",
@@ -97,12 +99,12 @@
     "worktrees",
     "xdist"
   ],
-  "codeium.enableConfig": {
-    "*": true,
-    "feature": true,
-    "log": true,
-    "markdown": true
-  },
+  // "codeium.enableConfig": {
+  //   "*": true,
+  //   "feature": true,
+  //   "log": true,
+  //   "markdown": true
+  // },
   "diffEditor.hideUnchangedRegions.enabled": true,
   "editor.accessibilitySupport": "off",
   "editor.autoIndent": "full",
@@ -260,8 +262,7 @@
   "svg.preview.mode": "svg",
   "terminal.integrated.scrollback": 100000,
   "testing.automaticallyOpenPeekView": "never",
-  // "yaml.format.bracketSpacing": false,
-  "testing.automaticallyOpenTestResults": "neverOpen", // prevent YAML formatter from breaking Jinja2 templates
+  "testing.automaticallyOpenTestResults": "neverOpen",
   "testing.followRunningTest": false,
   // "testing.openTesting": "neverOpen",
   "workbench.colorTheme": "GitHub Dark",
@@ -269,6 +270,11 @@
     "tag:yaml.org,2002:python/name:material.extensions.emoji.to_svg",
     "tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji"
   ],
-  "yaml.format.bracketSpacing": false // prevent YAML formatter from breaking Jinja2 templates
-  // "yaml.format.bracketSpacing": false,
+  "yaml.format.bracketSpacing": false, // prevent YAML formatter from breaking Jinja2 templates
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "devel"
+  ],
+  "yaml.schemas": {
+    "docs/mkdocs/docs/schema/partcad.json": "*/partcad.yaml"
+  }
 }

--- a/docs/mkdocs/docs/schema/partcad.json
+++ b/docs/mkdocs/docs/schema/partcad.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "desc": {
+      "type": "string"
+    },
+    "docs": {
+      "type": "object",
+      "properties": {
+        "intro": {
+          "type": "string"
+        },
+        "usage": {
+          "type": "string"
+        }
+      }
+    },
+    "parts": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": [
+            "object",
+            "string"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "cadquery",
+                "build123d",
+                "svg",
+                "dxf",
+                "extrude",
+                "sweep",
+                "stl",
+                "step",
+                "scad",
+                "ai-cadquery",
+                "ai-build123d",
+                "ai-openscad",
+                "3mf",
+                "enrich",
+                "alias"
+              ]
+            },
+            "path": {
+              "type": "string"
+            },
+            "desc": {
+              "type": "string"
+            },
+            "sketch": {
+              "type": "string"
+            },
+            "depth": {
+              "type": "number"
+            },
+            "ratio": {
+              "type": "number"
+            },
+            "axis": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            },
+            "provider": {
+              "type": "string"
+            },
+            "properties": {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                  "type": [
+                    "string",
+                    "number",
+                    "boolean"
+                  ]
+                }
+              }
+            },
+            "parameters": {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "default": {
+                      "type": [
+                        "string",
+                        "number",
+                        "boolean"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "aliases": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "source": {
+              "type": "string"
+            },
+            "with": {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                  "type": [
+                    "string",
+                    "number",
+                    "boolean"
+                  ]
+                }
+              }
+            },
+            "offset": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "type"
+          ]
+        }
+      }
+    },
+    "render": {
+      "type": "object",
+      "properties": {
+        "readme": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "svg": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "prefix": {
+              "type": "string"
+            }
+          }
+        },
+        "png": {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "type": "string"
+            },
+            "width": {
+              "type": "number"
+            },
+            "height": {
+              "type": "number"
+            }
+          }
+        },
+        "stl": {
+          "type": "string"
+        },
+        "3mf": {
+          "type": "string"
+        },
+        "threejs": {
+          "type": "string"
+        },
+        "obj": {
+          "type": "string"
+        },
+        "markdown": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "required": []
+}

--- a/examples/feature_interface/partcad.yaml
+++ b/examples/feature_interface/partcad.yaml
@@ -36,7 +36,7 @@ interfaces:
     abstract: True
     ports:
       m3:
-        location: [[0, 0, 0], [0, 0, 1], 0] # redandant, for demonstration
+        location: [[0, 0, 0], [0, 0, 1], 0] # redundant, for demonstration
         sketch: m3
   m3-opening:
     abstract: True
@@ -215,7 +215,7 @@ parts:
       m4-slotted-30-thru-3:
         L: # top left
           location: [[-15.0, -27.0, 27.0], [1.0, 0.0, 0.0], 90.0]
-          params: {offset: -15}
+          params: { offset: -15 }
         R: # top right
           location: [[15.0, -27.0, 27.0], [1.0, 0.0, 0.0], 90.0]
           # params: {offset: -15}

--- a/examples/feature_monorepo/package-b/partcad.yaml
+++ b/examples/feature_monorepo/package-b/partcad.yaml
@@ -3,4 +3,3 @@ parts:
     type: cadquery
     path: cylinder.py
     desc: This is a cylinder from examples
-

--- a/partcad/src/partcad/schema/partcad.json
+++ b/partcad/src/partcad/schema/partcad.json
@@ -88,10 +88,25 @@
               "type": "object",
               "patternProperties": {
                 "^[a-zA-Z0-9_-]+$": {
-                  "type": "object",
+                  "type": [
+                    "object",
+                    "string",
+                    "number",
+                    "boolean"
+                  ],
                   "properties": {
                     "type": {
                       "type": "string"
+                    },
+                    "min": {
+                      "type": [
+                        "number"
+                      ]
+                    },
+                    "max": {
+                      "type": [
+                        "number"
+                      ]
                     },
                     "default": {
                       "type": [


### PR DESCRIPTION
- Enable YAML support to in devcontainer.json again.
- Update settings.json with additional extensions and config.
- Create partcad.json schema in mkdocs documentation.
- Update examples for partcad.yaml schema.
- Improve partcad.yaml schema consistency.
- Improve partcad.yaml example files to use the updated partcad.json.

## Copilot Summary

This pull request includes various updates and improvements across multiple files, including configuration updates, schema additions, and minor corrections. The most important changes include re-enabling the YAML extension in the devcontainer, updating VSCode settings, adding a JSON schema for partcad, and making minor corrections in YAML files.

Configuration updates:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L56-R56): Re-enabled the `redhat.vscode-yaml` extension, addressing the TODO comment about the `jumpToSchema` command.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R56): Added new entries to the `ignoredPullRequestBranches` and `yaml.schemas` settings, commented out the `codeium.enableConfig` settings, and made other minor adjustments. [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R56) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R68) [[3]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L95-R102) [[4]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L234-R246)

Schema additions:

* [`docs/mkdocs/docs/schema/partcad.json`](diffhunk://#diff-c44a0e79c6eb1572301e4e464b625fccc8ce47f811d925eaad42ecd9d0e1c9b8R1-R212): Added a comprehensive JSON schema for partcad, including properties for `desc`, `docs`, `parts`, and `render`.

Minor corrections:

* [`examples/feature_interface/partcad.yaml`](diffhunk://#diff-959c34ac87a54627cb555ab0cc83df7444129143f5b6b92e6fa59d9e66b5db04L39-R39): Fixed a typo in the comment for the `location` property.
* [`examples/feature_monorepo/package-b/partcad.yaml`](diffhunk://#diff-e61c130364598e5129309c7888bed609ac20f468c3836439d531e094f12161beL6): Removed an unnecessary blank line.
* [`examples/produce_part_cadquery_primitive/partcad.yaml`](diffhunk://#diff-faa0f478a37d1e369893d46177015fcd78e0c6b5e81aac6da47673f5829c9aeaL20-R21): Corrected the format of the `height` property to include a `default` value.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->