### PR TITLE
feat(init): add private flag to init template

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -45,6 +45,7 @@ Besides the package properties and, optionally, a list of imported dependencies,
 
   name: <(optional) for advanced users, the assumed package path for standalone development>
   desc: <(optional) description>
+  private: <(optional) boolean flag to mark the package as private>
   url: <(optional) package or maintainer's url>
   poc: <(optional) point of contact, maintainer's email>
   partcad: <(optional) required PartCAD version spec string>

--- a/features/init.feature
+++ b/features/init.feature
@@ -29,6 +29,7 @@ Feature: `pc init` command
     Then the command should exit with a status code of "0"
     And a file named "partcad.yaml" should have YAML content:
       """
+      private: True
       dependencies:
       sketches:
       parts:

--- a/features/steps/partcad-cli/commands/init.py
+++ b/features/steps/partcad-cli/commands/init.py
@@ -94,6 +94,9 @@ def step_impl(context):
             if yaml_content is None:
                 raise ValueError("YAML content is empty or invalid")
 
+            if yaml_content.get("private") is not True:
+                raise ValueError("The package must be marked as private")
+
             # Check if the 'import.pub' key is not present
             import_section = yaml_content.get("dependencies")
             import_missing = import_section is None

--- a/partcad/src/partcad/template/init-private.yaml
+++ b/partcad/src/partcad/template/init-private.yaml
@@ -4,6 +4,8 @@
 # url: <package's or maintainer's url>
 # manufacturable: <are objects in this package manufacturable? true or false>
 
+private: True
+
 dependencies:
   # Add dependencies here
   # <package-name>:


### PR DESCRIPTION
- Add 'private: True' to the `init-private.yaml` template.
- Add 'private: True' to the `init.feature` file.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for initializing packages as private by default with the `private: True` setting.
  - Enhanced package configuration to include an optional privacy flag in the YAML content.
  - Expanded documentation to include a new section on dependencies with structured examples for clarity.

- **Bug Fixes**
  - Improved validation to ensure packages are correctly marked as private, enhancing error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->