### PR TITLE
feat(partcad): Add enrich and alias part definition types

### DIFF
--- a/examples/feature_enrich/partcad.yaml
+++ b/examples/feature_enrich/partcad.yaml
@@ -29,6 +29,7 @@ parts:
     type: alias
     package: /pub/std/imperial/dimensional-lumber
 
+sketches:
   # Enrich sketches
   dxf:
     type: enrich

--- a/examples/feature_enrich/partcad.yaml
+++ b/examples/feature_enrich/partcad.yaml
@@ -35,6 +35,12 @@ sketches:
     type: enrich
     source: dxf_01
     package: ../produce_sketch_dxf
+  dxf_enrich:
+    type: enrich
+    source: :dxf
+  dxf_alias:
+    type: alias
+    source: :dxf
   dxf_01:
     type: enrich
     package: ../produce_sketch_dxf
@@ -44,6 +50,12 @@ sketches:
   svg_01:
     type: alias
     package: ../produce_sketch_svg
+  sketch:
+    type: enrich
+    package: ../produce_sketch_cadquery
+    with:
+      width: 4.0
+      length: 5.0
 
 assemblies:
   desk-no-enrich:

--- a/examples/feature_enrich/partcad.yaml
+++ b/examples/feature_enrich/partcad.yaml
@@ -2,24 +2,47 @@ desc: Demonstrates the use of "enrich"
 
 parts:
   leg:
+    desc: Vertical 4x4
     type: enrich
     source: /pub/std/imperial/dimensional-lumber:lumber
     with:
-      # 4x4
       height: 4
       width: 4
     offset: [[0, 0, 0], [1, 0, 0], 90]
   side-support:
+    desc: Horizontal support 2x6
     type: enrich
     source: /pub/std/imperial/dimensional-lumber:lumber
     with:
-      # 2x6
       height: 2
       width: 6
     offset: [[0, 0, 0], [0, 1, 0], -90]
   table-top:
     type: enrich
     source: /pub/std/imperial/dimensional-lumber:plywood
+
+  # References to parts with the same names in other packages
+  lumber:
+    type: enrich
+    package: /pub/std/imperial/dimensional-lumber
+  plywood:
+    type: alias
+    package: /pub/std/imperial/dimensional-lumber
+
+  # Enrich sketches
+  dxf:
+    type: enrich
+    source: dxf_01
+    package: ../produce_sketch_dxf
+  dxf_01:
+    type: enrich
+    package: ../produce_sketch_dxf
+  svg:
+    type: alias
+    source: ../produce_sketch_svg:svg_01
+  svg_01:
+    type: alias
+    package: ../produce_sketch_svg
 
 assemblies:
   desk-no-enrich:

--- a/examples/produce_part_cadquery_primitive/partcad.yaml
+++ b/examples/produce_part_cadquery_primitive/partcad.yaml
@@ -30,13 +30,13 @@ parts:
   cube_enrich_enrich:
     desc: This is an example of enriching a part with params in the name
     type: enrich
-    source: :cube;width=20.0,height=20.0
+    source: ../produce_part_cadquery_primitive:cube;width=20.0,height=20.0
     with:
       length: 5.0
   cube_alias:
     desc: This is an example of an alias to a part
     type: alias
-    source: :cube
+    source: ../produce_part_cadquery_primitive:cube
   cube_alias_params:
     desc: This is an example of an alias to a part with params in the name
     type: alias

--- a/examples/produce_part_cadquery_primitive/partcad.yaml
+++ b/examples/produce_part_cadquery_primitive/partcad.yaml
@@ -10,8 +10,8 @@ docs:
 
 parts:
   cube:
-    type: cadquery
     desc: This is a cube from examples
+    type: cadquery
     parameters:
       width:
         default: 10.0
@@ -19,22 +19,36 @@ parts:
         default: 10.0
       height: 10.0
     aliases: ["box"]
-  brick:
+  cube_enrich:
+    desc: This is an example of a part defined by enriching another part
     type: enrich
     source: cube
     with:
       width: 20.0
       length: 10.0
       height: 7.5
-  # TODO(clairbee): add support for the below two
-  #brick2:
-  #  type: enrich
-  #  source: cube:width=20.0,height=20.0
-  #  with:
-  #    length: 10.0
-  #brick_alias:
-  #  type: alias
-  #   source: cube:width=20.0,height=20.0,length=7.5
+  cube_enrich_enrich:
+    desc: This is an example of enriching a part with params in the name
+    type: enrich
+    source: :cube;width=20.0,height=20.0
+    with:
+      length: 5.0
+  cube_alias:
+    desc: This is an example of an alias to a part
+    type: alias
+    source: :cube
+  cube_alias_params:
+    desc: This is an example of an alias to a part with params in the name
+    type: alias
+    source: :cube;width=20.0,height=20.0,length=7.5
+  cube_alias_alias:
+    type: alias
+    desc: This is an example of an alias to an alias
+    source: :cube_alias
+  cube_alias_enrich:
+    type: alias
+    desc: This is an example of an alias to an alias
+    source: :cube_enrich
   cylinder:
     type: cadquery
     path: cylinder.py

--- a/examples/produce_sketch_cadquery/partcad.yaml
+++ b/examples/produce_sketch_cadquery/partcad.yaml
@@ -10,6 +10,9 @@ sketches:
   sketch:
     type: cadquery
     desc: A sample sketch
+    parameters:
+      width: 3.0
+      length: 4.0
 
 render:
   readme:

--- a/examples/produce_sketch_cadquery/sketch.py
+++ b/examples/produce_sketch_cadquery/sketch.py
@@ -1,11 +1,9 @@
 import cadquery as cq
 
-sk1 = (
-    cq.Sketch()
-    .rect(3.0, 4.0)
-    .push([(0, 0.75), (0, -0.75)])
-    .regularPolygon(0.5, 6, 90, mode="s")
-)
+width = 3.0
+length = 4.0
+
+sk1 = cq.Sketch().rect(width, length).push([(0, 0.75), (0, -0.75)]).regularPolygon(0.5, 6, 90, mode="s")
 
 result = cq.Workplane("front").placeSketch(sk1)
 show_object(result)

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -153,7 +153,10 @@ def cli(ctx, verbose, quiet, no_ansi, package, format):
             exc.exit_code = 2
             raise exc from e
         except Exception as e:
+            import traceback
+
             pc.logging.error(e)
+            traceback.print_exc()
             raise click.Abort from e
 
 

--- a/partcad/src/partcad/assembly_factory_alias.py
+++ b/partcad/src/partcad/assembly_factory_alias.py
@@ -66,7 +66,7 @@ class AssemblyFactoryAlias(pf.AssemblyFactory):
     def instantiate(self, assembly):
         with pc_logging.Action("Alias", assembly.project_name, f"{assembly.name}:{self.source_assembly_name}"):
             source = self.ctx._get_assembly(self.source)
-            if source is None:
+            if source:
                 pc_logging.error(f"The alias source {self.source} is not found")
                 return
 
@@ -78,6 +78,6 @@ class AssemblyFactoryAlias(pf.AssemblyFactory):
 
             self.ctx.stats_assemblies_instantiated += 1
 
-            if source.path is not None:
+            if source.path:
                 assembly.path = source.path
             source.instantiate(assembly)

--- a/partcad/src/partcad/assembly_factory_alias.py
+++ b/partcad/src/partcad/assembly_factory_alias.py
@@ -11,7 +11,7 @@ import typing
 
 from . import assembly_factory as pf
 from . import logging as pc_logging
-from .utils import resolve_resource_path
+from .utils import resolve_resource_path, get_child_project_path
 
 
 class AssemblyFactoryAlias(pf.AssemblyFactory):
@@ -39,6 +39,9 @@ class AssemblyFactoryAlias(pf.AssemblyFactory):
                     self.source_project_name = config["package"]
                 if self.source_project_name == "this" or self.source_project_name == "":
                     self.source_project_name = self.project.name
+                elif not self.source_project_name.startswith("/"):
+                    # Resolve the project name relative to the target project
+                    self.source_project_name = get_child_project_path(target_project.name, self.source_project_name)
             else:
                 if ":" in self.source_assembly_name:
                     self.source_project_name, self.source_assembly_name = resolve_resource_path(

--- a/partcad/src/partcad/assembly_factory_alias.py
+++ b/partcad/src/partcad/assembly_factory_alias.py
@@ -66,7 +66,7 @@ class AssemblyFactoryAlias(pf.AssemblyFactory):
     def instantiate(self, assembly):
         with pc_logging.Action("Alias", assembly.project_name, f"{assembly.name}:{self.source_assembly_name}"):
             source = self.ctx._get_assembly(self.source)
-            if source:
+            if not source:
                 pc_logging.error(f"The alias source {self.source} is not found")
                 return
 

--- a/partcad/src/partcad/assembly_factory_alias.py
+++ b/partcad/src/partcad/assembly_factory_alias.py
@@ -29,11 +29,14 @@ class AssemblyFactoryAlias(pf.AssemblyFactory):
                 self.source_assembly_name = config["source"]
             else:
                 self.source_assembly_name = config["name"]
-                if "project" not in config:
+                if "project" not in config and "package" not in config:
                     raise Exception("Alias needs either the source assembly name or the source project name")
 
-            if "project" in config:
-                self.source_project_name = config["project"]
+            if "project" in config or "package" in config:
+                if "project" in config:
+                    self.source_project_name = config["project"]
+                else:
+                    self.source_project_name = config["package"]
                 if self.source_project_name == "this" or self.source_project_name == "":
                     self.source_project_name = self.project.name
             else:

--- a/partcad/src/partcad/assembly_factory_alias.py
+++ b/partcad/src/partcad/assembly_factory_alias.py
@@ -62,7 +62,7 @@ class AssemblyFactoryAlias(pf.AssemblyFactory):
             source = self.ctx._get_assembly(self.source)
             if source is None:
                 pc_logging.error(f"The alias source {self.source} is not found")
-                return None
+                return
 
             children = source.children
             if children:

--- a/partcad/src/partcad/context.py
+++ b/partcad/src/partcad/context.py
@@ -232,7 +232,7 @@ class Context(project_config.Configuration):
                 len_to_skip = 1
             project_path = project_path[len_to_skip:]
 
-            if not self.name in self.projects:
+            if self.name not in self.projects:
                 return None
             project = self.projects[self.name]
 

--- a/partcad/src/partcad/context.py
+++ b/partcad/src/partcad/context.py
@@ -232,6 +232,8 @@ class Context(project_config.Configuration):
                 len_to_skip = 1
             project_path = project_path[len_to_skip:]
 
+            if not self.name in self.projects:
+                return None
             project = self.projects[self.name]
 
             if project_path == "":

--- a/partcad/src/partcad/part_factory_alias.py
+++ b/partcad/src/partcad/part_factory_alias.py
@@ -11,7 +11,7 @@ import typing
 
 from . import part_factory as pf
 from . import logging as pc_logging
-from .utils import resolve_resource_path
+from .utils import resolve_resource_path, get_child_project_path
 
 
 class PartFactoryAlias(pf.PartFactory):
@@ -39,6 +39,9 @@ class PartFactoryAlias(pf.PartFactory):
                     self.source_project_name = config["package"]
                 if self.source_project_name == "this" or self.source_project_name == "":
                     self.source_project_name = source_project.name
+                elif not self.source_project_name.startswith("/"):
+                    # Resolve the project name relative to the target project
+                    self.source_project_name = get_child_project_path(target_project.name, self.source_project_name)
             else:
                 if ":" in self.source_part_name:
                     self.source_project_name, self.source_part_name = resolve_resource_path(

--- a/partcad/src/partcad/part_factory_alias.py
+++ b/partcad/src/partcad/part_factory_alias.py
@@ -67,7 +67,7 @@ class PartFactoryAlias(pf.PartFactory):
         with pc_logging.Action("Alias", part.project_name, f"{part.name}:{self.source_part_name}"):
 
             source = self.ctx._get_part(self.source)
-            if source is None:
+            if not source:
                 pc_logging.error(f"The alias source {self.source} is not found")
                 return None
 

--- a/partcad/src/partcad/part_factory_alias.py
+++ b/partcad/src/partcad/part_factory_alias.py
@@ -72,12 +72,12 @@ class PartFactoryAlias(pf.PartFactory):
                 return None
 
             shape = source.shape
-            if shape is not None:
+            if shape:
                 part.shape = shape
                 return shape
 
             self.ctx.stats_parts_instantiated += 1
 
-            if source.path is not None:
+            if source.path:
                 part.path = source.path
             return await source.instantiate(part)

--- a/partcad/src/partcad/part_factory_alias.py
+++ b/partcad/src/partcad/part_factory_alias.py
@@ -29,11 +29,14 @@ class PartFactoryAlias(pf.PartFactory):
                 self.source_part_name = config["source"]
             else:
                 self.source_part_name = config["name"]
-                if "project" not in config:
+                if "project" not in config and "package" not in config:
                     raise Exception("Alias needs either the source part name or the source project name")
 
-            if "project" in config:
-                self.source_project_name = config["project"]
+            if "project" in config or "package" in config:
+                if "project" in config:
+                    self.source_project_name = config["project"]
+                else:
+                    self.source_project_name = config["package"]
                 if self.source_project_name == "this" or self.source_project_name == "":
                     self.source_project_name = source_project.name
             else:

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -52,7 +52,7 @@ class PartFactoryEnrich(pf.PartFactory):
             if ";" in source_part_name:
                 self.source_part_name = source_part_name.split(";")[0]
                 suffix = source_part_name.split(";")[1]
-                self.extra_with = list(map(lambda p: p.split("="), suffix.split(",")))
+                self.extra_with = [p.split("=") for p in suffix.split(",")]
             else:
                 self.source_part_name = source_part_name
                 self.extra_with = []
@@ -131,6 +131,11 @@ class PartFactoryEnrich(pf.PartFactory):
             self.source_project.init_part_by_config(augmented_config, self.source_project)
 
             source = self.source_project.get_part(part.name)
+            name = part.config["name"]
+            part.config = source.config
+            part.config["source"] = self.source_project_name + ":" + self.source_part_name
+            part.config["orig_name"] = part.name
+            part.config["name"] = name
             shape = source.shape
             if shape is not None:
                 part.shape = shape

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -27,11 +27,14 @@ class PartFactoryEnrich(pf.PartFactory):
                 source_part_name = config["source"]
             else:
                 source_part_name = config["name"]
-                if "project" not in config:
+                if "project" not in config and "package" not in config:
                     raise Exception("Enrich needs either the source part name or the source project name")
 
-            if "project" in config:
-                source_project_name = config["project"]
+            if "project" in config or "package" in config:
+                if "project" in config:
+                    source_project_name = config["project"]
+                else:
+                    source_project_name = config["package"]
                 if source_project_name == "this" or source_project_name == "":
                     source_project_name = source_project.name
             else:

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -126,9 +126,8 @@ class PartFactoryEnrich(pf.PartFactory):
                             "Attempting to parametrize a part with an unknown parameter: %s:%s: %s"
                             % (self.source_project_name, self.source_part_name, param)
                         )
-                    augmented_config["parameters"][param]["default"] = eval(
-                        type(augmented_config["parameters"][param]["default"]).__name__
-                    )(part.config["with"][param])
+                    desired_type = type(augmented_config["parameters"][param]["default"])
+                    augmented_config["parameters"][param]["default"] = desired_type(part.config["with"][param])
 
             self.source_project.init_part_by_config(augmented_config, self.source_project)
 

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -66,7 +66,7 @@ class PartFactoryEnrich(pf.PartFactory):
             self._create(config)
 
     async def instantiate(self, part):
-        with pc_logging.Action("Enrich", part.project_name, part.name):
+        with pc_logging.Action("Enrich", part.project_name, f"{part.name}:{self.source_part_name}"):
 
             # Get the config of the part the 'enrich' points to
             if self.source_project_name == self.source_project.name:
@@ -144,12 +144,12 @@ class PartFactoryEnrich(pf.PartFactory):
             part.config["orig_name"] = part.name
             part.config["name"] = name
             shape = source.shape
-            if shape is not None:
+            if shape:
                 part.shape = shape
                 return shape
 
             self.ctx.stats_parts_instantiated += 1
 
-            if source.path is not None:
+            if source.path:
                 part.path = source.path
             return await source.instantiate(part)

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -126,7 +126,9 @@ class PartFactoryEnrich(pf.PartFactory):
                             "Attempting to parametrize a part with an unknown parameter: %s:%s: %s"
                             % (self.source_project_name, self.source_part_name, param)
                         )
-                    augmented_config["parameters"][param]["default"] = part.config["with"][param]
+                    augmented_config["parameters"][param]["default"] = eval(
+                        type(augmented_config["parameters"][param]["default"]).__name__
+                    )(part.config["with"][param])
 
             self.source_project.init_part_by_config(augmented_config, self.source_project)
 

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -13,7 +13,7 @@ import typing
 from . import part_config
 from . import part_factory as pf
 from . import logging as pc_logging
-from .utils import resolve_resource_path
+from .utils import resolve_resource_path, get_child_project_path
 
 
 class PartFactoryEnrich(pf.PartFactory):
@@ -37,6 +37,9 @@ class PartFactoryEnrich(pf.PartFactory):
                     source_project_name = config["package"]
                 if source_project_name == "this" or source_project_name == "":
                     source_project_name = source_project.name
+                elif not source_project_name.startswith("/"):
+                    # Resolve the project name relative to the target project
+                    source_project_name = get_child_project_path(target_project.name, source_project_name)
             else:
                 if ":" in source_part_name:
                     source_project_name, source_part_name = resolve_resource_path(

--- a/partcad/src/partcad/sketch_factory_alias.py
+++ b/partcad/src/partcad/sketch_factory_alias.py
@@ -28,8 +28,8 @@ class SketchFactoryAlias(SketchFactory):
             if "source" in config:
                 self.source_sketch_name = config["source"]
             else:
-                self.source_assembly_name = config["name"]
-                if not "project" in config:
+                self.source_sketch_name = config["name"]
+                if "project" not in config:
                     raise Exception("Alias needs either the source sketch name or the source project name")
 
             if "project" in config:
@@ -57,15 +57,20 @@ class SketchFactoryAlias(SketchFactory):
             pc_logging.debug("Initializing an alias to %s" % self.source)
 
     async def instantiate(self, sketch):
-        with pc_logging.Action("Alias", sketch.project_name, sketch.name):
+        with pc_logging.Action("Alias", sketch.project_name, f"{sketch.name}:{self.source_sketch_name}"):
 
             source = self.ctx._get_sketch(self.source)
+            if source is None:
+                pc_logging.error(f"The alias source {self.source} is not found")
+                return None
+
             shape = source.shape
-            if not shape is None:
+            if shape is not None:
+                sketch.shape = shape
                 return shape
 
             self.ctx.stats_sketches_instantiated += 1
 
-            if not source.path is None:
+            if source.path is not None:
                 sketch.path = source.path
             return await source.instantiate(sketch)

--- a/partcad/src/partcad/sketch_factory_alias.py
+++ b/partcad/src/partcad/sketch_factory_alias.py
@@ -29,11 +29,14 @@ class SketchFactoryAlias(SketchFactory):
                 self.source_sketch_name = config["source"]
             else:
                 self.source_sketch_name = config["name"]
-                if "project" not in config:
+                if "project" not in config and "package" not in config:
                     raise Exception("Alias needs either the source sketch name or the source project name")
 
-            if "project" in config:
-                self.source_project_name = config["project"]
+            if "project" in config or "package" in config:
+                if "project" in config:
+                    self.source_project_name = config["project"]
+                else:
+                    self.source_project_name = config["package"]
                 if self.source_project_name == "this" or self.source_project_name == "":
                     self.source_project_name = source_project.name
             else:

--- a/partcad/src/partcad/sketch_factory_alias.py
+++ b/partcad/src/partcad/sketch_factory_alias.py
@@ -11,7 +11,7 @@ import typing
 
 from .sketch_factory import SketchFactory
 from . import logging as pc_logging
-from .utils import resolve_resource_path
+from .utils import resolve_resource_path, get_child_project_path
 
 
 class SketchFactoryAlias(SketchFactory):
@@ -39,6 +39,9 @@ class SketchFactoryAlias(SketchFactory):
                     self.source_project_name = config["package"]
                 if self.source_project_name == "this" or self.source_project_name == "":
                     self.source_project_name = source_project.name
+                elif not self.source_project_name.startswith("/"):
+                    # Resolve the project name relative to the target project
+                    self.source_project_name = get_child_project_path(target_project.name, self.source_project_name)
             else:
                 if ":" in self.source_sketch_name:
                     self.source_project_name, self.source_sketch_name = resolve_resource_path(

--- a/partcad/src/partcad/sketch_factory_alias.py
+++ b/partcad/src/partcad/sketch_factory_alias.py
@@ -71,12 +71,12 @@ class SketchFactoryAlias(SketchFactory):
                 return None
 
             shape = source.shape
-            if shape is not None:
+            if shape:
                 sketch.shape = shape
                 return shape
 
             self.ctx.stats_sketches_instantiated += 1
 
-            if source.path is not None:
+            if source.path:
                 sketch.path = source.path
             return await source.instantiate(sketch)

--- a/partcad/src/partcad/sketch_factory_alias.py
+++ b/partcad/src/partcad/sketch_factory_alias.py
@@ -66,7 +66,7 @@ class SketchFactoryAlias(SketchFactory):
         with pc_logging.Action("Alias", sketch.project_name, f"{sketch.name}:{self.source_sketch_name}"):
 
             source = self.ctx._get_sketch(self.source)
-            if source is None:
+            if not source:
                 pc_logging.error(f"The alias source {self.source} is not found")
                 return None
 

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -126,9 +126,8 @@ class SketchFactoryEnrich(pf.SketchFactory):
                             "Attempting to parametrize a sketch with an unknown parameter: %s:%s: %s"
                             % (self.source_project_name, self.source_sketch_name, param)
                         )
-                    augmented_config["parameters"][param]["default"] = eval(
-                        type(augmented_config["parameters"][param]["default"]).__name__
-                    )(sketch.config["with"][param])
+                    desired_type = type(augmented_config["parameters"][param]["default"])
+                    augmented_config["parameters"][param]["default"] = desired_type(sketch.config["with"][param])
 
             self.source_project.init_sketch_by_config(augmented_config)
 

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -19,45 +19,62 @@ from .utils import resolve_resource_path
 class SketchFactoryEnrich(pf.SketchFactory):
     source_sketch_name: str
     source_project_name: typing.Optional[str]
-    source: str
 
     def __init__(self, ctx, source_project, target_project, config):
         with pc_logging.Action("InitEnrich", target_project.name, config["name"]):
-            super().__init__(ctx, source_project, target_project, config)
-
             # Determine the sketch the 'enrich' points to
             if "source" in config:
-                self.source_sketch_name = config["source"]
+                source_sketch_name = config["source"]
             else:
-                self.source_sketch_name = config["name"]
-                if not "project" in config:
+                source_sketch_name = config["name"]
+                if "project" not in config:
                     raise Exception("Enrich needs either the source sketch name or the source project name")
 
             if "project" in config:
-                self.source_project_name = config["project"]
-                if self.source_project_name == "this" or self.source_project_name == "":
-                    self.source_project_name = source_project.name
+                source_project_name = config["project"]
+                if source_project_name == "this" or source_project_name == "":
+                    source_project_name = source_project.name
             else:
-                if ":" in self.source_sketch_name:
-                    self.source_project_name, self.source_sketch_name = resolve_resource_path(
+                if ":" in source_sketch_name:
+                    source_project_name, source_sketch_name = resolve_resource_path(
                         source_project.name,
-                        self.source_sketch_name,
+                        source_sketch_name,
                     )
                 else:
-                    self.source_project_name = source_project.name
-            self.source = self.source_project_name + ":" + self.source_sketch_name
+                    source_project_name = source_project.name
 
-            pc_logging.debug("Initializing an enrich to %s" % self.source)
+            pc_logging.debug(f"Initializing an enrich to {source_project_name}:{source_sketch_name}")
+
+            super().__init__(ctx, source_project, target_project, config)
+            self.source_project = source_project
+            self.source_project_name = source_project_name
+
+            if ";" in source_sketch_name:
+                self.source_sketch_name = source_sketch_name.split(";")[0]
+                suffix = source_sketch_name.split(";")[1]
+                self.extra_with = list(map(lambda p: p.split("="), suffix.split(",")))
+            else:
+                self.source_sketch_name = source_sketch_name
+                self.extra_with = []
+
+            self._create(config)
+
+    async def instantiate(self, sketch):
+        with pc_logging.Action("Enrich", sketch.project_name, sketch.name):
 
             # Get the config of the sketch the 'enrich' points to
-            orig_source_project = source_project
-            if self.source_project_name == source_project.name:
-                augmented_config = source_project.get_sketch_config(self.source_sketch_name)
+            if self.source_project_name == self.source_project.name:
+                augmented_config = self.source_project.get_sketch_config(self.source_sketch_name)
             else:
-                source_project = ctx.get_project(self.source_project_name)
-                augmented_config = source_project.get_sketch_config(self.source_sketch_name)
+                self.source_project = self.ctx.get_project(self.source_project_name)
+                if self.source_project is None:
+                    pc_logging.debug("Available projects: %s" % str(sorted(list(self.ctx.projects.keys()))))
+                    raise Exception("Package not found: %s" % self.source_project_name)
+                augmented_config = self.source_project.get_sketch_config(self.source_sketch_name)
             if augmented_config is None:
-                pc_logging.error("Failed to find the sketch to enrich: %s" % self.source_sketch_name)
+                pc_logging.error(
+                    f"Failed to find the sketch to enrich: {self.source_project.name}:{self.source_sketch_name}"
+                )
                 return
 
             augmented_config = copy.deepcopy(augmented_config)
@@ -74,7 +91,7 @@ class SketchFactoryEnrich(pf.SketchFactory):
 
             # Fill in all non-enrich-specific properties from the enrich config into
             # the original config
-            for prop_to_copy in config:
+            for prop_to_copy in sketch.config:
                 if (
                     prop_to_copy == "type"
                     or prop_to_copy == "path"
@@ -84,13 +101,43 @@ class SketchFactoryEnrich(pf.SketchFactory):
                     or prop_to_copy == "with"
                 ):
                     continue
-                augmented_config[prop_to_copy] = config[prop_to_copy]
+                augmented_config[prop_to_copy] = sketch.config[prop_to_copy]
+
+            # See if there are any extra "with" parameters deduced from the source name
+            if len(self.extra_with):
+                # Create "with" if it wasn't there
+                if "with" not in sketch.config:
+                    sketch.config["with"] = {}
+
+                # The "with" values from the enrich config take precedence over the source name
+                for [name, value] in self.extra_with:
+                    if name not in sketch.config["with"]:
+                        sketch.config["with"][name] = value
 
             # Fill in the parameter values using the simplified "with" option
-            if "with" in config:
-                for param in config["with"]:
-                    augmented_config["parameters"][param]["default"] = config["with"][param]
-            orig_source_project.init_sketch_by_config(
-                augmented_config,
-                source_project,
-            )
+            if "with" in sketch.config:
+                if "parameters" not in augmented_config:
+                    raise Exception(
+                        "Attempting to parametrize a sketch that has no parameters: %s" % str(augmented_config)
+                    )
+                for param in sketch.config["with"]:
+                    if param not in augmented_config["parameters"]:
+                        raise Exception(
+                            "Attempting to parametrize a sketch with an unknown parameter: %s:%s: %s"
+                            % (self.source_project_name, self.source_sketch_name, param)
+                        )
+                    augmented_config["parameters"][param]["default"] = sketch.config["with"][param]
+
+            self.source_project.init_sketch_by_config(augmented_config)
+
+            source = self.source_project.get_sketch(sketch.name)
+            shape = source.shape
+            if shape is not None:
+                sketch.shape = shape
+                return shape
+
+            self.ctx.stats_sketches_instantiated += 1
+
+            if source.path is not None:
+                sketch.path = source.path
+            return await source.instantiate(sketch)

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -13,7 +13,7 @@ import typing
 from . import sketch_config
 from . import sketch_factory as pf
 from . import logging as pc_logging
-from .utils import resolve_resource_path
+from .utils import resolve_resource_path, get_child_project_path
 
 
 class SketchFactoryEnrich(pf.SketchFactory):
@@ -37,6 +37,9 @@ class SketchFactoryEnrich(pf.SketchFactory):
                     source_project_name = config["package"]
                 if source_project_name == "this" or source_project_name == "":
                     source_project_name = source_project.name
+                elif not source_project_name.startswith("/"):
+                    # Resolve the project name relative to the target project
+                    source_project_name = get_child_project_path(target_project.name, source_project_name)
             else:
                 if ":" in source_sketch_name:
                     source_project_name, source_sketch_name = resolve_resource_path(

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -27,11 +27,14 @@ class SketchFactoryEnrich(pf.SketchFactory):
                 source_sketch_name = config["source"]
             else:
                 source_sketch_name = config["name"]
-                if "project" not in config:
+                if "project" not in config and "package" not in config:
                     raise Exception("Enrich needs either the source sketch name or the source project name")
 
-            if "project" in config:
-                source_project_name = config["project"]
+            if "project" in config or "package" in config:
+                if "project" in config:
+                    source_project_name = config["project"]
+                else:
+                    source_project_name = config["package"]
                 if source_project_name == "this" or source_project_name == "":
                     source_project_name = source_project.name
             else:

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -126,7 +126,9 @@ class SketchFactoryEnrich(pf.SketchFactory):
                             "Attempting to parametrize a sketch with an unknown parameter: %s:%s: %s"
                             % (self.source_project_name, self.source_sketch_name, param)
                         )
-                    augmented_config["parameters"][param]["default"] = sketch.config["with"][param]
+                    augmented_config["parameters"][param]["default"] = eval(
+                        type(augmented_config["parameters"][param]["default"]).__name__
+                    )(sketch.config["with"][param])
 
             self.source_project.init_sketch_by_config(augmented_config)
 

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -66,7 +66,7 @@ class SketchFactoryEnrich(pf.SketchFactory):
             self._create(config)
 
     async def instantiate(self, sketch):
-        with pc_logging.Action("Enrich", sketch.project_name, sketch.name):
+        with pc_logging.Action("Enrich", sketch.project_name, f"{sketch.name}:{self.source_sketch_name}"):
 
             # Get the config of the sketch the 'enrich' points to
             if self.source_project_name == self.source_project.name:
@@ -144,12 +144,12 @@ class SketchFactoryEnrich(pf.SketchFactory):
             sketch.config["orig_name"] = sketch.name
             sketch.config["name"] = name
             shape = source.shape
-            if shape is not None:
+            if shape:
                 sketch.shape = shape
                 return shape
 
             self.ctx.stats_sketches_instantiated += 1
 
-            if source.path is not None:
+            if source.path:
                 sketch.path = source.path
             return await source.instantiate(sketch)

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -52,7 +52,7 @@ class SketchFactoryEnrich(pf.SketchFactory):
             if ";" in source_sketch_name:
                 self.source_sketch_name = source_sketch_name.split(";")[0]
                 suffix = source_sketch_name.split(";")[1]
-                self.extra_with = list(map(lambda p: p.split("="), suffix.split(",")))
+                self.extra_with = [p.split("=") for p in suffix.split(",")]
             else:
                 self.source_sketch_name = source_sketch_name
                 self.extra_with = []
@@ -131,6 +131,11 @@ class SketchFactoryEnrich(pf.SketchFactory):
             self.source_project.init_sketch_by_config(augmented_config)
 
             source = self.source_project.get_sketch(sketch.name)
+            name = sketch.config["name"]
+            sketch.config = source.config
+            sketch.config["source"] = self.source_project_name + ":" + self.source_sketch_name
+            sketch.config["orig_name"] = sketch.name
+            sketch.config["name"] = name
             shape = source.shape
             if shape is not None:
                 sketch.shape = shape

--- a/partcad/tests/unit/test_part_enrich.py
+++ b/partcad/tests/unit/test_part_enrich.py
@@ -16,9 +16,9 @@ import partcad as pc
 def test_part_enrich_get_1():
     """Load a CadQuery part using enrichment for parameters and see if the origin is intact"""
     ctx = pc.Context("examples/produce_part_cadquery_primitive")
-    brick = ctx._get_part(":brick")
-    assert brick is not None
-    assert asyncio.run(brick.get_wrapped()) is not None
+    cube_enrich = ctx._get_part(":cube_enrich")
+    assert cube_enrich is not None
+    assert asyncio.run(cube_enrich.get_wrapped()) is not None
 
     # Check whether the original part is stil ok or not
     cube_config = ctx.get_project(".").get_part_config("cube")
@@ -29,21 +29,32 @@ def test_part_enrich_get_1():
 def test_part_enrich_get_2():
     """Load a CadQuery part using enrichment for parameters and see if the parameters changed"""
     ctx = pc.Context("examples/produce_part_cadquery_primitive")
-    brick = ctx._get_part(":brick")
-    assert brick is not None
-    assert asyncio.run(brick.get_wrapped()) is not None
+    cube_enrich = ctx._get_part(":cube_enrich")
+    assert cube_enrich is not None
+    assert asyncio.run(cube_enrich.get_wrapped()) is not None
 
     # Check whether the parameter change is in effect
-    assert brick.config["parameters"]["width"]["default"] == 20.0
+    assert cube_enrich.config["parameters"]["width"]["default"] == 20.0
 
 
-# TODO(clairbee): add support for the following one
-# def test_part_enrich_get_3():
-#     """Load a CadQuery part using enrichment for parameters and see if the parameters changed"""
-#     ctx = pc.Context("examples/produce_part_cadquery_primitive")
-#     brick = ctx._get_part(":brick2")
-#     assert brick is not None
-#     assert asyncio.run(brick.get_wrapped()) is not None
+def test_part_enrich_get_3():
+    """Load a CadQuery part using enrichment for parameters and see if the parameters changed"""
+    ctx = pc.Context("examples/produce_part_cadquery_primitive")
+    cube_alias_enrich = ctx._get_part(":cube_alias_enrich")
+    assert cube_alias_enrich is not None
+    assert asyncio.run(cube_alias_enrich.get_wrapped()) is not None
 
-#     # Check whether the parameter change is in effect
-#     assert brick.config["parameters"]["width"]["default"] == 20.0
+    # Check whether the parameter change is in effect
+    assert cube_alias_enrich.config["parameters"]["width"]["default"] == 10.0
+
+
+def test_part_enrich_get_4():
+    """Load a CadQuery part using enrichment for parameters and see if the parameters changed"""
+    ctx = pc.Context("examples/produce_part_cadquery_primitive")
+    cube_enrich_enrich = ctx._get_part(":cube_enrich_enrich")
+    assert cube_enrich_enrich is not None
+    assert asyncio.run(cube_enrich_enrich.get_wrapped()) is not None
+
+    # Check whether the parameter change is in effect
+    assert cube_enrich_enrich.config["parameters"]["width"]["default"] == 20.0
+    assert cube_enrich_enrich.config["parameters"]["length"]["default"] == 5.0

--- a/partcad/tests/unit/test_sketch.py
+++ b/partcad/tests/unit/test_sketch.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+#
+# OpenVMP, 2025
+#
+# Author: Roman Kuzmenko
+# Created: 2025-01-12
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import asyncio
+
+import partcad as pc
+
+
+def test_sketch_get_dxf():
+    """Load a DXF sketch from a project by the part name"""
+    ctx = pc.Context("examples/produce_sketch_dxf")
+    repo1 = ctx.get_project(".")
+    assert repo1 is not None
+    sketch = repo1.get_sketch("dxf_01")
+    assert sketch is not None
+    wrapped = asyncio.run(sketch.get_wrapped())
+    assert wrapped is not None
+
+
+def test_sketch_get_svg():
+    """Load a SVG sketch from a project by the part name"""
+    ctx = pc.Context("examples/produce_sketch_svg")
+    repo1 = ctx.get_project(".")
+    assert repo1 is not None
+    sketch = repo1.get_sketch("svg_01")
+    assert sketch is not None
+    wrapped = asyncio.run(sketch.get_wrapped())
+    assert wrapped is not None


### PR DESCRIPTION
Fix for enriching and aliasing parts.
Improve error handling for alias and enrich parts. Support enriching parts with parameters in the name. Add aliases for parts with parameters in the name. Support aliasing an alias.
Enhancements to part instantiation.
Fix potential exceptions during initialization.

## Copilot Summary

<!-- Use GitHub Copilot to generate a summary of your changes here. -->

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced part definition capabilities in the configuration file with new parts: `cube_enrich`, `cube_alias`, and variations.
  - Introduced new enrich sketches and descriptions for existing parts, including `leg` and `side-support`.
  - Added new test cases for enriched part validation and sketch loading.

- **Bug Fixes**
  - Improved error handling for missing projects and sources.
  - Refined parameter validation in part and sketch factories.

- **Chores**
  - Refactored initialization and instantiation processes.
  - Improved code readability and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->