### PR TITLE
feat(sandbox): Update CadQuery and build123d versions in sandboxes

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,10 +1,10 @@
-aiofiles==24.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+aiofiles==24.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c \
     --hash=sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5
-aiohappyeyeballs==2.4.4 ; python_version >= "3.10" and python_version < "4.0" \
+aiohappyeyeballs==2.4.4 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5fdd7d87889c63183afc18ce9271f9b0a7d32c2303e394468dd45d514a757745 \
     --hash=sha256:a980909d50efcd44795c4afeca523296716d50cd756ddca6af8c65b996e27de8
-aiohttp==3.11.11 ; python_version >= "3.10" and python_version < "4.0" \
+aiohttp==3.11.11 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0882c2820fd0132240edbb4a51eb8ceb6eef8181db9ad5291ab3332e0d71df5f \
     --hash=sha256:0a6d3fbf2232e3a08c41eca81ae4f1dff3d8f1a30bae415ebe0af2d2458b8a33 \
     --hash=sha256:0b7fb429ab1aafa1f48578eb315ca45bd46e9c37de11fe45c7f5f4138091e2f1 \
@@ -81,56 +81,56 @@ aiohttp==3.11.11 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f047569d655f81cb70ea5be942ee5d4421b6219c3f05d131f64088c73bb0917f \
     --hash=sha256:ffa336210cf9cd8ed117011085817d00abe4c08f99968deef0013ea283547204 \
     --hash=sha256:ffb3dc385f6bb1568aa974fe65da84723210e5d9707e360e9ecb51f59406cd2e
-aiosignal==1.3.2 ; python_version >= "3.10" and python_version < "4.0" \
+aiosignal==1.3.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5 \
     --hash=sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54
-alabaster==1.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+alabaster==1.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e \
     --hash=sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b
-allure-behave==2.13.5 ; python_version >= "3.10" and python_version < "4.0" \
+allure-behave==2.13.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:338ca2cc7395d1ee3dd72f5d7d92d8920f1ade0e07ddebc637b38e61e06dc8dc \
     --hash=sha256:8b04291f435af536b46c3cbd20d33e61b27f5e25dd2fff2fdc1dc3fa2474e23e
-allure-pytest==2.13.5 ; python_version >= "3.10" and python_version < "4.0" \
+allure-pytest==2.13.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0ef8e1790c44a988db6b83c4d4f5e91451e2c4c8ea10601dfa88528d23afcf6e \
     --hash=sha256:94130bac32964b78058e62cf4b815ad97a5ac82a065e6dd2d43abac2be7640fc
-allure-python-commons==2.13.5 ; python_version >= "3.10" and python_version < "4.0" \
+allure-python-commons==2.13.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8b0e837b6e32d810adec563f49e1d04127a5b6770e0232065b7cb09b9953980d \
     --hash=sha256:a232e7955811f988e49a4c1dd6c16cce7e9b81d0ea0422b1e5654d3254e2caf3
-annotated-types==0.7.0 ; python_version >= "3.10" and python_version < "4.0" \
+annotated-types==0.7.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
-anyio==4.8.0 ; python_version >= "3.10" and python_version < "4.0" \
+anyio==4.8.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a \
     --hash=sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a
-anytree==2.12.1 ; python_version >= "3.10" and python_version < "4" \
+anytree==2.12.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:244def434ccf31b668ed282954e5d315b4e066c4940b94aff4a7962d85947830 \
     --hash=sha256:5ea9e61caf96db1e5b3d0a914378d2cd83c269dfce1fb8242ce96589fa3382f0
-appnope==0.1.4 ; python_version >= "3.10" and python_version < "4.0" and platform_system == "Darwin" \
+appnope==0.1.4 ; python_version >= "3.10" and python_version < "3.13" and platform_system == "Darwin" \
     --hash=sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee \
     --hash=sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c
-argcomplete==3.5.3 ; python_version >= "3.10" and python_version < "4.0" \
+argcomplete==3.5.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2ab2c4a215c59fd6caaff41a869480a23e8f6a5f910b266c1808037f4e375b61 \
     --hash=sha256:c12bf50eded8aebb298c7b7da7a5ff3ee24dffd9f5281867dfe1424b58c55392
-asttokens==3.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+asttokens==3.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7 \
     --hash=sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2
 async-timeout==5.0.1 ; python_version >= "3.10" and python_version < "3.11" \
     --hash=sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c \
     --hash=sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3
-attrs==24.3.0 ; python_version >= "3.10" and python_version < "4.0" \
+attrs==24.3.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff \
     --hash=sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308
-babel==2.16.0 ; python_version >= "3.10" and python_version < "4.0" \
+babel==2.16.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b \
     --hash=sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316
-behave==1.2.6 ; python_version >= "3.10" and python_version < "4.0" \
+behave==1.2.6 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:b9662327aa53294c1351b0a9c369093ccec1d21026f050c3bd9b3e5cccf81a86 \
     --hash=sha256:ebda1a6c9e5bfe95c5f9f0a2794e01c7098b3dde86c10a95d8621c5907ff6f1c
-behavex-images==3.0.8 ; python_version >= "3.10" and python_version < "4.0" \
+behavex-images==3.0.8 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:f76a8df531192415a5053d60e7f44600eb2873b99f57abd943f798a11facfdd5
-behavex==4.0.9 ; python_version >= "3.10" and python_version < "4.0" \
+behavex==4.0.9 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:27a937606a6f28b2398b27ca089c0e0285881ce5932ed9bd6f17196dacdccae3
-black==24.10.0 ; python_version >= "3.10" and python_version < "4.0" \
+black==24.10.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f \
     --hash=sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd \
     --hash=sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea \
@@ -153,16 +153,16 @@ black==24.10.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812 \
     --hash=sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50 \
     --hash=sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e
-blinker==1.9.0 ; python_version >= "3.10" and python_version < "4.0" \
+blinker==1.9.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf \
     --hash=sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc
-build123d==0.7.0 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:0771b6f8adf326a4e21a5224cac730045217021c2040e9884fc5dd5028bec3c8 \
-    --hash=sha256:530fe4807b0c6fcb682f872973d961c9ad9dbc4ebaf33e3cc1088d3117de54e7
-cachetools==5.5.0 ; python_version >= "3.10" and python_version < "4.0" \
+build123d==0.8.0 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:676be048c70b2a7b6c3a7c4022ede0f51369b88aba13e4c964b60ddf8c00f503 \
+    --hash=sha256:7c36e6ed8ca717187336e26358e98023c2af37a9a55fb3256bd58252549edfbe
+cachetools==5.5.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292 \
     --hash=sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a
-cadquery-ocp==7.7.2 ; python_version >= "3.10" and python_version < "4.0" \
+cadquery-ocp==7.7.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:10c9883a318212968525f3fece504106b81ca9ba4e187b00b8817b1f944e302a \
     --hash=sha256:2be9408551c03e1c715e3b158b41ce458178ecf530ba644e3e884a5989feb611 \
     --hash=sha256:35e2c8ca923e4ba77b833357eb14c7e8a939f17285ef6acde7c26961989a8dfe \
@@ -182,10 +182,10 @@ cadquery-ocp==7.7.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:d8f8225550db1f5da16e00197ec3a47606866227cfaedac9be2fe6a643db069c \
     --hash=sha256:d9e5c8ef5aeb1d3fb8f0b207ed1a2b781d22dc3e9b9c0551f52342f5a6ee7fc5 \
     --hash=sha256:feea223eaa2dfa33684f568b5ba2b02c35e96b5d894014f98927b5c08041a6be
-certifi==2024.12.14 ; python_version >= "3.10" and python_version < "4.0" \
+certifi==2024.12.14 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56 \
     --hash=sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db
-cffi==1.17.1 ; python_version >= "3.10" and python_version < "4.0" and implementation_name == "pypy" \
+cffi==1.17.1 ; python_version >= "3.10" and python_version < "3.13" and implementation_name == "pypy" \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
     --hash=sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2 \
     --hash=sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1 \
@@ -253,10 +253,10 @@ cffi==1.17.1 ; python_version >= "3.10" and python_version < "4.0" and implement
     --hash=sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99 \
     --hash=sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87 \
     --hash=sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b
-chardet==5.2.0 ; python_version >= "3.10" and python_version < "4" \
+chardet==5.2.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7 \
     --hash=sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970
-charset-normalizer==3.4.1 ; python_version >= "3.10" and python_version < "4.0" \
+charset-normalizer==3.4.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537 \
     --hash=sha256:01732659ba9b5b873fc117534143e4feefecf3b2078b0a6a2e925271bb6f4cfa \
     --hash=sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a \
@@ -349,28 +349,28 @@ charset-normalizer==3.4.1 ; python_version >= "3.10" and python_version < "4.0" 
     --hash=sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e \
     --hash=sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00 \
     --hash=sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616
-click==8.1.8 ; python_version >= "3.10" and python_version < "4.0" \
+click==8.1.8 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
     --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
-cloudpickle==3.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+cloudpickle==3.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:81a929b6e3c7335c863c771d673d105f02efdb89dfaba0c90495d1c64796601b \
     --hash=sha256:fe11acda67f61aaaec473e3afe030feb131d78a43461b718185363384f1ba12e
-colorama==0.4.6 ; python_version >= "3.10" and python_version < "4.0" \
+colorama==0.4.6 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-coloredlogs==15.0.1 ; python_version >= "3.10" and python_version < "4.0" \
+coloredlogs==15.0.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934 \
     --hash=sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0
-colorlog==6.9.0 ; python_version >= "3.10" and python_version < "4.0" \
+colorlog==6.9.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff \
     --hash=sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2
-comm==0.2.2 ; python_version >= "3.10" and python_version < "4.0" \
+comm==0.2.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e \
     --hash=sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3
-configobj==5.0.9 ; python_version >= "3.10" and python_version < "4.0" \
+configobj==5.0.9 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:03c881bbf23aa07bccf1b837005975993c4ab4427ba57f959afdd9d1a2386848 \
     --hash=sha256:1ba10c5b6ee16229c79a05047aeda2b55eb4e80d7c7d8ecf17ec1ca600c79882
-coverage==7.6.10 ; python_version >= "3.10" and python_version < "4.0" \
+coverage==7.6.10 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:05fca8ba6a87aabdd2d30d0b6c838b50510b56cdcfc604d40760dae7153b73d9 \
     --hash=sha256:0aa9692b4fdd83a4647eeb7db46410ea1322b5ed94cd1715ef09d1d5922ba87f \
     --hash=sha256:0c807ca74d5a5e64427c8805de15b9ca140bba13572d6d74e262f46f50b13273 \
@@ -433,7 +433,7 @@ coverage==7.6.10 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:ec22b5e7fe7a0fa8509181c4aac1db48f3dd4d3a566131b313d1efc102892c18 \
     --hash=sha256:f4f620668dbc6f5e909a0946a877310fb3d57aea8198bde792aae369ee1c23b5 \
     --hash=sha256:fd34e7b3405f0cc7ab03d54a334c17a9e802897580d964bd8c2001f4b9fd488f
-coverage[toml]==7.6.10 ; python_version >= "3.10" and python_version < "4.0" \
+coverage[toml]==7.6.10 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:05fca8ba6a87aabdd2d30d0b6c838b50510b56cdcfc604d40760dae7153b73d9 \
     --hash=sha256:0aa9692b4fdd83a4647eeb7db46410ea1322b5ed94cd1715ef09d1d5922ba87f \
     --hash=sha256:0c807ca74d5a5e64427c8805de15b9ca140bba13572d6d74e262f46f50b13273 \
@@ -496,12 +496,12 @@ coverage[toml]==7.6.10 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:ec22b5e7fe7a0fa8509181c4aac1db48f3dd4d3a566131b313d1efc102892c18 \
     --hash=sha256:f4f620668dbc6f5e909a0946a877310fb3d57aea8198bde792aae369ee1c23b5 \
     --hash=sha256:fd34e7b3405f0cc7ab03d54a334c17a9e802897580d964bd8c2001f4b9fd488f
-csscompressor==0.9.5 ; python_version >= "3.10" and python_version < "4.0" \
+csscompressor==0.9.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05
-cssselect2==0.7.0 ; python_version >= "3.10" and python_version < "4.0" \
+cssselect2==0.7.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1ccd984dab89fc68955043aca4e1b03e0cf29cad9880f6e28e3ba7a74b14aa5a \
     --hash=sha256:fd23a65bfd444595913f02fc71f6b286c29261e354c41d722ca7a261a49b5969
-debugpy==1.8.11 ; python_version >= "3.10" and python_version < "4.0" \
+debugpy==1.8.11 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0e22f846f4211383e6a416d04b4c13ed174d24cc5d43f5fd52e7821d0ebc8920 \
     --hash=sha256:116bf8342062246ca749013df4f6ea106f23bc159305843491f64672a55af2e5 \
     --hash=sha256:189058d03a40103a57144752652b3ab08ff02b7595d0ce1f651b9acc3a3a35a0 \
@@ -528,31 +528,31 @@ debugpy==1.8.11 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:c928bbf47f65288574b78518449edaa46c82572d340e2750889bbf8cd92f3737 \
     --hash=sha256:ce291a5aca4985d82875d6779f61375e959208cdf09fcec40001e65fb0a54768 \
     --hash=sha256:d8768edcbeb34da9e11bcb8b5c2e0958d25218df7a6e56adf415ef262cd7b6d1
-decorator==4.4.2 ; python_version >= "3.10" and python_version < "4.0" \
+decorator==4.4.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760 \
     --hash=sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7
-distconfig3==1.0.1 ; python_version >= "3.10" and python_version < "4.0" \
+distconfig3==1.0.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:7d2c7f30a57ef494c5683270587ba7593318746c6e22b9b8953e288c9c303c65 \
     --hash=sha256:823e35ae044677e8aa77bed8d9be0780862a2500c63cf95ce85544b9d3d9fc89
-distlib==0.3.9 ; python_version >= "3.10" and python_version < "4.0" \
+distlib==0.3.9 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87 \
     --hash=sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403
-distro==1.9.0 ; python_version >= "3.10" and python_version < "4.0" \
+distro==1.9.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
-docutils==0.21.2 ; python_version >= "3.10" and python_version < "4.0" \
+docutils==0.21.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f \
     --hash=sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
 exceptiongroup==1.2.2 ; python_version >= "3.10" and python_version < "3.11" \
     --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
     --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc
-execnet==2.1.1 ; python_version >= "3.10" and python_version < "4.0" \
+execnet==2.1.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc \
     --hash=sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3
-executing==2.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+executing==2.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf \
     --hash=sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab
-ezdxf==1.3.5 ; python_version >= "3.10" and python_version < "4.0" \
+ezdxf==1.3.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0cf6646fc64bc411d1362b3c9466a873caf739a9198ee972b37b12389ea23a39 \
     --hash=sha256:1113554bc3f24c31a4220c7415e6d0e6d3ae4206ac478398a4da4cba30ab4dea \
     --hash=sha256:16b12c698658021126a1cfe0f986fe32600ec7eee52f9717f8d2873d52ce213a \
@@ -595,22 +595,22 @@ ezdxf==1.3.5 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f79f656983937ea41a3f83bbb4fbeee8feb44f10ed4e7d2b515436513da9d4f9 \
     --hash=sha256:f8bc4272d17b2225d5340d255a39d973560f45094a568e6ff3cad86daa45e3f5 \
     --hash=sha256:fded6c3a34057b4eaff2ea78b1ce3b1b74ec7cca829ffc3fee936abfe431d9b9
-farama-notifications==0.0.4 ; python_version >= "3.10" and python_version < "4.0" \
+farama-notifications==0.0.4 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:13fceff2d14314cf80703c8266462ebf3733c7d165336eee998fc58e545efd18 \
     --hash=sha256:14de931035a41961f7c056361dc7f980762a143d05791ef5794a751a2caf05ae
-filelock==3.16.1 ; python_version >= "3.10" and python_version < "4.0" \
+filelock==3.16.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0 \
     --hash=sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435
-flake8==7.1.1 ; python_version >= "3.10" and python_version < "4.0" \
+flake8==7.1.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38 \
     --hash=sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213
-flask-sock==0.7.0 ; python_version >= "3.10" and python_version < "4.0" \
+flask-sock==0.7.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:caac4d679392aaf010d02fabcf73d52019f5bdaf1c9c131ec5a428cb3491204a \
     --hash=sha256:e023b578284195a443b8d8bdb4469e6a6acf694b89aeb51315b1a34fcf427b7d
-flask==3.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+flask==3.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac \
     --hash=sha256:d667207822eb83f1c4b50949b1623c8fc8d51f2341d65f72e1a1815397551136
-fonttools==4.55.3 ; python_version >= "3.10" and python_version < "4.0" \
+fonttools==4.55.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:07f8288aacf0a38d174445fc78377a97fb0b83cfe352a90c9d9c1400571963c7 \
     --hash=sha256:11e5de1ee0d95af4ae23c1a138b184b7f06e0b6abacabf1d0db41c90b03d834b \
     --hash=sha256:1bc7ad24ff98846282eef1cbeac05d013c2154f977a79886bb943015d2b1b261 \
@@ -661,7 +661,7 @@ fonttools==4.55.3 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f7d66c15ba875432a2d2fb419523f5d3d347f91f48f57b8b08a2dfc3c39b8a3f \
     --hash=sha256:f9e736f60f4911061235603a6119e72053073a12c6d7904011df2d8fad2c0e35 \
     --hash=sha256:fb594b5a99943042c702c550d5494bdd7577f6ef19b0bc73877c948a63184a32
-freetype-py==2.5.1 ; python_version >= "3.10" and python_version < "4.0" \
+freetype-py==2.5.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0b7f8e0342779f65ca13ef8bc103938366fecade23e6bb37cb671c2b8ad7f124 \
     --hash=sha256:289b443547e03a4f85302e3ac91376838e0d11636050166662a4f75e3087ed0b \
     --hash=sha256:3c1aefc4f0d5b7425f014daccc5fdc7c6f914fb7d6a695cc684f1c09cd8c1660 \
@@ -669,7 +669,7 @@ freetype-py==2.5.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:cd3bfdbb7e1a84818cfbc8025fca3096f4f2afcd5d4641184bf0a3a2e6f97bbf \
     --hash=sha256:cfe2686a174d0dd3d71a9d8ee9bf6a2c23f5872385cf8ce9f24af83d076e2fbd \
     --hash=sha256:d01ded2557694f06aa0413f3400c0c0b2b5ebcaabeef7aaf3d756be44f51e90b
-frozenlist==1.5.0 ; python_version >= "3.10" and python_version < "4.0" \
+frozenlist==1.5.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:000a77d6034fbad9b6bb880f7ec073027908f1b40254b5d6f26210d2dab1240e \
     --hash=sha256:03d33c2ddbc1816237a67f66336616416e2bbb6beb306e5f890f2eb22b959cdf \
     --hash=sha256:04a5c6babd5e8fb7d3c871dc8b321166b80e41b637c31a995ed844a6139942b6 \
@@ -762,42 +762,42 @@ frozenlist==1.5.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f5f9da7f5dbc00a604fe74aa02ae7c98bcede8a3b8b9666f9f86fc13993bc71a \
     --hash=sha256:fd74520371c3c4175142d02a976aee0b4cb4a7cc912a60586ffd8d5929979b30 \
     --hash=sha256:feeb64bc9bcc6b45c6311c9e9b99406660a9c05ca8a5b30d14a78555088b0b3a
-ghp-import==2.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+ghp-import==2.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619 \
     --hash=sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343
-gitdb==4.0.12 ; python_version >= "3.10" and python_version < "4.0" \
+gitdb==4.0.12 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
-gitpython==3.1.44 ; python_version >= "3.10" and python_version < "4.0" \
+gitpython==3.1.44 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110 \
     --hash=sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269
-google-ai-generativelanguage==0.6.10 ; python_version >= "3.10" and python_version < "4.0" \
+google-ai-generativelanguage==0.6.10 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:6fa642c964d8728006fe7e8771026fc0b599ae0ebeaf83caf550941e8e693455 \
     --hash=sha256:854a2bf833d18be05ad5ef13c755567b66a4f4a870f099b62c61fe11bddabcf4
-google-api-core==2.24.0 ; python_version >= "3.10" and python_version < "4.0" \
+google-api-core==2.24.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:10d82ac0fca69c82a25b3efdeefccf6f28e02ebb97925a8cce8edbfe379929d9 \
     --hash=sha256:e255640547a597a4da010876d333208ddac417d60add22b6851a0c66a831fcaf
-google-api-core[grpc]==2.24.0 ; python_version >= "3.10" and python_version < "4.0" \
+google-api-core[grpc]==2.24.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:10d82ac0fca69c82a25b3efdeefccf6f28e02ebb97925a8cce8edbfe379929d9 \
     --hash=sha256:e255640547a597a4da010876d333208ddac417d60add22b6851a0c66a831fcaf
-google-api-python-client==2.157.0 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:0b0231db106324c659bf8b85f390391c00da57a60ebc4271e33def7aac198c75 \
-    --hash=sha256:2ee342d0967ad1cedec43ccd7699671d94bff151e1f06833ea81303f9a6d86fd
-google-auth-httplib2==0.2.0 ; python_version >= "3.10" and python_version < "4.0" \
+google-api-python-client==2.158.0 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:36f8c8d2e79e50f76790ca5946d2f3f8333e210dc8539a6c88e0742416474ad2 \
+    --hash=sha256:b6664597a9955e04977a62752e33fe44cb35c580e190c1cb08a041893172bd67
+google-auth-httplib2==0.2.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:38aa7badf48f974f1eb9861794e9c0cb2a0511a4ec0679b1f886d108f5640e05 \
     --hash=sha256:b65a0a2123300dd71281a7bf6e64d65a0759287df52729bdd1ae2e47dc311a3d
-google-auth==2.37.0 ; python_version >= "3.10" and python_version < "4.0" \
+google-auth==2.37.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0054623abf1f9c83492c63d3f47e77f0a544caa3d40b2d98e099a611c2dd5d00 \
     --hash=sha256:42664f18290a6be591be5329a96fe30184be1a1badb7292a7f686a9659de9ca0
-google-generativeai==0.8.3 ; python_version >= "3.10" and python_version < "4.0" \
+google-generativeai==0.8.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1108ff89d5b8e59f51e63d1a8bf84701cd84656e17ca28d73aeed745e736d9b7
-googleapis-common-protos==1.66.0 ; python_version >= "3.10" and python_version < "4.0" \
+googleapis-common-protos==1.66.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:c3e7b33d15fdca5374cc0a7346dd92ffa847425cc4ea941d970f13680052ec8c \
     --hash=sha256:d7abcd75fabb2e0ec9f74466401f6c119a0b498e27370e9be4c94cb7e382b8ed
-grpcio-status==1.69.0 ; python_version >= "3.10" and python_version < "4.0" \
+grpcio-status==1.69.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:595ef84e5178d6281caa732ccf68ff83259241608d26b0e9c40a5e66eee2a2d2 \
     --hash=sha256:d6b2a3c9562c03a817c628d7ba9a925e209c228762d6d7677ae5c9401a542853
-grpcio==1.69.0 ; python_version >= "3.10" and python_version < "4.0" \
+grpcio==1.69.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:01f834732c22a130bdf3dc154d1053bdbc887eb3ccb7f3e6285cfbfc33d9d5cc \
     --hash=sha256:028337786f11fecb5d7b7fa660475a06aabf7e5e52b5ac2df47414878c0ce7ea \
     --hash=sha256:0470fa911c503af59ec8bc4c82b371ee4303ececbbdc055f55ce48e38b20fd67 \
@@ -853,64 +853,64 @@ grpcio==1.69.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f79e05f5bbf551c4057c227d1b041ace0e78462ac8128e2ad39ec58a382536d2 \
     --hash=sha256:fb9302afc3a0e4ba0b225cd651ef8e478bf0070cf11a529175caecd5ea2474e7 \
     --hash=sha256:fc18a4de8c33491ad6f70022af5c460b39611e39578a4d84de0fe92f12d5d47b
-gymnasium==1.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+gymnasium==1.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:9d2b66f30c1b34fe3c2ce7fae65ecf365d0e9982d2b3d860235e773328a3b403 \
     --hash=sha256:b6f40e1e24c5bd419361e1a5b86a9117d2499baecc3a660d44dfff4c465393ad
-h11==0.14.0 ; python_version >= "3.10" and python_version < "4.0" \
+h11==0.14.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
     --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
-htmlmin==0.1.12 ; python_version >= "3.10" and python_version < "4.0" \
+htmlmin==0.1.12 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:50c1ef4630374a5d723900096a961cff426dff46b48f34d194a81bbe14eca178
-httpcore==1.0.7 ; python_version >= "3.10" and python_version < "4.0" \
+httpcore==1.0.7 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c \
     --hash=sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd
-httplib2==0.22.0 ; python_version >= "3.10" and python_version < "4.0" \
+httplib2==0.22.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc \
     --hash=sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81
-httpx==0.27.2 ; python_version >= "3.10" and python_version < "4.0" \
+httpx==0.27.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0 \
     --hash=sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2
-humanfriendly==10.0 ; python_version >= "3.10" and python_version < "4.0" \
+humanfriendly==10.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
     --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
-idna==3.10 ; python_version >= "3.10" and python_version < "4.0" \
+idna==3.10 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
-imageio-ffmpeg==0.5.1 ; python_version >= "3.10" and python_version < "4.0" \
+imageio-ffmpeg==0.5.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0ed7a9b31f560b0c9d929c5291cd430edeb9bed3ce9a497480e536dd4326484c \
     --hash=sha256:1460e84712b9d06910c1f7bb524096b0341d4b7844cea6c20e099d0a24e795b1 \
     --hash=sha256:1521e79e253bedbdd36a547e0cbd94a025ba0b558e17f08fea687d805a0e4698 \
     --hash=sha256:5289f75c7f755b499653f3209fea4efd1430cba0e39831c381aad2d458f7a316 \
     --hash=sha256:7fa9132a291d5eb28c44553550deb40cbdab831f2a614e55360301a6582eb205 \
     --hash=sha256:89efe2c79979d8174ba8476deb7f74d74c331caee3fb2b65ba2883bec0737625
-imageio==2.36.1 ; python_version >= "3.10" and python_version < "4.0" \
+imageio==2.36.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:20abd2cae58e55ca1af8a8dcf43293336a59adf0391f1917bf8518633cfc2cdf \
     --hash=sha256:e4e1d231f47f9a9e16100b0f7ce1a86e8856fb4d1c0fa2c4365a316f1746be62
-imagesize==1.4.1 ; python_version >= "3.10" and python_version < "4.0" \
+imagesize==1.4.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b \
     --hash=sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a
-iniconfig==2.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+iniconfig==2.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
-ipykernel==6.29.5 ; python_version >= "3.10" and python_version < "4.0" \
+ipykernel==6.29.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5 \
     --hash=sha256:f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215
-ipython==8.31.0 ; python_version >= "3.10" and python_version < "4.0" \
+ipython==8.31.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:46ec58f8d3d076a61d128fe517a51eb730e3aaf0c184ea8c17d16e366660c6a6 \
     --hash=sha256:b6a2274606bec6166405ff05e54932ed6e5cfecaca1fc05f2cacde7bb074d70b
-isort==5.13.2 ; python_version >= "3.10" and python_version < "4.0" \
+isort==5.13.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109 \
     --hash=sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6
-itsdangerous==2.2.0 ; python_version >= "3.10" and python_version < "4.0" \
+itsdangerous==2.2.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef \
     --hash=sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173
-jedi==0.19.2 ; python_version >= "3.10" and python_version < "4.0" \
+jedi==0.19.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0 \
     --hash=sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9
-jinja2==3.1.5 ; python_version >= "3.10" and python_version < "4.0" \
+jinja2==3.1.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb \
     --hash=sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb
-jiter==0.8.2 ; python_version >= "3.10" and python_version < "4.0" \
+jiter==0.8.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:025337859077b41548bdcbabe38698bcd93cfe10b06ff66617a48ff92c9aec60 \
     --hash=sha256:03c9df035d4f8d647f8c210ddc2ae0728387275340668fb30d2421e17d9a0841 \
     --hash=sha256:08d4c92bf480e19fc3f2717c9ce2aa31dceaa9163839a311424b6862252c943e \
@@ -987,13 +987,13 @@ jiter==0.8.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:fc5adda618205bd4678b146612ce44c3cbfdee9697951f2c0ffdef1f26d72b63 \
     --hash=sha256:fc9043259ee430ecd71d178fccabd8c332a3bf1e81e50cae43cc2b28d19e4cb7 \
     --hash=sha256:ffd9fee7d0775ebaba131f7ca2e2d83839a62ad65e8e02fe2bd8fc975cedeb9e
-jupyter-client==8.6.3 ; python_version >= "3.10" and python_version < "4.0" \
+jupyter-client==8.6.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419 \
     --hash=sha256:e8a19cc986cc45905ac3362915f410f3af85424b4c0905e94fa5f2cb08e8f23f
-jupyter-core==5.7.2 ; python_version >= "3.10" and python_version < "4.0" \
+jupyter-core==5.7.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409 \
     --hash=sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9
-lxml==5.3.0 ; python_version >= "3.10" and python_version < "4.0" \
+lxml==5.3.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:01220dca0d066d1349bd6a1726856a78f7929f3878f7e2ee83c296c69495309e \
     --hash=sha256:02ced472497b8362c8e902ade23e3300479f4f43e45f4105c85ef43b8db85229 \
     --hash=sha256:052d99051e77a4f3e8482c65014cf6372e61b0a6f4fe9edb98503bb5364cfee3 \
@@ -1132,13 +1132,13 @@ lxml==5.3.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f7d4a670107d75dfe5ad080bed6c341d18c4442f9378c9f58e5851e86eb79965 \
     --hash=sha256:f914c03e6a31deb632e2daa881fe198461f4d06e57ac3d0e05bbcab8eae01945 \
     --hash=sha256:fb66442c2546446944437df74379e9cf9e9db353e61301d1a0e26482f43f0dd8
-markdown-it-py==3.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+markdown-it-py==3.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
     --hash=sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
-markdown==3.7 ; python_version >= "3.10" and python_version < "4.0" \
+markdown==3.7 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
-markupsafe==3.0.2 ; python_version >= "3.10" and python_version < "4.0" \
+markupsafe==3.0.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4 \
     --hash=sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30 \
     --hash=sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0 \
@@ -1200,36 +1200,36 @@ markupsafe==3.0.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79 \
     --hash=sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430 \
     --hash=sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50
-matplotlib-inline==0.1.7 ; python_version >= "3.10" and python_version < "4.0" \
+matplotlib-inline==0.1.7 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90 \
     --hash=sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca
-mccabe==0.7.0 ; python_version >= "3.10" and python_version < "4.0" \
+mccabe==0.7.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
-mdurl==0.1.2 ; python_version >= "3.10" and python_version < "4.0" \
+mdurl==0.1.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
-mdx-truly-sane-lists==1.3 ; python_version >= "3.10" and python_version < "4.0" \
+mdx-truly-sane-lists==1.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:b661022df7520a1e113af7c355c62216b384c867e4f59fb8ee7ad511e6e77f45 \
     --hash=sha256:b9546a4c40ff8f1ab692f77cee4b6bfe8ddf9cccf23f0a24e71f3716fe290a37
-mergedeep==1.3.4 ; python_version >= "3.10" and python_version < "4.0" \
+mergedeep==1.3.4 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8 \
     --hash=sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307
-mkdocs-get-deps==0.2.0 ; python_version >= "3.10" and python_version < "4.0" \
+mkdocs-get-deps==0.2.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c \
     --hash=sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134
-mkdocs-material-extensions==1.3.1 ; python_version >= "3.10" and python_version < "4.0" \
+mkdocs-material-extensions==1.3.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
     --hash=sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31
-mkdocs-material==9.5.49 ; python_version >= "3.10" and python_version < "4.0" \
+mkdocs-material==9.5.49 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:3671bb282b4f53a1c72e08adbe04d2481a98f85fed392530051f80ff94a9621d \
     --hash=sha256:c3c2d8176b18198435d3a3e119011922f3e11424074645c24019c2dcf08a360e
-mkdocs==1.6.1 ; python_version >= "3.10" and python_version < "4.0" \
+mkdocs==1.6.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2 \
     --hash=sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e
-moviepy==1.0.3 ; python_version >= "3.10" and python_version < "4.0" \
+moviepy==1.0.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2884e35d1788077db3ff89e763c5ba7bfddbd7ae9108c9bc809e7ba58fa433f5
-multidict==6.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+multidict==6.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:052e10d2d37810b99cc170b785945421141bf7bb7d2f8799d431e7db229c385f \
     --hash=sha256:06809f4f0f7ab7ea2cabf9caca7d79c22c0758b58a71f9d32943ae13c7ace056 \
     --hash=sha256:071120490b47aa997cca00666923a83f02c7fbb44f71cf7f136df753f7fa8761 \
@@ -1322,168 +1322,187 @@ multidict==6.1.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f67f217af4b1ff66c68a87318012de788dd95fcfeb24cc889011f4e1c7454dfd \
     --hash=sha256:f90c822a402cb865e396a504f9fc8173ef34212a342d92e362ca498cad308e28 \
     --hash=sha256:ff3827aef427c89a25cc96ded1759271a93603aba9fb977a6d264648ebf989db
-mypy-extensions==1.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+mypy-extensions==1.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
     --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
-nest-asyncio==1.6.0 ; python_version >= "3.10" and python_version < "4.0" \
+nest-asyncio==1.6.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe \
     --hash=sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c
-nox-poetry==1.0.3 ; python_version >= "3.10" and python_version < "4.0" \
+nox-poetry==1.0.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:a2fffeb70ae81840479e68287afe1c772bf376f70f1e92f99832a20b3c64d064 \
     --hash=sha256:dc7ecbbd812a333a0c0b558f57e5b37f7c12926cddbcecaf2264957fd373824e
-nox==2024.10.9 ; python_version >= "3.10" and python_version < "4.0" \
+nox==2024.10.9 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1d36f309a0a2a853e9bccb76bbef6bb118ba92fa92674d15604ca99adeb29eab \
     --hash=sha256:7aa9dc8d1c27e9f45ab046ffd1c3b2c4f7c91755304769df231308849ebded95
-numpy==1.26.4 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b \
-    --hash=sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818 \
-    --hash=sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20 \
-    --hash=sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0 \
-    --hash=sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010 \
-    --hash=sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a \
-    --hash=sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea \
-    --hash=sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c \
-    --hash=sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71 \
-    --hash=sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110 \
-    --hash=sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be \
-    --hash=sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a \
-    --hash=sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a \
-    --hash=sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5 \
-    --hash=sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed \
-    --hash=sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd \
-    --hash=sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c \
-    --hash=sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e \
-    --hash=sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0 \
-    --hash=sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c \
-    --hash=sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a \
-    --hash=sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b \
-    --hash=sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0 \
-    --hash=sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6 \
-    --hash=sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2 \
-    --hash=sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a \
-    --hash=sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30 \
-    --hash=sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218 \
-    --hash=sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5 \
-    --hash=sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07 \
-    --hash=sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2 \
-    --hash=sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4 \
-    --hash=sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764 \
-    --hash=sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef \
-    --hash=sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3 \
-    --hash=sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f
-ocp-tessellate==3.0.8 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:d82a8ffc0f765649456f3cd3bbc379b6e3a8c8a78ebd9ff1540e2d7aeeea6473 \
-    --hash=sha256:f2c1f5b2e0e0277624840946c04461742c0d30f15f55922f6c03e5358fddb16e
-ocp-vscode==2.6.1 ; python_version >= "3.10" and python_version < "4.0" \
+numpy==2.2.1 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:059e6a747ae84fce488c3ee397cee7e5f905fd1bda5fb18c66bc41807ff119b2 \
+    --hash=sha256:08ef779aed40dbc52729d6ffe7dd51df85796a702afbf68a4f4e41fafdc8bda5 \
+    --hash=sha256:164a829b6aacf79ca47ba4814b130c4020b202522a93d7bff2202bfb33b61c60 \
+    --hash=sha256:26c9c4382b19fcfbbed3238a14abf7ff223890ea1936b8890f058e7ba35e8d71 \
+    --hash=sha256:27f5cdf9f493b35f7e41e8368e7d7b4bbafaf9660cba53fb21d2cd174ec09631 \
+    --hash=sha256:31b89fa67a8042e96715c68e071a1200c4e172f93b0fbe01a14c0ff3ff820fc8 \
+    --hash=sha256:32cb94448be47c500d2c7a95f93e2f21a01f1fd05dd2beea1ccd049bb6001cd2 \
+    --hash=sha256:360137f8fb1b753c5cde3ac388597ad680eccbbbb3865ab65efea062c4a1fd16 \
+    --hash=sha256:3683a8d166f2692664262fd4900f207791d005fb088d7fdb973cc8d663626faa \
+    --hash=sha256:38efc1e56b73cc9b182fe55e56e63b044dd26a72128fd2fbd502f75555d92591 \
+    --hash=sha256:3d03883435a19794e41f147612a77a8f56d4e52822337844fff3d4040a142964 \
+    --hash=sha256:3ecc47cd7f6ea0336042be87d9e7da378e5c7e9b3c8ad0f7c966f714fc10d821 \
+    --hash=sha256:40f9e544c1c56ba8f1cf7686a8c9b5bb249e665d40d626a23899ba6d5d9e1484 \
+    --hash=sha256:4250888bcb96617e00bfa28ac24850a83c9f3a16db471eca2ee1f1714df0f957 \
+    --hash=sha256:4511d9e6071452b944207c8ce46ad2f897307910b402ea5fa975da32e0102800 \
+    --hash=sha256:45681fd7128c8ad1c379f0ca0776a8b0c6583d2f69889ddac01559dfe4390918 \
+    --hash=sha256:48fd472630715e1c1c89bf1feab55c29098cb403cc184b4859f9c86d4fcb6a95 \
+    --hash=sha256:4c86e2a209199ead7ee0af65e1d9992d1dce7e1f63c4b9a616500f93820658d0 \
+    --hash=sha256:4dfda918a13cc4f81e9118dea249e192ab167a0bb1966272d5503e39234d694e \
+    --hash=sha256:5062dc1a4e32a10dc2b8b13cedd58988261416e811c1dc4dbdea4f57eea61b0d \
+    --hash=sha256:51faf345324db860b515d3f364eaa93d0e0551a88d6218a7d61286554d190d73 \
+    --hash=sha256:526fc406ab991a340744aad7e25251dd47a6720a685fa3331e5c59fef5282a59 \
+    --hash=sha256:53c09385ff0b72ba79d8715683c1168c12e0b6e84fb0372e97553d1ea91efe51 \
+    --hash=sha256:55ba24ebe208344aa7a00e4482f65742969a039c2acfcb910bc6fcd776eb4355 \
+    --hash=sha256:5b6c390bfaef8c45a260554888966618328d30e72173697e5cabe6b285fb2348 \
+    --hash=sha256:5c5cc0cbabe9452038ed984d05ac87910f89370b9242371bd9079cb4af61811e \
+    --hash=sha256:5edb4e4caf751c1518e6a26a83501fda79bff41cc59dac48d70e6d65d4ec4440 \
+    --hash=sha256:61048b4a49b1c93fe13426e04e04fdf5a03f456616f6e98c7576144677598675 \
+    --hash=sha256:676f4eebf6b2d430300f1f4f4c2461685f8269f94c89698d832cdf9277f30b84 \
+    --hash=sha256:67d4cda6fa6ffa073b08c8372aa5fa767ceb10c9a0587c707505a6d426f4e046 \
+    --hash=sha256:694f9e921a0c8f252980e85bce61ebbd07ed2b7d4fa72d0e4246f2f8aa6642ab \
+    --hash=sha256:733585f9f4b62e9b3528dd1070ec4f52b8acf64215b60a845fa13ebd73cd0712 \
+    --hash=sha256:7671dc19c7019103ca44e8d94917eba8534c76133523ca8406822efdd19c9308 \
+    --hash=sha256:780077d95eafc2ccc3ced969db22377b3864e5b9a0ea5eb347cc93b3ea900315 \
+    --hash=sha256:7ba9cc93a91d86365a5d270dee221fdc04fb68d7478e6bf6af650de78a8339e3 \
+    --hash=sha256:89b16a18e7bba224ce5114db863e7029803c179979e1af6ad6a6b11f70545008 \
+    --hash=sha256:9036d6365d13b6cbe8f27a0eaf73ddcc070cae584e5ff94bb45e3e9d729feab5 \
+    --hash=sha256:93cf4e045bae74c90ca833cba583c14b62cb4ba2cba0abd2b141ab52548247e2 \
+    --hash=sha256:9ad014faa93dbb52c80d8f4d3dcf855865c876c9660cb9bd7553843dd03a4b1e \
+    --hash=sha256:9b1d07b53b78bf84a96898c1bc139ad7f10fda7423f5fd158fd0f47ec5e01ac7 \
+    --hash=sha256:a7746f235c47abc72b102d3bce9977714c2444bdfaea7888d241b4c4bb6a78bf \
+    --hash=sha256:aa3017c40d513ccac9621a2364f939d39e550c542eb2a894b4c8da92b38896ab \
+    --hash=sha256:b34d87e8a3090ea626003f87f9392b3929a7bbf4104a05b6667348b6bd4bf1cd \
+    --hash=sha256:b541032178a718c165a49638d28272b771053f628382d5e9d1c93df23ff58dbf \
+    --hash=sha256:ba5511d8f31c033a5fcbda22dd5c813630af98c70b2661f2d2c654ae3cdfcfc8 \
+    --hash=sha256:bc8a37ad5b22c08e2dbd27df2b3ef7e5c0864235805b1e718a235bcb200cf1cb \
+    --hash=sha256:bff7d8ec20f5f42607599f9994770fa65d76edca264a87b5e4ea5629bce12268 \
+    --hash=sha256:c1ad395cf254c4fbb5b2132fee391f361a6e8c1adbd28f2cd8e79308a615fe9d \
+    --hash=sha256:f1d09e520217618e76396377c81fba6f290d5f926f50c35f3a5f72b01a0da780 \
+    --hash=sha256:f3eac17d9ec51be534685ba877b6ab5edc3ab7ec95c8f163e5d7b39859524716 \
+    --hash=sha256:f419290bc8968a46c4933158c91a0012b7a99bb2e465d5ef5293879742f8797e \
+    --hash=sha256:f62aa6ee4eb43b024b0e5a01cf65a0bb078ef8c395e8713c6e8a12a697144528 \
+    --hash=sha256:f74e6fdeb9a265624ec3a3918430205dff1df7e95a230779746a6af78bc615af \
+    --hash=sha256:f9b57eaa3b0cd8db52049ed0330747b0364e899e8a606a624813452b8203d5f7 \
+    --hash=sha256:fce4f615f8ca31b2e61aa0eb5865a21e14f5629515c9151850aa936c02a1ee51
+ocp-tessellate==3.0.9 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:307d2fd0a94fa64627251c3b4633c9757ee7809c19fc233d9f44b30ea658b096 \
+    --hash=sha256:64e6ca902c63a90eacf49fa24c0bd93054f0a2865476e56a27a9d6e297c97282
+ocp-vscode==2.6.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:98f997fecae2668205f9ddaab416acba9e65816e848baa6552f73be09c448a2a \
     --hash=sha256:9e11aa89f6e60733846e553df4e347c19b82c8ca84912c43ce844af426daae7e
-ocpsvg==0.3.3 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:8c441e72110be0b53dd84a00229752d8ce7658ed2c3d66e79c9aade9fcb4b475 \
-    --hash=sha256:93a7d4b0edab119ca950e7e15132fdb69399f53851322a3fb56e03946939384a
-ollama==0.4.5 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:74936de89a41c87c9745f09f2e1db964b4783002188ac21241bfab747f46d925 \
-    --hash=sha256:e7fb71a99147046d028ab8b75e51e09437099aea6f8f9a0d91a71f787e97439e
-openai==1.59.4 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:82113498699998e98104f87c19a890e82df9b01251a0395484360575d3a1d98a \
-    --hash=sha256:b946dc5a2308dc1e03efbda80bf1cd64b6053b536851ad519f57ee44401663d2
-orjson==3.10.13 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:003721c72930dbb973f25c5d8e68d0f023d6ed138b14830cc94e57c6805a2eab \
-    --hash=sha256:0065896f85d9497990731dfd4a9991a45b0a524baec42ef0a63c34630ee26fd6 \
-    --hash=sha256:03b0f29d485411e3c13d79604b740b14e4e5fb58811743f6f4f9693ee6480a8f \
-    --hash=sha256:064b9dbb0217fd64a8d016a8929f2fae6f3312d55ab3036b00b1d17399ab2f3e \
-    --hash=sha256:0bc858086088b39dc622bc8219e73d3f246fb2bce70a6104abd04b3a080a66a8 \
-    --hash=sha256:0dbf3b97e52e093d7c3e93eb5eb5b31dc7535b33c2ad56872c83f0160f943487 \
-    --hash=sha256:0e2759d3172300b2f892dee85500b22fca5ac49e0c42cfff101aaf9c12ac9617 \
-    --hash=sha256:0fee076134398d4e6cb827002468679ad402b22269510cf228301b787fdff5ae \
-    --hash=sha256:1232c5e873a4d1638ef957c5564b4b0d6f2a6ab9e207a9b3de9de05a09d1d920 \
-    --hash=sha256:1884e53c6818686891cc6fc5a3a2540f2f35e8c76eac8dc3b40480fb59660b00 \
-    --hash=sha256:1a7d64f1db5ecbc21eb83097e5236d6ab7e86092c1cd4c216c02533332951afc \
-    --hash=sha256:2149e2fcd084c3fd584881c7f9d7f9e5ad1e2e006609d8b80649655e0d52cd02 \
-    --hash=sha256:22f1c9a30b43d14a041a6ea190d9eca8a6b80c4beb0e8b67602c82d30d6eec3e \
-    --hash=sha256:233aae4474078d82f425134bb6a10fb2b3fc5a1a1b3420c6463ddd1b6a97eda8 \
-    --hash=sha256:2cdaf8b028a976ebab837a2c27b82810f7fc76ed9fb243755ba650cc83d07730 \
-    --hash=sha256:33ef84f7e9513fb13b3999c2a64b9ca9c8143f3da9722fbf9c9ce51ce0d8076e \
-    --hash=sha256:3723e137772639af8adb68230f2aa4bcb27c48b3335b1b1e2d49328fed5e244c \
-    --hash=sha256:3a7df63076435f39ec024bdfeb4c9767ebe7b49abc4949068d61cf4857fa6d6c \
-    --hash=sha256:3ca6f17467ebbd763f8862f1d89384a5051b461bb0e41074f583a0ebd7120e8e \
-    --hash=sha256:4222881d0aab76224d7b003a8e5fdae4082e32c86768e0e8652de8afd6c4e2c1 \
-    --hash=sha256:46c249b4e934453be4ff2e518cd1adcd90467da7391c7a79eaf2fbb79c51e8c7 \
-    --hash=sha256:48a946796e390cbb803e069472de37f192b7a80f4ac82e16d6eb9909d9e39d56 \
-    --hash=sha256:4a11532cbfc2f5752c37e84863ef8435b68b0e6d459b329933294f65fa4bda1a \
-    --hash=sha256:527afb6ddb0fa3fe02f5d9fba4920d9d95da58917826a9be93e0242da8abe94a \
-    --hash=sha256:5385935a73adce85cc7faac9d396683fd813566d3857fa95a0b521ef84a5b588 \
-    --hash=sha256:54433e421618cd5873e51c0e9d0b9fb35f7bf76eb31c8eab20b3595bb713cd3d \
-    --hash=sha256:5f00c7fb18843bad2ac42dc1ce6dd214a083c53f1e324a0fd1c8137c6436269b \
-    --hash=sha256:5f74d878d1efb97a930b8a9f9898890067707d683eb5c7e20730030ecb3fb930 \
-    --hash=sha256:6066729cf9552d70de297b56556d14b4f49c8f638803ee3c90fd212fa43cc6af \
-    --hash=sha256:62c3cc00c7e776c71c6b7b9c48c5d2701d4c04e7d1d7cdee3572998ee6dc57cc \
-    --hash=sha256:63664bf12addb318dc8f032160e0f5dc17eb8471c93601e8f5e0d07f95003784 \
-    --hash=sha256:69b21d91c5c5ef8a201036d207b1adf3aa596b930b6ca3c71484dd11386cf6c3 \
-    --hash=sha256:6a428afb5720f12892f64920acd2eeb4d996595bf168a26dd9190115dbf1130d \
-    --hash=sha256:711878da48f89df194edd2ba603ad42e7afed74abcd2bac164685e7ec15f96de \
-    --hash=sha256:7184f608ad563032e398f311910bc536e62b9fbdca2041be889afcbc39500de8 \
-    --hash=sha256:8257c3fb8dd7b0b446b5e87bf85a28e4071ac50f8c04b6ce2d38cb4abd7dff57 \
-    --hash=sha256:89367767ed27b33c25c026696507c76e3d01958406f51d3a2239fe9e91959df2 \
-    --hash=sha256:8a1152e2761025c5d13b5e1908d4b1c57f3797ba662e485ae6f26e4e0c466388 \
-    --hash=sha256:92b4ec30d6025a9dcdfe0df77063cbce238c08d0404471ed7a79f309364a3d19 \
-    --hash=sha256:9c976bad3996aa027cd3aef78aa57873f3c959b6c38719de9724b71bdc7bd14b \
-    --hash=sha256:a3614b00621c77f3f6487792238f9ed1dd8a42f2ec0e6540ee34c2d4e6db813a \
-    --hash=sha256:a36c0d48d2f084c800763473020a12976996f1109e2fcb66cfea442fdf88047f \
-    --hash=sha256:a42b9fe4b0114b51eb5cdf9887d8c94447bc59df6dbb9c5884434eab947888d8 \
-    --hash=sha256:a5a7624ab4d121c7e035708c8dd1f99c15ff155b69a1c0affc4d9d8b551281ba \
-    --hash=sha256:a94542d12271c30044dadad1125ee060e7a2048b6c7034e432e116077e1d13d2 \
-    --hash=sha256:a9ecea472f3eb653e1c0a3d68085f031f18fc501ea392b98dcca3e87c24f9ebe \
-    --hash=sha256:aa6fe68f0981fba0d4bf9cdc666d297a7cdba0f1b380dcd075a9a3dd5649a69e \
-    --hash=sha256:ae537fcf330b3947e82c6ae4271e092e6cf16b9bc2cef68b14ffd0df1fa8832a \
-    --hash=sha256:b12a63f48bb53dba8453d36ca2661f2330126d54e26c1661e550b32864b28ce3 \
-    --hash=sha256:b42f56821c29e697c68d7d421410d7c1d8f064ae288b525af6a50cf99a4b1200 \
-    --hash=sha256:b5f7c298d4b935b222f52d6c7f2ba5eafb59d690d9a3840b7b5c5cda97f6ec5c \
-    --hash=sha256:ba5b13b8739ce5b630c65cb1c85aedbd257bcc2b9c256b06ab2605209af75a2e \
-    --hash=sha256:c0044b0b8c85a565e7c3ce0a72acc5d35cda60793edf871ed94711e712cb637d \
-    --hash=sha256:c96d2fb80467d1d0dfc4d037b4e1c0f84f1fe6229aa7fea3f070083acef7f3d7 \
-    --hash=sha256:cab83e67f6aabda1b45882254b2598b48b80ecc112968fc6483fa6dae609e9f0 \
-    --hash=sha256:cf16f06cb77ce8baf844bc222dbcb03838f61d0abda2c3341400c2b7604e436e \
-    --hash=sha256:d26a0eca3035619fa366cbaf49af704c7cb1d4a0e6c79eced9f6a3f2437964b6 \
-    --hash=sha256:d36f689e7e1b9b6fb39dbdebc16a6f07cbe994d3644fb1c22953020fc575935f \
-    --hash=sha256:d4b6acd7c9c829895e50d385a357d4b8c3fafc19c5989da2bae11783b0fd4977 \
-    --hash=sha256:d9c3a87abe6f849a4a7ac8a8a1dede6320a4303d5304006b90da7a3cd2b70d2c \
-    --hash=sha256:dbcd7aad6bcff258f6896abfbc177d54d9b18149c4c561114f47ebfe74ae6bfd \
-    --hash=sha256:dc03db4922e75bbc870b03fc49734cefbd50fe975e0878327d200022210b82d8 \
-    --hash=sha256:dca1d20f1af0daff511f6e26a27354a424f0b5cf00e04280279316df0f604a6f \
-    --hash=sha256:dce1cc42ed75b585c0c4dc5eb53a90a34ccb493c09a10750d1a1f9b9eff2bd12 \
-    --hash=sha256:dd2bcde107221bb9c2fa0c4aaba735a537225104173d7e19cf73f70b3126c993 \
-    --hash=sha256:dda4ba4d3e6f6c53b6b9c35266788053b61656a716a7fef5c884629c2a52e7aa \
-    --hash=sha256:e1ba0c5857dd743438acecc1cd0e1adf83f0a81fee558e32b2b36f89e40cee8b \
-    --hash=sha256:e384e330a67cf52b3597ee2646de63407da6f8fc9e9beec3eaaaef5514c7a1c9 \
-    --hash=sha256:e400436950ba42110a20c50c80dff4946c8e3ec09abc1c9cf5473467e83fd1c5 \
-    --hash=sha256:e49333d1038bc03a25fdfe11c86360df9b890354bfe04215f1f54d030f33c342 \
-    --hash=sha256:e4f998bbf300690be881772ee9c5281eb9c0044e295bcd4722504f5b5c6092ff \
-    --hash=sha256:eb9bfb14ab8f68d9d9492d4817ae497788a15fd7da72e14dfabc289c3bb088ec \
-    --hash=sha256:ee948c6c01f6b337589c88f8e0bb11e78d32a15848b8b53d3f3b6fea48842c12 \
-    --hash=sha256:f47c9e7d224b86ffb086059cdcf634f4b3f32480f9838864aa09022fe2617ce2 \
-    --hash=sha256:f81b26c03f5fb5f0d0ee48d83cea4d7bc5e67e420d209cc1a990f5d1c62f9be0
-packaging==24.2 ; python_version >= "3.10" and python_version < "4.0" \
+ocpsvg==0.3.4 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:dba117055b29d17ebc3bffd6e4f911c40fe518086c5a17ffc2b5b01a2938787f \
+    --hash=sha256:f99e3316451b2c34a716bd27ed822a2d48dbf9d040f688efc5152ac47fc8024a
+ollama==0.4.6 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:b00717651c829f96094ed4231b9f0d87e33cc92dc235aca50aeb5a2a4e6e95b7 \
+    --hash=sha256:cbb4ebe009e10dd12bdd82508ab415fd131945e185753d728a7747c9ebe762e9
+openai==1.59.7 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:043603def78c00befb857df9f0a16ee76a3af5984ba40cb7ee5e2f40db4646bf \
+    --hash=sha256:cfa806556226fa96df7380ab2e29814181d56fea44738c2b0e581b462c268692
+orjson==3.10.14 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:0293a88815e9bb5c90af4045f81ed364d982f955d12052d989d844d6c4e50945 \
+    --hash=sha256:03f61ca3674555adcb1aa717b9fc87ae936aa7a63f6aba90a474a88701278780 \
+    --hash=sha256:06d4ec218b1ec1467d8d64da4e123b4794c781b536203c309ca0f52819a16c03 \
+    --hash=sha256:07520685d408a2aba514c17ccc16199ff2934f9f9e28501e676c557f454a37fe \
+    --hash=sha256:0905ca08a10f7e0e0c97d11359609300eb1437490a7f32bbaa349de757e2e0c7 \
+    --hash=sha256:0de4d6315cfdbd9ec803b945c23b3a68207fd47cbe43626036d97e8e9561a436 \
+    --hash=sha256:164ac155109226b3a2606ee6dda899ccfbe6e7e18b5bdc3fbc00f79cc074157d \
+    --hash=sha256:16642f10c1ca5611251bd835de9914a4b03095e28a34c8ba6a5500b5074338bd \
+    --hash=sha256:175abf3d20e737fec47261d278f95031736a49d7832a09ab684026528c4d96db \
+    --hash=sha256:175cafd322e458603e8ce73510a068d16b6e6f389c13f69bf16de0e843d7d406 \
+    --hash=sha256:1b49e2af011c84c3f2d541bb5cd1e3c7c2df672223e7e3ea608f09cf295e5f8a \
+    --hash=sha256:21d3be4132f71ef1360385770474f29ea1538a242eef72ac4934fe142800e37f \
+    --hash=sha256:26336c0d4b2d44636e1e1e6ed1002f03c6aae4a8a9329561c8883f135e9ff010 \
+    --hash=sha256:29ca1a93e035d570e8b791b6c0feddd403c6a5388bfe870bf2aa6bba1b9d9b8e \
+    --hash=sha256:2ad4b7e367efba6dc3f119c9a0fcd41908b7ec0399a696f3cdea7ec477441b09 \
+    --hash=sha256:33449c67195969b1a677533dee9d76e006001213a24501333624623e13c7cc8e \
+    --hash=sha256:36f5bfc0399cd4811bf10ec7a759c7ab0cd18080956af8ee138097d5b5296a95 \
+    --hash=sha256:3871bad546aa66c155e3f36f99c459780c2a392d502a64e23fb96d9abf338511 \
+    --hash=sha256:397083806abd51cf2b3bbbf6c347575374d160331a2d33c5823e22249ad3118b \
+    --hash=sha256:3af8e42ae4363773658b8d578d56dedffb4f05ceeb4d1d4dd3fb504950b45526 \
+    --hash=sha256:4ddc8c866d7467f5ee2991397d2ea94bcf60d0048bdd8ca555740b56f9042725 \
+    --hash=sha256:4f5007abfdbb1d866e2aa8990bd1c465f0f6da71d19e695fc278282be12cffa5 \
+    --hash=sha256:56ee546c2bbe9599aba78169f99d1dc33301853e897dbaf642d654248280dc6e \
+    --hash=sha256:6169d3868b190d6b21adc8e61f64e3db30f50559dfbdef34a1cd6c738d409dfc \
+    --hash=sha256:64410696c97a35af2432dea7bdc4ce32416458159430ef1b4beb79fd30093ad6 \
+    --hash=sha256:691ab9a13834310a263664313e4f747ceb93662d14a8bdf20eb97d27ed488f16 \
+    --hash=sha256:6b1225024cf0ef5d15934b5ffe9baf860fe8bc68a796513f5ea4f5056de30bca \
+    --hash=sha256:6e2ec73b7099b6a29b40a62e08a23b936423bd35529f8f55c42e27acccde7954 \
+    --hash=sha256:76344269b550ea01488d19a2a369ab572c1ac4449a72e9f6ac0d70eb1cbfb953 \
+    --hash=sha256:7796692136a67b3e301ef9052bde6fe8e7bd5200da766811a3a608ffa62aaff0 \
+    --hash=sha256:7e947f70167fe18469f2023644e91ab3d24f9aed69a5e1c78e2c81b9cea553fb \
+    --hash=sha256:8050a5d81c022561ee29cd2739de5b4445f3c72f39423fde80a63299c1892c52 \
+    --hash=sha256:83adda3db595cb1a7e2237029b3249c85afbe5c747d26b41b802e7482cb3933e \
+    --hash=sha256:849ea7845a55f09965826e816cdc7689d6cf74fe9223d79d758c714af955bcb6 \
+    --hash=sha256:84dd83110503bc10e94322bf3ffab8bc49150176b49b4984dc1cce4c0a993bf9 \
+    --hash=sha256:868943660fb2a1e6b6b965b74430c16a79320b665b28dd4511d15ad5038d37d5 \
+    --hash=sha256:8cc8204f0b75606869c707da331058ddf085de29558b516fc43c73ee5ee2aadb \
+    --hash=sha256:901e826cb2f1bdc1fcef3ef59adf0c451e8f7c0b5deb26c1a933fb66fb505eae \
+    --hash=sha256:90937664e776ad316d64251e2fa2ad69265e4443067668e4727074fe39676414 \
+    --hash=sha256:92d13292249f9f2a3e418cbc307a9fbbef043c65f4bd8ba1eb620bc2aaba3d15 \
+    --hash=sha256:962c2ec0dcaf22b76dee9831fdf0c4a33d4bf9a257a2bc5d4adc00d5c8ad9034 \
+    --hash=sha256:96a1c0ee30fb113b3ae3c748fd75ca74a157ff4c58476c47db4d61518962a011 \
+    --hash=sha256:998019ef74a4997a9d741b1473533cdb8faa31373afc9849b35129b4b8ec048d \
+    --hash=sha256:9a0fba3b8a587a54c18585f077dcab6dd251c170d85cfa4d063d5746cd595a0f \
+    --hash=sha256:9d034abdd36f0f0f2240f91492684e5043d46f290525d1117712d5b8137784eb \
+    --hash=sha256:9d3f9ed72e7458ded9a1fb1b4d4ed4c4fdbaf82030ce3f9274b4dc1bff7ace2b \
+    --hash=sha256:9ed3d26c4cb4f6babaf791aa46a029265850e80ec2a566581f5c2ee1a14df4f1 \
+    --hash=sha256:9f1d2942605c894162252d6259b0121bf1cb493071a1ea8cb35d79cb3e6ac5bc \
+    --hash=sha256:a2d1679df9f9cd9504f8dff24555c1eaabba8aad7f5914f28dab99e3c2552c9d \
+    --hash=sha256:b11ed82054fce82fb74cea33247d825d05ad6a4015ecfc02af5fbce442fbf361 \
+    --hash=sha256:b49a28e30d3eca86db3fe6f9b7f4152fcacbb4a467953cd1b42b94b479b77956 \
+    --hash=sha256:b5947b139dfa33f72eecc63f17e45230a97e741942955a6c9e650069305eb73d \
+    --hash=sha256:c28ed60597c149a9e3f5ad6dd9cebaee6fb2f0e3f2d159a4a2b9b862d4748860 \
+    --hash=sha256:c6dfbaeb7afa77ca608a50e2770a0461177b63a99520d4928e27591b142c74b1 \
+    --hash=sha256:c7f189bbfcded40e41a6969c1068ba305850ba016665be71a217918931416fbf \
+    --hash=sha256:ca041ad20291a65d853a9523744eebc3f5a4b2f7634e99f8fe88320695ddf766 \
+    --hash=sha256:cde6d76910d3179dae70f164466692f4ea36da124d6fb1a61399ca589e81d69a \
+    --hash=sha256:cf31f6f071a6b8e7aa1ead1fa27b935b48d00fbfa6a28ce856cfff2d5dd68eed \
+    --hash=sha256:d313a2998b74bb26e9e371851a173a9b9474764916f1fc7971095699b3c6e964 \
+    --hash=sha256:d5075c54edf1d6ad81d4c6523ce54a748ba1208b542e54b97d8a882ecd810fd1 \
+    --hash=sha256:d6546e8073dc382e60fcae4a001a5a1bc46da5eab4a4878acc2d12072d6166d5 \
+    --hash=sha256:deaa2899dff7f03ab667e2ec25842d233e2a6a9e333efa484dfe666403f3501c \
+    --hash=sha256:e2979d0f2959990620f7e62da6cd954e4620ee815539bc57a8ae46e2dacf90e3 \
+    --hash=sha256:e2bc525e335a8545c4e48f84dd0328bc46158c9aaeb8a1c2276546e94540ea3d \
+    --hash=sha256:e4c9f60f9fb0b5be66e416dcd8c9d94c3eabff3801d875bdb1f8ffc12cf86905 \
+    --hash=sha256:e70a1d62b8288677d48f3bea66c21586a5f999c64ecd3878edb7393e8d1b548d \
+    --hash=sha256:eca04dfd792cedad53dc9a917da1a522486255360cb4e77619343a20d9f35364 \
+    --hash=sha256:eee4bc767f348fba485ed9dc576ca58b0a9eac237f0e160f7a59bce628ed06b3 \
+    --hash=sha256:efe5fd254cfb0eeee13b8ef7ecb20f5d5a56ddda8a587f3852ab2cedfefdb5f6 \
+    --hash=sha256:f1c3ea52642c9714dc6e56de8a451a066f6d2707d273e07fe8a9cc1ba073813d \
+    --hash=sha256:f496286fc85e93ce0f71cc84fc1c42de2decf1bf494094e188e27a53694777a7 \
+    --hash=sha256:f506fd666dd1ecd15a832bebc66c4df45c1902fd47526292836c339f7ba665a9 \
+    --hash=sha256:f77202c80e8ab5a1d1e9faf642343bee5aaf332061e1ada4e9147dbd9eb00c46 \
+    --hash=sha256:fa18f949d3183a8d468367056be989666ac2bef3a72eece0bade9cdb733b3c28 \
+    --hash=sha256:fa45e489ef80f28ff0e5ba0a72812b8cfc7c1ef8b46a694723807d1b07c89ebb
+packaging==24.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
-paginate==0.5.7 ; python_version >= "3.10" and python_version < "4.0" \
+paginate==0.5.7 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945 \
     --hash=sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591
-parse-type==0.6.4 ; python_version >= "3.10" and python_version < "4.0" \
+parse-type==0.6.4 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5e1ec10440b000c3f818006033372939e693a9ec0176f446d9303e4db88489a6 \
     --hash=sha256:83d41144a82d6b8541127bf212dd76c7f01baff680b498ce8a4d052a7a5bce4c
-parse==1.20.2 ; python_version >= "3.10" and python_version < "4.0" \
+parse==1.20.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558 \
     --hash=sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce
-parso==0.8.4 ; python_version >= "3.10" and python_version < "4.0" \
+parso==0.8.4 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18 \
     --hash=sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d
-pathspec==0.12.1 ; python_version >= "3.10" and python_version < "4.0" \
+pathspec==0.12.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08 \
     --hash=sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712
-pexpect==4.9.0 ; python_version >= "3.10" and python_version < "4.0" and (sys_platform != "win32" and sys_platform != "emscripten") \
+pexpect==4.9.0 ; python_version >= "3.10" and python_version < "3.13" and (sys_platform != "win32" and sys_platform != "emscripten") \
     --hash=sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523 \
     --hash=sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f
-pillow==11.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+pillow==11.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:015c6e863faa4779251436db398ae75051469f7c903b043a48f078e437656f83 \
     --hash=sha256:0a2f91f8a8b367e7a57c6e91cd25af510168091fb89ec5146003e424e1558a96 \
     --hash=sha256:11633d58b6ee5733bde153a8dafd25e505ea3d32e261accd388827ee987baf65 \
@@ -1555,19 +1574,19 @@ pillow==11.1.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f7955ecf5609dee9442cbface754f2c6e541d9e6eda87fad7f7a989b0bdb9d71 \
     --hash=sha256:f86d3a7a9af5d826744fabf4afd15b9dfef44fe69a98541f666f66fbb8d3fef9 \
     --hash=sha256:fbd43429d0d7ed6533b25fc993861b8fd512c42d04514a0dd6337fb3ccf22761
-platformdirs==4.3.6 ; python_version >= "3.10" and python_version < "4.0" \
+platformdirs==4.3.6 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907 \
     --hash=sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb
-pluggy==1.5.0 ; python_version >= "3.10" and python_version < "4.0" \
+pluggy==1.5.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \
     --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
-proglog==0.1.10 ; python_version >= "3.10" and python_version < "4.0" \
+proglog==0.1.10 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:19d5da037e8c813da480b741e3fa71fb1ac0a5b02bf21c41577c7f327485ec50 \
     --hash=sha256:658c28c9c82e4caeb2f25f488fff9ceace22f8d69b15d0c1c86d64275e4ddab4
-prompt-toolkit==3.0.48 ; python_version >= "3.10" and python_version < "4.0" \
+prompt-toolkit==3.0.48 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90 \
     --hash=sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e
-propcache==0.2.1 ; python_version >= "3.10" and python_version < "4.0" \
+propcache==0.2.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:03ff9d3f665769b2a85e6157ac8b439644f2d7fd17615a82fa55739bc97863f4 \
     --hash=sha256:049324ee97bb67285b49632132db351b41e77833678432be52bdd0289c0e05e4 \
     --hash=sha256:081a430aa8d5e8876c6909b67bd2d937bfd531b0382d3fdedb82612c618bc41a \
@@ -1650,22 +1669,22 @@ propcache==0.2.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f508b0491767bb1f2b87fdfacaba5f7eddc2f867740ec69ece6d1946d29029a6 \
     --hash=sha256:f7a31fc1e1bd362874863fdeed71aed92d348f5336fd84f2197ba40c59f061bd \
     --hash=sha256:f9479aa06a793c5aeba49ce5c5692ffb51fcd9a7016e017d555d5e2b0045d212
-proto-plus==1.25.0 ; python_version >= "3.10" and python_version < "4.0" \
+proto-plus==1.25.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:c91fc4a65074ade8e458e95ef8bac34d4008daa7cce4a12d6707066fca648961 \
     --hash=sha256:fbb17f57f7bd05a68b7707e745e26528b0b3c34e378db91eef93912c54982d91
-protobuf==5.29.2 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:13d6d617a2a9e0e82a88113d7191a1baa1e42c2cc6f5f1398d3b054c8e7e714a \
-    --hash=sha256:2d2e674c58a06311c8e99e74be43e7f3a8d1e2b2fdf845eaa347fbd866f23355 \
-    --hash=sha256:36000f97ea1e76e8398a3f02936aac2a5d2b111aae9920ec1b769fc4a222c4d9 \
-    --hash=sha256:494229ecd8c9009dd71eda5fd57528395d1eacdf307dbece6c12ad0dd09e912e \
-    --hash=sha256:842de6d9241134a973aab719ab42b008a18a90f9f07f06ba480df268f86432f9 \
-    --hash=sha256:a0c53d78383c851bfa97eb42e3703aefdc96d2036a41482ffd55dc5f529466eb \
-    --hash=sha256:b2cc8e8bb7c9326996f0e160137b0861f1a82162502658df2951209d0cb0309e \
-    --hash=sha256:b6b0d416bbbb9d4fbf9d0561dbfc4e324fd522f61f7af0fe0f282ab67b22477e \
-    --hash=sha256:c12ba8249f5624300cf51c3d0bfe5be71a60c63e4dcf51ffe9a68771d958c851 \
-    --hash=sha256:e621a98c0201a7c8afe89d9646859859be97cb22b8bf1d8eacfd90d5bda2eb19 \
-    --hash=sha256:fde4554c0e578a5a0bcc9a276339594848d1e89f9ea47b4427c80e5d72f90181
-psutil==6.1.1 ; python_version >= "3.10" and python_version < "4.0" \
+protobuf==5.29.3 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:0a18ed4a24198528f2333802eb075e59dea9d679ab7a6c5efb017a59004d849f \
+    --hash=sha256:0eb32bfa5219fc8d4111803e9a690658aa2e6366384fd0851064b963b6d1f2a7 \
+    --hash=sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888 \
+    --hash=sha256:5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620 \
+    --hash=sha256:6ce8cc3389a20693bfde6c6562e03474c40851b44975c9b2bf6df7d8c4f864da \
+    --hash=sha256:84a57163a0ccef3f96e4b6a20516cedcf5bb3a95a657131c5c3ac62200d23252 \
+    --hash=sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a \
+    --hash=sha256:a8434404bbf139aa9e1300dbf989667a83d42ddda9153d8ab76e0d5dcaca484e \
+    --hash=sha256:b89c115d877892a512f79a8114564fb435943b59067615894c3b13cd3e1fa107 \
+    --hash=sha256:c027e08a08be10b67c06bf2370b99c811c466398c357e615ca88c91c07f0910f \
+    --hash=sha256:daaf63f70f25e8689c072cfad4334ca0ac1d1e05a92fc15c54eb9cf23c3efd84
+psutil==6.1.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:018aeae2af92d943fdf1da6b58665124897cfc94faa2ca92098838f83e1b1bca \
     --hash=sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377 \
     --hash=sha256:1924e659d6c19c647e763e78670a05dbb7feaf44a0e9c94bf9e14dfc6ba50468 \
@@ -1683,24 +1702,24 @@ psutil==6.1.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:eaa912e0b11848c4d9279a93d7e2783df352b082f40111e078388701fd479e53 \
     --hash=sha256:f35cfccb065fff93529d2afb4a2e89e363fe63ca1e4a5da22b603a85833c2649 \
     --hash=sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8
-ptyprocess==0.7.0 ; python_version >= "3.10" and python_version < "4.0" and (sys_platform != "win32" and sys_platform != "emscripten") \
+ptyprocess==0.7.0 ; python_version >= "3.10" and python_version < "3.13" and (sys_platform != "win32" and sys_platform != "emscripten") \
     --hash=sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35 \
     --hash=sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
-pure-eval==0.2.3 ; python_version >= "3.10" and python_version < "4.0" \
+pure-eval==0.2.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0 \
     --hash=sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42
-py-lib3mf==2.3.1 ; python_version >= "3.10" and python_version < "4.0" \
+py-lib3mf==2.3.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:86a870ef386debba9b74683d3a08125a34c153aaa65e967f61677cc5a0a65e24
-pyaml==25.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+pyaml==25.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:33a93ac49218f57e020b81e280d2706cea554ac5a76445ac79add760d019c709 \
     --hash=sha256:f7b40629d2dae88035657c860f539db3525ddd0120a11e0bcb44d47d5968b3bc
-pyasn1-modules==0.4.1 ; python_version >= "3.10" and python_version < "4.0" \
+pyasn1-modules==0.4.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd \
     --hash=sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c
-pyasn1==0.6.1 ; python_version >= "3.10" and python_version < "4.0" \
+pyasn1==0.6.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629 \
     --hash=sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034
-pycairo==1.27.0 ; python_version >= "3.10" and python_version < "4.0" \
+pycairo==1.27.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:01505c138a313df2469f812405963532fc2511fb9bca9bdc8e0ab94c55d1ced8 \
     --hash=sha256:03bf570e3919901572987bc69237b648fe0de242439980be3e606b396e3318c9 \
     --hash=sha256:1b1321652a6e27c4de3069709b1cae22aed2707fd8c5e889c04a95669228af2a \
@@ -1712,13 +1731,13 @@ pycairo==1.27.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:e20f431244634cf244ab6b4c3a2e540e65746eed1324573cf291981c3e65fc05 \
     --hash=sha256:e2239b9bb6c05edae5f3be97128e85147a155465e644f4d98ea0ceac7afc04ee \
     --hash=sha256:f9ca8430751f1fdcd3f072377560c9e15608b9a42d61375469db853566993c9b
-pycodestyle==2.12.1 ; python_version >= "3.10" and python_version < "4.0" \
+pycodestyle==2.12.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3 \
     --hash=sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521
-pycparser==2.22 ; python_version >= "3.10" and python_version < "4.0" and implementation_name == "pypy" \
+pycparser==2.22 ; python_version >= "3.10" and python_version < "3.13" and implementation_name == "pypy" \
     --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
-pydantic-core==2.27.2 ; python_version >= "3.10" and python_version < "4.0" \
+pydantic-core==2.27.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:00bad2484fa6bda1e216e7345a798bd37c68fb2d97558edd584942aa41b7d278 \
     --hash=sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50 \
     --hash=sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9 \
@@ -1819,49 +1838,49 @@ pydantic-core==2.27.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f6f8e111843bbb0dee4cb6594cdc73e79b3329b526037ec242a3e49012495b3b \
     --hash=sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9 \
     --hash=sha256:fd1aea04935a508f62e0d0ef1f5ae968774a32afc306fb8545e06f5ff5cdf3ad
-pydantic==2.10.4 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d \
-    --hash=sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06
-pyflakes==3.2.0 ; python_version >= "3.10" and python_version < "4.0" \
+pydantic==2.10.5 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff \
+    --hash=sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53
+pyflakes==3.2.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f \
     --hash=sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a
-pygments==2.19.1 ; python_version >= "3.10" and python_version < "4.0" \
+pygments==2.19.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f \
     --hash=sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c
-pyhamcrest==2.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+pyhamcrest==2.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:c6acbec0923d0cb7e72c22af1926f3e7c97b8e8d69fc7498eabacaf7c975bd9c \
     --hash=sha256:f6913d2f392e30e0375b3ecbd7aee79e5d1faa25d345c8f4ff597665dcac2587
-pymdown-extensions==10.14 ; python_version >= "3.10" and python_version < "4.0" \
+pymdown-extensions==10.14 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:202481f716cc8250e4be8fce997781ebf7917701b59652458ee47f2401f818b5 \
     --hash=sha256:741bd7c4ff961ba40b7528d32284c53bc436b8b1645e8e37c3e57770b8700a34
-pyparsing==3.2.1 ; python_version >= "3.10" and python_version < "4.0" \
+pyparsing==3.2.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1 \
     --hash=sha256:61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a
-pyreadline3==3.5.4 ; sys_platform == "win32" and python_version >= "3.10" and python_version < "4.0" \
+pyreadline3==3.5.4 ; sys_platform == "win32" and python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7 \
     --hash=sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6
-pytest-cov==6.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+pytest-cov==6.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35 \
     --hash=sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0
-pytest-durations==1.3.1 ; python_version >= "3.10" and python_version < "4.0" \
+pytest-durations==1.3.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:3d1e60d5955174f3d98975296ca6370f7f03a5424b1d4356097f5da85c0df302 \
     --hash=sha256:80f078dd96520cc7e2bb766d1cb6370781141dd8d3a2add2cb50d90b7f920dcd
-pytest-html==4.1.1 ; python_version >= "3.10" and python_version < "4.0" \
+pytest-html==4.1.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:70a01e8ae5800f4a074b56a4cb1025c8f4f9b038bba5fe31e3c98eb996686f07 \
     --hash=sha256:c8152cea03bd4e9bee6d525573b67bbc6622967b72b9628dda0ea3e2a0b5dd71
-pytest-metadata==3.1.1 ; python_version >= "3.10" and python_version < "4.0" \
+pytest-metadata==3.1.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b \
     --hash=sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8
-pytest-xdist==3.6.1 ; python_version >= "3.10" and python_version < "4.0" \
+pytest-xdist==3.6.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7 \
     --hash=sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d
-pytest==8.3.4 ; python_version >= "3.10" and python_version < "4.0" \
+pytest==8.3.4 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6 \
     --hash=sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761
-python-dateutil==2.9.0.post0 ; python_version >= "3.10" and python_version < "4.0" \
+python-dateutil==2.9.0.post0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
-pywin32==308 ; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.10" and python_version < "4.0" \
+pywin32==308 ; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:00b3e11ef09ede56c6a43c71f2d31857cf7c54b0ab6e78ac659497abd2834f47 \
     --hash=sha256:100a5442b7332070983c4cd03f2e906a5648a5104b8a7f50175f7906efd16bb6 \
     --hash=sha256:13dcb914ed4347019fbec6697a01a0aec61019c1046c2b905410d197856326a6 \
@@ -1880,10 +1899,10 @@ pywin32==308 ; sys_platform == "win32" and platform_python_implementation != "Py
     --hash=sha256:a5ab5381813b40f264fa3495b98af850098f814a25a63589a8e9eb12560f450c \
     --hash=sha256:ef313c46d4c18dfb82a2431e3051ac8f112ccee1a34f29c263c583c568db63cd \
     --hash=sha256:fd380990e792eaf6827fcb7e187b2b4b1cede0585e3d0c9e84201ec27b9905e4
-pyyaml-env-tag==0.1 ; python_version >= "3.10" and python_version < "4.0" \
+pyyaml-env-tag==0.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb \
     --hash=sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069
-pyyaml==6.0.2 ; python_version >= "3.10" and python_version < "4.0" \
+pyyaml==6.0.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
     --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
     --hash=sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086 \
@@ -1937,7 +1956,7 @@ pyyaml==6.0.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
-pyzmq==26.2.0 ; python_version >= "3.10" and python_version < "4.0" \
+pyzmq==26.2.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:007137c9ac9ad5ea21e6ad97d3489af654381324d5d3ba614c323f60dab8fae6 \
     --hash=sha256:034da5fc55d9f8da09015d368f519478a52675e558c989bfcb5cf6d4e16a7d2a \
     --hash=sha256:05590cdbc6b902101d0e65d6a4780af14dc22914cc6ab995d99b85af45362cc9 \
@@ -2047,10 +2066,10 @@ pyzmq==26.2.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:eac5174677da084abf378739dbf4ad245661635f1600edd1221f150b165343f4 \
     --hash=sha256:fc4f7a173a5609631bb0c42c23d12c49df3966f89f496a51d3eb0ec81f4519d6 \
     --hash=sha256:fdb5b3e311d4d4b0eb8b3e8b4d1b0a512713ad7e6a68791d0923d1aec433d919
-readthedocs-sphinx-search==0.3.2 ; python_version >= "3.10" and python_version < "4.0" \
+readthedocs-sphinx-search==0.3.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:277773bfa28566a86694c08e568d5a648cd80f22826545555a764d6d20c365fb \
     --hash=sha256:58716fd21f01581e6e67bf3bc02e79c77e10dc58b5f8e4c7cc1977e013eda173
-regex==2024.11.6 ; python_version >= "3.10" and python_version < "4.0" \
+regex==2024.11.6 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:02a02d2bb04fec86ad61f3ea7f49c015a0681bf76abb9857f945d26159d2968c \
     --hash=sha256:02e28184be537f0e75c1f9b2f8847dc51e08e6e171c6bde130b2687e0c33cf60 \
     --hash=sha256:040df6fe1a5504eb0f04f048e6d09cd7c7110fef851d7c567a6b6e09942feb7d \
@@ -2145,23 +2164,23 @@ regex==2024.11.6 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:fdabbfc59f2c6edba2a6622c647b716e34e8e3867e0ab975412c5c2f79b82da2 \
     --hash=sha256:fdd6028445d2460f33136c55eeb1f601ab06d74cb3347132e1c24250187500d9 \
     --hash=sha256:ff590880083d60acc0433f9c3f713c51f7ac6ebb9adf889c79a261ecf541aa91
-renderlab==0.1.20230421184216 ; python_version >= "3.10" and python_version < "4.0" \
+renderlab==0.1.20230421184216 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:8a5880b75dd026a534eee47c17b18cd82f0cab6c04355f705f93f7e124bd2028
-reportlab==4.2.5 ; python_version >= "3.10" and python_version < "4" \
+reportlab==4.2.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5cf35b8fd609b68080ac7bbb0ae1e376104f7d5f7b2d3914c7adc63f2593941f \
     --hash=sha256:eb2745525a982d9880babb991619e97ac3f661fae30571b7d50387026ca765ee
-requests==2.32.3 ; python_version >= "3.10" and python_version < "4.0" \
+requests==2.32.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
-rich-click==1.8.5 ; python_version >= "3.10" and python_version < "4.0" \
+rich-click==1.8.5 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:0fab7bb5b66c15da17c210b4104277cd45f3653a7322e0098820a169880baee0 \
     --hash=sha256:a3eebe81da1c9da3c32f3810017c79bd687ff1b3fa35bfc9d8a3338797f1d1a1
-rich==13.9.4 ; python_version >= "3.10" and python_version < "4.0" \
+rich==13.9.4 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098 \
     --hash=sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90
-rlpycairo==0.3.0 ; python_version >= "3.10" and python_version < "4.0" \
+rlpycairo==0.3.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:f6ec712a76914f78c1491351e1d79eeb1a40d072accf5d36075e399963c17b17
-rsa==4.9 ; python_version >= "3.10" and python_version < "4" \
+rsa==4.9 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7 \
     --hash=sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21
 ruamel-yaml-clib==0.2.12 ; platform_python_implementation == "CPython" and python_version < "3.13" and python_version >= "3.10" \
@@ -2211,134 +2230,134 @@ ruamel-yaml-clib==0.2.12 ; platform_python_implementation == "CPython" and pytho
     --hash=sha256:f66efbc1caa63c088dead1c4170d148eabc9b80d95fb75b6c92ac0aad2437d76 \
     --hash=sha256:fc4b630cd3fa2cf7fce38afa91d7cfe844a9f75d7f0f36393fa98815e911d987 \
     --hash=sha256:fd5415dded15c3822597455bc02bcd66e81ef8b7a48cb71a33628fc9fdde39df
-ruamel-yaml==0.18.10 ; python_version >= "3.10" and python_version < "4.0" \
+ruamel-yaml==0.18.10 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58 \
     --hash=sha256:30f22513ab2301b3d2b577adc121c6471f28734d3d9728581245f1e76468b4f1
-scipy==1.15.0 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:0e5b34f8894f9904cc578008d1a9467829c1817e9f9cb45e6d6eeb61d2ab7731 \
-    --hash=sha256:0fcb16eb04d84670722ce8d93b05257df471704c913cb0ff9dc5a1c31d1e9422 \
-    --hash=sha256:129f899ed275c0515d553b8d31696924e2ca87d1972421e46c376b9eb87de3d2 \
-    --hash=sha256:161f80a98047c219c257bf5ce1777c574bde36b9d962a46b20d0d7e531f86863 \
-    --hash=sha256:1b29e4fc02e155a5fd1165f1e6a73edfdd110470736b0f48bcbe48083f0eee37 \
-    --hash=sha256:1e2448acd79c6374583581a1ded32ac71a00c2b9c62dfa87a40e1dd2520be111 \
-    --hash=sha256:2240e1fd0782e62e1aacdc7234212ee271d810f67e9cd3b8d521003a82603ef8 \
-    --hash=sha256:300742e2cc94e36a2880ebe464a1c8b4352a7b0f3e36ec3d2ac006cdbe0219ac \
-    --hash=sha256:327163ad73e54541a675240708244644294cb0a65cca420c9c79baeb9648e479 \
-    --hash=sha256:351899dd2a801edd3691622172bc8ea01064b1cada794f8641b89a7dc5418db6 \
-    --hash=sha256:35c68f7044b4e7ad73a3e68e513dda946989e523df9b062bd3cf401a1a882192 \
-    --hash=sha256:36be480e512d38db67f377add5b759fb117edd987f4791cdf58e59b26962bee4 \
-    --hash=sha256:37ce9394cdcd7c5f437583fc6ef91bd290014993900643fdfc7af9b052d1613b \
-    --hash=sha256:46e91b5b16909ff79224b56e19cbad65ca500b3afda69225820aa3afbf9ec020 \
-    --hash=sha256:4e08c6a36f46abaedf765dd2dfcd3698fa4bd7e311a9abb2d80e33d9b2d72c34 \
-    --hash=sha256:52475011be29dfcbecc3dfe3060e471ac5155d72e9233e8d5616b84e2b542054 \
-    --hash=sha256:5972e3f96f7dda4fd3bb85906a17338e65eaddfe47f750e240f22b331c08858e \
-    --hash=sha256:5abbdc6ede5c5fed7910cf406a948e2c0869231c0db091593a6b2fa78be77e5d \
-    --hash=sha256:5beb0a2200372b7416ec73fdae94fe81a6e85e44eb49c35a11ac356d2b8eccc6 \
-    --hash=sha256:61513b989ee8d5218fbeb178b2d51534ecaddba050db949ae99eeb3d12f6825d \
-    --hash=sha256:6d26f17c64abd6c6c2dfb39920f61518cc9e213d034b45b2380e32ba78fde4c0 \
-    --hash=sha256:6f376d7c767731477bac25a85d0118efdc94a572c6b60decb1ee48bf2391a73b \
-    --hash=sha256:767e8cf6562931f8312f4faa7ddea412cb783d8df49e62c44d00d89f41f9bbe8 \
-    --hash=sha256:82bff2eb01ccf7cea8b6ee5274c2dbeadfdac97919da308ee6d8e5bcbe846443 \
-    --hash=sha256:952d2e9eaa787f0a9e95b6e85da3654791b57a156c3e6609e65cc5176ccfe6f2 \
-    --hash=sha256:9c8254fe21dd2c6c8f7757035ec0c31daecf3bb3cffd93bc1ca661b731d28136 \
-    --hash=sha256:aeac60d3562a7bf2f35549bdfdb6b1751c50590f55ce7322b4b2fc821dc27fca \
-    --hash=sha256:b1432102254b6dc7766d081fa92df87832ac25ff0b3d3a940f37276e63eb74ff \
-    --hash=sha256:bdca4c7bb8dc41307e5f39e9e5d19c707d8e20a29845e7533b3bb20a9d4ccba0 \
-    --hash=sha256:c9624eeae79b18cab1a31944b5ef87aa14b125d6ab69b71db22f0dbd962caf1e \
-    --hash=sha256:ccb6248a9987193fe74363a2d73b93bc2c546e0728bd786050b7aef6e17db03c \
-    --hash=sha256:cd9d9198a7fd9a77f0eb5105ea9734df26f41faeb2a88a0e62e5245506f7b6df \
-    --hash=sha256:d13bbc0658c11f3d19df4138336e4bce2c4fbd78c2755be4bf7b8e235481557f \
-    --hash=sha256:d35aef233b098e4de88b1eac29f0df378278e7e250a915766786b773309137c4 \
-    --hash=sha256:de112c2dae53107cfeaf65101419662ac0a54e9a088c17958b51c95dac5de56d \
-    --hash=sha256:e9baff912ea4f78a543d183ed6f5b3bea9784509b948227daaf6f10727a0e2e5 \
-    --hash=sha256:eb1533c59f0ec6c55871206f15a5c72d1fae7ad3c0a8ca33ca88f7c309bbbf8c \
-    --hash=sha256:ec915cd26d76f6fc7ae8522f74f5b2accf39546f341c771bb2297f3871934a52 \
-    --hash=sha256:fde0f3104dfa1dfbc1f230f65506532d0558d43188789eaf68f97e106249a913 \
-    --hash=sha256:fe00169cf875bed0b3c40e4da45b57037dc21d7c7bf0c85ed75f210c281488f1
-setuptools==75.7.0 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:84fb203f278ebcf5cd08f97d3fb96d3fbed4b629d500b29ad60d11e00769b183 \
-    --hash=sha256:886ff7b16cd342f1d1defc16fc98c9ce3fde69e087a4e1983d7ab634e5f41f4f
-simple-websocket==1.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+scipy==1.15.1 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:033a75ddad1463970c96a88063a1df87ccfddd526437136b6ee81ff0312ebdf6 \
+    --hash=sha256:0458839c9f873062db69a03de9a9765ae2e694352c76a16be44f93ea45c28d2b \
+    --hash=sha256:070d10654f0cb6abd295bc96c12656f948e623ec5f9a4eab0ddb1466c000716e \
+    --hash=sha256:09c52320c42d7f5c7748b69e9f0389266fd4f82cf34c38485c14ee976cb8cb04 \
+    --hash=sha256:0ac102ce99934b162914b1e4a6b94ca7da0f4058b6d6fd65b0cef330c0f3346f \
+    --hash=sha256:0fb57b30f0017d4afa5fe5f5b150b8f807618819287c21cbe51130de7ccdaed2 \
+    --hash=sha256:100193bb72fbff37dbd0bf14322314fc7cbe08b7ff3137f11a34d06dc0ee6b85 \
+    --hash=sha256:14eaa373c89eaf553be73c3affb11ec6c37493b7eaaf31cf9ac5dffae700c2e0 \
+    --hash=sha256:2114a08daec64980e4b4cbdf5bee90935af66d750146b1d2feb0d3ac30613692 \
+    --hash=sha256:21e10b1dd56ce92fba3e786007322542361984f8463c6d37f6f25935a5a6ef52 \
+    --hash=sha256:2722a021a7929d21168830790202a75dbb20b468a8133c74a2c0230c72626b6c \
+    --hash=sha256:395be70220d1189756068b3173853029a013d8c8dd5fd3d1361d505b2aa58fa7 \
+    --hash=sha256:3fe1d95944f9cf6ba77aa28b82dd6bb2a5b52f2026beb39ecf05304b8392864b \
+    --hash=sha256:491d57fe89927fa1aafbe260f4cfa5ffa20ab9f1435025045a5315006a91b8f5 \
+    --hash=sha256:4b17d4220df99bacb63065c76b0d1126d82bbf00167d1730019d2a30d6ae01ea \
+    --hash=sha256:4c9d8fc81d6a3b6844235e6fd175ee1d4c060163905a2becce8e74cb0d7554ce \
+    --hash=sha256:55cc79ce4085c702ac31e49b1e69b27ef41111f22beafb9b49fea67142b696c4 \
+    --hash=sha256:5b190b935e7db569960b48840e5bef71dc513314cc4e79a1b7d14664f57fd4ff \
+    --hash=sha256:5bd8d27d44e2c13d0c1124e6a556454f52cd3f704742985f6b09e75e163d20d2 \
+    --hash=sha256:5dff14e75cdbcf07cdaa1c7707db6017d130f0af9ac41f6ce443a93318d6c6e0 \
+    --hash=sha256:5eb0ca35d4b08e95da99a9f9c400dc9f6c21c424298a0ba876fdc69c7afacedf \
+    --hash=sha256:63b9b6cd0333d0eb1a49de6f834e8aeaefe438df8f6372352084535ad095219e \
+    --hash=sha256:667f950bf8b7c3a23b4199db24cb9bf7512e27e86d0e3813f015b74ec2c6e3df \
+    --hash=sha256:6b3e71893c6687fc5e29208d518900c24ea372a862854c9888368c0b267387ab \
+    --hash=sha256:71ba9a76c2390eca6e359be81a3e879614af3a71dfdabb96d1d7ab33da6f2364 \
+    --hash=sha256:74bb864ff7640dea310a1377d8567dc2cb7599c26a79ca852fc184cc851954ac \
+    --hash=sha256:82add84e8a9fb12af5c2c1a3a3f1cb51849d27a580cb9e6bd66226195142be6e \
+    --hash=sha256:837299eec3d19b7e042923448d17d95a86e43941104d33f00da7e31a0f715d3c \
+    --hash=sha256:900f3fa3db87257510f011c292a5779eb627043dd89731b9c461cd16ef76ab3d \
+    --hash=sha256:9f151e9fb60fbf8e52426132f473221a49362091ce7a5e72f8aa41f8e0da4f25 \
+    --hash=sha256:af0b61c1de46d0565b4b39c6417373304c1d4f5220004058bdad3061c9fa8a95 \
+    --hash=sha256:bc7136626261ac1ed988dca56cfc4ab5180f75e0ee52e58f1e6aa74b5f3eacd5 \
+    --hash=sha256:be3deeb32844c27599347faa077b359584ba96664c5c79d71a354b80a0ad0ce0 \
+    --hash=sha256:c09aa9d90f3500ea4c9b393ee96f96b0ccb27f2f350d09a47f533293c78ea776 \
+    --hash=sha256:c352c1b6d7cac452534517e022f8f7b8d139cd9f27e6fbd9f3cbd0bfd39f5bef \
+    --hash=sha256:c64ded12dcab08afff9e805a67ff4480f5e69993310e093434b10e85dc9d43e1 \
+    --hash=sha256:cdde8414154054763b42b74fe8ce89d7f3d17a7ac5dd77204f0e142cdc9239e9 \
+    --hash=sha256:ce3a000cd28b4430426db2ca44d96636f701ed12e2b3ca1f2b1dd7abdd84b39a \
+    --hash=sha256:f735bc41bd1c792c96bc426dece66c8723283695f02df61dcc4d0a707a42fc54 \
+    --hash=sha256:f82fcf4e5b377f819542fbc8541f7b5fbcf1c0017d0df0bc22c781bf60abc4d8
+setuptools==75.8.0 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6 \
+    --hash=sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3
+simple-websocket==1.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c \
     --hash=sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4
-six==1.17.0 ; python_version >= "3.10" and python_version < "4.0" \
+six==1.17.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-smmap==5.0.2 ; python_version >= "3.10" and python_version < "4.0" \
+smmap==5.0.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5 \
     --hash=sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
-sniffio==1.3.1 ; python_version >= "3.10" and python_version < "4.0" \
+sniffio==1.3.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
     --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
-snowballstemmer==2.2.0 ; python_version >= "3.10" and python_version < "4.0" \
+snowballstemmer==2.2.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
-sphinx-autobuild==2024.10.3 ; python_version >= "3.10" and python_version < "4.0" \
+sphinx-autobuild==2024.10.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:158e16c36f9d633e613c9aaf81c19b0fc458ca78b112533b20dafcda430d60fa \
     --hash=sha256:248150f8f333e825107b6d4b86113ab28fa51750e5f9ae63b59dc339be951fb1
-sphinx-autodoc-typehints==1.12.0 ; python_version >= "3.10" and python_version < "4.0" \
+sphinx-autodoc-typehints==1.12.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:193617d9dbe0847281b1399d369e74e34cd959c82e02c7efde077fca908a9f52 \
     --hash=sha256:5e81776ec422dd168d688ab60f034fccfafbcd94329e9537712c93003bddc04a
-sphinx-copybutton==0.5.2 ; python_version >= "3.10" and python_version < "4.0" \
+sphinx-copybutton==0.5.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd \
     --hash=sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e
-sphinx-design==0.6.1 ; python_version >= "3.10" and python_version < "4.0" \
+sphinx-design==0.6.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:b11f37db1a802a183d61b159d9a202314d4d2fe29c163437001324fe2f19549c \
     --hash=sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632
-sphinx-hoverxref==1.4.2 ; python_version >= "3.10" and python_version < "4.0" \
+sphinx-hoverxref==1.4.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4fc2e283e908d9df61ea9196589934944a7e2e6e3cb753a420b938cd6d14e220 \
     --hash=sha256:74fab961b1b8c0e9c2cf22fa195c0e783d635e78686d39dd06ff157c196ca0c9
-sphinx-rtd-theme==3.0.2 ; python_version >= "3.10" and python_version < "4.0" \
+sphinx-rtd-theme==3.0.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:422ccc750c3a3a311de4ae327e82affdaf59eb695ba4936538552f3b00f4ee13 \
     --hash=sha256:b7457bc25dda723b20b086a670b9953c859eab60a2a03ee8eb2bb23e176e5f85
-sphinx==8.1.3 ; python_version >= "3.10" and python_version < "4.0" \
+sphinx==8.1.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2 \
     --hash=sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927
-sphinxcontrib-applehelp==2.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+sphinxcontrib-applehelp==2.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1 \
     --hash=sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5
-sphinxcontrib-devhelp==2.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+sphinxcontrib-devhelp==2.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad \
     --hash=sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2
-sphinxcontrib-htmlhelp==2.1.0 ; python_version >= "3.10" and python_version < "4.0" \
+sphinxcontrib-htmlhelp==2.1.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8 \
     --hash=sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9
-sphinxcontrib-jquery==4.1 ; python_version >= "3.10" and python_version < "4.0" \
+sphinxcontrib-jquery==4.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a \
     --hash=sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae
-sphinxcontrib-jsmath==1.0.1 ; python_version >= "3.10" and python_version < "4.0" \
+sphinxcontrib-jsmath==1.0.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178 \
     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8
-sphinxcontrib-qthelp==2.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+sphinxcontrib-qthelp==2.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab \
     --hash=sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb
-sphinxcontrib-serializinghtml==2.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+sphinxcontrib-serializinghtml==2.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331 \
     --hash=sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d
-stack-data==0.6.3 ; python_version >= "3.10" and python_version < "4.0" \
+stack-data==0.6.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
-starlette==0.45.2 ; python_version >= "3.10" and python_version < "4.0" \
+starlette==0.45.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4daec3356fb0cb1e723a5235e5beaf375d2259af27532958e2d79df549dad9da \
     --hash=sha256:bba1831d15ae5212b22feab2f218bab6ed3cd0fc2dc1d4442443bb1ee52260e0
-strip-ansi==0.1.1 ; python_version >= "3.10" and python_version < "4.0" \
+strip-ansi==0.1.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:5d60f239cc8a37fdd52b43c3e66e893d45ba0423115db59eca0d2eef83b07729 \
     --hash=sha256:9f55280e1b0ba84dac49d4f18aa6b51b90ff766b22e4918ffc01cc87b394ecd1
-svgelements==1.9.6 ; python_version >= "3.10" and python_version < "4.0" \
+svgelements==1.9.6 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:7c02ad6404cd3d1771fd50e40fbfc0550b0893933466f86a6eb815f3ba3f37f7 \
     --hash=sha256:8a5cf2cc066d98e713d5b875b1d6e5eeb9b92e855e835ebd7caab2713ae1dcad
-svglib==1.5.1 ; python_version >= "3.10" and python_version < "4.0" \
+svglib==1.5.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:3ae765d3a9409ee60c0fb4d24c2deb6a80617aa927054f5bcd7fc98f0695e587
-svgpathtools==1.6.1 ; python_version >= "3.10" and python_version < "4.0" \
+svgpathtools==1.6.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:39967f9a817b8a12cc6dd1646fc162d522fca6c3fd5f8c94913c15ee4cb3a906 \
     --hash=sha256:7054e6de1953e295bf565d535d585695453b09f8db4a2f7c4853348732097a3e
-svgwrite==1.4.3 ; python_version >= "3.10" and python_version < "4.0" \
+svgwrite==1.4.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:a8fbdfd4443302a6619a7f76bc937fc683daf2628d9b737c891ec08b8ce524c3 \
     --hash=sha256:bb6b2b5450f1edbfa597d924f9ac2dd099e625562e492021d7dd614f65f8a22d
-tinycss2==1.4.0 ; python_version >= "3.10" and python_version < "4.0" \
+tinycss2==1.4.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7 \
     --hash=sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289
-toml==0.10.2 ; python_version >= "3.10" and python_version < "4.0" \
+toml==0.10.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
 tomli==2.2.1 ; python_version >= "3.10" and python_full_version <= "3.11.0a6" \
@@ -2374,10 +2393,10 @@ tomli==2.2.1 ; python_version >= "3.10" and python_full_version <= "3.11.0a6" \
     --hash=sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272 \
     --hash=sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a \
     --hash=sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7
-tomlkit==0.13.2 ; python_version >= "3.10" and python_version < "4.0" \
+tomlkit==0.13.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde \
     --hash=sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79
-tornado==6.4.2 ; python_version >= "3.10" and python_version < "4.0" \
+tornado==6.4.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:072ce12ada169c5b00b7d92a99ba089447ccc993ea2143c9ede887e0937aa803 \
     --hash=sha256:1a017d239bd1bb0919f72af256a970624241f070496635784d9bf0db640d3fec \
     --hash=sha256:2876cef82e6c5978fde1e0d5b1f919d756968d5b4282418f3146b79b58556482 \
@@ -2389,34 +2408,34 @@ tornado==6.4.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:c36e62ce8f63409301537222faffcef7dfc5284f27eec227389f2ad11b09d946 \
     --hash=sha256:c82c46813ba483a385ab2a99caeaedf92585a1f90defb5693351fa7e4ea0bf73 \
     --hash=sha256:e828cce1123e9e44ae2a50a9de3055497ab1d0aeb440c5ac23064d9e44880da1
-tqdm==4.67.1 ; python_version >= "3.10" and python_version < "4.0" \
+tqdm==4.67.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \
     --hash=sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2
-traitlets==5.14.3 ; python_version >= "3.10" and python_version < "4.0" \
+traitlets==5.14.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7 \
     --hash=sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f
-trianglesolver==1.2 ; python_version >= "3.10" and python_version < "4.0" \
+trianglesolver==1.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4af18aade579d5c0d64389b3e65aeaf06cff26319762ccd859e3268559a76aea \
     --hash=sha256:aa0903c3708b4e2b496f06d490cae72c6ff6274b00d1edce420fcfa3b2b76682
-typing-extensions==4.12.2 ; python_version >= "3.10" and python_version < "4.0" \
+typing-extensions==4.12.2 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
-uritemplate==4.1.1 ; python_version >= "3.10" and python_version < "4.0" \
+uritemplate==4.1.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
     --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e
-urllib3==2.3.0 ; python_version >= "3.10" and python_version < "4.0" \
+urllib3==2.3.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
     --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
-uvicorn==0.34.0 ; python_version >= "3.10" and python_version < "4.0" \
+uvicorn==0.34.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4 \
     --hash=sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9
-virtualenv==20.28.1 ; python_version >= "3.10" and python_version < "4.0" \
+virtualenv==20.28.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb \
     --hash=sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329
-vyper-config==1.2.1 ; python_version >= "3.10" and python_version < "4.0" \
+vyper-config==1.2.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:a9907a5707602e7c289f964498a0d5d6e477e8005a9e3797bdab90771ec421c1 \
     --hash=sha256:d7e6ecaf363539caab4e3cb85d55a98df00a42547965b2703d1989302d30ec57
-watchdog==6.0.0 ; python_version >= "3.10" and python_version < "4.0" \
+watchdog==6.0.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a \
     --hash=sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2 \
     --hash=sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f \
@@ -2447,88 +2466,88 @@ watchdog==6.0.0 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8 \
     --hash=sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c \
     --hash=sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2
-watchfiles==1.0.3 ; python_version >= "3.10" and python_version < "4.0" \
-    --hash=sha256:0179252846be03fa97d4d5f8233d1c620ef004855f0717712ae1c558f1974a16 \
-    --hash=sha256:06ce08549e49ba69ccc36fc5659a3d0ff4e3a07d542b895b8a9013fcab46c2dc \
-    --hash=sha256:0b90651b4cf9e158d01faa0833b073e2e37719264bcee3eac49fc3c74e7d304b \
-    --hash=sha256:0d1ec043f02ca04bf21b1b32cab155ce90c651aaf5540db8eb8ad7f7e645cba8 \
-    --hash=sha256:0fe4e740ea94978b2b2ab308cbf9270a246bcbb44401f77cc8740348cbaeac3d \
-    --hash=sha256:127de3883bdb29dbd3b21f63126bb8fa6e773b74eaef46521025a9ce390e1073 \
-    --hash=sha256:1550be1a5cb3be08a3fb84636eaafa9b7119b70c71b0bed48726fd1d5aa9b868 \
-    --hash=sha256:160eff7d1267d7b025e983ca8460e8cc67b328284967cbe29c05f3c3163711a3 \
-    --hash=sha256:16db2d7e12f94818cbf16d4c8938e4d8aaecee23826344addfaaa671a1527b07 \
-    --hash=sha256:1c6cf7709ed3e55704cc06f6e835bf43c03bc8e3cb8ff946bf69a2e0a78d9d77 \
-    --hash=sha256:1da46bb1eefb5a37a8fb6fd52ad5d14822d67c498d99bda8754222396164ae42 \
-    --hash=sha256:1df924ba82ae9e77340101c28d56cbaff2c991bd6fe8444a545d24075abb0a87 \
-    --hash=sha256:1e263cc718545b7f897baeac1f00299ab6fabe3e18caaacacb0edf6d5f35513c \
-    --hash=sha256:228e2247de583475d4cebf6b9af5dc9918abb99d1ef5ee737155bb39fb33f3c0 \
-    --hash=sha256:275c1b0e942d335fccb6014d79267d1b9fa45b5ac0639c297f1e856f2f532552 \
-    --hash=sha256:29b9cb35b7f290db1c31fb2fdf8fc6d3730cfa4bca4b49761083307f441cac5a \
-    --hash=sha256:2b4691234d31686dca133c920f94e478b548a8e7c750f28dbbc2e4333e0d3da9 \
-    --hash=sha256:2b961b86cd3973f5822826017cad7f5a75795168cb645c3a6b30c349094e02e3 \
-    --hash=sha256:2dcc3f60c445f8ce14156854a072ceb36b83807ed803d37fdea2a50e898635d6 \
-    --hash=sha256:2f492d2907263d6d0d52f897a68647195bc093dafed14508a8d6817973586b6b \
-    --hash=sha256:310505ad305e30cb6c5f55945858cdbe0eb297fc57378f29bacceb534ac34199 \
-    --hash=sha256:34e87c7b3464d02af87f1059fedda5484e43b153ef519e4085fe1a03dd94801e \
-    --hash=sha256:418c5ce332f74939ff60691e5293e27c206c8164ce2b8ce0d9abf013003fb7fe \
-    --hash=sha256:46e86ed457c3486080a72bc837300dd200e18d08183f12b6ca63475ab64ed651 \
-    --hash=sha256:48681c86f2cb08348631fed788a116c89c787fdf1e6381c5febafd782f6c3b44 \
-    --hash=sha256:489b80812f52a8d8c7b0d10f0d956db0efed25df2821c7a934f6143f76938bd6 \
-    --hash=sha256:48c9f3bc90c556a854f4cab6a79c16974099ccfa3e3e150673d82d47a4bc92c9 \
-    --hash=sha256:49bc1bc26abf4f32e132652f4b3bfeec77d8f8f62f57652703ef127e85a3e38d \
-    --hash=sha256:52bb50a4c4ca2a689fdba84ba8ecc6a4e6210f03b6af93181bb61c4ec3abaf86 \
-    --hash=sha256:5691340f259b8f76b45fb31b98e594d46c36d1dc8285efa7975f7f50230c9093 \
-    --hash=sha256:62691f1c0894b001c7cde1195c03b7801aaa794a837bd6eef24da87d1542838d \
-    --hash=sha256:632a52dcaee44792d0965c17bdfe5dc0edad5b86d6a29e53d6ad4bf92dc0ff49 \
-    --hash=sha256:65ab1fb635476f6170b07e8e21db0424de94877e4b76b7feabfe11f9a5fc12b5 \
-    --hash=sha256:6a5bc3ca468bb58a2ef50441f953e1f77b9a61bd1b8c347c8223403dc9b4ac9a \
-    --hash=sha256:6a76494d2c5311584f22416c5a87c1e2cb954ff9b5f0988027bc4ef2a8a67181 \
-    --hash=sha256:6f8dc09ae69af50bead60783180f656ad96bd33ffbf6e7a6fce900f6d53b08f1 \
-    --hash=sha256:703aa5e50e465be901e0e0f9d5739add15e696d8c26c53bc6fc00eb65d7b9469 \
-    --hash=sha256:713f67132346bdcb4c12df185c30cf04bdf4bf6ea3acbc3ace0912cab6b7cb8c \
-    --hash=sha256:75d3bcfa90454dba8df12adc86b13b6d85fda97d90e708efc036c2760cc6ba44 \
-    --hash=sha256:7ca05cacf2e5c4a97d02a2878a24020daca21dbb8823b023b978210a75c79098 \
-    --hash=sha256:80bf4b459d94a0387617a1b499f314aa04d8a64b7a0747d15d425b8c8b151da0 \
-    --hash=sha256:84fac88278f42d61c519a6c75fb5296fd56710b05bbdcc74bdf85db409a03780 \
-    --hash=sha256:889a37e2acf43c377b5124166bece139b4c731b61492ab22e64d371cce0e6e80 \
-    --hash=sha256:8af4b582d5fc1b8465d1d2483e5e7b880cc1a4e99f6ff65c23d64d070867ac58 \
-    --hash=sha256:90b0fe1fcea9bd6e3084b44875e179b4adcc4057a3b81402658d0eb58c98edf8 \
-    --hash=sha256:93436ed550e429da007fbafb723e0769f25bae178fbb287a94cb4ccdf42d3af3 \
-    --hash=sha256:995c374e86fa82126c03c5b4630c4e312327ecfe27761accb25b5e1d7ab50ec8 \
-    --hash=sha256:9af037d3df7188ae21dc1c7624501f2f90d81be6550904e07869d8d0e6766655 \
-    --hash=sha256:9e080cf917b35b20c889225a13f290f2716748362f6071b859b60b8847a6aa43 \
-    --hash=sha256:a2ec98e31e1844eac860e70d9247db9d75440fc8f5f679c37d01914568d18721 \
-    --hash=sha256:abd85de513eb83f5ec153a802348e7a5baa4588b818043848247e3e8986094e8 \
-    --hash=sha256:ac1be85fe43b4bf9a251978ce5c3bb30e1ada9784290441f5423a28633a958a7 \
-    --hash=sha256:be37f9b1f8934cd9e7eccfcb5612af9fb728fecbe16248b082b709a9d1b348bf \
-    --hash=sha256:bfcae6aecd9e0cb425f5145afee871465b98b75862e038d42fe91fd753ddd780 \
-    --hash=sha256:c05b021f7b5aa333124f2a64d56e4cb9963b6efdf44e8d819152237bbd93ba15 \
-    --hash=sha256:c14a07bdb475eb696f85c715dbd0f037918ccbb5248290448488a0b4ef201aad \
-    --hash=sha256:c18f3502ad0737813c7dad70e3e1cc966cc147fbaeef47a09463bbffe70b0a00 \
-    --hash=sha256:c2e9fe695ff151b42ab06501820f40d01310fbd58ba24da8923ace79cf6d702d \
-    --hash=sha256:c68be72b1666d93b266714f2d4092d78dc53bd11cf91ed5a3c16527587a52e29 \
-    --hash=sha256:ca94c85911601b097d53caeeec30201736ad69a93f30d15672b967558df02885 \
-    --hash=sha256:cf745cbfad6389c0e331786e5fe9ae3f06e9d9c2ce2432378e1267954793975c \
-    --hash=sha256:d9dd2b89a16cf7ab9c1170b5863e68de6bf83db51544875b25a5f05a7269e678 \
-    --hash=sha256:ddff3f8b9fa24a60527c137c852d0d9a7da2a02cf2151650029fdc97c852c974 \
-    --hash=sha256:e153a690b7255c5ced17895394b4f109d5dcc2a4f35cb809374da50f0e5c456a \
-    --hash=sha256:ea2b51c5f38bad812da2ec0cd7eec09d25f521a8b6b6843cbccedd9a1d8a5c15 \
-    --hash=sha256:ef9ec8068cf23458dbf36a08e0c16f0a2df04b42a8827619646637be1769300a \
-    --hash=sha256:f280b02827adc9d87f764972fbeb701cf5611f80b619c20568e1982a277d6146 \
-    --hash=sha256:f3ff7da165c99a5412fe5dd2304dd2dbaaaa5da718aad942dcb3a178eaa70c56 \
-    --hash=sha256:f58d3bfafecf3d81c15d99fc0ecf4319e80ac712c77cf0ce2661c8cf8bf84066 \
-    --hash=sha256:f79fe7993e230a12172ce7d7c7db061f046f672f2b946431c81aff8f60b2758b \
-    --hash=sha256:ffe709b1d0bc2e9921257569675674cafb3a5f8af689ab9f3f2b3f88775b960f
-wcwidth==0.2.13 ; python_version >= "3.10" and python_version < "4.0" \
+watchfiles==1.0.4 ; python_version >= "3.10" and python_version < "3.13" \
+    --hash=sha256:02a526ee5b5a09e8168314c905fc545c9bc46509896ed282aeb5a8ba9bd6ca27 \
+    --hash=sha256:05d341c71f3d7098920f8551d4df47f7b57ac5b8dad56558064c3431bdfc0b74 \
+    --hash=sha256:076f293100db3b0b634514aa0d294b941daa85fc777f9c698adb1009e5aca0b1 \
+    --hash=sha256:0799ae68dfa95136dde7c472525700bd48777875a4abb2ee454e3ab18e9fc712 \
+    --hash=sha256:0986902677a1a5e6212d0c49b319aad9cc48da4bd967f86a11bde96ad9676ca1 \
+    --hash=sha256:0bc80d91ddaf95f70258cf78c471246846c1986bcc5fd33ccc4a1a67fcb40f9a \
+    --hash=sha256:13c2ce7b72026cfbca120d652f02c7750f33b4c9395d79c9790b27f014c8a5a2 \
+    --hash=sha256:1941b4e39de9b38b868a69b911df5e89dc43767feeda667b40ae032522b9b5f1 \
+    --hash=sha256:1eacd91daeb5158c598fe22d7ce66d60878b6294a86477a4715154990394c9b3 \
+    --hash=sha256:229e6ec880eca20e0ba2f7e2249c85bae1999d330161f45c78d160832e026ee2 \
+    --hash=sha256:22bb55a7c9e564e763ea06c7acea24fc5d2ee5dfc5dafc5cfbedfe58505e9f90 \
+    --hash=sha256:278aaa395f405972e9f523bd786ed59dfb61e4b827856be46a42130605fd0899 \
+    --hash=sha256:2a9f93f8439639dc244c4d2902abe35b0279102bca7bbcf119af964f51d53c19 \
+    --hash=sha256:308ac265c56f936636e3b0e3f59e059a40003c655228c131e1ad439957592303 \
+    --hash=sha256:31f1a379c9dcbb3f09cf6be1b7e83b67c0e9faabed0471556d9438a4a4e14202 \
+    --hash=sha256:32b026a6ab64245b584acf4931fe21842374da82372d5c039cba6bf99ef722f3 \
+    --hash=sha256:342622287b5604ddf0ed2d085f3a589099c9ae8b7331df3ae9845571586c4f3d \
+    --hash=sha256:39f4914548b818540ef21fd22447a63e7be6e24b43a70f7642d21f1e73371590 \
+    --hash=sha256:3f68d8e9d5a321163ddacebe97091000955a1b74cd43724e346056030b0bacee \
+    --hash=sha256:43b168bba889886b62edb0397cab5b6490ffb656ee2fcb22dec8bfeb371a9e12 \
+    --hash=sha256:47eb32ef8c729dbc4f4273baece89398a4d4b5d21a1493efea77a17059f4df8a \
+    --hash=sha256:4810ea2ae622add560f4aa50c92fef975e475f7ac4900ce5ff5547b2434642d8 \
+    --hash=sha256:4e997802d78cdb02623b5941830ab06f8860038faf344f0d288d325cc9c5d2ff \
+    --hash=sha256:4ebbeca9360c830766b9f0df3640b791be569d988f4be6c06d6fae41f187f105 \
+    --hash=sha256:4f8c4998506241dedf59613082d1c18b836e26ef2a4caecad0ec41e2a15e4226 \
+    --hash=sha256:55ccfd27c497b228581e2838d4386301227fc0cb47f5a12923ec2fe4f97b95af \
+    --hash=sha256:5717021b199e8353782dce03bd8a8f64438832b84e2885c4a645f9723bf656d9 \
+    --hash=sha256:5c11ea22304d17d4385067588123658e9f23159225a27b983f343fcffc3e796a \
+    --hash=sha256:5e0227b8ed9074c6172cf55d85b5670199c99ab11fd27d2c473aa30aec67ee42 \
+    --hash=sha256:62c9953cf85529c05b24705639ffa390f78c26449e15ec34d5339e8108c7c407 \
+    --hash=sha256:6ba473efd11062d73e4f00c2b730255f9c1bdd73cd5f9fe5b5da8dbd4a717205 \
+    --hash=sha256:740d103cd01458f22462dedeb5a3382b7f2c57d07ff033fbc9465919e5e1d0f3 \
+    --hash=sha256:74cb3ca19a740be4caa18f238298b9d472c850f7b2ed89f396c00a4c97e2d9ff \
+    --hash=sha256:7b75fee5a16826cf5c46fe1c63116e4a156924d668c38b013e6276f2582230f0 \
+    --hash=sha256:7cf684aa9bba4cd95ecb62c822a56de54e3ae0598c1a7f2065d51e24637a3c5d \
+    --hash=sha256:8012bd820c380c3d3db8435e8cf7592260257b378b649154a7948a663b5f84e9 \
+    --hash=sha256:857f5fc3aa027ff5e57047da93f96e908a35fe602d24f5e5d8ce64bf1f2fc733 \
+    --hash=sha256:8b1f135238e75d075359cf506b27bf3f4ca12029c47d3e769d8593a2024ce161 \
+    --hash=sha256:8d0d0630930f5cd5af929040e0778cf676a46775753e442a3f60511f2409f48f \
+    --hash=sha256:90192cdc15ab7254caa7765a98132a5a41471cf739513cc9bcf7d2ffcc0ec7b2 \
+    --hash=sha256:95b42cac65beae3a362629950c444077d1b44f1790ea2772beaea95451c086bb \
+    --hash=sha256:9745a4210b59e218ce64c91deb599ae8775c8a9da4e95fb2ee6fe745fc87d01a \
+    --hash=sha256:9d1ef56b56ed7e8f312c934436dea93bfa3e7368adfcf3df4c0da6d4de959a1e \
+    --hash=sha256:9eea33ad8c418847dd296e61eb683cae1c63329b6d854aefcd412e12d94ee235 \
+    --hash=sha256:9f25d0ba0fe2b6d2c921cf587b2bf4c451860086534f40c384329fb96e2044d1 \
+    --hash=sha256:9fe37a2de80aa785d340f2980276b17ef697ab8db6019b07ee4fd28a8359d2f3 \
+    --hash=sha256:a38320582736922be8c865d46520c043bff350956dfc9fbaee3b2df4e1740a4b \
+    --hash=sha256:a462490e75e466edbb9fc4cd679b62187153b3ba804868452ef0577ec958f5ff \
+    --hash=sha256:a5ae5706058b27c74bac987d615105da17724172d5aaacc6c362a40599b6de43 \
+    --hash=sha256:aa216f87594f951c17511efe5912808dfcc4befa464ab17c98d387830ce07b60 \
+    --hash=sha256:ab0311bb2ffcd9f74b6c9de2dda1612c13c84b996d032cd74799adb656af4e8b \
+    --hash=sha256:ab594e75644421ae0a2484554832ca5895f8cab5ab62de30a1a57db460ce06c6 \
+    --hash=sha256:aee397456a29b492c20fda2d8961e1ffb266223625346ace14e4b6d861ba9c80 \
+    --hash=sha256:b045c800d55bc7e2cadd47f45a97c7b29f70f08a7c2fa13241905010a5493f94 \
+    --hash=sha256:b77d5622ac5cc91d21ae9c2b284b5d5c51085a0bdb7b518dba263d0af006132c \
+    --hash=sha256:ba5bb3073d9db37c64520681dd2650f8bd40902d991e7b4cfaeece3e32561d08 \
+    --hash=sha256:bdef5a1be32d0b07dcea3318a0be95d42c98ece24177820226b56276e06b63b0 \
+    --hash=sha256:c2acfa49dd0ad0bf2a9c0bb9a985af02e89345a7189be1efc6baa085e0f72d7c \
+    --hash=sha256:c7cce76c138a91e720d1df54014a047e680b652336e1b73b8e3ff3158e05061e \
+    --hash=sha256:cc27a65069bcabac4552f34fd2dce923ce3fcde0721a16e4fb1b466d63ec831f \
+    --hash=sha256:cdbd912a61543a36aef85e34f212e5d2486e7c53ebfdb70d1e0b060cc50dd0bf \
+    --hash=sha256:cdcc92daeae268de1acf5b7befcd6cfffd9a047098199056c72e4623f531de18 \
+    --hash=sha256:d3452c1ec703aa1c61e15dfe9d482543e4145e7c45a6b8566978fbb044265a21 \
+    --hash=sha256:d6097538b0ae5c1b88c3b55afa245a66793a8fec7ada6755322e465fb1a0e8cc \
+    --hash=sha256:d8d3d9203705b5797f0af7e7e5baa17c8588030aaadb7f6a86107b7247303817 \
+    --hash=sha256:e0611d244ce94d83f5b9aff441ad196c6e21b55f77f3c47608dcf651efe54c4a \
+    --hash=sha256:f12969a3765909cf5dc1e50b2436eb2c0e676a3c75773ab8cc3aa6175c16e902 \
+    --hash=sha256:f44a39aee3cbb9b825285ff979ab887a25c5d336e5ec3574f1506a4671556a8d \
+    --hash=sha256:f9ce064e81fe79faa925ff03b9f4c1a98b0bbb4a1b8c1b015afa93030cb21a49 \
+    --hash=sha256:fb2c46e275fbb9f0c92e7654b231543c7bbfa1df07cdc4b99fa73bedfde5c844 \
+    --hash=sha256:fc2eb5d14a8e0d5df7b36288979176fbb39672d45184fc4b1c004d7c3ce29317
+wcwidth==0.2.13 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859 \
     --hash=sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5
-webcolors==24.8.0 ; python_version >= "3.10" and python_version < "4.0" \
+webcolors==24.8.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:08b07af286a01bcd30d583a7acadf629583d1f79bfef27dd2c2c5c263817277d \
     --hash=sha256:fc4c3b59358ada164552084a8ebee637c221e4059267d0f8325b3b560f6c7f0a
-webencodings==0.5.1 ; python_version >= "3.10" and python_version < "4.0" \
+webencodings==0.5.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
-websockets==13.1 ; python_version >= "3.10" and python_version < "4.0" \
+websockets==13.1 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:004280a140f220c812e65f36944a9ca92d766b6cc4560be652a0a3883a79ed8a \
     --hash=sha256:035233b7531fb92a76beefcbf479504db8c72eb3bff41da55aecce3a0f729e54 \
     --hash=sha256:149e622dc48c10ccc3d2760e5f36753db9cacf3ad7bc7bbbfd7d9c819e286f23 \
@@ -2615,13 +2634,13 @@ websockets==13.1 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:f1c3cf67185543730888b20682fb186fc8d0fa6f07ccc3ef4390831ab4b388d9 \
     --hash=sha256:f48c749857f8fb598fb890a75f540e3221d0976ed0bf879cf3c7eef34151acee \
     --hash=sha256:f779498eeec470295a2b1a5d97aa1bc9814ecd25e1eb637bd9d1c73a327387f6
-werkzeug==3.1.3 ; python_version >= "3.10" and python_version < "4.0" \
+werkzeug==3.1.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e \
     --hash=sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746
-wsproto==1.2.0 ; python_version >= "3.10" and python_version < "4.0" \
+wsproto==1.2.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065 \
     --hash=sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736
-yarl==1.18.3 ; python_version >= "3.10" and python_version < "4.0" \
+yarl==1.18.3 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:00e5a1fea0fd4f5bfa7440a47eff01d9822a65b4488f7cff83155a0f31a2ecba \
     --hash=sha256:02ddb6756f8f4517a2d5e99d8b2f272488e18dd0bfbc802f31c16c6c20f22193 \
     --hash=sha256:045b8482ce9483ada4f3f23b3774f4e1bf4f23a2d5c912ed5170f68efb053318 \

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,7 @@
     "ADDOPTS",
     "Automathor",
     "autouse",
+    "cadquery",
     "capsys",
     "coderabbitai",
     "CQGI",

--- a/partcad/requirements.txt
+++ b/partcad/requirements.txt
@@ -1,3 +1,5 @@
+cadquery-ocp==7.7.2
+ocpsvg==0.3.4
 build123d==0.8.0
 pyyaml>=6.0.1
 GitPython>=3.1.40

--- a/partcad/src/partcad/part_factory_build123d.py
+++ b/partcad/src/partcad/part_factory_build123d.py
@@ -35,10 +35,10 @@ class PartFactoryBuild123d(PartFactoryPython):
         python_version = source_project.python_version
         if python_version is None:
             # Stay one step ahead of the minimum required Python version
-            python_version = "3.10"
-        if python_version == "3.12" or python_version == "3.11":
-            pc_logging.debug("Downgrading Python version to 3.10 to avoid compatibility issues with build123d")
-            python_version = "3.10"
+            python_version = "3.11"
+        if python_version == "3.12" or python_version == "3.10":
+            pc_logging.debug("Switching Python version to 3.11 to avoid compatibility issues with build123d")
+            python_version = "3.11"
         with pc_logging.Action("InitBuild123d", target_project.name, config["name"]):
             super().__init__(
                 ctx,
@@ -88,11 +88,11 @@ class PartFactoryBuild123d(PartFactoryPython):
 
             # TODO: @alexanderilyin: those should be read from the package/part config?
             await self.runtime.ensure_async(
-                "ocp-tessellate==3.0.8",
+                "ocp-tessellate==3.0.9",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "nlopt==2.7.1",
+                "typing_extensions==4.12.2",
                 session=self.session,
             )
             await self.runtime.ensure_async(
@@ -100,28 +100,11 @@ class PartFactoryBuild123d(PartFactoryPython):
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "cadquery==2.4.0",
+                "ocpsvg==0.3.4",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "numpy==1.26.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "numpy-quaternion==2023.0.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "nptyping==2.0.1",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                # "typing_extensions>=4.6.0,<5", # doesn't work on Windows
-                "typing_extensions==4.12.2",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "build123d==0.7.0",
+                "build123d==0.8.0",
                 session=self.session,
             )
             cwd = self.project.config_dir

--- a/partcad/src/partcad/part_factory_cadquery.py
+++ b/partcad/src/partcad/part_factory_cadquery.py
@@ -30,10 +30,10 @@ class PartFactoryCadquery(PartFactoryPython):
         python_version = source_project.python_version
         if python_version is None:
             # Stay one step ahead of the minimum required Python version
-            python_version = "3.10"
-        if python_version == "3.12" or python_version == "3.11":
-            pc_logging.debug("Downgrading Python version to 3.10 to avoid compatibility issues with CadQuery")
-            python_version = "3.10"
+            python_version = "3.11"
+        if python_version == "3.12" or python_version == "3.10":
+            pc_logging.debug("Switching Python version to 3.11 to avoid compatibility issues with CadQuery")
+            python_version = "3.11"
         with pc_logging.Action("InitCadQuery", target_project.name, config["name"]):
             super().__init__(
                 ctx,
@@ -82,36 +82,27 @@ class PartFactoryCadquery(PartFactoryPython):
             request_serialized = base64.b64encode(picklestring).decode()
 
             await self.runtime.ensure_async(
-                "ocp-tessellate==3.0.8",
+                "ocp-tessellate==3.0.9",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "nlopt==2.7.1",
+                "nlopt==2.9.0",
+                session=self.session,
+            )
+            await self.runtime.ensure_async(
+                "cadquery==2.5.2",
+                session=self.session,
+            )
+            await self.runtime.ensure_async(
+                "numpy==2.2.1",
+                session=self.session,
+            )
+            await self.runtime.ensure_async(
+                "typing_extensions==4.12.2",
                 session=self.session,
             )
             await self.runtime.ensure_async(
                 "cadquery-ocp==7.7.2",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "cadquery==2.4.0",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "numpy==1.26.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "numpy-quaternion==2023.0.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "nptyping==2.0.1",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                # "typing_extensions>=4.6.0,<5", # doesn't work on Windows
-                "typing_extensions==4.12.2",
                 session=self.session,
             )
             cwd = self.project.config_dir

--- a/partcad/src/partcad/part_factory_step.py
+++ b/partcad/src/partcad/part_factory_step.py
@@ -81,7 +81,7 @@ class PartFactoryStep(PartFactoryFile):
                         # We don't care about customer preferences much here
                         # as this is expected to be hermetic.
                         # Stick to the version where CadQuery is known to work.
-                        self.runtime = self.ctx.get_python_runtime("3.10")
+                        self.runtime = self.ctx.get_python_runtime("3.11")
 
             if do_subprocess:
                 wrapper_path = wrapper.get("step.py")

--- a/partcad/src/partcad/provider_factory_python.py
+++ b/partcad/src/partcad/provider_factory_python.py
@@ -51,10 +51,10 @@ class ProviderFactoryPython(ProviderFactoryFile):
             python_version = self.project.python_version
         if python_version is None:
             # Stay one step ahead of the minimum required Python version
-            python_version = "3.10"
-        if python_version == "3.12" or python_version == "3.11":
-            pc_logging.debug("Downgrading Python version to 3.10 to minimize compatibility issues")
-            python_version = "3.10"
+            python_version = "3.11"
+        if python_version == "3.12" or python_version == "3.10":
+            pc_logging.debug("Downgrading Python version to 3.11 to minimize compatibility issues")
+            python_version = "3.11"
 
         self.runtime = self.ctx.get_python_runtime(python_version)
         self.session = self.runtime.get_session(source_project.name)
@@ -135,36 +135,27 @@ class ProviderFactoryPython(ProviderFactoryFile):
             # TODO-200: Create a version resolution mechanism that can handle dependency conflicts
             # TODO-201: Implement a version update strategy for security patches
             await self.runtime.ensure_async(
-                "ocp-tessellate==3.0.8",
+                "ocp-tessellate==3.0.9",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "nlopt==2.7.1",
+                "nlopt==2.9.0",
+                session=self.session,
+            )
+            await self.runtime.ensure_async(
+                "cadquery==2.5.2",
+                session=self.session,
+            )
+            await self.runtime.ensure_async(
+                "numpy==2.2.1",
+                session=self.session,
+            )
+            await self.runtime.ensure_async(
+                "typing_extensions==4.12.2",
                 session=self.session,
             )
             await self.runtime.ensure_async(
                 "cadquery-ocp==7.7.2",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "cadquery==2.4.0",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "numpy==1.26.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "numpy-quaternion==2023.0.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "nptyping==2.0.1",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                # "typing_extensions>=4.6.0,<5", # doesn't work on Windows
-                "typing_extensions==4.12.2",
                 session=self.session,
             )
             cwd = self.project.config_dir

--- a/partcad/src/partcad/runtime_python.py
+++ b/partcad/src/partcad/runtime_python.py
@@ -95,16 +95,14 @@ class PythonRuntime(runtime.Runtime):
             if not self.initialized:
                 # Preinstall the most common packages to avoid race conditions
                 # TODO(clairbee): Lock the entire runtime instead
-                self.ensure_onced("ocp-tessellate==3.0.8")
-                self.ensure_onced("nlopt==2.7.1")
-                self.ensure_onced("cadquery-ocp==7.7.2")
-                self.ensure_onced("cadquery==2.4.0")
-                self.ensure_onced("numpy==1.26.4")
-                self.ensure_onced("numpy-quaternion==2023.0.4")
-                self.ensure_onced("nptyping==2.0.1")
-                # self.ensure_onced("typing_extensions>=4.6.0,<5") # doesn't work on Windows
+                self.ensure_onced("ocp-tessellate==3.0.9")
+                self.ensure_onced("nlopt==2.9.0")
+                self.ensure_onced("cadquery==2.5.2")
+                self.ensure_onced("numpy==2.2.1")
                 self.ensure_onced("typing_extensions==4.12.2")
-                self.ensure_onced("build123d==0.7.0")
+                self.ensure_onced("cadquery-ocp==7.7.2")
+                self.ensure_onced("ocpsvg==0.3.4")
+                self.ensure_onced("build123d==0.8.0")
                 self.initialized = True
 
     async def once_async(self):
@@ -113,16 +111,14 @@ class PythonRuntime(runtime.Runtime):
                 if not self.initialized:
                     # Preinstall the most common packages to avoid
                     # TODO(clairbee): Lock the entire runtime instead
-                    await self.ensure_async_onced_locked("ocp-tessellate==3.0.8")
-                    await self.ensure_async_onced_locked("nlopt==2.7.1")
-                    await self.ensure_async_onced_locked("cadquery-ocp==7.7.2")
-                    await self.ensure_async_onced_locked("cadquery==2.4.0")
-                    await self.ensure_async_onced_locked("numpy==1.26.4")
-                    await self.ensure_async_onced_locked("numpy-quaternion==2023.0.4")
-                    await self.ensure_async_onced_locked("nptyping==2.0.1")
-                    # await self.ensure_async_onced_locked("typing_extensions>=4.6.0,<5") # doesn't work on Windows
+                    await self.ensure_async_onced_locked("ocp-tessellate==3.0.9")
+                    await self.ensure_async_onced_locked("nlopt==2.9.0")
+                    await self.ensure_async_onced_locked("cadquery==2.5.2")
+                    await self.ensure_async_onced_locked("numpy==2.2.1")
                     await self.ensure_async_onced_locked("typing_extensions==4.12.2")
-                    await self.ensure_async_onced_locked("build123d==0.7.0")
+                    await self.ensure_async_onced_locked("cadquery-ocp==7.7.2")
+                    await self.ensure_async_onced_locked("ocpsvg==0.3.4")
+                    await self.ensure_async_onced_locked("build123d==0.8.0")
                     self.initialized = True
 
     def run(self, cmd, stdin="", cwd=None, session=None):

--- a/partcad/src/partcad/runtime_python_conda.py
+++ b/partcad/src/partcad/runtime_python_conda.py
@@ -100,6 +100,29 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                             "--json",
                             "-p",
                             self.path,
+                            "vtk",
+                            "-c",
+                            "conda-forge",
+                        ],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        shell=False,
+                        encoding="utf-8",
+                    )
+                    _, stderr = p.communicate()
+                    if not stderr is None and stderr.strip() != "":
+                        pc_logging.error("conda vtk install error: %s" % stderr)
+
+                    # Install pip into the newly created conda environment
+                    p = subprocess.Popen(
+                        [
+                            self.conda_path,
+                            "install",
+                            "-y",
+                            "-q",
+                            "--json",
+                            "-p",
+                            self.path,
                             "pip",
                         ],
                         stdout=subprocess.PIPE,

--- a/partcad/src/partcad/shape.py
+++ b/partcad/src/partcad/shape.py
@@ -252,9 +252,10 @@ class Shape(ShapeConfiguration):
         # We don't care about customer preferences much here
         # as this is expected to be hermetic.
         # Stick to the version where CadQuery and build123d are known to work.
-        runtime = ctx.get_python_runtime(version="3.10")
+        runtime = ctx.get_python_runtime(version="3.11")
         await runtime.ensure_async("cadquery-ocp==7.7.2")
-        await runtime.ensure_async("build123d==0.7.0")
+        await runtime.ensure_async("ocpsvg==0.3.4")
+        await runtime.ensure_async("build123d==0.8.0")
         response_serialized, errors = await runtime.run_async(
             [
                 wrapper_path,
@@ -555,9 +556,9 @@ class Shape(ShapeConfiguration):
             # We don't care about customer preferences much here
             # as this is expected to be hermetic.
             # Stick to the version where CadQuery and build123d are known to work.
-            runtime = ctx.get_python_runtime(version="3.10")
+            runtime = ctx.get_python_runtime(version="3.11")
             await runtime.ensure_async("cadquery-ocp==7.7.2")
-            await runtime.ensure_async("cadquery==2.4.0")
+            await runtime.ensure_async("cadquery==2.5.2")
             response_serialized, errors = await runtime.run_async(
                 [
                     wrapper_path,
@@ -622,7 +623,7 @@ class Shape(ShapeConfiguration):
             # We don't care about customer preferences much here
             # as this is expected to be hermetic.
             # Stick to the version where CadQuery and build123d are known to work.
-            runtime = ctx.get_python_runtime(version="3.10")
+            runtime = ctx.get_python_runtime(version="3.11")
             await runtime.ensure_async("cadquery-ocp==7.7.2")
             response_serialized, errors = await runtime.run_async(
                 [
@@ -688,7 +689,7 @@ class Shape(ShapeConfiguration):
             # We don't care about customer preferences much here
             # as this is expected to be hermetic.
             # Stick to the version where CadQuery and build123d are known to work.
-            runtime = ctx.get_python_runtime(version="3.10")
+            runtime = ctx.get_python_runtime(version="3.11")
             await runtime.ensure_async("cadquery-ocp==7.7.2")
             response_serialized, errors = await runtime.run_async(
                 [

--- a/partcad/src/partcad/sketch_factory_build123d.py
+++ b/partcad/src/partcad/sketch_factory_build123d.py
@@ -35,10 +35,10 @@ class SketchFactoryBuild123d(SketchFactoryPython):
         python_version = source_project.python_version
         if python_version is None:
             # Stay one step ahead of the minimum required Python version
-            python_version = "3.10"
-        if python_version == "3.12" or python_version == "3.11":
-            pc_logging.debug("Downgrading Python version to 3.10 to avoid compatibility issues with build123d")
-            python_version = "3.10"
+            python_version = "3.11"
+        if python_version == "3.12" or python_version == "3.10":
+            pc_logging.debug("Switching Python version to 3.11 to avoid compatibility issues with build123d")
+            python_version = "3.11"
         with pc_logging.Action("InitBuild123d", target_project.name, config["name"]):
             super().__init__(
                 ctx,
@@ -87,11 +87,7 @@ class SketchFactoryBuild123d(SketchFactoryPython):
             request_serialized = base64.b64encode(picklestring).decode()
 
             await self.runtime.ensure_async(
-                "ocp-tessellate==3.0.8",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "nlopt==2.7.1",
+                "ocp-tessellate==3.0.9",
                 session=self.session,
             )
             await self.runtime.ensure_async(
@@ -99,28 +95,15 @@ class SketchFactoryBuild123d(SketchFactoryPython):
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "cadquery==2.4.0",
+                "ocpsvg==0.3.4",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "numpy==1.26.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "numpy-quaternion==2023.0.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "nptyping==2.0.1",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                # "typing_extensions>=4.6.0,<5", # doesn't work on Windows
                 "typing_extensions==4.12.2",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "build123d==0.7.0",
+                "build123d==0.8.0",
                 session=self.session,
             )
             cwd = self.project.config_dir

--- a/partcad/src/partcad/sketch_factory_cadquery.py
+++ b/partcad/src/partcad/sketch_factory_cadquery.py
@@ -35,10 +35,10 @@ class SketchFactoryCadquery(SketchFactoryPython):
         python_version = source_project.python_version
         if python_version is None:
             # Stay one step ahead of the minimum required Python version
-            python_version = "3.10"
-        if python_version == "3.12" or python_version == "3.11":
-            pc_logging.debug("Downgrading Python version to 3.10 to avoid compatibility issues with CadQuery")
-            python_version = "3.10"
+            python_version = "3.11"
+        if python_version == "3.12" or python_version == "3.10":
+            pc_logging.debug("Switching Python version to 3.11 to avoid compatibility issues with CadQuery")
+            python_version = "3.11"
         with pc_logging.Action("InitCadQuery", target_project.name, config["name"]):
             super().__init__(
                 ctx,
@@ -83,11 +83,15 @@ class SketchFactoryCadquery(SketchFactoryPython):
             request_serialized = base64.b64encode(picklestring).decode()
 
             await self.runtime.ensure_async(
-                "ocp-tessellate==3.0.8",
+                "ocp-tessellate==3.0.9",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "nlopt==2.7.1",
+                "nlopt==2.9.0",
+                session=self.session,
+            )
+            await self.runtime.ensure_async(
+                "cadquery==2.5.2",
                 session=self.session,
             )
             await self.runtime.ensure_async(
@@ -95,23 +99,10 @@ class SketchFactoryCadquery(SketchFactoryPython):
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "cadquery==2.4.0",
+                "numpy==2.2.1",
                 session=self.session,
             )
             await self.runtime.ensure_async(
-                "numpy==1.26.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "numpy-quaternion==2023.0.4",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                "nptyping==2.0.1",
-                session=self.session,
-            )
-            await self.runtime.ensure_async(
-                # "typing_extensions>=4.6.0,<5", # doesn't work on Windows
                 "typing_extensions==4.12.2",
                 session=self.session,
             )

--- a/partcad/src/partcad/sketch_factory_dxf.py
+++ b/partcad/src/partcad/sketch_factory_dxf.py
@@ -30,10 +30,10 @@ class SketchFactoryDxf(SketchFactoryPython):
             python_version = source_project.python_version
             if python_version is None:
                 # Stay one step ahead of the minimum required Python version
-                python_version = "3.10"
-            if python_version == "3.12" or python_version == "3.11":
-                pc_logging.debug("Downgrading Python version to 3.10 to avoid compatibility issues with CadQuery")
-                python_version = "3.10"
+                python_version = "3.11"
+            if python_version == "3.12" or python_version == "3.10":
+                pc_logging.debug("Switching Python version to 3.11 to avoid compatibility issues with CadQuery")
+                python_version = "3.11"
             super().__init__(
                 ctx,
                 source_project,
@@ -79,7 +79,7 @@ class SketchFactoryDxf(SketchFactoryPython):
                 request_serialized = base64.b64encode(picklestring).decode()
 
                 await self.runtime.ensure_async("cadquery-ocp==7.7.2")
-                await self.runtime.ensure_async("cadquery==2.4.0")
+                await self.runtime.ensure_async("cadquery==2.5.2")
                 response_serialized, errors = await self.runtime.run_async(
                     [
                         wrapper_path,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1477,13 +1477,13 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-api-python-client"
-version = "2.157.0"
+version = "2.158.0"
 description = "Google API Client Library for Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google_api_python_client-2.157.0-py2.py3-none-any.whl", hash = "sha256:0b0231db106324c659bf8b85f390391c00da57a60ebc4271e33def7aac198c75"},
-    {file = "google_api_python_client-2.157.0.tar.gz", hash = "sha256:2ee342d0967ad1cedec43ccd7699671d94bff151e1f06833ea81303f9a6d86fd"},
+    {file = "google_api_python_client-2.158.0-py2.py3-none-any.whl", hash = "sha256:36f8c8d2e79e50f76790ca5946d2f3f8333e210dc8539a6c88e0742416474ad2"},
+    {file = "google_api_python_client-2.158.0.tar.gz", hash = "sha256:b6664597a9955e04977a62752e33fe44cb35c580e190c1cb08a041893172bd67"},
 ]
 
 [package.dependencies]
@@ -2790,13 +2790,13 @@ files = [
 
 [[package]]
 name = "ocp-tessellate"
-version = "3.0.8"
+version = "3.0.9"
 description = "Tessellate OCP (https://github.com/cadquery/OCP) objects to use with threejs"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "ocp_tessellate-3.0.8-py3-none-any.whl", hash = "sha256:f2c1f5b2e0e0277624840946c04461742c0d30f15f55922f6c03e5358fddb16e"},
-    {file = "ocp_tessellate-3.0.8.tar.gz", hash = "sha256:d82a8ffc0f765649456f3cd3bbc379b6e3a8c8a78ebd9ff1540e2d7aeeea6473"},
+    {file = "ocp_tessellate-3.0.9-py3-none-any.whl", hash = "sha256:64e6ca902c63a90eacf49fa24c0bd93054f0a2865476e56a27a9d6e297c97282"},
+    {file = "ocp_tessellate-3.0.9.tar.gz", hash = "sha256:307d2fd0a94fa64627251c3b4633c9757ee7809c19fc233d9f44b30ea658b096"},
 ]
 
 [package.dependencies]
@@ -2835,17 +2835,17 @@ dev = ["black", "bump-my-version", "questionary (>=1.10.0,<1.11.0)", "twine"]
 
 [[package]]
 name = "ocpsvg"
-version = "0.3.3"
+version = "0.3.4"
 description = ""
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "ocpsvg-0.3.3-py3-none-any.whl", hash = "sha256:93a7d4b0edab119ca950e7e15132fdb69399f53851322a3fb56e03946939384a"},
-    {file = "ocpsvg-0.3.3.tar.gz", hash = "sha256:8c441e72110be0b53dd84a00229752d8ce7658ed2c3d66e79c9aade9fcb4b475"},
+    {file = "ocpsvg-0.3.4-py3-none-any.whl", hash = "sha256:f99e3316451b2c34a716bd27ed822a2d48dbf9d040f688efc5152ac47fc8024a"},
+    {file = "ocpsvg-0.3.4.tar.gz", hash = "sha256:dba117055b29d17ebc3bffd6e4f911c40fe518086c5a17ffc2b5b01a2938787f"},
 ]
 
 [package.dependencies]
-cadquery-ocp = ">=7.7.0"
+cadquery-ocp = ">=7.7.0,<7.8"
 svgelements = ">=1.9.1,<2"
 
 [package.extras]
@@ -2853,13 +2853,13 @@ dev = ["pytest"]
 
 [[package]]
 name = "ollama"
-version = "0.4.5"
+version = "0.4.6"
 description = "The official Python client for Ollama."
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "ollama-0.4.5-py3-none-any.whl", hash = "sha256:74936de89a41c87c9745f09f2e1db964b4783002188ac21241bfab747f46d925"},
-    {file = "ollama-0.4.5.tar.gz", hash = "sha256:e7fb71a99147046d028ab8b75e51e09437099aea6f8f9a0d91a71f787e97439e"},
+    {file = "ollama-0.4.6-py3-none-any.whl", hash = "sha256:cbb4ebe009e10dd12bdd82508ab415fd131945e185753d728a7747c9ebe762e9"},
+    {file = "ollama-0.4.6.tar.gz", hash = "sha256:b00717651c829f96094ed4231b9f0d87e33cc92dc235aca50aeb5a2a4e6e95b7"},
 ]
 
 [package.dependencies]
@@ -2868,13 +2868,13 @@ pydantic = ">=2.9.0,<3.0.0"
 
 [[package]]
 name = "openai"
-version = "1.59.5"
+version = "1.59.7"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "openai-1.59.5-py3-none-any.whl", hash = "sha256:e646b44856b0dda9345d3c43639e056334d792d1690e99690313c0ef7ca4d8cc"},
-    {file = "openai-1.59.5.tar.gz", hash = "sha256:9886e77c02dad9dc6a7b67a11ab372a56842a9b5d376aa476672175ab10e83a0"},
+    {file = "openai-1.59.7-py3-none-any.whl", hash = "sha256:cfa806556226fa96df7380ab2e29814181d56fea44738c2b0e581b462c268692"},
+    {file = "openai-1.59.7.tar.gz", hash = "sha256:043603def78c00befb857df9f0a16ee76a3af5984ba40cb7ee5e2f40db4646bf"},
 ]
 
 [package.dependencies]
@@ -3498,13 +3498,13 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.4"
+version = "2.10.5"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.10.4-py3-none-any.whl", hash = "sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d"},
-    {file = "pydantic-2.10.4.tar.gz", hash = "sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06"},
+    {file = "pydantic-2.10.5-py3-none-any.whl", hash = "sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53"},
+    {file = "pydantic-2.10.5.tar.gz", hash = "sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff"},
 ]
 
 [package.dependencies]
@@ -4376,51 +4376,51 @@ files = [
 
 [[package]]
 name = "scipy"
-version = "1.15.0"
+version = "1.15.1"
 description = "Fundamental algorithms for scientific computing in Python"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "scipy-1.15.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:aeac60d3562a7bf2f35549bdfdb6b1751c50590f55ce7322b4b2fc821dc27fca"},
-    {file = "scipy-1.15.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:5abbdc6ede5c5fed7910cf406a948e2c0869231c0db091593a6b2fa78be77e5d"},
-    {file = "scipy-1.15.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:eb1533c59f0ec6c55871206f15a5c72d1fae7ad3c0a8ca33ca88f7c309bbbf8c"},
-    {file = "scipy-1.15.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:de112c2dae53107cfeaf65101419662ac0a54e9a088c17958b51c95dac5de56d"},
-    {file = "scipy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2240e1fd0782e62e1aacdc7234212ee271d810f67e9cd3b8d521003a82603ef8"},
-    {file = "scipy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d35aef233b098e4de88b1eac29f0df378278e7e250a915766786b773309137c4"},
-    {file = "scipy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1b29e4fc02e155a5fd1165f1e6a73edfdd110470736b0f48bcbe48083f0eee37"},
-    {file = "scipy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:0e5b34f8894f9904cc578008d1a9467829c1817e9f9cb45e6d6eeb61d2ab7731"},
-    {file = "scipy-1.15.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:46e91b5b16909ff79224b56e19cbad65ca500b3afda69225820aa3afbf9ec020"},
-    {file = "scipy-1.15.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:82bff2eb01ccf7cea8b6ee5274c2dbeadfdac97919da308ee6d8e5bcbe846443"},
-    {file = "scipy-1.15.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:9c8254fe21dd2c6c8f7757035ec0c31daecf3bb3cffd93bc1ca661b731d28136"},
-    {file = "scipy-1.15.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:c9624eeae79b18cab1a31944b5ef87aa14b125d6ab69b71db22f0dbd962caf1e"},
-    {file = "scipy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d13bbc0658c11f3d19df4138336e4bce2c4fbd78c2755be4bf7b8e235481557f"},
-    {file = "scipy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdca4c7bb8dc41307e5f39e9e5d19c707d8e20a29845e7533b3bb20a9d4ccba0"},
-    {file = "scipy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6f376d7c767731477bac25a85d0118efdc94a572c6b60decb1ee48bf2391a73b"},
-    {file = "scipy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:61513b989ee8d5218fbeb178b2d51534ecaddba050db949ae99eeb3d12f6825d"},
-    {file = "scipy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5beb0a2200372b7416ec73fdae94fe81a6e85e44eb49c35a11ac356d2b8eccc6"},
-    {file = "scipy-1.15.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fde0f3104dfa1dfbc1f230f65506532d0558d43188789eaf68f97e106249a913"},
-    {file = "scipy-1.15.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:35c68f7044b4e7ad73a3e68e513dda946989e523df9b062bd3cf401a1a882192"},
-    {file = "scipy-1.15.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:52475011be29dfcbecc3dfe3060e471ac5155d72e9233e8d5616b84e2b542054"},
-    {file = "scipy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5972e3f96f7dda4fd3bb85906a17338e65eaddfe47f750e240f22b331c08858e"},
-    {file = "scipy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe00169cf875bed0b3c40e4da45b57037dc21d7c7bf0c85ed75f210c281488f1"},
-    {file = "scipy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:161f80a98047c219c257bf5ce1777c574bde36b9d962a46b20d0d7e531f86863"},
-    {file = "scipy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:327163ad73e54541a675240708244644294cb0a65cca420c9c79baeb9648e479"},
-    {file = "scipy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0fcb16eb04d84670722ce8d93b05257df471704c913cb0ff9dc5a1c31d1e9422"},
-    {file = "scipy-1.15.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:767e8cf6562931f8312f4faa7ddea412cb783d8df49e62c44d00d89f41f9bbe8"},
-    {file = "scipy-1.15.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:37ce9394cdcd7c5f437583fc6ef91bd290014993900643fdfc7af9b052d1613b"},
-    {file = "scipy-1.15.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6d26f17c64abd6c6c2dfb39920f61518cc9e213d034b45b2380e32ba78fde4c0"},
-    {file = "scipy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e2448acd79c6374583581a1ded32ac71a00c2b9c62dfa87a40e1dd2520be111"},
-    {file = "scipy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36be480e512d38db67f377add5b759fb117edd987f4791cdf58e59b26962bee4"},
-    {file = "scipy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ccb6248a9987193fe74363a2d73b93bc2c546e0728bd786050b7aef6e17db03c"},
-    {file = "scipy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:952d2e9eaa787f0a9e95b6e85da3654791b57a156c3e6609e65cc5176ccfe6f2"},
-    {file = "scipy-1.15.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b1432102254b6dc7766d081fa92df87832ac25ff0b3d3a940f37276e63eb74ff"},
-    {file = "scipy-1.15.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:4e08c6a36f46abaedf765dd2dfcd3698fa4bd7e311a9abb2d80e33d9b2d72c34"},
-    {file = "scipy-1.15.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:ec915cd26d76f6fc7ae8522f74f5b2accf39546f341c771bb2297f3871934a52"},
-    {file = "scipy-1.15.0-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:351899dd2a801edd3691622172bc8ea01064b1cada794f8641b89a7dc5418db6"},
-    {file = "scipy-1.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9baff912ea4f78a543d183ed6f5b3bea9784509b948227daaf6f10727a0e2e5"},
-    {file = "scipy-1.15.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cd9d9198a7fd9a77f0eb5105ea9734df26f41faeb2a88a0e62e5245506f7b6df"},
-    {file = "scipy-1.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:129f899ed275c0515d553b8d31696924e2ca87d1972421e46c376b9eb87de3d2"},
-    {file = "scipy-1.15.0.tar.gz", hash = "sha256:300742e2cc94e36a2880ebe464a1c8b4352a7b0f3e36ec3d2ac006cdbe0219ac"},
+    {file = "scipy-1.15.1-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:c64ded12dcab08afff9e805a67ff4480f5e69993310e093434b10e85dc9d43e1"},
+    {file = "scipy-1.15.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:5b190b935e7db569960b48840e5bef71dc513314cc4e79a1b7d14664f57fd4ff"},
+    {file = "scipy-1.15.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:4b17d4220df99bacb63065c76b0d1126d82bbf00167d1730019d2a30d6ae01ea"},
+    {file = "scipy-1.15.1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:63b9b6cd0333d0eb1a49de6f834e8aeaefe438df8f6372352084535ad095219e"},
+    {file = "scipy-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f151e9fb60fbf8e52426132f473221a49362091ce7a5e72f8aa41f8e0da4f25"},
+    {file = "scipy-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21e10b1dd56ce92fba3e786007322542361984f8463c6d37f6f25935a5a6ef52"},
+    {file = "scipy-1.15.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5dff14e75cdbcf07cdaa1c7707db6017d130f0af9ac41f6ce443a93318d6c6e0"},
+    {file = "scipy-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:f82fcf4e5b377f819542fbc8541f7b5fbcf1c0017d0df0bc22c781bf60abc4d8"},
+    {file = "scipy-1.15.1-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:5bd8d27d44e2c13d0c1124e6a556454f52cd3f704742985f6b09e75e163d20d2"},
+    {file = "scipy-1.15.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:be3deeb32844c27599347faa077b359584ba96664c5c79d71a354b80a0ad0ce0"},
+    {file = "scipy-1.15.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:5eb0ca35d4b08e95da99a9f9c400dc9f6c21c424298a0ba876fdc69c7afacedf"},
+    {file = "scipy-1.15.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:74bb864ff7640dea310a1377d8567dc2cb7599c26a79ca852fc184cc851954ac"},
+    {file = "scipy-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:667f950bf8b7c3a23b4199db24cb9bf7512e27e86d0e3813f015b74ec2c6e3df"},
+    {file = "scipy-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395be70220d1189756068b3173853029a013d8c8dd5fd3d1361d505b2aa58fa7"},
+    {file = "scipy-1.15.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce3a000cd28b4430426db2ca44d96636f701ed12e2b3ca1f2b1dd7abdd84b39a"},
+    {file = "scipy-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:3fe1d95944f9cf6ba77aa28b82dd6bb2a5b52f2026beb39ecf05304b8392864b"},
+    {file = "scipy-1.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c09aa9d90f3500ea4c9b393ee96f96b0ccb27f2f350d09a47f533293c78ea776"},
+    {file = "scipy-1.15.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:0ac102ce99934b162914b1e4a6b94ca7da0f4058b6d6fd65b0cef330c0f3346f"},
+    {file = "scipy-1.15.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:09c52320c42d7f5c7748b69e9f0389266fd4f82cf34c38485c14ee976cb8cb04"},
+    {file = "scipy-1.15.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:cdde8414154054763b42b74fe8ce89d7f3d17a7ac5dd77204f0e142cdc9239e9"},
+    {file = "scipy-1.15.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c9d8fc81d6a3b6844235e6fd175ee1d4c060163905a2becce8e74cb0d7554ce"},
+    {file = "scipy-1.15.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fb57b30f0017d4afa5fe5f5b150b8f807618819287c21cbe51130de7ccdaed2"},
+    {file = "scipy-1.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:491d57fe89927fa1aafbe260f4cfa5ffa20ab9f1435025045a5315006a91b8f5"},
+    {file = "scipy-1.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:900f3fa3db87257510f011c292a5779eb627043dd89731b9c461cd16ef76ab3d"},
+    {file = "scipy-1.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:100193bb72fbff37dbd0bf14322314fc7cbe08b7ff3137f11a34d06dc0ee6b85"},
+    {file = "scipy-1.15.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:2114a08daec64980e4b4cbdf5bee90935af66d750146b1d2feb0d3ac30613692"},
+    {file = "scipy-1.15.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6b3e71893c6687fc5e29208d518900c24ea372a862854c9888368c0b267387ab"},
+    {file = "scipy-1.15.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:837299eec3d19b7e042923448d17d95a86e43941104d33f00da7e31a0f715d3c"},
+    {file = "scipy-1.15.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82add84e8a9fb12af5c2c1a3a3f1cb51849d27a580cb9e6bd66226195142be6e"},
+    {file = "scipy-1.15.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:070d10654f0cb6abd295bc96c12656f948e623ec5f9a4eab0ddb1466c000716e"},
+    {file = "scipy-1.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:55cc79ce4085c702ac31e49b1e69b27ef41111f22beafb9b49fea67142b696c4"},
+    {file = "scipy-1.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:c352c1b6d7cac452534517e022f8f7b8d139cd9f27e6fbd9f3cbd0bfd39f5bef"},
+    {file = "scipy-1.15.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0458839c9f873062db69a03de9a9765ae2e694352c76a16be44f93ea45c28d2b"},
+    {file = "scipy-1.15.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:af0b61c1de46d0565b4b39c6417373304c1d4f5220004058bdad3061c9fa8a95"},
+    {file = "scipy-1.15.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:71ba9a76c2390eca6e359be81a3e879614af3a71dfdabb96d1d7ab33da6f2364"},
+    {file = "scipy-1.15.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:14eaa373c89eaf553be73c3affb11ec6c37493b7eaaf31cf9ac5dffae700c2e0"},
+    {file = "scipy-1.15.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f735bc41bd1c792c96bc426dece66c8723283695f02df61dcc4d0a707a42fc54"},
+    {file = "scipy-1.15.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2722a021a7929d21168830790202a75dbb20b468a8133c74a2c0230c72626b6c"},
+    {file = "scipy-1.15.1-cp313-cp313t-win_amd64.whl", hash = "sha256:bc7136626261ac1ed988dca56cfc4ab5180f75e0ee52e58f1e6aa74b5f3eacd5"},
+    {file = "scipy-1.15.1.tar.gz", hash = "sha256:033a75ddad1463970c96a88063a1df87ccfddd526437136b6ee81ff0312ebdf6"},
 ]
 
 [package.dependencies]
@@ -5179,82 +5179,82 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "watchfiles"
-version = "1.0.3"
+version = "1.0.4"
 description = "Simple, modern and high performance file watching and code reload in python."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "watchfiles-1.0.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:1da46bb1eefb5a37a8fb6fd52ad5d14822d67c498d99bda8754222396164ae42"},
-    {file = "watchfiles-1.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2b961b86cd3973f5822826017cad7f5a75795168cb645c3a6b30c349094e02e3"},
-    {file = "watchfiles-1.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34e87c7b3464d02af87f1059fedda5484e43b153ef519e4085fe1a03dd94801e"},
-    {file = "watchfiles-1.0.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d9dd2b89a16cf7ab9c1170b5863e68de6bf83db51544875b25a5f05a7269e678"},
-    {file = "watchfiles-1.0.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2b4691234d31686dca133c920f94e478b548a8e7c750f28dbbc2e4333e0d3da9"},
-    {file = "watchfiles-1.0.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:90b0fe1fcea9bd6e3084b44875e179b4adcc4057a3b81402658d0eb58c98edf8"},
-    {file = "watchfiles-1.0.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0b90651b4cf9e158d01faa0833b073e2e37719264bcee3eac49fc3c74e7d304b"},
-    {file = "watchfiles-1.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2e9fe695ff151b42ab06501820f40d01310fbd58ba24da8923ace79cf6d702d"},
-    {file = "watchfiles-1.0.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62691f1c0894b001c7cde1195c03b7801aaa794a837bd6eef24da87d1542838d"},
-    {file = "watchfiles-1.0.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:275c1b0e942d335fccb6014d79267d1b9fa45b5ac0639c297f1e856f2f532552"},
-    {file = "watchfiles-1.0.3-cp310-cp310-win32.whl", hash = "sha256:06ce08549e49ba69ccc36fc5659a3d0ff4e3a07d542b895b8a9013fcab46c2dc"},
-    {file = "watchfiles-1.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:f280b02827adc9d87f764972fbeb701cf5611f80b619c20568e1982a277d6146"},
-    {file = "watchfiles-1.0.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ffe709b1d0bc2e9921257569675674cafb3a5f8af689ab9f3f2b3f88775b960f"},
-    {file = "watchfiles-1.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:418c5ce332f74939ff60691e5293e27c206c8164ce2b8ce0d9abf013003fb7fe"},
-    {file = "watchfiles-1.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f492d2907263d6d0d52f897a68647195bc093dafed14508a8d6817973586b6b"},
-    {file = "watchfiles-1.0.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:48c9f3bc90c556a854f4cab6a79c16974099ccfa3e3e150673d82d47a4bc92c9"},
-    {file = "watchfiles-1.0.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:75d3bcfa90454dba8df12adc86b13b6d85fda97d90e708efc036c2760cc6ba44"},
-    {file = "watchfiles-1.0.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5691340f259b8f76b45fb31b98e594d46c36d1dc8285efa7975f7f50230c9093"},
-    {file = "watchfiles-1.0.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e263cc718545b7f897baeac1f00299ab6fabe3e18caaacacb0edf6d5f35513c"},
-    {file = "watchfiles-1.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c6cf7709ed3e55704cc06f6e835bf43c03bc8e3cb8ff946bf69a2e0a78d9d77"},
-    {file = "watchfiles-1.0.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:703aa5e50e465be901e0e0f9d5739add15e696d8c26c53bc6fc00eb65d7b9469"},
-    {file = "watchfiles-1.0.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bfcae6aecd9e0cb425f5145afee871465b98b75862e038d42fe91fd753ddd780"},
-    {file = "watchfiles-1.0.3-cp311-cp311-win32.whl", hash = "sha256:6a76494d2c5311584f22416c5a87c1e2cb954ff9b5f0988027bc4ef2a8a67181"},
-    {file = "watchfiles-1.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:cf745cbfad6389c0e331786e5fe9ae3f06e9d9c2ce2432378e1267954793975c"},
-    {file = "watchfiles-1.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:2dcc3f60c445f8ce14156854a072ceb36b83807ed803d37fdea2a50e898635d6"},
-    {file = "watchfiles-1.0.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:93436ed550e429da007fbafb723e0769f25bae178fbb287a94cb4ccdf42d3af3"},
-    {file = "watchfiles-1.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c18f3502ad0737813c7dad70e3e1cc966cc147fbaeef47a09463bbffe70b0a00"},
-    {file = "watchfiles-1.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a5bc3ca468bb58a2ef50441f953e1f77b9a61bd1b8c347c8223403dc9b4ac9a"},
-    {file = "watchfiles-1.0.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d1ec043f02ca04bf21b1b32cab155ce90c651aaf5540db8eb8ad7f7e645cba8"},
-    {file = "watchfiles-1.0.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f58d3bfafecf3d81c15d99fc0ecf4319e80ac712c77cf0ce2661c8cf8bf84066"},
-    {file = "watchfiles-1.0.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1df924ba82ae9e77340101c28d56cbaff2c991bd6fe8444a545d24075abb0a87"},
-    {file = "watchfiles-1.0.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:632a52dcaee44792d0965c17bdfe5dc0edad5b86d6a29e53d6ad4bf92dc0ff49"},
-    {file = "watchfiles-1.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bf4b459d94a0387617a1b499f314aa04d8a64b7a0747d15d425b8c8b151da0"},
-    {file = "watchfiles-1.0.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ca94c85911601b097d53caeeec30201736ad69a93f30d15672b967558df02885"},
-    {file = "watchfiles-1.0.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:65ab1fb635476f6170b07e8e21db0424de94877e4b76b7feabfe11f9a5fc12b5"},
-    {file = "watchfiles-1.0.3-cp312-cp312-win32.whl", hash = "sha256:49bc1bc26abf4f32e132652f4b3bfeec77d8f8f62f57652703ef127e85a3e38d"},
-    {file = "watchfiles-1.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:48681c86f2cb08348631fed788a116c89c787fdf1e6381c5febafd782f6c3b44"},
-    {file = "watchfiles-1.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:9e080cf917b35b20c889225a13f290f2716748362f6071b859b60b8847a6aa43"},
-    {file = "watchfiles-1.0.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e153a690b7255c5ced17895394b4f109d5dcc2a4f35cb809374da50f0e5c456a"},
-    {file = "watchfiles-1.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac1be85fe43b4bf9a251978ce5c3bb30e1ada9784290441f5423a28633a958a7"},
-    {file = "watchfiles-1.0.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a2ec98e31e1844eac860e70d9247db9d75440fc8f5f679c37d01914568d18721"},
-    {file = "watchfiles-1.0.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0179252846be03fa97d4d5f8233d1c620ef004855f0717712ae1c558f1974a16"},
-    {file = "watchfiles-1.0.3-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:995c374e86fa82126c03c5b4630c4e312327ecfe27761accb25b5e1d7ab50ec8"},
-    {file = "watchfiles-1.0.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:29b9cb35b7f290db1c31fb2fdf8fc6d3730cfa4bca4b49761083307f441cac5a"},
-    {file = "watchfiles-1.0.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f8dc09ae69af50bead60783180f656ad96bd33ffbf6e7a6fce900f6d53b08f1"},
-    {file = "watchfiles-1.0.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:489b80812f52a8d8c7b0d10f0d956db0efed25df2821c7a934f6143f76938bd6"},
-    {file = "watchfiles-1.0.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:228e2247de583475d4cebf6b9af5dc9918abb99d1ef5ee737155bb39fb33f3c0"},
-    {file = "watchfiles-1.0.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1550be1a5cb3be08a3fb84636eaafa9b7119b70c71b0bed48726fd1d5aa9b868"},
-    {file = "watchfiles-1.0.3-cp313-cp313-win32.whl", hash = "sha256:16db2d7e12f94818cbf16d4c8938e4d8aaecee23826344addfaaa671a1527b07"},
-    {file = "watchfiles-1.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:160eff7d1267d7b025e983ca8460e8cc67b328284967cbe29c05f3c3163711a3"},
-    {file = "watchfiles-1.0.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c05b021f7b5aa333124f2a64d56e4cb9963b6efdf44e8d819152237bbd93ba15"},
-    {file = "watchfiles-1.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:310505ad305e30cb6c5f55945858cdbe0eb297fc57378f29bacceb534ac34199"},
-    {file = "watchfiles-1.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ddff3f8b9fa24a60527c137c852d0d9a7da2a02cf2151650029fdc97c852c974"},
-    {file = "watchfiles-1.0.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46e86ed457c3486080a72bc837300dd200e18d08183f12b6ca63475ab64ed651"},
-    {file = "watchfiles-1.0.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f79fe7993e230a12172ce7d7c7db061f046f672f2b946431c81aff8f60b2758b"},
-    {file = "watchfiles-1.0.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ea2b51c5f38bad812da2ec0cd7eec09d25f521a8b6b6843cbccedd9a1d8a5c15"},
-    {file = "watchfiles-1.0.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fe4e740ea94978b2b2ab308cbf9270a246bcbb44401f77cc8740348cbaeac3d"},
-    {file = "watchfiles-1.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9af037d3df7188ae21dc1c7624501f2f90d81be6550904e07869d8d0e6766655"},
-    {file = "watchfiles-1.0.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:52bb50a4c4ca2a689fdba84ba8ecc6a4e6210f03b6af93181bb61c4ec3abaf86"},
-    {file = "watchfiles-1.0.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c14a07bdb475eb696f85c715dbd0f037918ccbb5248290448488a0b4ef201aad"},
-    {file = "watchfiles-1.0.3-cp39-cp39-win32.whl", hash = "sha256:be37f9b1f8934cd9e7eccfcb5612af9fb728fecbe16248b082b709a9d1b348bf"},
-    {file = "watchfiles-1.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:ef9ec8068cf23458dbf36a08e0c16f0a2df04b42a8827619646637be1769300a"},
-    {file = "watchfiles-1.0.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:84fac88278f42d61c519a6c75fb5296fd56710b05bbdcc74bdf85db409a03780"},
-    {file = "watchfiles-1.0.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:c68be72b1666d93b266714f2d4092d78dc53bd11cf91ed5a3c16527587a52e29"},
-    {file = "watchfiles-1.0.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:889a37e2acf43c377b5124166bece139b4c731b61492ab22e64d371cce0e6e80"},
-    {file = "watchfiles-1.0.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ca05cacf2e5c4a97d02a2878a24020daca21dbb8823b023b978210a75c79098"},
-    {file = "watchfiles-1.0.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8af4b582d5fc1b8465d1d2483e5e7b880cc1a4e99f6ff65c23d64d070867ac58"},
-    {file = "watchfiles-1.0.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:127de3883bdb29dbd3b21f63126bb8fa6e773b74eaef46521025a9ce390e1073"},
-    {file = "watchfiles-1.0.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:713f67132346bdcb4c12df185c30cf04bdf4bf6ea3acbc3ace0912cab6b7cb8c"},
-    {file = "watchfiles-1.0.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abd85de513eb83f5ec153a802348e7a5baa4588b818043848247e3e8986094e8"},
-    {file = "watchfiles-1.0.3.tar.gz", hash = "sha256:f3ff7da165c99a5412fe5dd2304dd2dbaaaa5da718aad942dcb3a178eaa70c56"},
+    {file = "watchfiles-1.0.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:ba5bb3073d9db37c64520681dd2650f8bd40902d991e7b4cfaeece3e32561d08"},
+    {file = "watchfiles-1.0.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f25d0ba0fe2b6d2c921cf587b2bf4c451860086534f40c384329fb96e2044d1"},
+    {file = "watchfiles-1.0.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47eb32ef8c729dbc4f4273baece89398a4d4b5d21a1493efea77a17059f4df8a"},
+    {file = "watchfiles-1.0.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:076f293100db3b0b634514aa0d294b941daa85fc777f9c698adb1009e5aca0b1"},
+    {file = "watchfiles-1.0.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1eacd91daeb5158c598fe22d7ce66d60878b6294a86477a4715154990394c9b3"},
+    {file = "watchfiles-1.0.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:13c2ce7b72026cfbca120d652f02c7750f33b4c9395d79c9790b27f014c8a5a2"},
+    {file = "watchfiles-1.0.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:90192cdc15ab7254caa7765a98132a5a41471cf739513cc9bcf7d2ffcc0ec7b2"},
+    {file = "watchfiles-1.0.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:278aaa395f405972e9f523bd786ed59dfb61e4b827856be46a42130605fd0899"},
+    {file = "watchfiles-1.0.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a462490e75e466edbb9fc4cd679b62187153b3ba804868452ef0577ec958f5ff"},
+    {file = "watchfiles-1.0.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8d0d0630930f5cd5af929040e0778cf676a46775753e442a3f60511f2409f48f"},
+    {file = "watchfiles-1.0.4-cp310-cp310-win32.whl", hash = "sha256:cc27a65069bcabac4552f34fd2dce923ce3fcde0721a16e4fb1b466d63ec831f"},
+    {file = "watchfiles-1.0.4-cp310-cp310-win_amd64.whl", hash = "sha256:8b1f135238e75d075359cf506b27bf3f4ca12029c47d3e769d8593a2024ce161"},
+    {file = "watchfiles-1.0.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2a9f93f8439639dc244c4d2902abe35b0279102bca7bbcf119af964f51d53c19"},
+    {file = "watchfiles-1.0.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9eea33ad8c418847dd296e61eb683cae1c63329b6d854aefcd412e12d94ee235"},
+    {file = "watchfiles-1.0.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31f1a379c9dcbb3f09cf6be1b7e83b67c0e9faabed0471556d9438a4a4e14202"},
+    {file = "watchfiles-1.0.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ab594e75644421ae0a2484554832ca5895f8cab5ab62de30a1a57db460ce06c6"},
+    {file = "watchfiles-1.0.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc2eb5d14a8e0d5df7b36288979176fbb39672d45184fc4b1c004d7c3ce29317"},
+    {file = "watchfiles-1.0.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f68d8e9d5a321163ddacebe97091000955a1b74cd43724e346056030b0bacee"},
+    {file = "watchfiles-1.0.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9ce064e81fe79faa925ff03b9f4c1a98b0bbb4a1b8c1b015afa93030cb21a49"},
+    {file = "watchfiles-1.0.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b77d5622ac5cc91d21ae9c2b284b5d5c51085a0bdb7b518dba263d0af006132c"},
+    {file = "watchfiles-1.0.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1941b4e39de9b38b868a69b911df5e89dc43767feeda667b40ae032522b9b5f1"},
+    {file = "watchfiles-1.0.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4f8c4998506241dedf59613082d1c18b836e26ef2a4caecad0ec41e2a15e4226"},
+    {file = "watchfiles-1.0.4-cp311-cp311-win32.whl", hash = "sha256:4ebbeca9360c830766b9f0df3640b791be569d988f4be6c06d6fae41f187f105"},
+    {file = "watchfiles-1.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:05d341c71f3d7098920f8551d4df47f7b57ac5b8dad56558064c3431bdfc0b74"},
+    {file = "watchfiles-1.0.4-cp311-cp311-win_arm64.whl", hash = "sha256:32b026a6ab64245b584acf4931fe21842374da82372d5c039cba6bf99ef722f3"},
+    {file = "watchfiles-1.0.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:229e6ec880eca20e0ba2f7e2249c85bae1999d330161f45c78d160832e026ee2"},
+    {file = "watchfiles-1.0.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5717021b199e8353782dce03bd8a8f64438832b84e2885c4a645f9723bf656d9"},
+    {file = "watchfiles-1.0.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0799ae68dfa95136dde7c472525700bd48777875a4abb2ee454e3ab18e9fc712"},
+    {file = "watchfiles-1.0.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43b168bba889886b62edb0397cab5b6490ffb656ee2fcb22dec8bfeb371a9e12"},
+    {file = "watchfiles-1.0.4-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb2c46e275fbb9f0c92e7654b231543c7bbfa1df07cdc4b99fa73bedfde5c844"},
+    {file = "watchfiles-1.0.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:857f5fc3aa027ff5e57047da93f96e908a35fe602d24f5e5d8ce64bf1f2fc733"},
+    {file = "watchfiles-1.0.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:55ccfd27c497b228581e2838d4386301227fc0cb47f5a12923ec2fe4f97b95af"},
+    {file = "watchfiles-1.0.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c11ea22304d17d4385067588123658e9f23159225a27b983f343fcffc3e796a"},
+    {file = "watchfiles-1.0.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:74cb3ca19a740be4caa18f238298b9d472c850f7b2ed89f396c00a4c97e2d9ff"},
+    {file = "watchfiles-1.0.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c7cce76c138a91e720d1df54014a047e680b652336e1b73b8e3ff3158e05061e"},
+    {file = "watchfiles-1.0.4-cp312-cp312-win32.whl", hash = "sha256:b045c800d55bc7e2cadd47f45a97c7b29f70f08a7c2fa13241905010a5493f94"},
+    {file = "watchfiles-1.0.4-cp312-cp312-win_amd64.whl", hash = "sha256:c2acfa49dd0ad0bf2a9c0bb9a985af02e89345a7189be1efc6baa085e0f72d7c"},
+    {file = "watchfiles-1.0.4-cp312-cp312-win_arm64.whl", hash = "sha256:22bb55a7c9e564e763ea06c7acea24fc5d2ee5dfc5dafc5cfbedfe58505e9f90"},
+    {file = "watchfiles-1.0.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:8012bd820c380c3d3db8435e8cf7592260257b378b649154a7948a663b5f84e9"},
+    {file = "watchfiles-1.0.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa216f87594f951c17511efe5912808dfcc4befa464ab17c98d387830ce07b60"},
+    {file = "watchfiles-1.0.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62c9953cf85529c05b24705639ffa390f78c26449e15ec34d5339e8108c7c407"},
+    {file = "watchfiles-1.0.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7cf684aa9bba4cd95ecb62c822a56de54e3ae0598c1a7f2065d51e24637a3c5d"},
+    {file = "watchfiles-1.0.4-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f44a39aee3cbb9b825285ff979ab887a25c5d336e5ec3574f1506a4671556a8d"},
+    {file = "watchfiles-1.0.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a38320582736922be8c865d46520c043bff350956dfc9fbaee3b2df4e1740a4b"},
+    {file = "watchfiles-1.0.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39f4914548b818540ef21fd22447a63e7be6e24b43a70f7642d21f1e73371590"},
+    {file = "watchfiles-1.0.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f12969a3765909cf5dc1e50b2436eb2c0e676a3c75773ab8cc3aa6175c16e902"},
+    {file = "watchfiles-1.0.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:0986902677a1a5e6212d0c49b319aad9cc48da4bd967f86a11bde96ad9676ca1"},
+    {file = "watchfiles-1.0.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:308ac265c56f936636e3b0e3f59e059a40003c655228c131e1ad439957592303"},
+    {file = "watchfiles-1.0.4-cp313-cp313-win32.whl", hash = "sha256:aee397456a29b492c20fda2d8961e1ffb266223625346ace14e4b6d861ba9c80"},
+    {file = "watchfiles-1.0.4-cp313-cp313-win_amd64.whl", hash = "sha256:d6097538b0ae5c1b88c3b55afa245a66793a8fec7ada6755322e465fb1a0e8cc"},
+    {file = "watchfiles-1.0.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:d3452c1ec703aa1c61e15dfe9d482543e4145e7c45a6b8566978fbb044265a21"},
+    {file = "watchfiles-1.0.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7b75fee5a16826cf5c46fe1c63116e4a156924d668c38b013e6276f2582230f0"},
+    {file = "watchfiles-1.0.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e997802d78cdb02623b5941830ab06f8860038faf344f0d288d325cc9c5d2ff"},
+    {file = "watchfiles-1.0.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0611d244ce94d83f5b9aff441ad196c6e21b55f77f3c47608dcf651efe54c4a"},
+    {file = "watchfiles-1.0.4-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9745a4210b59e218ce64c91deb599ae8775c8a9da4e95fb2ee6fe745fc87d01a"},
+    {file = "watchfiles-1.0.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4810ea2ae622add560f4aa50c92fef975e475f7ac4900ce5ff5547b2434642d8"},
+    {file = "watchfiles-1.0.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:740d103cd01458f22462dedeb5a3382b7f2c57d07ff033fbc9465919e5e1d0f3"},
+    {file = "watchfiles-1.0.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbd912a61543a36aef85e34f212e5d2486e7c53ebfdb70d1e0b060cc50dd0bf"},
+    {file = "watchfiles-1.0.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0bc80d91ddaf95f70258cf78c471246846c1986bcc5fd33ccc4a1a67fcb40f9a"},
+    {file = "watchfiles-1.0.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ab0311bb2ffcd9f74b6c9de2dda1612c13c84b996d032cd74799adb656af4e8b"},
+    {file = "watchfiles-1.0.4-cp39-cp39-win32.whl", hash = "sha256:02a526ee5b5a09e8168314c905fc545c9bc46509896ed282aeb5a8ba9bd6ca27"},
+    {file = "watchfiles-1.0.4-cp39-cp39-win_amd64.whl", hash = "sha256:a5ae5706058b27c74bac987d615105da17724172d5aaacc6c362a40599b6de43"},
+    {file = "watchfiles-1.0.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cdcc92daeae268de1acf5b7befcd6cfffd9a047098199056c72e4623f531de18"},
+    {file = "watchfiles-1.0.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d8d3d9203705b5797f0af7e7e5baa17c8588030aaadb7f6a86107b7247303817"},
+    {file = "watchfiles-1.0.4-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bdef5a1be32d0b07dcea3318a0be95d42c98ece24177820226b56276e06b63b0"},
+    {file = "watchfiles-1.0.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:342622287b5604ddf0ed2d085f3a589099c9ae8b7331df3ae9845571586c4f3d"},
+    {file = "watchfiles-1.0.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9fe37a2de80aa785d340f2980276b17ef697ab8db6019b07ee4fd28a8359d2f3"},
+    {file = "watchfiles-1.0.4-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:9d1ef56b56ed7e8f312c934436dea93bfa3e7368adfcf3df4c0da6d4de959a1e"},
+    {file = "watchfiles-1.0.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95b42cac65beae3a362629950c444077d1b44f1790ea2772beaea95451c086bb"},
+    {file = "watchfiles-1.0.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e0227b8ed9074c6172cf55d85b5670199c99ab11fd27d2c473aa30aec67ee42"},
+    {file = "watchfiles-1.0.4.tar.gz", hash = "sha256:6ba473efd11062d73e4f00c2b730255f9c1bdd73cd5f9fe5b5da8dbd4a717205"},
 ]
 
 [package.dependencies]
@@ -5522,4 +5522,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "af23e8ec74240ea60aadf12d57e5bcb072460b1d4b1017c244f15098d59f0f25"
+content-hash = "cfd6134e51e8a501f6128bdc20f1bebdea5acaa739f5df30a6244170bbe40176"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ mdx-truly-sane-lists = "^1.3"
 sphinx-autobuild = "^2024.10.3"
 
 [tool.poetry.group.partcad.dependencies]
+cadquery-ocp = "7.7.2"
 build123d = "0.8.0"
 pyyaml = ">=6.0.1"
 gitpython = ">=3.1.40"


### PR DESCRIPTION

## Copilot Summary

<!-- Use GitHub Copilot to generate a summary of your changes here. -->

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated Python runtime version from 3.10 to 3.11
	- Added `cadquery-ocp` package (version 7.7.2)
	- Added `ocpsvg` package (version 0.3.4)
	- Updated several package versions, including:
		- `cadquery` to 2.5.2
		- `build123d` to 0.8.0
		- `numpy` to 2.2.1
		- `ocp-tessellate` to 3.0.9
		- `nlopt` to 2.9.0

- **Compatibility**
	- Adjusted Python version handling across multiple components
	- Removed some deprecated dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->