### PR TITLE
PC-279: Disable hooks based on UX feedback.

### DIFF
--- a/.devcontainer/.pre-commit-config.yaml
+++ b/.devcontainer/.pre-commit-config.yaml
@@ -41,8 +41,8 @@ repos:
       - id: poetry-check
       - id: poetry-lock
       - id: poetry-export
-        args:
-          [
+        args: [
+            # TODO: This should be updating corresponding ./{partcad,docs,partcad-cli}/requirements.txt
             "--format=requirements.txt",
             "--output=.devcontainer/requirements.txt",
             "--with=dev",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,10 @@
   },
   "remoteEnv": {
     // TODO: @alexanderilyin do not patch PATH here but make `mamba` discoverable.
-    "PATH": "${containerEnv:PATH}:/home/vscode/miniforge3/bin"
+    "PATH": "${containerEnv:PATH}:/home/vscode/miniforge3/bin",
+    // TODO: Enable prepare-commit-msg once rebase problem is fixed.
+    // TODO: poetry-* hooks are source of unnecessary conflicts in PRs and should be handled by dependabot.
+    "SKIP": "prepare-commit-msg,poetry-install,poetry-lock,poetry-export"
   },
   "postCreateCommand": {
     "setup-utils": "sudo apt-get update && sudo apt-get install -y file xxd",
@@ -24,7 +27,7 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "dotfiles.repository": "deepspacecartel/dotfiles"
+        "dotfiles.repository": "partcad/dotfiles"
       },
       // <!-- prettier-ignore-start -->
       "extensions": [


### PR DESCRIPTION
## Copilot Summary

This pull request includes modifications to the `.devcontainer` configuration files to improve environment setup and repository references. The most important changes include updates to the `PATH` and `SKIP` environment variables, and the correction of the dotfiles repository reference.

Environment setup improvements:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L9-R11): Updated the `PATH` environment variable and added a `SKIP` environment variable to skip specific pre-commit hooks.

Repository reference correction:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L27-R29): Changed the `dotfiles.repository` setting from `deepspacecartel/dotfiles` to `partcad/dotfiles`.

Configuration updates:

* [`.devcontainer/.pre-commit-config.yaml`](diffhunk://#diff-63160ee79c10095395e21ece8c1bc965aa50c230a6ffdc59ad295a4315d3c474L44-R45): Added a TODO comment for updating corresponding requirements files when using `poetry-export`.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated pre-commit configuration with a TODO comment for requirements file updates.
	- Modified devcontainer environment settings to skip specific tasks during setup.
	- Updated dotfiles repository reference in development environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->