### PR TITLE
feat(cli): update log format options

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -45,7 +45,9 @@ The commands and options supported by PartCAD CLI:
   │            -q                     Decrease verbosity level                                                  │
   │ --no-ansi                         Produce plain text logs without colors or animations                      │
   │            -p  PATH               Specify the package path (YAML file or directory with 'partcad.yaml')     │
-  │ --format       [time|path|level]  Set the log prefix format                                                 │
+  │ --level                           Use log level as log prefix [default: level]                              │
+  │ --time                            Use time with milliseconds as log prefix [default: level]                 │
+  │ --path                            Use source file path and line number as log prefix [default: level]       │
   │ --help                            Show this message and exit.                                               │
   ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
   ╭─ Commands ──────────────────────────────────────────────────────────────────────────────────────────────────╮

--- a/features/pc.feature
+++ b/features/pc.feature
@@ -73,14 +73,14 @@ Feature: `pc` command
 
   @wip @pc-format @pc-format-level @pc-version
   Scenario: Use log level as output prefix
-    When I run "partcad --format=level version"
+    When I run "partcad --level version"
     Then the command should exit with a status code of "0"
     And STDERR should match the regex "^INFO PartCAD Python Module version: \d+\.\d+\.\d+$"
     And STDERR should match the regex "^INFO PartCAD CLI version: \d+\.\d+\.\d+$"
 
   @wip @pc-format @pc-format-time @pc-version
   Scenario: Use time with milliseconds as output prefix
-    When I run "partcad --format=time version"
+    When I run "partcad --time version"
     Then the command should exit with a status code of "0"
     And STDERR should match the regex "^\d{2}:\d{2}:\d{2}\.\d{3} INFO PartCAD Python Module version: \d+\.\d+\.\d+$"
     And STDERR should match the regex "^\d{2}:\d{2}:\d{2}\.\d{3} INFO PartCAD CLI version: \d+\.\d+\.\d+$"
@@ -88,7 +88,7 @@ Feature: `pc` command
 
   @wip @pc-format @pc-format-path @pc-version
   Scenario: Use source file path and line number as output prefix
-    When I run "partcad --format=path version"
+    When I run "partcad --path version"
     Then the command should exit with a status code of "0"
     And STDERR should match the regex "^/.+\.py:\d+ PartCAD Python Module version: \d+\.\d+\.\d+$"
     And STDERR should match the regex "^/.+\.py:\d+ PartCAD CLI version: \d+\.\d+\.\d+$"

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -56,13 +56,9 @@ pc.plugins.export_png = pc.PluginExportPngReportlab()
     type=click.Path(exists=True),
     help="Specify the package path (YAML file or directory with 'partcad.yaml')",
 )
-@click.option(
-    "--format",
-    help="Set the log prefix format",
-    type=click.Choice(["time", "path", "level"]),
-    default=None,
-    show_envvar=True,
-)
+@click.option('--level', 'format', flag_value='level', default=True, help="Use log level as log prefix")
+@click.option('--time', 'format', flag_value='time', help="Use time with milliseconds as log prefix")
+@click.option('--path', 'format', flag_value='path', help="Use source file path and line number as log prefix")
 @click.pass_context
 def cli(ctx, verbose, quiet, no_ansi, package, format):
     """


### PR DESCRIPTION
- Removed `--format` option.
- Added `--level`, `--time`, `--path` options to customize log prefix.
- Updated some wip test cases to reflect new options.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new CLI options for log prefix formatting:
		- `--level`: Set log level as prefix (default)
		- `--time`: Use time with milliseconds as prefix
		- `--path`: Display source file path and line number as prefix

- **Deprecation**
	- Removed `--format` option for log prefix configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->