### PR TITLE
fix(partcad): Use shorted names for files in ~/.partcad

### DIFF
--- a/partcad-cli/src/partcad_cli/click/commands/reset.py
+++ b/partcad-cli/src/partcad_cli/click/commands/reset.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import rich_click as click
-from partcad.logging import Process, info
+from partcad.logging import Action, Process, info
 from partcad.context import Context
 from partcad.user_config import user_config
 
@@ -9,15 +9,19 @@ from partcad.user_config import user_config
 @click.command(help="Reset all internal states maintained by PartCAD")
 @click.pass_obj
 def cli(ctx: Context) -> None:
-    with Process("Reset", "this"):
-        for _, package_info in ctx.config_obj.get("dependencies", {}).items():
-            import_type = package_info["type"]
+    with Process("Reset", ctx.name):
+        cached_import_types = ["git", "tar"]
+        for import_type in cached_import_types:
             cache_dir = os.path.join(user_config.internal_state_dir, import_type)
             if os.path.exists(cache_dir):
-                info(f"Removing cached {import_type} dependencies: '{cache_dir}'")
-                shutil.rmtree(cache_dir)
+                with Action(f"Repos", import_type):
+                    shutil.rmtree(cache_dir)
+                    info(f"Removed cached {import_type} dependencies: '{cache_dir}'")
 
         runtime_dir = os.path.join(user_config.internal_state_dir, "runtime")
         if os.path.exists(runtime_dir):
-            info(f"Removing runtime: '{runtime_dir}'")
-            shutil.rmtree(runtime_dir)
+            for subdir in os.listdir(runtime_dir):
+                with Action("Runtime", subdir):
+                    runtime_subdir = os.path.join(runtime_dir, subdir)
+                    shutil.rmtree(runtime_subdir)
+                    info(f"Removed runtime: '{subdir}'")

--- a/partcad-cli/src/partcad_cli/click/commands/reset.py
+++ b/partcad-cli/src/partcad_cli/click/commands/reset.py
@@ -14,7 +14,7 @@ def cli(ctx: Context) -> None:
         for import_type in cached_import_types:
             cache_dir = os.path.join(user_config.internal_state_dir, import_type)
             if os.path.exists(cache_dir):
-                with Action(f"Repos", import_type):
+                with Action("Repos", import_type):
                     shutil.rmtree(cache_dir)
                     info(f"Removed cached {import_type} dependencies: '{cache_dir}'")
 

--- a/partcad/src/partcad/project_factory_tar.py
+++ b/partcad/src/partcad/project_factory_tar.py
@@ -60,7 +60,7 @@ class ProjectFactoryTar(pf.ProjectFactory, TarImportConfiguration):
             cache_dir = os.path.join(user_config.internal_state_dir, "tar")
 
         # Generate a unique identifier for the file based on its URL.
-        url_hash = hashlib.sha256(tarball_url.encode()).hexdigest()
+        url_hash = hashlib.sha256(tarball_url.encode()).hexdigest()[:16]
         cache_path = os.path.join(cache_dir, url_hash)
 
         # Check if the tarball is already cached.

--- a/partcad/src/partcad/runtime.py
+++ b/partcad/src/partcad/runtime.py
@@ -24,6 +24,6 @@ class Runtime:
         self.name = name
         self.path = os.path.join(
             Runtime.get_internal_state_dir(),
-            "partcad-" + name,  # Leave "partcad" for UX (e.g. in VS Code)
+            "pc-" + name,  # Leave "pc-" for UX (e.g. in VS Code)
         )
         self.initialized = os.path.exists(self.path)

--- a/partcad/src/partcad/runtime_python.py
+++ b/partcad/src/partcad/runtime_python.py
@@ -19,10 +19,10 @@ from . import logging as pc_logging
 from . import sync_threads
 
 
-class VenvLock(object):
+class VenvLock:
     def __init__(self, runtime, venv: str):
         runtime.venv_locks_lock.acquire()
-        if not venv in runtime.venv_locks:
+        if venv not in runtime.venv_locks:
             runtime.venv_locks[venv] = threading.Lock()
         self.lock = runtime.venv_locks[venv]
         runtime.venv_locks_lock.release()
@@ -34,7 +34,7 @@ class VenvLock(object):
         self.lock.release()
 
 
-class AsyncVenvLock(object):
+class AsyncVenvLock:
     def __init__(self, runtime, venv: str):
         self.runtime = runtime
         self.venv = venv
@@ -59,7 +59,7 @@ class PythonRuntime(runtime.Runtime):
 
         if version is None:
             version = "%d.%d" % (sys.version_info.major, sys.version_info.minor)
-        super().__init__(ctx, "python-" + sandbox + "-" + version)
+        super().__init__(ctx, "py-" + sandbox + "-" + version)
         self.version = version
 
         # Runtimes are meant to be executed from dedicated threads, outside of
@@ -250,7 +250,7 @@ class PythonRuntime(runtime.Runtime):
         if path is None:
             path = self.path
 
-        python_package_hash = hashlib.sha256(python_package.encode()).hexdigest()
+        python_package_hash = hashlib.sha256(python_package.encode()).hexdigest()[:16]
         guard_path = os.path.join(path, ".partcad.installed." + python_package_hash)
         if session:
             # Add the dependency to the session dependencies
@@ -277,7 +277,7 @@ class PythonRuntime(runtime.Runtime):
 
         # TODO(clairbee): expire the guard file after a certain time
 
-        python_package_hash = hashlib.sha256(python_package.encode()).hexdigest()
+        python_package_hash = hashlib.sha256(python_package.encode()).hexdigest()[:16]
         guard_path = os.path.join(path, ".partcad.installed." + python_package_hash)
         if session:
             # Add the dependency to the session dependencies
@@ -305,7 +305,7 @@ class PythonRuntime(runtime.Runtime):
 
         # TODO(clairbee): expire the guard file after a certain time
 
-        python_package_hash = hashlib.sha256(python_package.encode()).hexdigest()
+        python_package_hash = hashlib.sha256(python_package.encode()).hexdigest()[:16]
         guard_path = os.path.join(path, ".partcad.installed." + python_package_hash)
         if session:
             # Add the dependency to the session dependencies
@@ -399,7 +399,7 @@ class PythonRuntime(runtime.Runtime):
 
     def get_session(self, name: str):
         """Create a context to describe the venv environment in case it is needed"""
-        name_hash = hashlib.sha256(name.encode()).hexdigest()
+        name_hash = hashlib.sha256(name.encode()).hexdigest()[:16]
         venv_path = os.path.join(self.path, "v-env-" + name_hash)
         return {
             "name": name,


### PR DESCRIPTION
Add better handling of Python package hashes for runtime.
Use shorter hash for import config URLs.
Update Runtime class to use \"pc-\" prefix.
Refactor PythonRuntime get_session method.
Refactor PythonRuntime install and uninstall methods.
Refactor VenvLock and AsyncVenvLock to remove object.
Refactor reset command to use Action for logging.
Improve reset command to handle git/tar dependencies deletion.
Remove unnecessary pathlib import
Replace fatal error patterns.

## Copilot Summary

<!-- Use GitHub Copilot to generate a summary of your changes here. -->

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced logging during the reset process with more detailed feedback

- **Bug Fixes**
  - Improved runtime directory and cache management
  - Refined error logging for Python runtime operations

- **Style**
  - Consistent code formatting across multiple modules
  - Simplified class definitions
  - Updated string handling and hash generation

- **Chores**
  - Streamlined internal state management
  - Optimized dependency tracking mechanisms
  - Adjusted runtime identifier naming conventions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->