### PR TITLE
feat: Add "pc convert" (PCO-39) | FROM FORK

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -87,6 +87,63 @@ Now the part can be exported:
 
     pc export -t stl :test
 
+
+Convert a part, assembly, or sketch
+-----------------------------------
+
+The `pc convert` command allows you to convert parts, assemblies, or sketches to a different format, and optionally update their type in the `partcad.yaml` configuration.
+
+For example, to convert a part defined in STL format to STEP format:
+
+.. code-block:: shell
+
+    # Convert the part "cube" to STEP format
+    pc convert -t step :cube
+
+To update the part's type in `partcad.yaml` after conversion, use the ``--in-place`` flag:
+
+.. code-block:: shell
+
+    # Convert the part "cube" to STEP format and update its type in the configuration
+    pc convert -t step --in-place :cube
+
+You can also specify an output directory for the converted files:
+
+.. code-block:: shell
+
+    # Convert the part "cube" to STEP format and save it in the specified directory
+    pc convert -t step -O ./output :cube
+
+To convert objects from a specific package, use the `--package` flag:
+
+.. code-block:: shell
+
+    # Convert the part "cube" in the "produce_part_stl" package to STEP format
+    pc convert -t step --package /produce_part_stl :cube
+
+For recursive processing of all packages, use the ``--recursive`` flag:
+
+.. code-block:: shell
+
+    # Convert all parts in the "produce_part_cadquery" package and its dependencies to STEP format
+    pc convert --recursive -t step --package /produce_part_cadquery
+
+Supported formats for conversion include:
+
+- STEP
+- BREP
+- STL
+- 3MF
+- Three.js (JSON)
+- OBJ
+- glTF (JSON)
+
+.. note::
+
+    - The object must exist in the `partcad.yaml` file and be defined as a part, assembly, or sketch.
+    - The `--in-place` option ensures that the type of the object is updated in `partcad.yaml` after conversion.
+    - If the target format is not supported by the object, a warning will be displayed, and the conversion will be skipped.
+
 Reset partcad
 ---------------------
 

--- a/features/convert.feature
+++ b/features/convert.feature
@@ -1,0 +1,144 @@
+@cli @pc-convert
+Feature: `pc convert` command
+
+  Background: Sandbox
+    Given I am in "/tmp/sandbox/behave" directory
+    Given I have temporary $HOME in "/tmp/sandbox/home"
+    Given a file named "partcad.yaml" does not exist
+
+  Scenario Outline: `pc convert` command
+    When I run "partcad -p /workspaces/partcad/examples convert --package <package> -t <type> -O ./ <object>"
+    Then the command should exit with a status code of "0"
+    Then a file named "<filename>" should be created
+    Then STDOUT should contain "DONE: Convert: this:"
+    Then STDOUT should not contain "WARN:"
+    Then STDOUT should not contain "ERROR:"
+
+  @part
+  Examples: Convert Part
+    | package               | object | type    | filename        |
+    | /produce_part_stl     | cube   | step    | cube.step       |
+    | /produce_part_stl     | cube   | brep    | cube.brep       |
+    | /produce_part_stl     | cube   | stl     | cube.stl        |
+    | /produce_part_stl     | cube   | threejs | cube.json       |
+    | /produce_part_stl     | cube   | gltf    | cube.json       |
+
+  @assembly
+  Examples: Convert Assembly
+    | package                   | object           | type    | filename              |
+    | /produce_assembly_assy    | logo_embedded    | step    | logo_embedded.step    |
+    | /produce_assembly_assy    | logo_embedded    | stl     | logo_embedded.stl     |
+    | /produce_assembly_assy    | logo_embedded    | obj     | logo_embedded.obj     |
+
+  @sketch
+  Examples: Convert Sketch
+    | package                | object     | type    | filename          |
+    | /produce_sketch_basic  | circle_01  | svg     | circle_01.svg     |
+    | /produce_sketch_basic  | rect_01    | svg     | rect_01.svg       |
+    | /produce_sketch_svg    | svg_01     | svg     | svg_01.svg        |
+
+---
+
+### Feature: `pc convert` In-Place Updates
+
+@cli @pc-convert-in-place
+Feature: `pc convert` command with `--in-place`
+
+  Background: Sandbox
+    Given I am in "/tmp/sandbox/behave" directory
+    Given I have temporary $HOME in "/tmp/sandbox/home"
+    Given a file named "partcad.yaml" with content:
+      """
+      parts:
+        cube:
+          type: stl
+      """
+
+  Scenario Outline: Convert and update type in partcad.yaml
+    When I run "partcad -p /workspaces/partcad/examples convert -t <type> --in-place <object>"
+    Then the command should exit with a status code of "0"
+    Then a file named "<filename>" should be created
+    Then STDOUT should contain "DONE: Convert: this:"
+    Then STDOUT should not contain "WARN:"
+    Then the `partcad.yaml` file should contain:
+      """
+      parts:
+        cube:
+          type: <type>
+      """
+
+  @type-object
+  Examples: In-Place Conversion
+    | type    | object | filename    |
+    | step    | cube   | cube.step   |
+    | stl     | cube   | cube.stl    |
+
+---
+
+### Feature: Error Handling for `pc convert`
+
+```gherkin
+@cli @pc-convert-errors
+Feature: `pc convert` error handling
+
+  Background: Sandbox
+    Given I am in "/tmp/sandbox/behave" directory
+    Given I have temporary $HOME in "/tmp/sandbox/home"
+    Given a file named "partcad.yaml" with content:
+      """
+      parts:
+        cube:
+          type: stl
+      """
+
+  @error
+  Scenario: Convert non-existent object
+    When I run "partcad convert -t step non_existent_object"
+    Then the command should exit with a status code of "1"
+    And STDERR should contain "Object 'non_existent_object' not found in parts, assemblies, or sketches"
+
+  @error
+  Scenario: Convert with unsupported format
+    When I run "partcad convert -t unsupported_format cube"
+    Then the command should exit with a status code of "1"
+    And STDERR should contain "Invalid choice: 'unsupported_format'"
+
+  @error
+  Scenario: Convert without specifying object
+    When I run "partcad convert -t step"
+    Then the command should exit with a status code of "1"
+    And STDERR should contain "Object must be specified for conversion"
+
+---
+
+### Feature: Recursive Package Conversion
+
+```gherkin
+@cli @pc-convert-recursive
+Feature: `pc convert` command with recursive packages
+
+  Background: Sandbox
+    Given I am in "/tmp/sandbox/behave" directory
+    Given I have temporary $HOME in "/tmp/sandbox/home"
+    Given the following files exist:
+      """
+      /workspaces/partcad/examples/produce_part_recursive/partcad.yaml:
+      parts:
+        cube_1:
+          type: stl
+        cube_2:
+          type: stl
+        cube_3:
+          type: stl
+      """
+
+  Scenario: Convert all parts in a recursive package
+    When I run "partcad -p /workspaces/partcad/examples/produce_part_recursive convert -r -t step"
+    Then the command should exit with a status code of "0"
+    Then the following files should be created:
+      | cube_1.step |
+      | cube_2.step |
+      | cube_3.step |
+    Then STDOUT should contain "DONE: Convert: this:"
+    Then STDOUT should not contain "WARN:"
+    Then STDOUT should not contain "ERROR:"

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -271,6 +271,7 @@ def cli(ctx, verbose, quiet, no_ansi, package, format, **kwargs):
     commands_with_context = [
         "add",
         "ai",
+        "convert",
         "info",
         "inspect",
         "install",

--- a/partcad-cli/src/partcad_cli/click/commands/convert.py
+++ b/partcad-cli/src/partcad_cli/click/commands/convert.py
@@ -88,14 +88,37 @@ def _resolve_package_object(ctx, package, object):
 
 def _convert_object(project, object, target_format, output_dir, in_place):
     """Perform the conversion of the specified object."""
-    parts = [object]  # Assume the object is a part by default
+    # Determine the object type from the project configuration
+    if object in project.parts:
+        parts = [object]
+        sketches = []
+        assemblies = []
+    elif object in project.assemblies:
+        parts = []
+        sketches = []
+        assemblies = [object]
+    elif object in project.sketches:
+        parts = []
+        sketches = [object]
+        assemblies = []
+    else:
+        raise click.UsageError(f"Object '{object}' not found in parts, assemblies, or sketches.")
+
+    # Log the conversion process
     logging.info(f"Converting object '{object}' to format '{target_format}'")
 
+    # Perform the conversion
     project.convert(
-        sketches=[], interfaces=[], parts=parts, assemblies=[],
-        target_format=target_format, output_dir=output_dir, in_place=in_place
+        sketches=sketches,
+        interfaces=[],
+        parts=parts,
+        assemblies=assemblies,
+        target_format=target_format,
+        output_dir=output_dir,
+        in_place=in_place,
     )
 
+    # Update configuration if in-place is enabled
     if in_place:
         logging.info(f"Updating configuration for object '{object}' to type '{target_format}'")
         project.update_part_config(object, {"type": target_format})

--- a/partcad-cli/src/partcad_cli/click/commands/convert.py
+++ b/partcad-cli/src/partcad_cli/click/commands/convert.py
@@ -2,6 +2,8 @@ import rich_click as click
 import partcad.logging as logging
 import partcad.utils as pc_utils
 from partcad import Project
+from typing import List, Optional, Tuple
+
 
 @click.command(help="Convert parts, assemblies, or scenes to another format and update their type")
 @click.option(
@@ -44,7 +46,16 @@ from partcad import Project
 )
 @click.argument("object", type=str, required=True)
 @click.pass_obj
-def cli(ctx, create_dirs, output_dir, target_format, package, recursive, in_place, object):
+def cli(
+    ctx: object,
+    create_dirs: bool,
+    output_dir: Optional[str],
+    target_format: str,
+    package: Optional[str],
+    recursive: bool,
+    in_place: bool,
+    object: str,
+) -> None:
     """CLI command to convert parts, assemblies, or scenes."""
     logging.info(f"Starting 'pc convert' with object={object}, target_format={target_format}, in_place={in_place}")
 
@@ -68,16 +79,16 @@ def cli(ctx, create_dirs, output_dir, target_format, package, recursive, in_plac
     logging.info("Finished 'pc convert' command.")
 
 
-def _get_packages(ctx, package, recursive):
+def _get_packages(ctx: object, package: str, recursive: bool) -> List[str]:
     """Retrieve a list of packages to process."""
     if recursive:
-        start_package = pc_utils.get_child_project_path(ctx.get_current_project_path(), package)
+        start_package: str = pc_utils.get_child_project_path(ctx.get_current_project_path(), package)
         all_packages = ctx.get_all_packages(start_package)
         return [pkg["name"] for pkg in all_packages]
     return [package]
 
 
-def _resolve_package_object(ctx, package, object):
+def _resolve_package_object(ctx: object, package: str, object: str) -> Tuple[str, str]:
     """Resolve the package and object if provided in 'package:object' format."""
     if ":" not in object:
         object = f":{object}"
@@ -86,13 +97,19 @@ def _resolve_package_object(ctx, package, object):
     return package, object
 
 
-def _convert_object(project, object, target_format, output_dir, in_place):
+def _convert_object(
+    project: Project,
+    object: str,
+    target_format: str,
+    output_dir: Optional[str],
+    in_place: bool,
+) -> None:
     """Perform the conversion of the specified object."""
     # Determine the object type from the project configuration
     if object in project.parts:
         parts = [object]
-        sketches = []
-        assemblies = []
+        sketches: List[str] = []
+        assemblies: List[str] = []
     elif object in project.assemblies:
         parts = []
         sketches = []

--- a/partcad-cli/src/partcad_cli/click/commands/convert.py
+++ b/partcad-cli/src/partcad_cli/click/commands/convert.py
@@ -1,0 +1,101 @@
+import rich_click as click
+import partcad.logging as logging
+import partcad.utils as pc_utils
+from partcad import Project
+
+@click.command(help="Convert parts, assemblies, or scenes to another format and update their type")
+@click.option(
+    "-p",
+    "--create-dirs",
+    help="Create the necessary directory structure if it is missing",
+    is_flag=True,
+)
+@click.option(
+    "-O",
+    "--output-dir",
+    help="Output directory for converted files",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+)
+@click.option(
+    "-t",
+    "--target-format",
+    help="Target format to convert to",
+    type=click.Choice(["step", "brep", "stl", "3mf", "threejs", "obj", "gltf"]),
+    required=True,
+)
+@click.option(
+    "-P",
+    "--package",
+    help="Specify the package containing the object",
+    type=str,
+)
+@click.option(
+    "-r",
+    "--recursive",
+    help="Recursively process all imported packages",
+    is_flag=True,
+)
+@click.option(
+    "-i",
+    "--in-place",
+    help="Update the object's type in place after conversion",
+    is_flag=True,
+    default=False,
+)
+@click.argument("object", type=str, required=True)
+@click.pass_obj
+def cli(ctx, create_dirs, output_dir, target_format, package, recursive, in_place, object):
+    """CLI command to convert parts, assemblies, or scenes."""
+    logging.info(f"Starting 'pc convert' with object={object}, target_format={target_format}, in_place={in_place}")
+
+    # Set options for creating directories
+    ctx.option_create_dirs = create_dirs
+
+    # Determine package(s) to process
+    package = package or ""
+    packages = _get_packages(ctx, package, recursive)
+
+    # Process each package
+    for pkg in packages:
+        package, object = _resolve_package_object(ctx, pkg, object)
+
+        if not object:
+            raise click.UsageError("Object must be specified for conversion.")
+
+        project: Project = ctx.get_project(package)
+        _convert_object(project, object, target_format, output_dir, in_place)
+
+    logging.info("Finished 'pc convert' command.")
+
+
+def _get_packages(ctx, package, recursive):
+    """Retrieve a list of packages to process."""
+    if recursive:
+        start_package = pc_utils.get_child_project_path(ctx.get_current_project_path(), package)
+        all_packages = ctx.get_all_packages(start_package)
+        return [pkg["name"] for pkg in all_packages]
+    return [package]
+
+
+def _resolve_package_object(ctx, package, object):
+    """Resolve the package and object if provided in 'package:object' format."""
+    if ":" not in object:
+        object = f":{object}"
+    package, object = pc_utils.resolve_resource_path(ctx.get_current_project_path() + package, object)
+    logging.info(f"Resolved object '{object}' in package '{package}'")
+    return package, object
+
+
+def _convert_object(project, object, target_format, output_dir, in_place):
+    """Perform the conversion of the specified object."""
+    parts = [object]  # Assume the object is a part by default
+    logging.info(f"Converting object '{object}' to format '{target_format}'")
+
+    project.convert(
+        sketches=[], interfaces=[], parts=parts, assemblies=[],
+        target_format=target_format, output_dir=output_dir, in_place=in_place
+    )
+
+    if in_place:
+        logging.info(f"Updating configuration for object '{object}' to type '{target_format}'")
+        project.update_part_config(object, {"type": target_format})

--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -1441,7 +1441,7 @@ class Project(project_config.Configuration):
         if not target_format:
             raise ValueError("Target format must be specified for conversion.")
 
-        with pc_logging.Action("AsyncConvert", self.name):
+        with pc_logging.Action("Convert", self.name):
             shapes = []
             if sketches:
                 shapes.extend(self.get_sketch(name) for name in sketches)


### PR DESCRIPTION
## Copilot Summary

<!-- Use GitHub Copilot to generate a summary of your changes here. -->

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new CLI command `convert` to transform parts, assemblies, and sketches between various formats.
	- Supports conversion to formats like STEP, BREP, STL, 3MF, Three.js, OBJ, and glTF.
	- Provides options for recursive package processing, in-place updates, and custom output directories.
	- Added comprehensive documentation for the `pc convert` command, including usage examples and supported formats.

- **Improvements**
	- Enhanced project conversion capabilities with new synchronous and asynchronous conversion methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->