### PR TITLE
PC-322-move-acceptance-tests-to-dedicated-scheduled-job

### DIFF
--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -612,9 +612,10 @@ jobs:
       #     retention-days: 7
 
   integration-tests:
+    if: github.event_name == 'schedule'
     name: "Run: pc"
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 60
     needs: poetry-install
     steps:
       - name: Checkout (GitHub)


### PR DESCRIPTION
## Copilot Summary

This pull request includes a change to the `.github/workflows/dev-container.yml` file to improve the integration tests workflow.

Changes to the integration tests workflow:

* `jobs:` section in `.github/workflows/dev-container.yml`: Added a condition to run integration tests only when the GitHub event is 'schedule' and increased the timeout for the integration tests from 10 to 60 minutes.

<!--

CodeRabbit will automatically analyze your PR and provide:
- Code review comments
- Security analysis
- Performance insights
No action needed in this section - let AI do the heavy lifting!

@coderabbitai
-->
