### PR TITLE
Pco 17 update user configurations

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -144,7 +144,6 @@ Some PartCAD commands and interfaces allow referencing multiple packages at once
 ``"<package-path>/..."`` is a reference to ``"<package-path>"`` and to all of its
 sub-packages.
 
-.. _object-ids:
 Object IDs
 ==========
 

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -144,6 +144,7 @@ Some PartCAD commands and interfaces allow referencing multiple packages at once
 ``"<package-path>/..."`` is a reference to ``"<package-path>"`` and to all of its
 sub-packages.
 
+.. _object-ids:
 Object IDs
 ==========
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -328,7 +328,9 @@ Example:
         <parameter name>: <parameter value>
 
 
-`Object IDs <http://localhost:8002/design.html#object-ids>`_ are used to reference different types of objects within a package, such as sketches, parts, assemblies, scenes, interfaces, and providers.
+:ref:`Object IDs <object-ids>` are used to reference different
+types of objects within a package, such as sketches, parts,
+assemblies, scenes, interfaces, and providers.
 
 
 Accessing Parameters in Providers

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -328,7 +328,7 @@ Example:
         <parameter name>: <parameter value>
 
 
-:ref:`Object IDs <object-ids>` are used to reference different
+Object IDs are used to reference different
 types of objects within a package, such as sketches, parts,
 assemblies, scenes, interfaces, and providers.
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -239,3 +239,116 @@ to the ~/.partcad/config.yaml:
       overrides:
         url:
           "git@github.com:": "https://github.com/"
+
+===================================
+Personally Identifiable Information
+===================================
+
+The user section in ``~/.partcad/config.yaml`` defines the default personal
+and contact details used throughout the system. These details include
+the user's name, email, phone number, company, and address information.
+
+  .. code-block:: yaml
+
+    # ~/.partcad/config.yaml
+    user:
+        firstName: <...>
+        lastName: <...>
+        email: <...>
+        phone: <...>
+        company: <...>
+        line1: <...>
+        line2: <(optional)>
+        countryCode: US
+        stateCode: <...>
+        zipCode: <...>
+        city: <...>
+
+Address Configuration
+---------------------
+
+Users can override any details from the user section
+by specifying shippingAddress and billingAddress separately.
+
+  .. code-block:: yaml
+
+    # ~/.partcad/config.yaml
+    user: # Default user details (includes firstName, lastName, email, phone, company, address, etc.)
+
+    shippingAddress:  # Optional, overrides user details for shipping
+        firstName: <(optional)>
+        lastName: <(optional)>
+        phone: <(optional)>
+        company: <(optional)>
+        line1: <(optional)>
+        line2: <(optional)>
+        countryCode: <(optional)>
+        stateCode: <(optional)>
+        zipCode: <(optional)>
+        city: <(optional)>
+
+    billingAddress:  # Optional, overrides user details for billing
+        firstName: <(optional)>
+        lastName: <(optional)>
+        phone: <(optional)>
+        company: <(optional)>
+        line1: <(optional)>
+        line2: <(optional)>
+        countryCode: <(optional)>
+        stateCode: <(optional)>
+        zipCode: <(optional)>
+        city: <(optional)>
+
+**Override Behavior**
+
+- If shippingAddress is not specified, the system will use the user details for shipping.
+- If billingAddress is not specified, the system will use the user details for billing.
+- If shippingAddress or billingAddress is provided, it completely replaces the corresponding fields from user.
+
+This setup allows full customization of shipping and billing details,
+supporting scenarios where items need to be sent to different recipients or addresses.
+
+
+=======================
+Parameter Configuration
+=======================
+
+The configuration file (``~/.partcad/config.yaml``) allows users to define
+reusable parameters, which can be accessed dynamically within the provider configurations.
+
+In ``~/.partcad/config.yaml``, parameters are stored under a parameters section.
+
+Example:
+
+  .. code-block:: yaml
+
+    # ~/.partcad/config.yaml
+    parameters:
+      object_id:
+        <parameter name>: <parameter value>
+
+
+`Object IDs <http://localhost:8002/design.html#object-ids>`_ are used to reference different types of objects within a package, such as sketches, parts, assemblies, scenes, interfaces, and providers.
+
+
+Accessing Parameters in Providers
+---------------------------------
+
+In the providers section, parameters can be referenced dynamically
+using a function ``get_from_config()``, ensuring that sensitive
+or reusable values (e.g., API keys, URLs) do not need to be
+hardcoded multiple times.
+
+Example:
+
+  .. code-block:: yaml
+
+    # ~/.partcad/config.yaml
+    providers:
+      <provider name>:
+        type: <store|manufacturer|enrich>
+        url: <...>
+        parameters:
+          url:
+            type: string
+            default: {{ get_from_config() }}

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -323,7 +323,7 @@ def cli(ctx, verbose, quiet, no_ansi, package, format, **kwargs):
     for params in kwargs["extra_param"]:
         param, value = params.split("=")
         object_id, key = param.split(".")
-        if not user_config.parameter_config[object_id]:
+        if object_id not in user_config.parameter_config:
             user_config.parameter_config[object_id] = {}
         user_config.parameter_config[object_id][key] = value
 

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -214,6 +214,14 @@ help_config.dump_to_globals()
     show_envvar=True,
     help="Traces sample rate for Sentry in percent",
 )
+@click.option(
+    "--extra-param",
+    type=str,
+    multiple=True,
+    default=(),
+    show_envvar=True,
+    help="parameter(s) for configuration. Example: --extra-param key1=value1 --extra-param key2=value2",
+)
 @click.option("--level", "format", flag_value="level", default=True, help="Use log level as log prefix")
 @click.option("--time", "format", flag_value="time", help="Use time with milliseconds as log prefix")
 @click.option("--path", "format", flag_value="path", help="Use source file path and line number as log prefix")
@@ -310,6 +318,14 @@ def cli(ctx, verbose, quiet, no_ansi, package, format, **kwargs):
                 user_config.set(attrib, value)
             else:
                 setattr(user_config, attrib, value)
+
+    # parse extra parameters and add them to the user_config
+    for params in kwargs["extra_param"]:
+        param, value = params.split("=")
+        object_id, key = param.split(".")
+        if not user_config.parameter_config[object_id]:
+            user_config.parameter_config[object_id] = {}
+        user_config.parameter_config[object_id][key] = value
 
     if ctx.invoked_subcommand in commands_with_forced_update:
         user_config.force_update = True        

--- a/partcad-cli/src/partcad_cli/click/commands/info.py
+++ b/partcad-cli/src/partcad_cli/click/commands/info.py
@@ -84,6 +84,7 @@ def cli(ctx, package, interface, assembly, sketch, scene, object, params):  # , 
         else:
             logging.error(f"Object {object} not found in package {package}")
     else:
+        # TODO: call normalize config method for updating the parameters
         logging.info(f"CONFIGURATION: {pformat(obj.config)}")
         info = obj.info()
         for k, v in info.items():

--- a/partcad/src/partcad/config.py
+++ b/partcad/src/partcad/config.py
@@ -1,0 +1,57 @@
+from .user_config import user_config
+
+
+class Configuration:
+    def __init__(self, name, config) -> None:
+        super().__init__(name, config)
+
+    @staticmethod
+    def normalize(name, config, object_name):
+        if config is None:
+            config = {}
+
+        # Instead of passing the name as a parameter,
+        # enrich the configuration object
+        # TODO(clairbee): reconsider passing the name as a parameter
+        config["name"] = name
+        config["orig_name"] = name
+
+        if "parameters" in config:
+            for param_name, param_value in config["parameters"].items():
+                # Expand short formats
+                if isinstance(param_value, str):
+                    config["parameters"][param_name] = {
+                        "type": "string",
+                        "default": param_value,
+                    }
+                elif isinstance(param_value, bool):
+                    config["parameters"][param_name] = {
+                        "type": "bool",
+                        "default": param_value,
+                    }
+                elif isinstance(param_value, float):
+                    config["parameters"][param_name] = {
+                        "type": "float",
+                        "default": param_value,
+                    }
+                elif isinstance(param_value, int):
+                    config["parameters"][param_name] = {
+                        "type": "int",
+                        "default": param_value,
+                    }
+                elif isinstance(param_value, list):
+                    config["parameters"][param_name] = {
+                        "type": "array",
+                        "default": param_value,
+                    }
+                # All params are float unless another type is explicitly specified
+                elif isinstance(param_value, dict) and "type" not in param_value:
+                    param_value["type"] = "float"
+
+        # Override parameters with user configuration
+        config_parameters = user_config.parameter_config.to_dict()
+        if object_name in config_parameters and "parameters" in config:
+            parameter_config = config_parameters[object_name]
+            for param_name in parameter_config:
+                config["parameters"][param_name]["default"] = parameter_config[param_name]
+        return config

--- a/partcad/src/partcad/interface.py
+++ b/partcad/src/partcad/interface.py
@@ -112,6 +112,11 @@ class InterfaceParameter:
 
     @staticmethod
     def config_normalize(config):
+        """
+        TODO: This logic should be part of the part normalization process to maintain
+        consistency. Performing it separately doesn't make sense and may lead to
+        inconsistencies.
+        """
         if isinstance(config, (int, float)):
             config = {
                 "min": config,

--- a/partcad/src/partcad/part_config.py
+++ b/partcad/src/partcad/part_config.py
@@ -7,52 +7,22 @@
 # Licensed under Apache License, Version 2.0.
 #
 
+from .config import Configuration
 from .shape_config import ShapeConfiguration
 from .part_config_manufacturing import PartConfigManufacturing
 
 
-class PartConfiguration(ShapeConfiguration):
+class PartConfiguration(Configuration, ShapeConfiguration):
     def __init__(self, name, config):
         super().__init__(name, config)
 
     @staticmethod
-    def normalize(name, config):
+    def normalize(name, config, object_name):
         if isinstance(config, str):
             # This is a short form alias
             config = {"type": "alias", "source": config}
 
-        if "parameters" in config:
-            for param_name, param_value in config["parameters"].items():
-                # Expand short formats
-                if isinstance(param_value, str):
-                    config["parameters"][param_name] = {
-                        "type": "string",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, bool):
-                    config["parameters"][param_name] = {
-                        "type": "bool",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, float):
-                    config["parameters"][param_name] = {
-                        "type": "float",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, int):
-                    config["parameters"][param_name] = {
-                        "type": "int",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, list):
-                    config["parameters"][param_name] = {
-                        "type": "array",
-                        "default": param_value,
-                    }
-                # All params are float unless another type is explicitly speciifed
-                elif isinstance(param_value, dict) and not "type" in param_value:
-                    param_value["type"] = "float"
-
+        config = Configuration.normalize(name, config, object_name)
         return ShapeConfiguration.normalize(name, config)
 
     @staticmethod

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -86,11 +86,12 @@ class PartFactoryEnrich(pf.PartFactory):
                 return
 
             augmented_config = copy.deepcopy(augmented_config)
+            object_name = f"{self.project.name}:{self.name}"
             # TODO(clairbee): ideally whatever we pull from the project is already normalized
             augmented_config = part_config.PartConfiguration.normalize(
                 self.source_part_name,
                 augmented_config,
-                self.source_part_name # TODO: @azhar - send object_name instead of self.source_part_name
+                object_name
             )
 
             # Drop fields we don't want to be inherited by enriched clones

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -90,6 +90,7 @@ class PartFactoryEnrich(pf.PartFactory):
             augmented_config = part_config.PartConfiguration.normalize(
                 self.source_part_name,
                 augmented_config,
+                self.source_part_name # TODO: @azhar - send object_name instead of self.source_part_name
             )
 
             # Drop fields we don't want to be inherited by enriched clones

--- a/partcad/src/partcad/part_factory_enrich.py
+++ b/partcad/src/partcad/part_factory_enrich.py
@@ -157,6 +157,13 @@ class PartFactoryEnrich(pf.PartFactory):
             part.cache_dependencies = copy.copy(source.cache_dependencies)
             part.cache_dependencies_broken = source.cache_dependencies_broken
 
+            # Recalling normalize to normalize data after replacing target parameters from with key.
+            part.config = part_config.PartConfiguration.normalize(
+                self.name,
+                part.config,
+                object_name
+            )
+
             _wrapped = source._wrapped
             if _wrapped:
                 part._wrapped = _wrapped

--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -358,7 +358,11 @@ class Project(project_config.Configuration):
 
         for sketch_name in self.sketch_configs:
             config = self.get_sketch_config(sketch_name)
-            config = sketch_config.SketchConfiguration.normalize(sketch_name, config)
+            config = sketch_config.SketchConfiguration.normalize(
+                sketch_name,
+                config,
+                sketch_name # TODO: @azhar - send object_name instead of sketch_name
+            )
             self.init_sketch_by_config(config)
 
     def init_sketch_by_config(self, config, source_project=None):
@@ -398,7 +402,11 @@ class Project(project_config.Configuration):
                     "name": alias,
                     "source": ":" + sketch_name,
                 }
-                alias_sketch_config = sketch_config.SketchConfiguration.normalize(alias, alias_sketch_config)
+                alias_sketch_config = sketch_config.SketchConfiguration.normalize(
+                    alias,
+                    alias_sketch_config,
+                    alias # TODO: @azhar - send object_name instead of alias
+                )
                 pfa.SketchFactoryAlias(self.ctx, source_project, self, alias_sketch_config)
 
     def get_sketch(self, sketch_name, func_params=None) -> sketch.Sketch:
@@ -451,7 +459,11 @@ class Project(project_config.Configuration):
                     return None
                 # This is not yet created (invalidated?)
                 config = self.get_sketch_config(sketch_name)
-                config = sketch_config.SketchConfiguration.normalize(sketch_name, config)
+                config = sketch_config.SketchConfiguration.normalize(
+                    sketch_name,
+                    config,
+                    sketch_name # TODO: @azhar - send object_name instead of alias
+                )
                 self.init_sketch_by_config(config)
 
                 if not sketch_name in self.sketches or self.sketches[sketch_name] is None:
@@ -489,7 +501,11 @@ class Project(project_config.Configuration):
                 return None
 
             # Expand the config object so that the parameter values can be set
-            config = sketch_config.SketchConfiguration.normalize(result_name, config)
+            config = sketch_config.SketchConfiguration.normalize(
+                result_name,
+                config,
+                result_name # TODO: @azhar - send object_name instead of result_name
+            )
             config["orig_name"] = base_sketch_name
 
             # Fill in the parameter values
@@ -550,7 +566,11 @@ class Project(project_config.Configuration):
 
         for part_name in self.part_configs:
             config = self.get_part_config(part_name)
-            config = part_config.PartConfiguration.normalize(part_name, config)
+            config = part_config.PartConfiguration.normalize(
+                part_name,
+                config,
+                part_name # TODO: @azhar - send object_name instead of part_name
+            )
             self.init_part_by_config(config)
 
     def init_part_by_config(self, config: dict, source_project: "Project" = None):
@@ -608,7 +628,11 @@ class Project(project_config.Configuration):
                     "name": alias,
                     "source": ":" + part_name,
                 }
-                alias_part_config = part_config.PartConfiguration.normalize(alias, alias_part_config)
+                alias_part_config = part_config.PartConfiguration.normalize(
+                    alias,
+                    alias_part_config,
+                    alias # TODO: @azhar - send object_name instead of alias
+                )
                 pfa.PartFactoryAlias(self.ctx, source_project, self, alias_part_config)
 
     def get_part(self, part_name, func_params=None, quiet=False) -> Optional[Part]:
@@ -662,7 +686,11 @@ class Project(project_config.Configuration):
                     return None
                 # This is not yet created (invalidated?)
                 config = self.get_part_config(part_name)
-                config = part_config.PartConfiguration.normalize(part_name, config)
+                config = part_config.PartConfiguration.normalize(
+                    part_name,
+                    config,
+                    part_name # TODO: @azhar - send object_name instead of part_name
+                )
                 self.init_part_by_config(config)
 
                 if not part_name in self.parts or self.parts[part_name] is None:
@@ -700,7 +728,11 @@ class Project(project_config.Configuration):
                 return None
 
             # Expand the config object so that the parameter values can be set
-            config = part_config.PartConfiguration.normalize(result_name, config)
+            config = part_config.PartConfiguration.normalize(
+                result_name,
+                config,
+                result_name # TODO: @azhar - send object_name instead of result_name
+            )
             config["orig_name"] = base_part_name
 
             # Fill in the parameter values
@@ -917,7 +949,8 @@ class Project(project_config.Configuration):
 
         for provider_name in self.provider_configs:
             config = self.get_provider_config(provider_name)
-            config = provider_config.ProviderConfiguration.normalize(provider_name, config)
+            object_name = f"{self.name}:{provider_name}"
+            config = provider_config.ProviderConfiguration.normalize(provider_name, config, object_name)
             factory.instantiate("provider", config["type"], self.ctx, self, self, config)
 
     # TODO(clairbee): either call init_*_by_config or call
@@ -984,7 +1017,8 @@ class Project(project_config.Configuration):
                     return None
                 # This is not yet created (invalidated?)
                 config = self.get_provider_config(provider_name)
-                config = provider_config.ProviderConfiguration.normalize(provider_name, config)
+                object_name = f"{self.name}:{provider_name}"
+                config = provider_config.ProviderConfiguration.normalize(provider_name, config, object_name)
                 factory.instantiate("provider", config["type"], self.ctx, self, self, config)
 
                 if not provider_name in self.providers or self.providers[provider_name] is None:
@@ -1022,7 +1056,8 @@ class Project(project_config.Configuration):
                 return None
 
             # Expand the config object so that the parameter values can be set
-            config = provider_config.ProviderConfiguration.normalize(result_name, config)
+            object_name = f"{self.name}:{result_name}"
+            config = provider_config.ProviderConfiguration.normalize(result_name, config, object_name)
             config["orig_name"] = base_provider_name
 
             # Fill in the parameter values

--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -357,11 +357,12 @@ class Project(project_config.Configuration):
             return
 
         for sketch_name in self.sketch_configs:
+            object_name = f"{self.name}:{sketch_name}"
             config = self.get_sketch_config(sketch_name)
             config = sketch_config.SketchConfiguration.normalize(
                 sketch_name,
                 config,
-                sketch_name # TODO: @azhar - send object_name instead of sketch_name
+                object_name
             )
             self.init_sketch_by_config(config)
 
@@ -402,10 +403,11 @@ class Project(project_config.Configuration):
                     "name": alias,
                     "source": ":" + sketch_name,
                 }
+                object_name = f"{self.name}:{alias}"
                 alias_sketch_config = sketch_config.SketchConfiguration.normalize(
                     alias,
                     alias_sketch_config,
-                    alias # TODO: @azhar - send object_name instead of alias
+                    object_name
                 )
                 pfa.SketchFactoryAlias(self.ctx, source_project, self, alias_sketch_config)
 
@@ -457,12 +459,13 @@ class Project(project_config.Configuration):
                     # We don't know anything about such a sketch
                     pc_logging.error("Sketch '%s' not found in '%s'", sketch_name, self.name)
                     return None
+                object_name = f"{self.name}:{sketch_name}"
                 # This is not yet created (invalidated?)
                 config = self.get_sketch_config(sketch_name)
                 config = sketch_config.SketchConfiguration.normalize(
                     sketch_name,
                     config,
-                    sketch_name # TODO: @azhar - send object_name instead of alias
+                    object_name
                 )
                 self.init_sketch_by_config(config)
 
@@ -499,12 +502,12 @@ class Project(project_config.Configuration):
                     str(config),
                 )
                 return None
-
+            object_name = f"{self.name}:{result_name}"
             # Expand the config object so that the parameter values can be set
             config = sketch_config.SketchConfiguration.normalize(
                 result_name,
                 config,
-                result_name # TODO: @azhar - send object_name instead of result_name
+                object_name
             )
             config["orig_name"] = base_sketch_name
 
@@ -565,11 +568,12 @@ class Project(project_config.Configuration):
             return
 
         for part_name in self.part_configs:
+            object_name = f"{self.name}:{part_name}"
             config = self.get_part_config(part_name)
             config = part_config.PartConfiguration.normalize(
                 part_name,
                 config,
-                part_name # TODO: @azhar - send object_name instead of part_name
+                object_name
             )
             self.init_part_by_config(config)
 
@@ -628,10 +632,11 @@ class Project(project_config.Configuration):
                     "name": alias,
                     "source": ":" + part_name,
                 }
+                object_name = f"{self.name}:{alias}"
                 alias_part_config = part_config.PartConfiguration.normalize(
                     alias,
                     alias_part_config,
-                    alias # TODO: @azhar - send object_name instead of alias
+                    object_name
                 )
                 pfa.PartFactoryAlias(self.ctx, source_project, self, alias_part_config)
 
@@ -684,12 +689,13 @@ class Project(project_config.Configuration):
                     if not quiet:
                         pc_logging.error("Part '%s' not found in '%s'", part_name, self.name)
                     return None
+                object_name = f"{self.name}:{part_name}"
                 # This is not yet created (invalidated?)
                 config = self.get_part_config(part_name)
                 config = part_config.PartConfiguration.normalize(
                     part_name,
                     config,
-                    part_name # TODO: @azhar - send object_name instead of part_name
+                    object_name
                 )
                 self.init_part_by_config(config)
 
@@ -727,11 +733,12 @@ class Project(project_config.Configuration):
                 )
                 return None
 
+            object_name = f"{self.name}:{result_name}"
             # Expand the config object so that the parameter values can be set
             config = part_config.PartConfiguration.normalize(
                 result_name,
                 config,
-                result_name # TODO: @azhar - send object_name instead of result_name
+                object_name
             )
             config["orig_name"] = base_part_name
 

--- a/partcad/src/partcad/project_config.py
+++ b/partcad/src/partcad/project_config.py
@@ -72,6 +72,7 @@ class Configuration:
                 "INCHES": 25.4,
                 "FOOT": 304.8,
                 "FEET": 304.8,
+                "get_from_config": lambda: None
             }
         )
 

--- a/partcad/src/partcad/provider_config.py
+++ b/partcad/src/partcad/provider_config.py
@@ -7,13 +7,15 @@
 # Licensed under Apache License, Version 2.0.
 #
 
+from .config import Configuration
+
 
 class ProviderConfiguration:
     def __init__(self, name, config):
         super().__init__(name, config)
 
     @staticmethod
-    def normalize(name, config):
+    def normalize(name, config, object_name):
         if config is None:
             config = {}
 
@@ -23,36 +25,4 @@ class ProviderConfiguration:
         config["name"] = name
         config["orig_name"] = name
 
-        if "parameters" in config:
-            for param_name, param_value in config["parameters"].items():
-                # Expand short formats
-                if isinstance(param_value, str):
-                    config["parameters"][param_name] = {
-                        "type": "string",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, bool):
-                    config["parameters"][param_name] = {
-                        "type": "bool",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, float):
-                    config["parameters"][param_name] = {
-                        "type": "float",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, int):
-                    config["parameters"][param_name] = {
-                        "type": "int",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, list):
-                    config["parameters"][param_name] = {
-                        "type": "array",
-                        "default": param_value,
-                    }
-                # All params are float unless another type is explicitly specified
-                elif isinstance(param_value, dict) and not "type" in param_value:
-                    param_value["type"] = "float"
-
-        return config
+        return Configuration.normalize(name, config, object_name)

--- a/partcad/src/partcad/provider_factory_enrich.py
+++ b/partcad/src/partcad/provider_factory_enrich.py
@@ -80,7 +80,7 @@ class ProviderFactoryEnrich(pf.ProviderFactory):
                 for param in config["with"]:
                     augmented_config["parameters"][param]["default"] = config["with"][param]
 
-            # TODO: (azhar) - discuss about the same function call at line 72
+            # TODO: @azhar - discuss about the same function call at line 72
             augmented_config = provider_config.ProviderConfiguration.normalize(
                 self.source_provider_name,
                 augmented_config,

--- a/partcad/src/partcad/provider_factory_enrich.py
+++ b/partcad/src/partcad/provider_factory_enrich.py
@@ -80,7 +80,7 @@ class ProviderFactoryEnrich(pf.ProviderFactory):
                 for param in config["with"]:
                     augmented_config["parameters"][param]["default"] = config["with"][param]
 
-            # TODO: @azhar - discuss about the same function call at line 72
+            # Recalling normalize to normalize data after replacing target parameters from with key.
             augmented_config = provider_config.ProviderConfiguration.normalize(
                 self.source_provider_name,
                 augmented_config,

--- a/partcad/src/partcad/provider_factory_python.py
+++ b/partcad/src/partcad/provider_factory_python.py
@@ -15,6 +15,7 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "wrappers"))
 from ocp_serialize import register as register_ocp_helper
 
+from .user_config import user_config
 from .provider_factory_file import ProviderFactoryFile
 from .runtime_python import PythonRuntime
 
@@ -113,6 +114,7 @@ class ProviderFactoryPython(ProviderFactoryFile):
             request["partcad_version"] = sys.modules["partcad"].__version__
             request["verbose"] = pc_logging.getLevel() <= pc_logging.DEBUG
             request["api"] = script_name
+            request["user"] = user_config.pii_config.to_dict()
             request["parameters"] = {}
             if "parameters" in self.config:
                 for param_name, param in self.config["parameters"].items():

--- a/partcad/src/partcad/sketch_config.py
+++ b/partcad/src/partcad/sketch_config.py
@@ -7,49 +7,19 @@
 # Licensed under Apache License, Version 2.0.
 #
 
+from .config import Configuration
 from .shape_config import ShapeConfiguration
 
 
-class SketchConfiguration(ShapeConfiguration):
+class SketchConfiguration(Configuration, ShapeConfiguration):
     def __init__(self, name, config):
         super().__init__(name, config)
 
     @staticmethod
-    def normalize(name, config):
+    def normalize(name, config, object_name):
         if isinstance(config, str):
             # This is a short form alias
             config = {"type": "alias", "source": config}
 
-        if "parameters" in config:
-            for param_name, param_value in config["parameters"].items():
-                # Expand short formats
-                if isinstance(param_value, str):
-                    config["parameters"][param_name] = {
-                        "type": "string",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, bool):
-                    config["parameters"][param_name] = {
-                        "type": "bool",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, float):
-                    config["parameters"][param_name] = {
-                        "type": "float",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, int):
-                    config["parameters"][param_name] = {
-                        "type": "int",
-                        "default": param_value,
-                    }
-                elif isinstance(param_value, list):
-                    config["parameters"][param_name] = {
-                        "type": "array",
-                        "default": param_value,
-                    }
-                # All params are float unless another type is explicitly speciifed
-                elif isinstance(param_value, dict) and not "type" in param_value:
-                    param_value["type"] = "float"
-
+        config = Configuration.normalize(name, config, object_name)
         return ShapeConfiguration.normalize(name, config)

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -139,6 +139,13 @@ class SketchFactoryEnrich(pf.SketchFactory):
                     desired_type = type(augmented_config["parameters"][param]["default"])
                     augmented_config["parameters"][param]["default"] = desired_type(sketch.config["with"][param])
 
+            # Recalling normalize to normalize data after replacing target parameters from with key.
+            augmented_config = sketch_config.SketchConfiguration.normalize(
+                sketch.config["name"],
+                augmented_config,
+                object_name
+            )
+
             self.source_project.init_sketch_by_config(augmented_config)
 
             source = self.source_project.get_sketch(sketch.name)

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -90,6 +90,7 @@ class SketchFactoryEnrich(pf.SketchFactory):
             augmented_config = sketch_config.SketchConfiguration.normalize(
                 self.source_sketch_name,
                 augmented_config,
+                self.source_sketch_name # TODO: @azhar - send object_name instead of self.source_sketch_name
             )
 
             # Drop fields we don't want to be inherited by enriched clones

--- a/partcad/src/partcad/sketch_factory_enrich.py
+++ b/partcad/src/partcad/sketch_factory_enrich.py
@@ -85,12 +85,13 @@ class SketchFactoryEnrich(pf.SketchFactory):
                 )
                 return
 
+            object_name = f"{self.project.name}:{self.name}"
             augmented_config = copy.deepcopy(augmented_config)
             # TODO(clairbee): ideally whatever we pull from the project is already normalized
             augmented_config = sketch_config.SketchConfiguration.normalize(
                 self.source_sketch_name,
                 augmented_config,
-                self.source_sketch_name # TODO: @azhar - send object_name instead of self.source_sketch_name
+                object_name
             )
 
             # Drop fields we don't want to be inherited by enriched clones

--- a/partcad/tests/unit/test_part_params.py
+++ b/partcad/tests/unit/test_part_params.py
@@ -9,6 +9,7 @@
 #
 
 import asyncio
+from unittest.mock import patch
 
 import partcad as pc
 
@@ -29,3 +30,12 @@ def test_part_params_get_2():
     assert brick is not None
     assert asyncio.run(brick.get_wrapped(ctx)) is not None
     assert brick.config["parameters"]["width"]["default"] == 17.0
+
+def test_part_user_config_params_get():
+    """Load a CadQuery part using enrichment for parameters and see if the parameters changed from user_config"""
+    ctx = pc.Context("examples/produce_part_cadquery_primitive")
+    pc.user_config.parameter_config["//pub/examples/partcad/produce_part_cadquery_primitive:cube_enrich"] = {"width": 33.0}
+    cube_enrich = ctx._get_part(":cube_enrich")
+    assert cube_enrich is not None
+    assert asyncio.run(cube_enrich.get_wrapped(ctx)) is not None
+    assert cube_enrich.config["parameters"]["width"]["default"] == 33.0

--- a/partcad/tests/unit/test_provider.py
+++ b/partcad/tests/unit/test_provider.py
@@ -62,3 +62,12 @@ def test_provider_quote_store_csv_2():
     assert len(quotes.keys()) == 1
     assert FULL_PROVIDER_NAME in quotes
     assert quotes[FULL_PROVIDER_NAME].result["price"] == 0.01
+
+def test_provider_user_config_params_get():
+    """Load a CadQuery part using enrichment for provider and see if the parameters changed from user_config"""
+    import partcad as pc
+    ctx = pc.Context("examples/provider_store")
+    pc.user_config.parameter_config["//pub/examples/partcad/provider_store:myGarage"] = {"currency": "INR"}
+    provider = ctx.get_provider("myGarage")
+    assert provider is not None
+    assert provider.config["parameters"]["currency"]["default"] == "INR"


### PR DESCRIPTION
- Users can now specify Personally Identifiable Information (PII) in '~/.partcad/config.yaml' under the 'user' key.
- Added support for overriding parameters via 'parameter_config' in 'user_config.py'.
- Parameters can be set either in '~/.partcad/config.yaml' or using the '--extra_param' flag.