### PR TITLE
perf(behave): share a pre-warmed state directory and run features in parallel

### DIFF
--- a/.devcontainer/behave_hook.sh
+++ b/.devcontainer/behave_hook.sh
@@ -11,7 +11,10 @@ echo "Running tests with $WORKERS workers"
 # own private $HOME. Already-seeded runs return immediately.
 poetry run python -m features.seed || exit 1
 
-# behavex is configured separately from behave and ignores the "tags" setting
-# in behave.ini, so the exclusions that file applies have to be repeated here
-# or the @ai scenarios silently start running. behavex contributes ~@WIP itself.
-poetry run behavex features -t '~@ai' --parallel-processes="$WORKERS" --parallel-scheme=feature
+# Worth knowing, and deliberately not acted on here: behavex is configured
+# separately from behave and ignores the "tags" setting in behave.ini, so this
+# runs the @ai scenarios that `behave` on its own would exclude. Passing
+# -t '~@ai' would match behave.ini's intent, but it would also stop running
+# scenarios that run today, and narrowing what gets tested is not this change's
+# business. Add it deliberately, as its own change, if that is what you want.
+poetry run behavex features --parallel-processes="$WORKERS" --parallel-scheme=feature

--- a/.devcontainer/behave_hook.sh
+++ b/.devcontainer/behave_hook.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-CORES=$(lscpu -b -p=Core,Socket | grep -v "^#" | sort -u | wc -l)
-echo "Detected $CORES cores"
-
-# The maximum optimal number of workers to use for running the tests
-# efficiently in parallel withoug overloading the system
-MAX_WORKERS=4
-WORKERS=$(( CORES <= MAX_WORKERS ? CORES : MAX_WORKERS ))
+# Clamp to [1, 4]: os.cpu_count() can come back as None, and past four workers
+# the scenarios contend for CPU and for their state directory copies more than
+# the extra parallelism buys back.
+WORKERS=$(poetry run python -c "import os; print(min(4, os.cpu_count() or 1))")
 echo "Running tests with $WORKERS workers"
-poetry run behavex features --parallel-processes=$WORKERS --parallel-scheme=feature
+
+# Warm the shared PartCAD state directory before any worker starts. Without
+# this each scenario would re-clone //pub and rebuild the conda sandbox in its
+# own private $HOME. Already-seeded runs return immediately.
+poetry run python -m features.seed || exit 1
+
+# behavex is configured separately from behave and ignores the "tags" setting
+# in behave.ini, so the exclusions that file applies have to be repeated here
+# or the @ai scenarios silently start running. behavex contributes ~@WIP itself.
+poetry run behavex features -t '~@ai' --parallel-processes="$WORKERS" --parallel-scheme=feature

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -335,6 +335,15 @@ jobs:
             git config --global url."git@github.com:".insteadOf "https://github.com/"
             git config --global protocol.version 2
             mkdir -pv behave-results
+
+            # Warm the shared PartCAD state directory once, before the suite
+            # starts, rather than letting each scenario rebuild the //pub clone
+            # and the conda sandbox in its own private $HOME. Not cached the way
+            # test.yml caches it: this job runs inside devcontainers/ci, where
+            # $HOME is the container's rather than the runner's, so it pays the
+            # full ~10 min build.
+            poetry --no-ansi --no-interaction run python -m features.seed
+
             poetry --no-ansi --no-interaction run coverage run $(poetry run which behave)
             poetry --no-ansi --no-interaction run coverage xml --data-file=./.coverage -o behave-results/coverage.xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,7 +378,11 @@ jobs:
           export PYTHONUTF8=1
           export PYTHONIOENCODING=utf-8
 
-          python -m features.seed
+          # '|| true' so the disk report below still runs: the numbers matter
+          # most when seeding has just gone wrong, and features/seed.py already
+          # degrades rather than failing, so a non-zero exit here is unexpected
+          # and worth seeing the disk state for.
+          python -m features.seed || echo "seed step exited non-zero"
 
           # The headroom the suite starts with. A Windows shard ran out of disk
           # partway through and the failure arrived as an unwritable log file,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -362,6 +362,13 @@ jobs:
           export PYTHONIOENCODING=utf-8
 
           python -m features.seed
+
+          # The headroom the suite starts with. A Windows shard ran out of disk
+          # partway through and the failure arrived as an unwritable log file,
+          # with nothing to say how close it had been, so this is here to make
+          # the next one diagnosable rather than inferred.
+          echo "Disk after seeding:"
+          df -h . || true
           mamba deactivate
 
       - name: Test with behave

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -315,38 +315,33 @@ jobs:
       # re-cloning //pub and rebuilding a ~2.3 GB conda sandbox. features/seed.py
       # builds that state once and hands each scenario a copy (see there).
       #
-      # The seed is ~3.5 GB, but GitHub allows 10 GB of cache per repository
-      # across every cache in it - including the conda and pip entries from
-      # setup-all - and this job has 24 cells. Caching all of it everywhere would
-      # ask for ~84 GB and evict everything else, so only the parts worth a slot
-      # are cached.
+      # The seed is ~3.5 GB, and GitHub allows 10 GB of cache per repository
+      # across every cache in it. This repo already sits at ~8.9 GB of that from
+      # the conda and pip entries in setup-all, so anything cached here comes
+      # straight out of their budget: go over and the LRU evicts them, and every
+      # job in the workflow gets slower to make this one faster.
       #
-      # The conda sandbox is ~2.3 GB of the seed and is deliberately not cached:
-      # it is the largest part, the least portable, and it rebuilds in ~70s.
-      # Leaving it out is also why '.seeded' is not cached - see features/seed.py.
-      - name: Cache the seed's git clones
-        uses: actions/cache@v6
-        with:
-          # ~1.2 GB, and its content depends on neither the Python version nor
-          # the shard, so one entry per OS instead of one per cell: three, not
-          # 24. A stale restore is harmless - 'pc list all -r' fetches whatever
-          # moved upstream.
-          path: ~/.partcad-behave/seed/state/git
-          key: ${{ runner.os }}-pcseed-git-${{ env.VERSION }}-${{ hashFiles('features/seed.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pcseed-git-${{ env.VERSION }}-
-            ${{ runner.os }}-pcseed-git-
-
+      # Only the object cache is therefore cached, and it earns its place by a
+      # wide margin. The two parts left out:
+      #
+      #  * the conda sandbox, ~2.3 GB, rebuilt in ~70s - the largest and least
+      #    portable part of the seed for the smallest saving. Leaving it out is
+      #    also why '.seeded' is not cached; see features/seed.py.
+      #  * the git clones, ~1.2 GB (834 MB compressed, measured). Caching those
+      #    on the first run took the repo to 9.69 GB with only Linux saved; all
+      #    three OSes would have been ~2.5 GB and over the limit. They buy back
+      #    only the ~90s clone, because 'pc list all -r' has to run and check the
+      #    index either way.
       - name: Cache the seed's object cache
         uses: actions/cache@v6
         with:
-          # A couple of megabytes holding the result of ~120 exports, which is
-          # ~7.5 minutes of work - by far the best value per byte here. Shared
-          # across shards for the same OS/Python, since every shard seeds the
-          # same objects. No restore-keys: the manifest tells the build which
-          # exports to skip, so accepting one written against a different PartCAD
-          # version would skip exports whose cache entries no longer apply,
-          # quietly giving up the warm cache instead of rebuilding it.
+          # ~2 MB holding the result of ~120 exports, which is ~7.5 minutes of
+          # work: three orders of magnitude better value per byte than either of
+          # the above. Shared across shards for the same OS/Python, since every
+          # shard seeds the same objects. No restore-keys: the manifest tells the
+          # build which exports to skip, so accepting one written against a
+          # different PartCAD version would skip exports whose cache entries no
+          # longer apply, quietly giving up the warm cache instead of rebuilding.
           path: |
             ~/.partcad-behave/seed/state/cache
             ~/.partcad-behave/seed/state/.seed-exports.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,6 +310,65 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_RO }}
 
+      # Every scenario gets a private $HOME, and PartCAD roots its whole on-disk
+      # state at $HOME/.partcad, so each one used to start with a cold cache:
+      # re-cloning //pub and rebuilding a ~2.3 GB conda sandbox. features/seed.py
+      # builds that state once and hands each scenario a copy (see there).
+      #
+      # The seed is ~3.5 GB, but GitHub allows 10 GB of cache per repository
+      # across every cache in it - including the conda and pip entries from
+      # setup-all - and this job has 24 cells. Caching all of it everywhere would
+      # ask for ~84 GB and evict everything else, so only the parts worth a slot
+      # are cached.
+      #
+      # The conda sandbox is ~2.3 GB of the seed and is deliberately not cached:
+      # it is the largest part, the least portable, and it rebuilds in ~70s.
+      # Leaving it out is also why '.seeded' is not cached - see features/seed.py.
+      - name: Cache the seed's git clones
+        uses: actions/cache@v6
+        with:
+          # ~1.2 GB, and its content depends on neither the Python version nor
+          # the shard, so one entry per OS instead of one per cell: three, not
+          # 24. A stale restore is harmless - 'pc list all -r' fetches whatever
+          # moved upstream.
+          path: ~/.partcad-behave/seed/state/git
+          key: ${{ runner.os }}-pcseed-git-${{ env.VERSION }}-${{ hashFiles('features/seed.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pcseed-git-${{ env.VERSION }}-
+            ${{ runner.os }}-pcseed-git-
+
+      - name: Cache the seed's object cache
+        uses: actions/cache@v6
+        with:
+          # A couple of megabytes holding the result of ~120 exports, which is
+          # ~7.5 minutes of work - by far the best value per byte here. Shared
+          # across shards for the same OS/Python, since every shard seeds the
+          # same objects. No restore-keys: the manifest tells the build which
+          # exports to skip, so accepting one written against a different PartCAD
+          # version would skip exports whose cache entries no longer apply,
+          # quietly giving up the warm cache instead of rebuilding it.
+          path: |
+            ~/.partcad-behave/seed/state/cache
+            ~/.partcad-behave/seed/state/.seed-exports.json
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-pcseed-obj-${{ env.VERSION }}-${{ hashFiles('features/seed.py') }}
+
+      # Kept out of the test step so that cloning //pub and building the conda
+      # sandbox are timed and attributed on their own rather than inside the
+      # first scenario that happens to need them.
+      - name: Seed the shared PartCAD state directory
+        shell: bash -el {0}
+        run: |
+          . ~/.bashrc
+          . ~/.bash_profile
+
+          mamba activate ${{ format('env-test-behave-{0}', matrix.python-version) }}
+
+          export PYTHONUTF8=1
+          export PYTHONIOENCODING=utf-8
+
+          python -m features.seed
+          mamba deactivate
+
       - name: Test with behave
         shell: bash -el {0}
         # Pass matrix.* through env rather than interpolating templates straight

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,16 +290,6 @@ jobs:
     # Windows). 60m leaves generous margin for the slowest shard.
     timeout-minutes: 60
 
-    env:
-      # Where features/seed.py keeps the shared state directory and the
-      # per-scenario copies. It defaults to $HOME, which on a Windows runner is
-      # C: - the OS disk, and the one that filled up and took a shard down with
-      # an unwritable log file. runner.temp is on the same volume as the
-      # workspace, which the runner reported as 147 GB free against C:'s
-      # handful, and is cleaned between jobs. Set for every OS so there is one
-      # path to reason about rather than a Windows special case.
-      PARTCAD_BEHAVE_DIR: ${{ runner.temp }}/partcad-behave
-
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-all
@@ -319,6 +309,23 @@ jobs:
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_RO }}
+
+      # features/seed.py keeps its state directory under $HOME by default. On a
+      # Windows runner that is C:\Users\runneradmin - the OS disk, and the one
+      # that filled up and took a shard down with an unwritable log file, while
+      # the runner reported 147 GB free on D:. Pin it to the large volume.
+      #
+      # Resolved in a step rather than the job's 'env:' because the runner
+      # context is not available there - setting it at job level is a workflow
+      # error that fails the run before any job starts.
+      - name: Choose where the behave seed lives
+        shell: bash -el {0}
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "PARTCAD_BEHAVE_DIR=D:/partcad-behave" >> "$GITHUB_ENV"
+          else
+            echo "PARTCAD_BEHAVE_DIR=${RUNNER_TEMP}/partcad-behave" >> "$GITHUB_ENV"
+          fi
 
       # Every scenario gets a private $HOME, and PartCAD roots its whole on-disk
       # state at $HOME/.partcad, so each one used to start with a cold cache:
@@ -353,8 +360,8 @@ jobs:
           # different PartCAD version would skip exports whose cache entries no
           # longer apply, quietly giving up the warm cache instead of rebuilding.
           path: |
-            ${{ runner.temp }}/partcad-behave/seed/state/cache
-            ${{ runner.temp }}/partcad-behave/seed/state/.seed-exports.json
+            ${{ env.PARTCAD_BEHAVE_DIR }}/seed/state/cache
+            ${{ env.PARTCAD_BEHAVE_DIR }}/seed/state/.seed-exports.json
           key: ${{ runner.os }}-py${{ matrix.python-version }}-pcseed-obj-${{ env.VERSION }}-${{ hashFiles('features/seed.py') }}
 
       # Kept out of the test step so that cloning //pub and building the conda

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,6 +290,16 @@ jobs:
     # Windows). 60m leaves generous margin for the slowest shard.
     timeout-minutes: 60
 
+    env:
+      # Where features/seed.py keeps the shared state directory and the
+      # per-scenario copies. It defaults to $HOME, which on a Windows runner is
+      # C: - the OS disk, and the one that filled up and took a shard down with
+      # an unwritable log file. runner.temp is on the same volume as the
+      # workspace, which the runner reported as 147 GB free against C:'s
+      # handful, and is cleaned between jobs. Set for every OS so there is one
+      # path to reason about rather than a Windows special case.
+      PARTCAD_BEHAVE_DIR: ${{ runner.temp }}/partcad-behave
+
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-all
@@ -343,8 +353,8 @@ jobs:
           # different PartCAD version would skip exports whose cache entries no
           # longer apply, quietly giving up the warm cache instead of rebuilding.
           path: |
-            ~/.partcad-behave/seed/state/cache
-            ~/.partcad-behave/seed/state/.seed-exports.json
+            ${{ runner.temp }}/partcad-behave/seed/state/cache
+            ${{ runner.temp }}/partcad-behave/seed/state/.seed-exports.json
           key: ${{ runner.os }}-py${{ matrix.python-version }}-pcseed-obj-${{ env.VERSION }}-${{ hashFiles('features/seed.py') }}
 
       # Kept out of the test step so that cloning //pub and building the conda
@@ -365,10 +375,12 @@ jobs:
 
           # The headroom the suite starts with. A Windows shard ran out of disk
           # partway through and the failure arrived as an unwritable log file,
-          # with nothing to say how close it had been, so this is here to make
-          # the next one diagnosable rather than inferred.
-          echo "Disk after seeding:"
-          df -h . || true
+          # with nothing to say how close it had been. Report the volume the
+          # seed is actually on, not the working directory: the first version of
+          # this measured the workspace, said 147 GB free, and missed that the
+          # seed was filling a different and much smaller disk.
+          echo "Disk where the seed lives:"
+          df -h "$PARTCAD_BEHAVE_DIR" || df -h . || true
           mamba deactivate
 
       - name: Test with behave

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,11 @@ poetry run behave                                                               
 
 `behave` gives each scenario a private `$HOME`, so it would start with a cold PartCAD cache every time. The suite
 avoids that by building one internal state directory up front — the `//pub` clone plus the conda sandbox — and
-copying it per scenario via `PC_INTERNAL_STATE_DIR`. The first run builds it (~10 min, ~3.5 GB); later runs reuse
+pointing each scenario at its own via `PC_INTERNAL_STATE_DIR`. Each scenario gets a private copy of the `cache`,
+`git` and `external` subdirectories (~2.8k files, ~0.6s) and **shares** the conda sandbox through a link: the
+sandbox is 36k of the seed's 39k files, and copying it cost ~133s per scenario on a Windows runner against ~2s
+on Linux, which was killing those jobs at the 60-minute cap. PartCAD locks the sandbox across processes, and
+behave is serial within a CI shard, so sharing it is what a developer's own machine does anyway. The first run builds it (~10 min, ~3.5 GB); later runs reuse
 it. Build or rebuild it explicitly with `poetry run python -m features.seed`, relocate it with
 `PARTCAD_BEHAVE_DIR`, and delete that directory to force a rebuild. A scenario that needs a cold cache — one
 asserting that `pc install` clones, or that the state directory is at the default `$HOME/.partcad` — must be

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ it for conda and pip, so anything cached here evicts those and makes every other
 cached either: restored without the sandbox, the build would be skipped and every scenario would build a sandbox
 inside its own throwaway copy.
 
+Seeding is bounded, because it shares a CI job's deadline with the suite it exists to speed up — unbounded, it took 32 of a Windows job's 60 minutes and the suite was killed. The whole of it gets `PARTCAD_BEHAVE_SEED_BUDGET` seconds (default 1500) and the export phase gets `PARTCAD_BEHAVE_EXPORT_BUDGET` (default 600); exports left over are deferred, not dropped, and a later run picks them up from the manifest. If the budget runs out before the seed is usable, the suite runs unseeded rather than the job failing.
+
 CI parallelises the suite by sharding it across jobs (`BEHAVE_SHARDS` in `test.yml`, split by
 `dev-tools/behave_shard.py`), so each job runs plain serial `behave` over a slice of the feature files. Locally,
 `.devcontainer/behave_hook.sh` instead uses `behavex` to parallelise within one machine. `behavex` does **not**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,27 @@ poetry run pytest partcad partcad-cli -x -p no:error-for-skips -p no:warnings --
 poetry run behave                                                                        # integration tests (./features)
 ```
 
+`behave` gives each scenario a private `$HOME`, so it would start with a cold PartCAD cache every time. The suite
+avoids that by building one internal state directory up front — the `//pub` clone plus the conda sandbox — and
+copying it per scenario via `PC_INTERNAL_STATE_DIR`. The first run builds it (~10 min, ~3.5 GB); later runs reuse
+it. Build or rebuild it explicitly with `poetry run python -m features.seed`, relocate it with
+`PARTCAD_BEHAVE_DIR`, and delete that directory to force a rebuild. A scenario that needs a cold cache — one
+asserting that `pc install` clones, or that the state directory is at the default `$HOME/.partcad` — must be
+tagged `@cold-state`. See `features/seed.py`.
+
+The build resumes rather than starting over, which is what lets CI cache the expensive parts. It caches the git
+clones and the object cache (plus `.seed-exports.json`, the manifest saying which exports are already covered)
+but **not** the conda sandbox — ~2.3 GB of the 3.5 GB, against a ~70s rebuild, and GitHub allows only 10 GB of
+cache per repository. `.seeded` is likewise not cached: were it restored without the sandbox, the build would be
+skipped and every scenario would build a sandbox inside its own throwaway copy. A restored-cache build takes
+~90s instead of ~10 min.
+
+CI parallelises the suite by sharding it across jobs (`BEHAVE_SHARDS` in `test.yml`, split by
+`dev-tools/behave_shard.py`), so each job runs plain serial `behave` over a slice of the feature files. Locally,
+`.devcontainer/behave_hook.sh` instead uses `behavex` to parallelise within one machine. `behavex` does **not**
+read the `tags` setting from `behave.ini`, so pass the exclusions yourself or `@ai` scenarios silently start
+running: `poetry run behavex features -t '~@ai' --parallel-processes=4 --parallel-scheme=feature`.
+
 Lint/format (Python): `black`, `flake8`, `isort` — configured in `pyproject.toml`.
 
 ### Packaging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,9 +107,10 @@ Seeding is bounded, because it shares a CI job's deadline with the suite it exis
 
 CI parallelises the suite by sharding it across jobs (`BEHAVE_SHARDS` in `test.yml`, split by
 `dev-tools/behave_shard.py`), so each job runs plain serial `behave` over a slice of the feature files. Locally,
-`.devcontainer/behave_hook.sh` instead uses `behavex` to parallelise within one machine. `behavex` does **not**
-read the `tags` setting from `behave.ini`, so pass the exclusions yourself or `@ai` scenarios silently start
-running: `poetry run behavex features -t '~@ai' --parallel-processes=4 --parallel-scheme=feature`.
+`.devcontainer/behave_hook.sh` instead uses `behavex` to parallelise within one machine:
+`poetry run behavex features --parallel-processes=4 --parallel-scheme=feature`. Note that `behavex` does **not**
+read the `tags` setting from `behave.ini`, so it runs the `@ai` scenarios that plain `behave` excludes. Pass
+`-t '~@ai'` if you want behave.ini's intent; the hook does not, so that it never runs less than it does today.
 
 Lint/format (Python): `black`, `flake8`, `isort` — configured in `pyproject.toml`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,12 +91,13 @@ it. Build or rebuild it explicitly with `poetry run python -m features.seed`, re
 asserting that `pc install` clones, or that the state directory is at the default `$HOME/.partcad` — must be
 tagged `@cold-state`. See `features/seed.py`.
 
-The build resumes rather than starting over, which is what lets CI cache the expensive parts. It caches the git
-clones and the object cache (plus `.seed-exports.json`, the manifest saying which exports are already covered)
-but **not** the conda sandbox — ~2.3 GB of the 3.5 GB, against a ~70s rebuild, and GitHub allows only 10 GB of
-cache per repository. `.seeded` is likewise not cached: were it restored without the sandbox, the build would be
-skipped and every scenario would build a sandbox inside its own throwaway copy. A restored-cache build takes
-~90s instead of ~10 min.
+The build resumes rather than starting over, which is what lets CI cache the part worth caching: the object
+cache and `.seed-exports.json`, the manifest saying which exports are already covered. That is ~2 MB standing in
+for ~7.5 min of exports. The conda sandbox (~2.3 GB, ~70s to rebuild) and the git clones (~1.2 GB, ~90s) are
+deliberately **not** cached — GitHub allows 10 GB of cache per repository and this repo already uses ~8.9 GB of
+it for conda and pip, so anything cached here evicts those and makes every other job slower. `.seeded` is not
+cached either: restored without the sandbox, the build would be skipped and every scenario would build a sandbox
+inside its own throwaway copy.
 
 CI parallelises the suite by sharding it across jobs (`BEHAVE_SHARDS` in `test.yml`, split by
 `dev-tools/behave_shard.py`), so each job runs plain serial `behave` over a slice of the feature files. Locally,

--- a/dev-tools/behave_hook.sh
+++ b/dev-tools/behave_hook.sh
@@ -11,7 +11,10 @@ echo "Running tests with $WORKERS workers"
 # own private $HOME. Already-seeded runs return immediately.
 poetry run python -m features.seed || exit 1
 
-# behavex is configured separately from behave and ignores the "tags" setting
-# in behave.ini, so the exclusions that file applies have to be repeated here
-# or the @ai scenarios silently start running. behavex contributes ~@WIP itself.
-poetry run behavex features -t '~@ai' --parallel-processes="$WORKERS" --parallel-scheme=feature
+# Worth knowing, and deliberately not acted on here: behavex is configured
+# separately from behave and ignores the "tags" setting in behave.ini, so this
+# runs the @ai scenarios that `behave` on its own would exclude. Passing
+# -t '~@ai' would match behave.ini's intent, but it would also stop running
+# scenarios that run today, and narrowing what gets tested is not this change's
+# business. Add it deliberately, as its own change, if that is what you want.
+poetry run behavex features --parallel-processes="$WORKERS" --parallel-scheme=feature

--- a/dev-tools/behave_hook.sh
+++ b/dev-tools/behave_hook.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-CORES=$(lscpu -b -p=Core,Socket | grep -v "^#" | sort -u | wc -l)
-echo "Detected $CORES cores"
-
-# The maximum optimal number of workers to use for running the tests
-# efficiently in parallel withoug overloading the system
-MAX_WORKERS=4
-WORKERS=$(( CORES <= MAX_WORKERS ? CORES : MAX_WORKERS ))
+# Clamp to [1, 4]: os.cpu_count() can come back as None, and past four workers
+# the scenarios contend for CPU and for their state directory copies more than
+# the extra parallelism buys back.
+WORKERS=$(poetry run python -c "import os; print(min(4, os.cpu_count() or 1))")
 echo "Running tests with $WORKERS workers"
-poetry run behavex features --parallel-processes=$WORKERS --parallel-scheme=feature
+
+# Warm the shared PartCAD state directory before any worker starts. Without
+# this each scenario would re-clone //pub and rebuild the conda sandbox in its
+# own private $HOME. Already-seeded runs return immediately.
+poetry run python -m features.seed || exit 1
+
+# behavex is configured separately from behave and ignores the "tags" setting
+# in behave.ini, so the exclusions that file applies have to be repeated here
+# or the @ai scenarios silently start running. behavex contributes ~@WIP itself.
+poetry run behavex features -t '~@ai' --parallel-processes="$WORKERS" --parallel-scheme=feature

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -564,12 +564,14 @@ unset for them, so they see an empty state directory in their temporary ``$HOME`
 
 CI parallelises the suite by sharding it across jobs, so each job runs plain serial ``behave`` over a slice of the
 feature files. Locally, ``.devcontainer/behave_hook.sh`` instead parallelises within one machine using
-``behavex``. Note that ``behavex`` does not read the ``tags`` setting from ``behave.ini``, so its exclusions have
-to be passed explicitly:
+``behavex``:
 
 .. code-block:: bash
 
-    $ poetry run behavex features -t '~@ai' --parallel-processes=4 --parallel-scheme=feature
+    $ poetry run behavex features --parallel-processes=4 --parallel-scheme=feature
+
+Note that ``behavex`` does not read the ``tags`` setting from ``behave.ini``, so it runs the ``@ai`` scenarios
+that plain ``behave`` excludes. Pass ``-t '~@ai'`` if you want behave.ini's intent applied.
 
 Commit & Push Changes
 ---------------------

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -532,6 +532,40 @@ To run tests using ``behave``, execute the following command in an activated env
 
 Feature definitions and step implementations are located in the ``./features`` directory.
 
+Every scenario runs ``pc`` against its own private ``$HOME``, which would otherwise mean a cold PartCAD cache
+each time: re-cloning the ``//pub`` index and rebuilding the conda sandbox that script parts run in. Instead the
+suite builds that state once, in a temporary directory, and hands each scenario a copy of it through
+``PC_INTERNAL_STATE_DIR``. The copy is deleted when the scenario ends, so scenarios stay independent - a scenario
+is free to write to, or corrupt, the state it was given.
+
+The first run builds the seed and takes around ten minutes; later runs reuse it. To build it ahead of time, or to
+rebuild it after changing what it covers:
+
+.. code-block:: bash
+
+    $ poetry run python -m features.seed
+
+Both the seed and the live copies sit under ``~/.partcad-behave``; set ``PARTCAD_BEHAVE_DIR`` to move them.
+Deleting that directory forces a rebuild.
+
+The build resumes instead of starting over: it skips the exports recorded in ``state/.seed-exports.json`` and
+rebuilds the conda sandbox only if it is missing. That is what lets CI cache the git clones and the object cache
+without caching the ~2.3 GB sandbox, which rebuilds in about 70 seconds and would otherwise consume most of the
+10 GB of cache GitHub allows a repository. A build that starts from a restored cache takes about 90 seconds.
+
+Scenarios that assert on cold-cache behaviour - that ``pc install`` reports cloning, or that the state directory
+sits at its default ``$HOME/.partcad`` - must be tagged ``@cold-state``. That leaves ``PC_INTERNAL_STATE_DIR``
+unset for them, so they see an empty state directory in their temporary ``$HOME``.
+
+CI parallelises the suite by sharding it across jobs, so each job runs plain serial ``behave`` over a slice of the
+feature files. Locally, ``.devcontainer/behave_hook.sh`` instead parallelises within one machine using
+``behavex``. Note that ``behavex`` does not read the ``tags`` setting from ``behave.ini``, so its exclusions have
+to be passed explicitly:
+
+.. code-block:: bash
+
+    $ poetry run behavex features -t '~@ai' --parallel-processes=4 --parallel-scheme=feature
+
 Commit & Push Changes
 ---------------------
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -549,9 +549,11 @@ Both the seed and the live copies sit under ``~/.partcad-behave``; set ``PARTCAD
 Deleting that directory forces a rebuild.
 
 The build resumes instead of starting over: it skips the exports recorded in ``state/.seed-exports.json`` and
-rebuilds the conda sandbox only if it is missing. That is what lets CI cache the git clones and the object cache
-without caching the ~2.3 GB sandbox, which rebuilds in about 70 seconds and would otherwise consume most of the
-10 GB of cache GitHub allows a repository. A build that starts from a restored cache takes about 90 seconds.
+rebuilds the conda sandbox only if a success marker says it finished. That is what lets CI cache the object
+cache alone - about 2 MB standing in for some seven minutes of exports - and rebuild the rest. Neither the
+~2.3 GB conda sandbox nor the ~1.2 GB of git clones is cached: GitHub allows a repository 10 GB of cache in
+total, this one already uses close to 9 GB of that for conda and pip, and evicting those to speed up one job
+would slow down every other.
 
 Scenarios that assert on cold-cache behaviour - that ``pc install`` reports cloning, or that the state directory
 sits at its default ``$HOME/.partcad`` - must be tagged ``@cold-state``. That leaves ``PC_INTERNAL_STATE_DIR``

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -534,9 +534,12 @@ Feature definitions and step implementations are located in the ``./features`` d
 
 Every scenario runs ``pc`` against its own private ``$HOME``, which would otherwise mean a cold PartCAD cache
 each time: re-cloning the ``//pub`` index and rebuilding the conda sandbox that script parts run in. Instead the
-suite builds that state once, in a temporary directory, and hands each scenario a copy of it through
-``PC_INTERNAL_STATE_DIR``. The copy is deleted when the scenario ends, so scenarios stay independent - a scenario
-is free to write to, or corrupt, the state it was given.
+suite builds that state once, in a temporary directory, and points each scenario at its own state directory
+through ``PC_INTERNAL_STATE_DIR``. The ``cache``, ``git`` and ``external`` subdirectories are copied per scenario
+and deleted when it ends, so a scenario is free to write to them. The conda sandbox is shared through a link
+rather than copied: it holds 36k of the seed's 39k files, and copying it cost about 133 seconds per scenario on a
+Windows runner against two on Linux. PartCAD locks the sandbox across processes, and behave runs scenarios
+serially within a CI shard, so sharing it matches what happens on a developer's own machine.
 
 The first run builds the seed and takes around ten minutes; later runs reuse it. To build it ahead of time, or to
 rebuild it after changing what it covers:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -534,7 +534,7 @@ Feature definitions and step implementations are located in the ``./features`` d
 
 Every scenario runs ``pc`` against its own private ``$HOME``, which would otherwise mean a cold PartCAD cache
 each time: re-cloning the ``//pub`` index and rebuilding the conda sandbox that script parts run in. Instead the
-suite builds that state once, in a temporary directory, and points each scenario at its own state directory
+suite builds that state once, in a directory that persists between runs, and points each scenario at its own
 through ``PC_INTERNAL_STATE_DIR``. The ``cache``, ``git`` and ``external`` subdirectories are copied per scenario
 and deleted when it ends, so a scenario is free to write to them. The conda sandbox is shared through a link
 rather than copied: it holds 36k of the seed's 39k files, and copying it cost about 133 seconds per scenario on a

--- a/features/environment.py
+++ b/features/environment.py
@@ -111,7 +111,12 @@ def before_scenario(context: Context, scenario) -> None:
     # the seed instead of `$HOME/.partcad`. A step that sets
     # PC_INTERNAL_STATE_DIR explicitly runs after this hook and overwrites it,
     # which is what the scenarios exercising `--internal-state-dir` rely on.
-    if COLD_STATE_TAG not in scenario.effective_tags:
+    #
+    # `seed_state_dir` is None when the seed could not be built - see
+    # ensure_seed. Then this does nothing and the scenario runs against the cold
+    # `$HOME/.partcad` in its temporary home, which is what it did before the
+    # seed existed: slower, but the same scenario.
+    if context.seed_state_dir and COLD_STATE_TAG not in scenario.effective_tags:
         state_dir = os.path.join(SCENARIO_STATE_ROOT, f"state-{os.getpid()}-{uuid.uuid4().hex[:8]}")
         provision(state_dir)
         context.state_dir = state_dir

--- a/features/environment.py
+++ b/features/environment.py
@@ -8,7 +8,14 @@ from allure_behave.hooks import (  # noqa: F401  # used by the commented-out rep
 )
 from behave.runner import Context
 
-from features.seed import SCENARIO_STATE_ROOT, ensure_seed, provision, release
+from features.seed import (
+    SCENARIO_STATE_ROOT,
+    ensure_seed,
+    provision,
+    prune_sandbox_venvs,
+    release,
+    sandbox_venvs,
+)
 
 # Caps on the thread pools the numeric stack creates when it is imported.
 #
@@ -93,6 +100,10 @@ def before_all(context: Context) -> None:
     # them find the marker already written and return immediately.
     context.seed_state_dir = ensure_seed(subprocess_env())
 
+    # What the shared sandbox looked like once seeding finished. Anything a
+    # scenario adds to it is removed again in after_scenario; see sandbox_venvs.
+    context.sandbox_baseline = sandbox_venvs() if context.seed_state_dir else set()
+
 
 def before_scenario(context: Context, scenario) -> None:
     # Skipping comes first, and returns: there is no point provisioning a state
@@ -134,3 +145,9 @@ def after_scenario(context: Context, scenario) -> None:
     if state_dir:
         release(state_dir)
         logging.debug("Removed scenario state directory: %s", state_dir)
+
+    # The sandbox is shared, so anything this scenario built inside it would
+    # otherwise outlive it and accumulate for the whole run.
+    baseline = getattr(context, "sandbox_baseline", None)
+    if baseline is not None:
+        prune_sandbox_venvs(baseline)

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,10 +1,47 @@
+import logging
 import os
 import socket
+import uuid
 
-from allure_behave.hooks import allure_report
-
-
+from allure_behave.hooks import (  # noqa: F401  # used by the commented-out reporting hook below
+    allure_report,
+)
 from behave.runner import Context
+
+from features.seed import SCENARIO_STATE_ROOT, ensure_seed, provision, release
+
+# Caps on the thread pools the numeric stack creates when it is imported.
+#
+# `import partcad` reaches build123d, which reaches scipy, which asks its BLAS
+# for one thread per core at import time. On an idle workstation that hides in
+# the spare cores, but it is ~8s of CPU on every `pc` invocation against ~1.4s
+# with these set, and the suite starts hundreds of them. It matters most exactly
+# where there is no headroom: a 2-core CI runner, and any run under
+# `--parallel-processes`, where the workers would otherwise each try to fill the
+# whole machine.
+THREAD_LIMIT_ENV = {
+    "OMP_NUM_THREADS": "1",
+    "OPENBLAS_NUM_THREADS": "1",
+    "MKL_NUM_THREADS": "1",
+    "NUMEXPR_NUM_THREADS": "1",
+    "VECLIB_MAXIMUM_THREADS": "1",
+}
+
+# Scenarios carrying this tag assert on PartCAD's shipped telemetry behaviour -
+# that it defaults to Sentry, and that `pc system set telemetry` changes it.
+# Forcing a value through the environment would decide the answer before the
+# command ran, so they are the one place the default is left alone.
+TELEMETRY_TAG = "pc-system-telemetry"
+
+# Scenarios carrying this tag are left entirely alone: no seed copy, and
+# PC_INTERNAL_STATE_DIR unset, so PartCAD falls back to `$HOME/.partcad` and
+# finds it empty because the scenario's `$HOME` is a fresh temporary directory.
+# Two kinds of assertion need that. Some assert on cache-miss behaviour -
+# `pc install` reports "Cloning the GIT repo:", which it does not do for a
+# repository the seed already cloned. Others assert on the default location
+# itself, which pointing PC_INTERNAL_STATE_DIR elsewhere would change. They pay
+# the cold-start cost the rest of the suite no longer does, which is the point.
+COLD_STATE_TAG = "cold-state"
 
 
 # Scenarios tagged with this require live outbound network access (e.g. an
@@ -32,12 +69,63 @@ def _network_available(host: str = "github.com", port: int = 443, timeout: float
         return False
 
 
-def before_scenario(context: Context, scenario) -> None:
-    if NETWORK_TAG in scenario.effective_tags and not _network_available():
-        scenario.skip("network not available: skipping @%s scenario" % NETWORK_TAG)
-
-
 # def before_all(context: Context) -> None:
 #     import steps
 
 #     allure_report("allure-results")
+
+
+def subprocess_env() -> dict:
+    """The environment the suite's `pc` invocations inherit."""
+    env = dict(os.environ)
+    env.update(THREAD_LIMIT_ENV)
+    return env
+
+
+def before_all(context: Context) -> None:
+    # Applied to this process rather than handed to each subprocess, so that
+    # anything the suite starts inherits them, including the seed build below.
+    os.environ.update(THREAD_LIMIT_ENV)
+
+    # Building here rather than in a fixture keeps `behave` usable on its own.
+    # Under behavex every worker reaches this line; `ensure_seed` locks so only
+    # the first one builds. CI builds it in an earlier step, and then all of
+    # them find the marker already written and return immediately.
+    context.seed_state_dir = ensure_seed(subprocess_env())
+
+
+def before_scenario(context: Context, scenario) -> None:
+    # Skipping comes first, and returns: there is no point provisioning a state
+    # directory for a scenario that is not going to run, and `release` in
+    # after_scenario would then have to tidy up after a scenario that never
+    # started. This and the seed setup below were separate `before_scenario`
+    # definitions after a merge, where the second silently shadowed the first.
+    if NETWORK_TAG in scenario.effective_tags and not _network_available():
+        scenario.skip("network not available: skipping @%s scenario" % NETWORK_TAG)
+        return
+
+    if not hasattr(context, "env"):
+        context.env = {}
+
+    # Every `pc` invocation in this scenario reads and writes its own copy of
+    # the seed instead of `$HOME/.partcad`. A step that sets
+    # PC_INTERNAL_STATE_DIR explicitly runs after this hook and overwrites it,
+    # which is what the scenarios exercising `--internal-state-dir` rely on.
+    if COLD_STATE_TAG not in scenario.effective_tags:
+        state_dir = os.path.join(SCENARIO_STATE_ROOT, f"state-{os.getpid()}-{uuid.uuid4().hex[:8]}")
+        provision(state_dir)
+        context.state_dir = state_dir
+        context.env["PC_INTERNAL_STATE_DIR"] = state_dir
+
+    # Left unset for the telemetry scenarios; see TELEMETRY_TAG. Everywhere else
+    # this stops each invocation from opening a connection to Sentry and
+    # flushing it on exit, which the suite was doing several times per command.
+    if TELEMETRY_TAG not in scenario.effective_tags:
+        context.env["PC_TELEMETRY_TYPE"] = "none"
+
+
+def after_scenario(context: Context, scenario) -> None:
+    state_dir = getattr(context, "state_dir", None)
+    if state_dir:
+        release(state_dir)
+        logging.debug("Removed scenario state directory: %s", state_dir)

--- a/features/environment.py
+++ b/features/environment.py
@@ -104,6 +104,21 @@ def before_all(context: Context) -> None:
     # scenario adds to it is removed again in after_scenario; see sandbox_venvs.
     context.sandbox_baseline = sandbox_venvs() if context.seed_state_dir else set()
 
+    # Pruning is only safe while this process is the sandbox's only user.
+    # behavex runs several behave processes against the same shared sandbox and
+    # tells each one its worker id, so a worker past the first must leave other
+    # workers' venvs alone: "appeared since seeding" cannot distinguish one this
+    # scenario made from one another worker is running out of right now.
+    # Serial `behave`, which is how CI shards run, has no such reader.
+    worker = str(context.config.userdata.get("worker_id", "0"))
+    context.sandbox_exclusive = worker in ("", "0")
+    if not context.sandbox_exclusive:
+        logging.info(
+            "Parallel worker %s: leaving the shared sandbox alone. Venvs built by scenarios will "
+            "accumulate for this run; that is disk, where pruning them would be a race.",
+            worker,
+        )
+
 
 def before_scenario(context: Context, scenario) -> None:
     # Skipping comes first, and returns: there is no point provisioning a state
@@ -145,6 +160,10 @@ def after_scenario(context: Context, scenario) -> None:
     if state_dir:
         release(state_dir)
         logging.debug("Removed scenario state directory: %s", state_dir)
+
+    # Only when nothing else is using the sandbox; see before_all.
+    if not getattr(context, "sandbox_exclusive", True):
+        return
 
     # The sandbox is shared, so anything this scenario built inside it would
     # otherwise outlive it and accumulate for the whole run.

--- a/features/environment.py
+++ b/features/environment.py
@@ -104,18 +104,25 @@ def before_all(context: Context) -> None:
     # scenario adds to it is removed again in after_scenario; see sandbox_venvs.
     context.sandbox_baseline = sandbox_venvs() if context.seed_state_dir else set()
 
-    # Pruning is only safe while this process is the sandbox's only user.
-    # behavex runs several behave processes against the same shared sandbox and
-    # tells each one its worker id, so a worker past the first must leave other
-    # workers' venvs alone: "appeared since seeding" cannot distinguish one this
-    # scenario made from one another worker is running out of right now.
-    # Serial `behave`, which is how CI shards run, has no such reader.
-    worker = str(context.config.userdata.get("worker_id", "0"))
-    context.sandbox_exclusive = worker in ("", "0")
+    # Pruning is only safe while this process is the sandbox's only user, so the
+    # test is "is anything else possibly running", not "am I the first worker".
+    # "A venv that appeared since seeding" cannot distinguish one this scenario
+    # built from one another worker is running a scenario out of right now, and
+    # deleting the latter fails that scenario unreproducibly.
+    #
+    # behavex passes a worker id to every behave it starts, 0 for its serial
+    # path and 1..N for its parallel one - but reading that number cannot
+    # separate "serial" from "the worker that happened to be numbered 0", so
+    # its mere presence is what disqualifies pruning. Plain `behave`, which is
+    # how CI runs each shard, passes nothing and is the only case that prunes.
+    # Under behavex the venvs accumulate for the run instead: that costs disk,
+    # where pruning them would cost correctness.
+    worker = context.config.userdata.get("worker_id")
+    context.sandbox_exclusive = worker is None
     if not context.sandbox_exclusive:
         logging.info(
-            "Parallel worker %s: leaving the shared sandbox alone. Venvs built by scenarios will "
-            "accumulate for this run; that is disk, where pruning them would be a race.",
+            "behavex worker %s: leaving the shared sandbox alone, since other workers may be using it. "
+            "Scenario venvs will accumulate for this run.",
             worker,
         )
 

--- a/features/install.feature
+++ b/features/install.feature
@@ -1,4 +1,8 @@
-@cli @install-packages
+# @cold-state: these assert that `pc install` reports cloning, which it only
+# does for a repository not in the cache yet, and two of them read the clone
+# back out of $HOME/.partcad. Both need the state directory left at its default
+# and empty, so they opt out of the seed the rest of the suite starts from.
+@cli @install-packages @cold-state
 Feature: `pc install` command
 
   Background: Create temporary $HOME and working directory

--- a/features/seed.py
+++ b/features/seed.py
@@ -1,0 +1,349 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""A pre-warmed PartCAD internal state directory shared by the whole suite.
+
+Every scenario that runs `pc` gets a private `$HOME`, and PartCAD roots its
+entire on-disk state - the git cache of imported packages and the conda sandbox
+it runs script parts in - at `$HOME/.partcad`. A private `$HOME` therefore means
+a cold cache, so each scenario re-cloned the `//pub` tree and rebuilt a ~2.3 GB
+conda environment from scratch. One such sandbox build was observed stalling the
+suite for ~35 minutes; the suite paid that cost over and over.
+
+This module builds that state once, in `SEED_ROOT`, and hands every scenario a
+copy of it. The copy is what keeps the scenarios independent: a scenario may
+write to its state directory (populate the cache, re-clone at a different
+revision, corrupt it on purpose) without any of it reaching the seed or the next
+scenario. Copying ~3.5 GB costs ~2.2s, against the minutes the cold
+build costs, and the copy is deleted when the scenario ends so at most
+`--parallel-processes` of them exist at a time.
+
+The seed is built by `ensure_seed()`, which is safe to call from every behavex
+worker at once: an inter-process lock serializes them and a marker file written
+last means a build that died halfway is never mistaken for a finished one.
+
+Run `python -m features.seed` to build the seed ahead of time - CI does this so
+the cost lands in its own step rather than inside the first worker to start.
+"""
+
+import json
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+from filelock import FileLock
+
+# Everything this module writes lives under here. Overridable so CI can place it
+# on a volume it caches, and so a developer can point several checkouts at one
+# already-built seed.
+#
+# Deliberately not `tempfile.gettempdir()`. behavex points the TEMP environment
+# variable at its own output folder, and each worker is a separate process that
+# imports this module, so a temp-derived default would give every worker a
+# different location: each would rebuild the whole seed instead of sharing it,
+# and each would drop multi-gigabyte scenario copies inside the very folder CI
+# archives as an artifact. The home directory is identical in every worker and
+# outside anything that gets uploaded.
+BASE_DIR = os.environ.get("PARTCAD_BEHAVE_DIR") or os.path.join(os.path.expanduser("~"), ".partcad-behave")
+
+# The seed, built once.
+SEED_ROOT = os.path.join(BASE_DIR, "seed")
+
+# The state directory itself - this is what gets copied per scenario.
+SEED_STATE_DIR = os.path.join(SEED_ROOT, "state")
+
+# Where the per-scenario copies go. Kept together so that an interrupted run
+# leaves one identifiable tree to delete rather than scattering copies about.
+SCENARIO_STATE_ROOT = os.path.join(BASE_DIR, "state")
+
+# The throwaway package the seeding commands run in. It is not copied; only the
+# state directory the commands populate as a side effect is.
+_SEED_PROJECT_DIR = os.path.join(SEED_ROOT, "project")
+
+# Written last, once the build has fully succeeded. Its absence means "rebuild".
+#
+# Deliberately outside SEED_STATE_DIR, and so deliberately outside what CI
+# caches. A restored cache brings back the expensive-to-produce parts but not the
+# conda sandbox, which is too large to be worth a cache slot and cheap to
+# rebuild; if this marker came back with them, the build would be skipped, the
+# sandbox would never be built, and every scenario needing it would build one
+# inside its own throwaway copy of the state directory.
+_SEED_MARKER = os.path.join(SEED_ROOT, ".seeded")
+
+# Records the (kind, type, format) exports already done, so a build that finds a
+# restored object cache does not spend ~7.5 minutes re-exporting what is in it.
+# Inside the state directory, and so cached alongside the cache it describes -
+# the two are only meaningful together.
+_EXPORTS_MANIFEST = os.path.join(SEED_STATE_DIR, ".seed-exports.json")
+
+# The sandbox the script parts run in.
+_SANDBOX_DIR = os.path.join(SEED_STATE_DIR, "sandbox")
+
+# Written only once the sandbox has been built successfully. The directory's mere
+# existence is not the test: conda creates it and populates it as it goes, so an
+# attempt that failed or timed out partway leaves a directory that looks built
+# and is not, and skipping the rebuild would hand every scenario a broken
+# sandbox. Outside SEED_STATE_DIR for the same reason as _SEED_MARKER - a
+# restored cache must not be able to claim a sandbox it does not carry.
+_SANDBOX_MARKER = os.path.join(SEED_ROOT, ".sandbox-built")
+
+# Kept beside SEED_ROOT rather than inside it, so that discarding a failed seed
+# never deletes the lock the discarding process is holding.
+_SEED_LOCK = SEED_ROOT + ".lock"
+
+# Every format `pc export` accepts. The seed exports each object below to each
+# of them so the first scenario to ask for any combination finds it warm.
+EXPORT_FORMATS = (
+    "step",
+    "brep",
+    "stl",
+    "3mf",
+    "threejs",
+    "obj",
+    "gltf",
+    "iges",
+)
+
+# One representative object per part type published in `//pub`, paired with the
+# type it exercises. Hardcoded rather than discovered because discovery would
+# mean resolving all ~12k objects in the index on every run, and because the
+# point is to pin what the seed covers so a change to it is visible in review.
+#
+# `//pub` tracks a released PartCAD, so it lags this checkout: types the repo has
+# under `examples/` but the index has not published yet (`sdf`, `compound`) have
+# no entry here and stay cold. The `ai-*` types are published but deliberately
+# left out - generating them calls a model provider, which needs credentials and
+# is what the suite-wide `~@ai` tag already excludes.
+PART_OBJECTS = (
+    ("step", "//pub/examples/partcad/produce_part_step:bolt"),
+    ("stl", "//pub/examples/partcad/produce_part_stl:cube"),
+    ("3mf", "//pub/examples/partcad/produce_part_3mf:cube"),
+    ("brep", "//pub/examples/partcad/produce_part_brep:box"),
+    ("obj", "//pub/examples/partcad/produce_part_obj:cube"),
+    ("build123d", "//pub/examples/partcad/produce_part_build123d_primitive:cube"),
+    ("cadquery", "//pub/examples/partcad/produce_part_cadquery_primitive:cube"),
+    ("scad", "//pub/examples/partcad/produce_part_openscad:cube"),
+    ("extrude", "//pub/examples/partcad/produce_part_extrude:cylinder"),
+    ("sweep", "//pub/examples/partcad/produce_part_sweep:pipe"),
+    ("kicad", "//pub/examples/partcad/produce_part_kicad:Arduino_Nano"),
+    ("alias", "//pub/examples/partcad/produce_part_step:screw"),
+    ("enrich", "//pub/examples/partcad/feature_convert:cube_enrich"),
+)
+
+# The same, for the assembly types `//pub` publishes.
+ASSEMBLY_OBJECTS = (
+    ("assy", "//pub/examples/partcad/produce_assembly_assy:primitive"),
+    ("alias", "//pub/examples/partcad/produce_assembly_assy:partcad_logo"),
+)
+
+# The object exported purely to force the conda sandbox into existence. Any
+# script-backed type would do; cadquery is the cheapest one `//pub` publishes.
+_SANDBOX_TRIGGER = "//pub/examples/partcad/produce_part_cadquery_primitive:cube"
+
+# No single seeding command should be able to wedge a CI run. Cloning the whole
+# index is the long pole, so the budget is generous; an export that has not
+# finished in five minutes is stuck, not slow. The sandbox gets its own budget
+# because it is solving a conda environment, not exporting geometry.
+_LIST_TIMEOUT = 1800
+_SANDBOX_TIMEOUT = 1800
+_EXPORT_TIMEOUT = 300
+
+logger = logging.getLogger(__name__)
+
+
+def _pc_command(*args: str) -> list:
+    """The argv that runs this checkout's `pc` under the running interpreter.
+
+    Going through `sys.executable -m` rather than a `pc` on PATH keeps the seed
+    on the same interpreter behave itself is using, which matters in CI where
+    the environment is a conda env activated for the job. Unlike the test steps,
+    which wrap the CLI in `coverage run` on the one cell that reports coverage
+    (see features/steps/run.py), the seed never does: it is fixture setup, and
+    attributing it would credit lines no scenario actually exercised.
+    """
+    return [sys.executable, "-m", "partcad_cli.click.command", "--no-ansi", *args]
+
+
+def _run(argv: list, cwd: str, env: dict, timeout: int) -> subprocess.CompletedProcess:
+    logger.debug("seed: running %s", " ".join(argv[3:]))
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        env=env,
+        timeout=timeout,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _load_manifest() -> set:
+    """The exports a previous build - possibly a cached one - already did."""
+    try:
+        with open(_EXPORTS_MANIFEST, encoding="utf-8") as manifest:
+            return set(json.load(manifest))
+    except (OSError, ValueError):
+        # Missing is the normal first-run case. Unreadable or malformed means a
+        # build died mid-write, and redoing every export is the safe answer.
+        return set()
+
+
+def _save_manifest(done: set) -> None:
+    with open(_EXPORTS_MANIFEST, "w", encoding="utf-8") as manifest:
+        json.dump(sorted(done), manifest)
+
+
+def _build(env: dict) -> None:
+    """Populate `SEED_STATE_DIR`. Raises if the parts that must work do not."""
+    os.makedirs(_SEED_PROJECT_DIR, exist_ok=True)
+    os.makedirs(SEED_STATE_DIR, exist_ok=True)
+    output_dir = os.path.join(SEED_ROOT, "output")
+    os.makedirs(output_dir, exist_ok=True)
+
+    build_env = dict(env)
+    build_env["PC_INTERNAL_STATE_DIR"] = SEED_STATE_DIR
+
+    # `pc init` writes a package whose only dependency is `//pub`, so the
+    # recursive list below walks the public index and nothing else. It refuses to
+    # overwrite, so a resumed build has to skip it rather than treat the refusal
+    # as a failure.
+    if not os.path.exists(os.path.join(_SEED_PROJECT_DIR, "partcad.yaml")):
+        result = _run(_pc_command("init"), _SEED_PROJECT_DIR, build_env, _EXPORT_TIMEOUT)
+        if result.returncode != 0:
+            raise RuntimeError(f"seed: 'pc init' failed ({result.returncode}):\n{result.stderr}")
+
+    # Resolving every package in the index is what fills the git cache, and it
+    # is the single most valuable thing the seed does: it is the work that was
+    # previously repeated by every scenario that touched a `//pub` object.
+    result = _run(_pc_command("list", "all", "-r"), _SEED_PROJECT_DIR, build_env, _LIST_TIMEOUT)
+    if result.returncode != 0:
+        raise RuntimeError(f"seed: 'pc list all -r' failed ({result.returncode}):\n{result.stderr}")
+
+    # The sandbox used to appear as a side effect of the first script part
+    # exported. It gets its own step now, because the loop below skips exports a
+    # restored cache already covers - and on a full cache hit it would skip every
+    # one of them, leaving no script part to trigger the build.
+    if not (os.path.exists(_SANDBOX_MARKER) and os.path.isdir(_SANDBOX_DIR)):
+        # Whatever a previous attempt left is not repairable by conda, and half
+        # an environment is worse than none, so it goes before trying again.
+        shutil.rmtree(_SANDBOX_DIR, ignore_errors=True)
+        args = ["export", "-t", "stl", "-O", output_dir, _SANDBOX_TRIGGER]
+        try:
+            result = _run(_pc_command(*args), _SEED_PROJECT_DIR, build_env, _SANDBOX_TIMEOUT)
+        except subprocess.TimeoutExpired as timeout:
+            raise RuntimeError(f"seed: building the sandbox timed out after {_SANDBOX_TIMEOUT}s") from timeout
+        if result.returncode != 0:
+            raise RuntimeError(f"seed: building the sandbox failed ({result.returncode}):\n{result.stderr}")
+        with open(_SANDBOX_MARKER, "w", encoding="utf-8") as marker:
+            marker.write("ok\n")
+
+    # Exporting fills the object cache. Individual combinations are allowed to
+    # fail: not every type can be expressed in every format, and a type that
+    # cannot be exported today should leave the suite slower, not broken.
+    done = _load_manifest()
+    failures = []
+    skipped = 0
+    for kind, objects in (("part", PART_OBJECTS), ("assembly", ASSEMBLY_OBJECTS)):
+        for type_name, object_path in objects:
+            for export_format in EXPORT_FORMATS:
+                entry = f"{kind}|{type_name}|{export_format}"
+                if entry in done:
+                    skipped += 1
+                    continue
+                args = ["export", "-t", export_format, "-O", output_dir]
+                if kind == "assembly":
+                    args.append("-a")
+                args.append(object_path)
+                try:
+                    result = _run(_pc_command(*args), _SEED_PROJECT_DIR, build_env, _EXPORT_TIMEOUT)
+                    rc = result.returncode
+                except subprocess.TimeoutExpired:
+                    rc = "timeout"
+                if rc == 0:
+                    # Recorded as they succeed rather than in one write at the
+                    # end, so an interrupted build still shortens the next one.
+                    done.add(entry)
+                    _save_manifest(done)
+                else:
+                    failures.append(f"{kind} {type_name} -> {export_format} ({rc})")
+
+    if skipped:
+        logger.info("seed: %d exports already covered by the restored object cache", skipped)
+
+    if failures:
+        logger.info(
+            "seed: %d of %d exports did not succeed; those combinations stay cold: %s",
+            len(failures),
+            (len(PART_OBJECTS) + len(ASSEMBLY_OBJECTS)) * len(EXPORT_FORMATS),
+            ", ".join(failures),
+        )
+
+
+def ensure_seed(env: dict) -> str:
+    """Return the seeded state directory, building it if it is not there yet.
+
+    Safe to call concurrently: behavex starts one behave per worker and each
+    runs `before_all`, so the first caller builds while the others wait on the
+    lock and then observe the marker.
+    """
+    os.makedirs(os.path.dirname(_SEED_LOCK) or ".", exist_ok=True)
+
+    with FileLock(_SEED_LOCK):
+        if os.path.exists(_SEED_MARKER):
+            return SEED_STATE_DIR
+
+        logger.info("seed: building the shared PartCAD state directory in %s", SEED_ROOT)
+
+        # Whatever is already here is built on rather than discarded, because in
+        # CI it is a restored cache and discarding it would defeat the point.
+        # Every step in `_build` is individually resumable: PartCAD's own guard
+        # file makes a half-finished clone re-clone, the sandbox is rebuilt
+        # unless its directory is there, and the manifest records exports one at
+        # a time. Delete BASE_DIR to force a genuinely clean rebuild.
+        _build(env)
+
+        with open(_SEED_MARKER, "w", encoding="utf-8") as marker:
+            marker.write("ok\n")
+
+        logger.info("seed: ready")
+        return SEED_STATE_DIR
+
+
+def provision(destination: str) -> str:
+    """Copy the seed to `destination` and return it, for one scenario's use."""
+    # shutil.copytree walks the ~27k files in Python; `cp -a` does the same work
+    # in one process and measurably faster, which is worth having on the path
+    # that runs once per scenario. Windows has no `cp`, so it falls back.
+    if platform.system() == "Windows":
+        shutil.copytree(SEED_STATE_DIR, destination, symlinks=True)
+    else:
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        subprocess.run(["cp", "-a", SEED_STATE_DIR, destination], check=True)
+    return destination
+
+
+def release(destination: str) -> None:
+    """Delete a scenario's copy. Never fails the scenario it belongs to."""
+    shutil.rmtree(destination, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+
+    # Both imports are deferred to here because `features.environment` imports
+    # this module: at module scope they would be a cycle. `ensure_seed` is
+    # re-imported rather than called directly because `-m` runs this file as
+    # `__main__`, a second module object from the `features.seed` that
+    # `features.environment` holds - calling that one keeps the whole run
+    # working against a single copy of this module's state.
+    from features.environment import subprocess_env  # noqa: E402
+    from features.seed import ensure_seed as ensure  # noqa: E402
+
+    print(ensure(subprocess_env()))

--- a/features/seed.py
+++ b/features/seed.py
@@ -17,9 +17,14 @@ This module builds that state once, in `SEED_ROOT`, and hands every scenario a
 copy of it. The copy is what keeps the scenarios independent: a scenario may
 write to its state directory (populate the cache, re-clone at a different
 revision, corrupt it on purpose) without any of it reaching the seed or the next
-scenario. Copying ~3.5 GB costs ~2.2s, against the minutes the cold
-build costs, and the copy is deleted when the scenario ends so at most
-`--parallel-processes` of them exist at a time.
+scenario. Copying ~3.5 GB costs ~2.2s, against the minutes the cold build costs,
+and the copy is deleted when the scenario ends - so one exists at a time under
+plain `behave`, and one per worker under `behavex --parallel-processes`.
+
+Seeding is an optimization, never a precondition: if it cannot be done - a runner
+that cannot reach github.com, most often - `ensure_seed` says so and returns
+None, and every scenario falls back to the cold `$HOME/.partcad` it used before
+this existed.
 
 The seed is built by `ensure_seed()`, which is safe to call from every behavex
 worker at once: an inter-process lock serializes them and a marker file written
@@ -36,6 +41,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import time
 
 from filelock import FileLock
 
@@ -154,6 +160,18 @@ _LIST_TIMEOUT = 1800
 _SANDBOX_TIMEOUT = 1800
 _EXPORT_TIMEOUT = 300
 
+# Attempts per seeding step, and the base backoff between them (multiplied by
+# the attempt number). Cloning the index and solving a conda environment both
+# reach the network, and hosted runners lose connections to github.com often
+# enough that one attempt is not a fair test of whether seeding is possible.
+_ATTEMPTS = 3
+_RETRY_DELAY = 10
+
+
+class SeedError(Exception):
+    """A seeding step could not be completed, after retrying."""
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -200,8 +218,33 @@ def _save_manifest(done: set) -> None:
         json.dump(sorted(done), manifest)
 
 
+def _run_step(label: str, argv: list, cwd: str, env: dict, timeout: int) -> None:
+    """Run one seeding command, retrying before giving up.
+
+    The steps that matter here reach the network - cloning the whole public
+    index, and solving a conda environment - and hosted runners drop
+    connections to github.com often enough that a single attempt is not a fair
+    test of whether seeding is possible.
+    """
+    detail = "no attempt made"
+    for attempt in range(1, _ATTEMPTS + 1):
+        try:
+            result = _run(argv, cwd, env, timeout)
+            if result.returncode == 0:
+                return
+            stderr = (result.stderr or "").strip()
+            detail = stderr.splitlines()[-1] if stderr else f"exit status {result.returncode}"
+        except subprocess.TimeoutExpired:
+            detail = f"timed out after {timeout}s"
+        if attempt < _ATTEMPTS:
+            delay = _RETRY_DELAY * attempt
+            logger.warning("seed: %s failed (%s); retrying in %ds", label, detail, delay)
+            time.sleep(delay)
+    raise SeedError(f"{label} failed after {_ATTEMPTS} attempts: {detail}")
+
+
 def _build(env: dict) -> None:
-    """Populate `SEED_STATE_DIR`. Raises if the parts that must work do not."""
+    """Populate `SEED_STATE_DIR`. Raises SeedError if a required step will not run."""
     os.makedirs(_SEED_PROJECT_DIR, exist_ok=True)
     os.makedirs(SEED_STATE_DIR, exist_ok=True)
     output_dir = os.path.join(SEED_ROOT, "output")
@@ -215,16 +258,18 @@ def _build(env: dict) -> None:
     # overwrite, so a resumed build has to skip it rather than treat the refusal
     # as a failure.
     if not os.path.exists(os.path.join(_SEED_PROJECT_DIR, "partcad.yaml")):
-        result = _run(_pc_command("init"), _SEED_PROJECT_DIR, build_env, _EXPORT_TIMEOUT)
-        if result.returncode != 0:
-            raise RuntimeError(f"seed: 'pc init' failed ({result.returncode}):\n{result.stderr}")
+        _run_step("'pc init'", _pc_command("init"), _SEED_PROJECT_DIR, build_env, _EXPORT_TIMEOUT)
 
     # Resolving every package in the index is what fills the git cache, and it
     # is the single most valuable thing the seed does: it is the work that was
     # previously repeated by every scenario that touched a `//pub` object.
-    result = _run(_pc_command("list", "all", "-r"), _SEED_PROJECT_DIR, build_env, _LIST_TIMEOUT)
-    if result.returncode != 0:
-        raise RuntimeError(f"seed: 'pc list all -r' failed ({result.returncode}):\n{result.stderr}")
+    _run_step(
+        "'pc list all -r'",
+        _pc_command("list", "all", "-r"),
+        _SEED_PROJECT_DIR,
+        build_env,
+        _LIST_TIMEOUT,
+    )
 
     # The sandbox used to appear as a side effect of the first script part
     # exported. It gets its own step now, because the loop below skips exports a
@@ -234,13 +279,13 @@ def _build(env: dict) -> None:
         # Whatever a previous attempt left is not repairable by conda, and half
         # an environment is worse than none, so it goes before trying again.
         shutil.rmtree(_SANDBOX_DIR, ignore_errors=True)
-        args = ["export", "-t", "stl", "-O", output_dir, _SANDBOX_TRIGGER]
-        try:
-            result = _run(_pc_command(*args), _SEED_PROJECT_DIR, build_env, _SANDBOX_TIMEOUT)
-        except subprocess.TimeoutExpired as timeout:
-            raise RuntimeError(f"seed: building the sandbox timed out after {_SANDBOX_TIMEOUT}s") from timeout
-        if result.returncode != 0:
-            raise RuntimeError(f"seed: building the sandbox failed ({result.returncode}):\n{result.stderr}")
+        _run_step(
+            "building the sandbox",
+            _pc_command("export", "-t", "stl", "-O", output_dir, _SANDBOX_TRIGGER),
+            _SEED_PROJECT_DIR,
+            build_env,
+            _SANDBOX_TIMEOUT,
+        )
         with open(_SANDBOX_MARKER, "w", encoding="utf-8") as marker:
             marker.write("ok\n")
 
@@ -286,8 +331,15 @@ def _build(env: dict) -> None:
         )
 
 
-def ensure_seed(env: dict) -> str:
-    """Return the seeded state directory, building it if it is not there yet.
+def ensure_seed(env: dict):
+    """Return the seeded state directory, or None if it could not be built.
+
+    None is a supported outcome, not an error: the seed is an optimization, so a
+    runner that cannot reach github.com should still run the suite - each
+    scenario falling back to the cold `$HOME/.partcad` it used before this
+    existed. Correct, and much slower. Raising instead would turn one dropped
+    connection into a failure of every sharded behave job, which is exactly what
+    it did the first time this ran on the macOS runners.
 
     Safe to call concurrently: behavex starts one behave per worker and each
     runs `before_all`, so the first caller builds while the others wait on the
@@ -305,9 +357,18 @@ def ensure_seed(env: dict) -> str:
         # CI it is a restored cache and discarding it would defeat the point.
         # Every step in `_build` is individually resumable: PartCAD's own guard
         # file makes a half-finished clone re-clone, the sandbox is rebuilt
-        # unless its directory is there, and the manifest records exports one at
-        # a time. Delete BASE_DIR to force a genuinely clean rebuild.
-        _build(env)
+        # unless its success marker is there, and the manifest records exports
+        # one at a time. Delete BASE_DIR to force a genuinely clean rebuild.
+        try:
+            _build(env)
+        except SeedError as error:
+            logger.warning("seed: %s", error)
+            logger.warning(
+                "seed: continuing WITHOUT a shared state directory - every scenario will start from a cold "
+                "cache, which is correct but much slower. This is usually a runner that cannot reach "
+                "github.com; re-run the job."
+            )
+            return None
 
         with open(_SEED_MARKER, "w", encoding="utf-8") as marker:
             marker.write("ok\n")
@@ -346,4 +407,8 @@ if __name__ == "__main__":
     from features.environment import subprocess_env  # noqa: E402
     from features.seed import ensure_seed as ensure  # noqa: E402
 
-    print(ensure(subprocess_env()))
+    seeded = ensure(subprocess_env())
+    # Exit 0 either way. A CI step that fails here would take the whole sharded
+    # behave job with it over what is only a lost optimization; the warning
+    # ensure_seed logs is what says the run will be slow.
+    print(seeded if seeded else "not seeded")

--- a/features/seed.py
+++ b/features/seed.py
@@ -153,12 +153,21 @@ ASSEMBLY_OBJECTS = (
 _SANDBOX_TRIGGER = "//pub/examples/partcad/produce_part_cadquery_primitive:cube"
 
 # No single seeding command should be able to wedge a CI run. Cloning the whole
-# index is the long pole, so the budget is generous; an export that has not
-# finished in five minutes is stuck, not slow. The sandbox gets its own budget
-# because it is solving a conda environment, not exporting geometry.
-_LIST_TIMEOUT = 1800
-_SANDBOX_TIMEOUT = 1800
+# index is the long pole; an export that has not finished in five minutes is
+# stuck, not slow. The sandbox gets its own allowance because it is solving a
+# conda environment, not exporting geometry.
+_LIST_TIMEOUT = 900
+_SANDBOX_TIMEOUT = 900
 _EXPORT_TIMEOUT = 300
+
+# Wall-clock budget for the whole of seeding, retries included.
+#
+# Per-command timeouts alone do not bound this: three attempts at two 900s steps
+# is 45 minutes before the exports even start, which on a runner with flaky
+# connectivity would eat a 60 minute job by itself. Every phase is therefore
+# given whatever is left of this and no more, and once it is gone seeding stops
+# and the suite runs unseeded rather than the job being killed.
+_SEED_BUDGET = int(os.environ.get("PARTCAD_BEHAVE_SEED_BUDGET", "1500"))
 
 # Attempts per seeding step, and the base backoff between them (multiplied by
 # the attempt number). Cloning the index and solving a conda environment both
@@ -166,6 +175,14 @@ _EXPORT_TIMEOUT = 300
 # enough that one attempt is not a fair test of whether seeding is possible.
 _ATTEMPTS = 3
 _RETRY_DELAY = 10
+
+# Wall-clock budget for the export phase as a whole. It exists because a CI job
+# has a deadline the seed shares with the suite it is meant to speed up: on a
+# Windows runner the unbounded phase took 32 of the job's 60 minutes and the
+# suite was killed before finishing. Exports are resumable through the manifest,
+# so a budget defers work rather than dropping it. Overridable for a machine that
+# would rather pay once and be done.
+_EXPORT_BUDGET = int(os.environ.get("PARTCAD_BEHAVE_EXPORT_BUDGET", "600"))
 
 
 class SeedError(Exception):
@@ -218,26 +235,50 @@ def _save_manifest(done: set) -> None:
         json.dump(sorted(done), manifest)
 
 
-def _run_step(label: str, argv: list, cwd: str, env: dict, timeout: int) -> None:
-    """Run one seeding command, retrying before giving up.
+def _budget_left(deadline: float, label: str) -> float:
+    """Seconds left of the overall seeding budget, or raise if it is spent."""
+    left = deadline - time.monotonic()
+    if left <= 0:
+        raise SeedError(f"the {_SEED_BUDGET}s seeding budget was spent before {label} could run")
+    return left
+
+
+def _run_step(label: str, argv: list, cwd: str, env: dict, allowance: int, deadline: float) -> None:
+    """Run one seeding command, retrying until it works or the budget is gone.
 
     The steps that matter here reach the network - cloning the whole public
-    index, and solving a conda environment - and hosted runners drop
-    connections to github.com often enough that a single attempt is not a fair
-    test of whether seeding is possible.
+    index, and solving a conda environment - and hosted runners drop connections
+    to github.com often enough that a single attempt is not a fair test of
+    whether seeding is possible.
+
+    Every attempt is clamped to whatever is left of the overall deadline, not
+    just to this step's own allowance. Clamping only to the allowance would let
+    three attempts at a 900s step run for 45 minutes, which is the whole point of
+    having a budget.
+
+    Each step is timed and logged: seeding runs on machines an order of magnitude
+    apart in speed, and without per-phase numbers a slow job says only that the
+    whole thing took half an hour.
     """
+    started = time.monotonic()
     detail = "no attempt made"
     for attempt in range(1, _ATTEMPTS + 1):
+        timeout = min(allowance, _budget_left(deadline, label))
         try:
             result = _run(argv, cwd, env, timeout)
             if result.returncode == 0:
+                logger.info("seed: %s took %.0fs", label, time.monotonic() - started)
                 return
             stderr = (result.stderr or "").strip()
             detail = stderr.splitlines()[-1] if stderr else f"exit status {result.returncode}"
         except subprocess.TimeoutExpired:
-            detail = f"timed out after {timeout}s"
+            detail = f"timed out after {timeout:.0f}s"
         if attempt < _ATTEMPTS:
             delay = _RETRY_DELAY * attempt
+            # Sleeping past the deadline only to be refused by the clamp above
+            # wastes time the suite could be using.
+            if time.monotonic() + delay >= deadline:
+                raise SeedError(f"{label} failed ({detail}) and the seeding budget is spent")
             logger.warning("seed: %s failed (%s); retrying in %ds", label, detail, delay)
             time.sleep(delay)
     raise SeedError(f"{label} failed after {_ATTEMPTS} attempts: {detail}")
@@ -253,12 +294,23 @@ def _build(env: dict) -> None:
     build_env = dict(env)
     build_env["PC_INTERNAL_STATE_DIR"] = SEED_STATE_DIR
 
+    # Everything below shares this deadline, so that seeding costs a job a
+    # bounded amount no matter how badly the network behaves.
+    deadline = time.monotonic() + _SEED_BUDGET
+
     # `pc init` writes a package whose only dependency is `//pub`, so the
     # recursive list below walks the public index and nothing else. It refuses to
     # overwrite, so a resumed build has to skip it rather than treat the refusal
     # as a failure.
     if not os.path.exists(os.path.join(_SEED_PROJECT_DIR, "partcad.yaml")):
-        _run_step("'pc init'", _pc_command("init"), _SEED_PROJECT_DIR, build_env, _EXPORT_TIMEOUT)
+        _run_step(
+            "'pc init'",
+            _pc_command("init"),
+            _SEED_PROJECT_DIR,
+            build_env,
+            _EXPORT_TIMEOUT,
+            deadline,
+        )
 
     # Resolving every package in the index is what fills the git cache, and it
     # is the single most valuable thing the seed does: it is the work that was
@@ -269,6 +321,7 @@ def _build(env: dict) -> None:
         _SEED_PROJECT_DIR,
         build_env,
         _LIST_TIMEOUT,
+        deadline,
     )
 
     # The sandbox used to appear as a side effect of the first script part
@@ -285,6 +338,7 @@ def _build(env: dict) -> None:
             _SEED_PROJECT_DIR,
             build_env,
             _SANDBOX_TIMEOUT,
+            deadline,
         )
         with open(_SANDBOX_MARKER, "w", encoding="utf-8") as marker:
             marker.write("ok\n")
@@ -292,9 +346,26 @@ def _build(env: dict) -> None:
     # Exporting fills the object cache. Individual combinations are allowed to
     # fail: not every type can be expressed in every format, and a type that
     # cannot be exported today should leave the suite slower, not broken.
+    #
+    # The phase is also time-boxed, because it is the one part of the seed whose
+    # cost scales with how much it covers, and it is the least valuable per
+    # second: the clone and the sandbox above are what stop every scenario
+    # repeating minutes of work, while these only pre-warm objects some scenarios
+    # then export again. Unbounded, it took 32 of a Windows job's 60 allowed
+    # minutes and left too little for the suite, so the job was killed.
+    #
+    # Stopping early is not giving up. Each success is recorded in the manifest
+    # as it happens, and CI caches the manifest with the objects it describes, so
+    # the next run resumes where this one stopped and the coverage converges over
+    # a few runs instead of being paid all at once.
     done = _load_manifest()
     failures = []
     skipped = 0
+    exported = 0
+    remaining = 0
+    # Whichever runs out first: the phase's own budget, or what is left of the
+    # overall one after cloning and building the sandbox.
+    export_deadline = min(time.monotonic() + _EXPORT_BUDGET, deadline)
     for kind, objects in (("part", PART_OBJECTS), ("assembly", ASSEMBLY_OBJECTS)):
         for type_name, object_path in objects:
             for export_format in EXPORT_FORMATS:
@@ -302,12 +373,16 @@ def _build(env: dict) -> None:
                 if entry in done:
                     skipped += 1
                     continue
+                if time.monotonic() >= export_deadline:
+                    remaining += 1
+                    continue
                 args = ["export", "-t", export_format, "-O", output_dir]
                 if kind == "assembly":
                     args.append("-a")
                 args.append(object_path)
                 try:
-                    result = _run(_pc_command(*args), _SEED_PROJECT_DIR, build_env, _EXPORT_TIMEOUT)
+                    export_timeout = min(_EXPORT_TIMEOUT, max(1, export_deadline - time.monotonic()))
+                    result = _run(_pc_command(*args), _SEED_PROJECT_DIR, build_env, export_timeout)
                     rc = result.returncode
                 except subprocess.TimeoutExpired:
                     rc = "timeout"
@@ -316,19 +391,30 @@ def _build(env: dict) -> None:
                     # end, so an interrupted build still shortens the next one.
                     done.add(entry)
                     _save_manifest(done)
+                    exported += 1
                 else:
                     failures.append(f"{kind} {type_name} -> {export_format} ({rc})")
 
-    if skipped:
-        logger.info("seed: %d exports already covered by the restored object cache", skipped)
+    total = (len(PART_OBJECTS) + len(ASSEMBLY_OBJECTS)) * len(EXPORT_FORMATS)
+    logger.info(
+        "seed: exports - %d done now, %d already cached, %d deferred, %d failed (of %d)",
+        exported,
+        skipped,
+        remaining,
+        len(failures),
+        total,
+    )
+
+    if remaining:
+        logger.info(
+            "seed: the %ds export budget ran out with %d left; they stay cold until a later run picks "
+            "them up from the manifest",
+            _EXPORT_BUDGET,
+            remaining,
+        )
 
     if failures:
-        logger.info(
-            "seed: %d of %d exports did not succeed; those combinations stay cold: %s",
-            len(failures),
-            (len(PART_OBJECTS) + len(ASSEMBLY_OBJECTS)) * len(EXPORT_FORMATS),
-            ", ".join(failures),
-        )
+        logger.info("seed: these combinations stay cold: %s", ", ".join(failures))
 
 
 def ensure_seed(env: dict):

--- a/features/seed.py
+++ b/features/seed.py
@@ -88,6 +88,11 @@ _SEED_MARKER = os.path.join(SEED_ROOT, ".seeded")
 # the two are only meaningful together.
 _EXPORTS_MANIFEST = os.path.join(SEED_STATE_DIR, ".seed-exports.json")
 
+# The parts of the state directory each scenario gets a private copy of: the
+# caches it may write to and would otherwise have to refill. Everything else in
+# there is either shared (the sandbox, see provision) or scenario-irrelevant.
+_COPIED_SUBDIRS = ("cache", "git", "external")
+
 # The sandbox the script parts run in.
 _SANDBOX_DIR = os.path.join(SEED_STATE_DIR, "sandbox")
 
@@ -463,21 +468,80 @@ def ensure_seed(env: dict):
         return SEED_STATE_DIR
 
 
-def provision(destination: str) -> str:
-    """Copy the seed to `destination` and return it, for one scenario's use."""
-    # shutil.copytree walks the ~27k files in Python; `cp -a` does the same work
-    # in one process and measurably faster, which is worth having on the path
-    # that runs once per scenario. Windows has no `cp`, so it falls back.
+def _copy_dir(source: str, destination: str) -> None:
+    """Copy one directory. `cp -a` beats shutil.copytree, which walks in Python."""
     if platform.system() == "Windows":
-        shutil.copytree(SEED_STATE_DIR, destination, symlinks=True)
+        shutil.copytree(source, destination, symlinks=True)
     else:
-        os.makedirs(os.path.dirname(destination), exist_ok=True)
-        subprocess.run(["cp", "-a", SEED_STATE_DIR, destination], check=True)
+        subprocess.run(["cp", "-a", source, destination], check=True)
+
+
+def _link_dir(source: str, destination: str) -> None:
+    """Point `destination` at `source` without copying it.
+
+    A directory symlink on Windows needs either administrator rights or
+    Developer Mode, neither of which a hosted runner offers, so it gets a
+    junction instead - `mklink /J` is a cmd builtin and needs no privileges on
+    NTFS. Everywhere else a symlink does.
+    """
+    if platform.system() == "Windows":
+        subprocess.run(["cmd", "/c", "mklink", "/J", destination, source], check=True, capture_output=True)
+    else:
+        os.symlink(source, destination, target_is_directory=True)
+
+
+def provision(destination: str) -> str:
+    """Give one scenario a state directory of its own, and return it.
+
+    Only the package and object caches are copied. The conda sandbox is shared
+    through a link, because copying it is what made this unaffordable: it is
+    36k of the seed's 39k files, and on a Windows runner copying the whole seed
+    cost ~133s per scenario against ~2s on Linux - more than an hour per shard,
+    which is why those jobs were being killed at the 60 minute cap. Copying the
+    directories below is ~2.8k files and half a second.
+
+    Sharing the sandbox is safe for the way CI runs the suite: behave is serial
+    within a shard, so one scenario uses it at a time, and it is what a
+    developer's own machine does anyway - PartCAD locks it across processes
+    (see the FileLocks in runtime_python_conda.py). It does mean a scenario that
+    corrupted the sandbox would affect later ones in the same job, and that
+    concurrent workers under `behavex --parallel-processes` share it; the
+    scenarios that care about a cold or private state directory are tagged
+    @cold-state and get no copy at all.
+    """
+    os.makedirs(destination, exist_ok=True)
+
+    # 'tar' is deliberately not here: nothing in the seed produces one today, so
+    # copying it would be a no-op, and a scenario that does use a tar dependency
+    # simply downloads it as it did before.
+    for name in _COPIED_SUBDIRS:
+        source = os.path.join(SEED_STATE_DIR, name)
+        if os.path.isdir(source):
+            _copy_dir(source, os.path.join(destination, name))
+
+    # Without this the scenario would find no sandbox under its own state
+    # directory and build a fresh 2.3 GB one, which is the cost this whole
+    # module exists to remove.
+    sandbox = os.path.join(SEED_STATE_DIR, "sandbox")
+    if os.path.isdir(sandbox):
+        _link_dir(sandbox, os.path.join(destination, "sandbox"))
+
     return destination
 
 
 def release(destination: str) -> None:
     """Delete a scenario's copy. Never fails the scenario it belongs to."""
+    # The sandbox is a link to the shared one, so remove it as a link first:
+    # rmtree would otherwise follow it on the platforms where it is a junction
+    # and delete the seed's sandbox along with the scenario's copy.
+    sandbox = os.path.join(destination, "sandbox")
+    try:
+        if os.path.islink(sandbox):
+            os.unlink(sandbox)
+        elif os.path.isdir(sandbox):
+            os.rmdir(sandbox)  # an empty junction point on Windows
+    except OSError:
+        pass
     shutil.rmtree(destination, ignore_errors=True)
 
 

--- a/features/seed.py
+++ b/features/seed.py
@@ -56,7 +56,15 @@ from filelock import FileLock
 # and each would drop multi-gigabyte scenario copies inside the very folder CI
 # archives as an artifact. The home directory is identical in every worker and
 # outside anything that gets uploaded.
-BASE_DIR = os.environ.get("PARTCAD_BEHAVE_DIR") or os.path.join(os.path.expanduser("~"), ".partcad-behave")
+#
+# Normalised, because on Windows this arrives from CI as a POSIX-style path and
+# everything derived from it is then joined with backslashes. Python does not
+# care, but `cmd` does: `mklink /J D:/partcad-behave\state\...` reads the
+# forward-slash segment as a switch and fails, which took out every scenario on
+# every Windows shard until the paths were made consistent.
+BASE_DIR = os.path.normpath(
+    os.environ.get("PARTCAD_BEHAVE_DIR") or os.path.join(os.path.expanduser("~"), ".partcad-behave")
+)
 
 # The seed, built once.
 SEED_ROOT = os.path.join(BASE_DIR, "seed")
@@ -485,7 +493,15 @@ def _link_dir(source: str, destination: str) -> None:
     NTFS. Everywhere else a symlink does.
     """
     if platform.system() == "Windows":
-        subprocess.run(["cmd", "/c", "mklink", "/J", destination, source], check=True, capture_output=True)
+        # normpath again rather than trusting the caller: a single forward slash
+        # anywhere in these makes cmd read the rest of the path as switches.
+        result = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", os.path.normpath(destination), os.path.normpath(source)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise OSError(f"mklink /J failed ({result.returncode}): {result.stdout.strip()} {result.stderr.strip()}")
     else:
         os.symlink(source, destination, target_is_directory=True)
 

--- a/features/seed.py
+++ b/features/seed.py
@@ -531,17 +531,35 @@ def provision(destination: str) -> str:
 
 def release(destination: str) -> None:
     """Delete a scenario's copy. Never fails the scenario it belongs to."""
-    # The sandbox is a link to the shared one, so remove it as a link first:
-    # rmtree would otherwise follow it on the platforms where it is a junction
-    # and delete the seed's sandbox along with the scenario's copy.
+    # The sandbox here is a link to the shared one, and detaching it before the
+    # delete is a safety requirement rather than tidiness. shutil.rmtree does not
+    # follow POSIX symlinks, but a Windows junction is a mount-point reparse
+    # point that os.path.islink() reports as False and scandir can report as a
+    # real directory - so an rmtree that reached one could walk through it and
+    # delete the seed's sandbox, wrecking every later scenario in the job.
+    #
+    # os.rmdir removes a junction without touching what it points at, which is
+    # why the isdir branch is safe and is the one that runs on Windows.
     sandbox = os.path.join(destination, "sandbox")
     try:
         if os.path.islink(sandbox):
             os.unlink(sandbox)
         elif os.path.isdir(sandbox):
-            os.rmdir(sandbox)  # an empty junction point on Windows
-    except OSError:
-        pass
+            os.rmdir(sandbox)
+    except OSError as error:
+        # Leaving a scenario's directory behind costs disk. Deleting it with the
+        # link still in place could cost the seed, so the leak is the better bug:
+        # this is louder than a leak deserves precisely because it should not
+        # happen, and the alternative is silent and unrecoverable.
+        logger.warning(
+            "seed: could not detach the shared sandbox at %s (%s); leaving %s in place rather than "
+            "risking a delete that follows the link into the seed",
+            sandbox,
+            error,
+            destination,
+        )
+        return
+
     shutil.rmtree(destination, ignore_errors=True)
 
 

--- a/features/seed.py
+++ b/features/seed.py
@@ -529,6 +529,41 @@ def provision(destination: str) -> str:
     return destination
 
 
+def sandbox_venvs() -> set:
+    """The per-project virtual environments currently inside the shared sandbox.
+
+    PartCAD builds one of these per project that runs a script part, as
+    `<sandbox>/<runtime>/v-env-<hash>` (runtime_python.py). While each scenario
+    copied the sandbox they died with the copy; now that it is shared they would
+    accumulate for the length of the run, which is how a Windows job ran out of
+    disk after 65 scenarios. Snapshotting them after seeding and removing what
+    appears later restores the old lifetime without restoring the old cost.
+    """
+    found = set()
+    sandbox = os.path.join(SEED_STATE_DIR, "sandbox")
+    if not os.path.isdir(sandbox):
+        return found
+    try:
+        for runtime in os.scandir(sandbox):
+            if not runtime.is_dir():
+                continue
+            for entry in os.scandir(runtime.path):
+                if entry.is_dir() and entry.name.startswith("v-env-"):
+                    found.add(entry.path)
+    except OSError:
+        # Worth no more than it costs: a snapshot that cannot be taken means
+        # nothing gets pruned, which is the behaviour before this existed.
+        pass
+    return found
+
+
+def prune_sandbox_venvs(baseline: set) -> None:
+    """Remove venvs the seed did not leave behind, keeping the seed's own."""
+    for path in sandbox_venvs() - baseline:
+        shutil.rmtree(path, ignore_errors=True)
+        logger.debug("seed: pruned scenario venv %s from the shared sandbox", path)
+
+
 def release(destination: str) -> None:
     """Delete a scenario's copy. Never fails the scenario it belongs to."""
     # The sandbox here is a link to the shared one, and detaching it before the

--- a/features/seed.py
+++ b/features/seed.py
@@ -112,6 +112,13 @@ _SANDBOX_DIR = os.path.join(SEED_STATE_DIR, "sandbox")
 # restored cache must not be able to claim a sandbox it does not carry.
 _SANDBOX_MARKER = os.path.join(SEED_ROOT, ".sandbox-built")
 
+# Records a failed attempt so that the other behavex workers, each of which
+# calls ensure_seed, do not queue up to repeat it. Expires, so that a later run
+# is never held back by an old failure - the point is to avoid N workers paying
+# the same doomed budget in one run, not to remember it.
+_SEED_FAILED_MARKER = os.path.join(SEED_ROOT, ".seed-failed")
+_FAILURE_TTL = int(os.environ.get("PARTCAD_BEHAVE_FAILURE_TTL", "900"))
+
 # Kept beside SEED_ROOT rather than inside it, so that discarding a failed seed
 # never deletes the lock the discarding process is holding.
 _SEED_LOCK = SEED_ROOT + ".lock"
@@ -430,6 +437,31 @@ def _build(env: dict) -> None:
         logger.info("seed: these combinations stay cold: %s", ", ".join(failures))
 
 
+def _record_failure(reason: str) -> None:
+    """Note that seeding just failed, so sibling workers do not each retry it."""
+    try:
+        os.makedirs(SEED_ROOT, exist_ok=True)
+        with open(_SEED_FAILED_MARKER, "w", encoding="utf-8") as marker:
+            json.dump({"at": time.time(), "reason": reason}, marker)
+    except OSError:
+        # Only an optimization; failing to record it costs a retry, not
+        # correctness.
+        pass
+
+
+def _recent_failure():
+    """(age, reason) if seeding failed recently enough to trust, else None."""
+    try:
+        with open(_SEED_FAILED_MARKER, encoding="utf-8") as marker:
+            record = json.load(marker)
+        age = time.time() - float(record["at"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+    if age < 0 or age > _FAILURE_TTL:
+        return None
+    return age, record.get("reason", "unknown")
+
+
 def ensure_seed(env: dict):
     """Return the seeded state directory, or None if it could not be built.
 
@@ -450,6 +482,17 @@ def ensure_seed(env: dict):
         if os.path.exists(_SEED_MARKER):
             return SEED_STATE_DIR
 
+        # A failure just recorded is taken at face value rather than retried.
+        # behavex starts one behave per worker and each calls this, so without
+        # it a seed that cannot be built is attempted once per worker, each
+        # spending the full budget on the same doomed clone. The record expires
+        # so that a later run - a new job, or the developer trying again after
+        # fixing their network - is never held back by an old failure.
+        recorded = _recent_failure()
+        if recorded:
+            logger.warning("seed: not retrying, seeding failed %.0fs ago in this run: %s", recorded[0], recorded[1])
+            return None
+
         logger.info("seed: building the shared PartCAD state directory in %s", SEED_ROOT)
 
         # Whatever is already here is built on rather than discarded, because in
@@ -461,6 +504,7 @@ def ensure_seed(env: dict):
         try:
             _build(env)
         except SeedError as error:
+            _record_failure(str(error))
             logger.warning("seed: %s", error)
             logger.warning(
                 "seed: continuing WITHOUT a shared state directory - every scenario will start from a cold "
@@ -493,15 +537,14 @@ def _link_dir(source: str, destination: str) -> None:
     NTFS. Everywhere else a symlink does.
     """
     if platform.system() == "Windows":
-        # normpath again rather than trusting the caller: a single forward slash
-        # anywhere in these makes cmd read the rest of the path as switches.
-        result = subprocess.run(
-            ["cmd", "/c", "mklink", "/J", os.path.normpath(destination), os.path.normpath(source)],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            raise OSError(f"mklink /J failed ({result.returncode}): {result.stdout.strip()} {result.stderr.strip()}")
+        # _winapi.CreateJunction rather than 'cmd /c mklink /J'. Going through
+        # cmd means cmd re-parses the paths: a forward slash starts a switch
+        # (which is how moving the seed to D: broke every Windows shard), and
+        # '&', '|' or '%VAR%' in a path would be interpreted rather than used.
+        # The API call takes the strings as given.
+        import _winapi  # noqa: PLC0415  # Windows-only, and absent elsewhere
+
+        _winapi.CreateJunction(os.path.normpath(source), os.path.normpath(destination))
     else:
         os.symlink(source, destination, target_is_directory=True)
 
@@ -574,7 +617,15 @@ def sandbox_venvs() -> set:
 
 
 def prune_sandbox_venvs(baseline: set) -> None:
-    """Remove venvs the seed did not leave behind, keeping the seed's own."""
+    """Remove venvs the seed did not leave behind, keeping the seed's own.
+
+    Only safe while this process is the only one using the sandbox, which is why
+    the caller has to say so: the sandbox is shared, so under
+    `behavex --parallel-processes` "a venv that appeared since seeding" may well
+    be one another worker is running a scenario out of right now, and deleting
+    it would fail that scenario for reasons impossible to reproduce. Serial runs
+    - which is how CI shards behave - have no such reader.
+    """
     for path in sandbox_venvs() - baseline:
         shutil.rmtree(path, ignore_errors=True)
         logger.debug("seed: pruned scenario venv %s from the shared sandbox", path)

--- a/features/status.feature
+++ b/features/status.feature
@@ -1,4 +1,7 @@
-@cli
+# @cold-state: these report on the internal state directory itself, including
+# asserting that it is at its default $HOME/.partcad location, so they opt out
+# of the seeded directory the rest of the suite is pointed at.
+@cli @cold-state
 Feature: `pc system status` command
 
   Background: Initialize Private PartCAD project

--- a/features/system/telemetry.feature
+++ b/features/system/telemetry.feature
@@ -7,7 +7,13 @@
 # Licensed under Apache License, Version 2.0.
 #
 
-@cli
+# @cold-state: `pc system set` writes to `<internalStateDir>/config.yaml` while
+# UserConfig reads `$HOME/.partcad/config.yaml`. Those are the same file only
+# while internalStateDir is at its default, so pointing the suite's shared state
+# directory elsewhere would stop these scenarios reading back what they just
+# wrote. They need the default location, and they do not touch the caches the
+# shared directory exists to warm.
+@cli @cold-state
 Feature: `pc system telemetry` and `pc system set telemetry` commands
 
   Background: Initialize Private PartCAD project


### PR DESCRIPTION
## Why

The `behave` suite took **66m02s**. Measuring it (full run, per-step durations from behave's JSON) put the cost in two places.

**The tail — 83% of the run.** 44 of 382 `pc` invocations took over 60s each. Every scenario gets a private `$HOME`, and PartCAD roots its entire on-disk state at `$HOME/.partcad`, so every scenario started cold: re-cloning the `//pub` index and rebuilding the conda sandbox. One sandbox build was observed stalling the suite for ~35 minutes.

**The floor.** The other 275 invocations had a median of 2.49s against a measured 2.71s startup, so they were essentially nothing but `import partcad`. That import reaches build123d → scipy, whose BLAS takes one thread per core at import time: **8.62s of CPU per invocation against 1.96s** with the count pinned. No wall cost on an idle box; decisive on a 2-core runner.

## Scope

`devel` moved while this was in review and solved two of the original five items better than this branch did, so both were **dropped** from it: parallelism is now CI sharding (`BEHAVE_SHARDS`), and coverage overhead is now `PC_BEHAVE_COVERAGE` in `features/steps/run.py`. What remains is the shared state directory plus two suite-wide environment fixes.

## What this does

- **`features/seed.py`** builds one state directory up front — `pc init`, `pc list all -r`, then all 8 export formats × 13 part types × 2 assembly types against real `//pub` paths — and gives each scenario its own via `PC_INTERNAL_STATE_DIR`.

- **Each scenario copies `cache`, `git` and `external`; the conda sandbox is shared through a link** (symlink, or a junction on Windows where a directory symlink needs privileges a runner lacks). The sandbox is 36k of the seed's 39k files: copying it cost **133s per scenario on Windows** and 2.2s on Linux. Copying the rest is ~2.8k files and **0.64s**. On Linux this alone took a shard's behave step from **14m13s to 7m31s** with identical results.

- **The build resumes**, so CI caches the object cache and `.seed-exports.json` (~2 MB standing in for ~7.5 min of exports). The sandbox (~2.3 GB) and git clones (~1.2 GB) are **not** cached: GitHub allows 10 GB per repository and this one already uses ~8.9 GB for conda and pip, so caching those evicts them and slows every other job. Measured: saving just the Linux git entry took the repo from 8.88 GB to 9.69 GB.

- **Seeding is bounded and optional.** `PARTCAD_BEHAVE_SEED_BUDGET` (1500s) and `PARTCAD_BEHAVE_EXPORT_BUDGET` (600s), every attempt clamped to what is left. Unbounded it took 32 of a Windows job's 60 minutes and the suite was killed. If seeding cannot be done at all — a runner that cannot reach github.com — it warns and returns `None`, and every scenario falls back to the cold `$HOME/.partcad` it used before.

- **Scenario venvs are pruned.** PartCAD builds one per project inside the sandbox; while the sandbox was copied they died with the copy, and sharing it made them accumulate until a Windows shard ran out of disk after 65 scenarios.

- **The seed lives on `D:` on Windows** (`RUNNER_TEMP` elsewhere). `$HOME` there is `C:`, the small OS disk that filled, while the runner reported 147 GB free on `D:`.

- **Thread counts pinned and telemetry defaulted to `none`** for the suite.

## This does not reduce what CI runs

Per-shard scenario totals, this branch against a devel-based branch, ubuntu-latest 3.10:

| Shard | This branch | devel-based | Total |
|---|---|---|---|
| 1 | 17 pass, 0 fail, 53 skip | 17 pass, 0 fail, 53 skip | 70 = 70 |
| 2 | 71 pass, 0 fail, 4 skip | 71 pass, 0 fail, 4 skip | 75 = 75 |
| 3 | 31 pass, 0 fail, 43 skip | 31 pass, 0 fail, 43 skip | 74 = 74 |
| 4 | 46 pass, 0 fail, 18 skip | 44 pass, **2 fail**, 18 skip | 64 = 64 |

Identical in every shard; shard 4 differs only in two scenarios that fail on `devel` and pass here. Also: `behave.ini` is untouched, the feature-file diffs are tags and comments only, `@cold-state` changes which state directory a scenario gets rather than whether it runs, coverage still collects on the reporting cell, and `coverage.rc`'s include scope never covered `features/` so the new module cannot dilute it. An earlier revision added `-t '~@ai'` to `behave_hook.sh`; that ran *fewer* scenarios than the hook runs today, so it has been removed and the behavex/behave.ini discrepancy documented instead.

## Results

| | Before | After |
|---|---|---|
| Suite (local, 4 workers) | 66m02s | **15m00s** |
| One ubuntu shard's behave step | 14m13s | **7m31s** |
| Seed, cold | — | ~10–17 min |
| Seed, restored cache (local) | — | **52.8s** |
| Per-scenario provisioning | 2.2s / 133s (Linux/Windows) | **0.64s** |

Behave in the last complete run: **ubuntu 8/8 pass**, macOS 3.14 4/4 pass, Windows 4/8 pass (from 0/8 ever completing), macOS 3.10 3 failures.

## Known failures, none from this PR

- **macOS 3.10 Behave** — those runners log 11–12 `failed to connect to github.com`; the failing scenarios are the ones that must clone. The seed degrades correctly and 42 of 46 scenarios still pass.
- **`Pytest (macos-*)` and `Examples (PartCAD)`** — the refreshed dependency stack produces a conda sandbox with broken natives (`No module named 'vtkmodules.vtkCommonDataModel'`; locally `libstdc++: CXXABI_1.3.15 not found`). Reproduced on an unrelated branch off the same base, and `export.feature:45` fails identically with this branch's `features/` changes stashed. Worth its own issue.

## A PartCAD coupling this surfaced, not fixed

`system_config_get()` (`partcad/src/partcad/actions/config/system.py:21`) writes `<internalStateDir>/config.yaml` while `UserConfig` reads `$HOME/.partcad/config.yaml`. Those are the same file *only* at the default, so anyone setting `--internal-state-dir` silently loses `pc system set` round-tripping. Worked around here with `@cold-state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
