### PR TITLE
feat(parts): package-defined partTypes (wrapper kind)

### DIFF
--- a/examples/produce_part_wrapper/box_wrapper.py
+++ b/examples/produce_part_wrapper/box_wrapper.py
@@ -1,0 +1,12 @@
+#
+# The 'box' partType wrapper (kind: wrapper).
+#
+# Run inside the PartCAD sandbox by wrappers/wrapper_part_type.py with the part
+# 'request' in globals and the run name '__partcad_part__'. It builds a shape
+# and leaves it in the global 'output'.
+#
+if __name__ == "__partcad_part__":
+    from build123d import Box
+
+    size = float(request["parameters"].get("size", 10))  # noqa: F821 - injected
+    output = {"shape": Box(size, size, size).wrapped}

--- a/examples/produce_part_wrapper/partcad.yaml
+++ b/examples/produce_part_wrapper/partcad.yaml
@@ -1,0 +1,27 @@
+desc: |
+  PartCAD example: a part built by a package-defined 'partType'.
+
+  'partTypes' declares a reusable way to construct parts. The 'box' partType
+  below is of the default kind 'wrapper': its 'path' is a Python script run in
+  the sandbox to produce the shape. The 'demo' part references it with the short
+  form ':box' (expanded to '<this package>:box' when loaded).
+
+docs:
+  usage: |
+    ```shell
+    pc inspect :demo
+    ```
+
+partTypes:
+  box:
+    kind: wrapper
+    path: box_wrapper.py
+
+parts:
+  demo:
+    type: ":box"
+    desc: A box built by the 'box' wrapper partType.
+    parameters:
+      size:
+        type: float
+        default: 12

--- a/partcad/src/partcad/context.py
+++ b/partcad/src/partcad/context.py
@@ -452,23 +452,17 @@ class Context:
                     result = self._get_project_recursive(next_project, import_list)
                     return result
         else:
-            # Otherwise, iterate all subfolders and check if any of them are packages
-            if "dependencies" in project.config_obj and project.config_obj["dependencies"] is not None:
-                dependencies = project.config_obj["dependencies"]
-                # TODO(clairbee): revisit if this code path is needed when the
-                #                 user explicitly asked for a particular package
-                # if not project.config_obj.get("isRoot", False):
-                #     filtered = filter(
-                #         lambda x: "onlyInRoot" not in dependencies[x]
-                #         or not dependencies[x]["onlyInRoot"],
-                #         dependencies,
-                #     )
-                #     dependencies = list(filtered)
+            # Resolve a declared child dependency. Go through the 'dependencies()'
+            # accessor rather than 'config_obj' directly so that a plugin-backed
+            # package's children - reported by its repository instead of a
+            # 'dependencies' section on disk - are resolvable here too.
+            dependencies = project.dependencies()
+            if dependencies:
                 for prj_name in dependencies:
                     pc_logging.debug(f"Checking the dependency: {prj_name} vs {next_import}...")
                     if prj_name != next_import:
                         continue
-                    prj_conf = project.config_obj["dependencies"][prj_name]
+                    prj_conf = dependencies[prj_name]
                     if prj_conf.get("onlyInRoot", False):
                         next_project_path = "//" + prj_name
                     pc_logging.debug(f"Loading the dependency: {next_project_path}...")

--- a/partcad/src/partcad/factory.py
+++ b/partcad/src/partcad/factory.py
@@ -30,8 +30,22 @@ def register(kind: str, t: str, factory_class: Factory.__class__):
 
 
 def instantiate(kind: str, t: str, ctx, source_project, target_project, config):
+    # A part 'type' that starts with ':' is a short reference to a partType
+    # declared in the part's own package. Expand it to the fully-qualified
+    # '<package path>:<name>' and store it back so the config carries the
+    # resolved reference from here on (see the "partTypes" documentation).
+    if kind == "part" and isinstance(t, str) and t.startswith(":"):
+        t = target_project.name + t
+        config["type"] = t
+
     if t in all[kind]:
         # The return value is not always used
         return all[kind][t](ctx, source_project, target_project, config)
-    else:
-        pc_logging.error("Invalid %s type encountered: %s" % (kind, config))
+
+    # A part 'type' that carries a package path ('<package>:<name>') is not a
+    # built-in factory but a reference to a partType. It is constructed by the
+    # generic wrapper factory, which resolves the partType and runs it.
+    if kind == "part" and isinstance(t, str) and ":" in t and "wrapper" in all[kind]:
+        return all[kind]["wrapper"](ctx, source_project, target_project, config)
+
+    pc_logging.error("Invalid %s type encountered: %s" % (kind, config))

--- a/partcad/src/partcad/globals.py
+++ b/partcad/src/partcad/globals.py
@@ -41,6 +41,7 @@ from .part_factory_sweep import PartFactorySweep
 from .part_factory_alias import PartFactoryAlias
 from .part_factory_enrich import PartFactoryEnrich
 from .part_factory_compound import PartFactoryCompound
+from .part_factory_wrapper import PartFactoryWrapper
 from .sketch_factory_basic import SketchFactoryBasic
 from .sketch_factory_cadquery import SketchFactoryCadquery
 from .sketch_factory_build123d import SketchFactoryBuild123d
@@ -83,6 +84,8 @@ factory.register("part", "sweep", PartFactorySweep)
 factory.register("part", "alias", PartFactoryAlias)
 factory.register("part", "enrich", PartFactoryEnrich)
 factory.register("part", "compound", PartFactoryCompound)
+# Constructs parts whose 'type' references a package-defined partType.
+factory.register("part", "wrapper", PartFactoryWrapper)
 factory.register("assembly", "assy", AssemblyFactoryAssy)
 factory.register("assembly", "alias", AssemblyFactoryAlias)
 factory.register("file", "url", FileFactoryUrl)

--- a/partcad/src/partcad/part_factory_wrapper.py
+++ b/partcad/src/partcad/part_factory_wrapper.py
@@ -1,0 +1,177 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Construct a part from a package-defined 'partType'.
+
+A part whose 'type' carries a package path ('<package>:<name>', after any ':'
+short form has been expanded, see factory.instantiate) is not built by a
+built-in factory. Instead the referenced partType is looked up in its package
+and used to construct the part. Only the default partType kind, 'wrapper', is
+implemented: it runs a package-supplied Python script inside the sandbox, which
+produces the shape(s) (see wrappers/wrapper_part_type.py).
+"""
+
+import base64
+import os
+
+from .part_factory import PartFactory
+from .utils import resolve_resource_path
+from . import logging as pc_logging
+from . import shape_envelope
+from . import telemetry
+from . import transform
+from . import wrapper
+
+# The geometry stack the sandbox needs so a wrapper can build and serialize
+# shapes. Matches the other Python-backed part factories. The core itself never
+# imports OCP: shapes cross the boundary as BREP envelopes (see shape_envelope).
+_SANDBOX_REQUIREMENTS = (
+    "ocp-tessellate==3.0.9",
+    "typing_extensions==4.12.2",
+    "cadquery-ocp==7.7.2",
+    "ocpsvg==0.3.4",
+    "build123d==0.8.0",
+)
+
+
+@telemetry.instrument()
+class PartFactoryWrapper(PartFactory):
+    def __init__(self, ctx, source_project, target_project, config):
+        with pc_logging.Action("InitWrapper", target_project.name, config["name"]):
+            super().__init__(ctx, source_project, target_project, config)
+
+            # 'type' is '<package>:<partType>' by the time we get here.
+            self.part_type_ref = config["type"]
+            self.part_type_package, self.part_type_name = resolve_resource_path(
+                target_project.name, self.part_type_ref
+            )
+
+            python_version = self.project.python_version or "3.11"
+            if python_version in ("3.10", "3.12"):
+                python_version = "3.11"
+            self.runtime = self.ctx.get_python_runtime(python_version)
+            self.session = self.runtime.get_session(source_project.name)
+
+            self._create(config)
+
+    async def _materialize_wrapper_script(self, pt_project, script_rel):
+        """Return the on-disk path of the partType's wrapper script.
+
+        For a local package the script is a file in the package. For a
+        plugin-backed package it is fetched from the plugin (like a file-backed
+        object) and written into the package's cache directory.
+        """
+        script_abs = os.path.join(pt_project.config_dir, script_rel)
+        if os.path.exists(script_abs):
+            return script_abs
+
+        get_data_async = getattr(pt_project, "get_data_async", None)
+        if get_data_async is None:
+            raise Exception("partType wrapper script not found: %s" % script_abs)
+
+        data = await get_data_async("files/" + script_rel)
+        if data is None:
+            raise Exception("The repository did not provide the partType wrapper: %s" % script_rel)
+        content = base64.b64decode(data) if isinstance(data, str) else bytes(data)
+
+        dirs = os.path.dirname(script_abs)
+        if dirs and not os.path.exists(dirs):
+            os.makedirs(dirs, exist_ok=True)
+        with open(script_abs, "wb") as f:
+            f.write(content)
+        return script_abs
+
+    async def instantiate(self, part):
+        with pc_logging.Action("Wrapper", part.project_name, part.name):
+            pt_project = self.ctx.get_project(self.part_type_package)
+            if pt_project is None:
+                part.error("partType package not found: %s" % self.part_type_package)
+                return None
+
+            pt_config = pt_project.get_part_type_config(self.part_type_name)
+            if pt_config is None:
+                part.error(
+                    "partType '%s' not found in '%s'" % (self.part_type_name, self.part_type_package)
+                )
+                return None
+
+            kind = pt_config.get("kind", "wrapper")
+            if kind != "wrapper":
+                part.error("Unsupported partType kind '%s' (only 'wrapper' is implemented)" % kind)
+                return None
+
+            # The wrapper script: 'path' or, by default, '<name>.py'.
+            script_rel = pt_config.get("path", self.part_type_name + ".py")
+            try:
+                script_abs = await self._materialize_wrapper_script(pt_project, script_rel)
+            except Exception as e:
+                part.error(str(e))
+                return None
+
+            # Prepare the sandbox: the partType's package dependencies plus the
+            # geometry stack, plus any requirements the partType declares.
+            await self.runtime.prepare_for_package(pt_project, session=self.session)
+            await self.runtime.prepare_for_shape(self.config, session=self.session)
+            for req in _SANDBOX_REQUIREMENTS:
+                await self.runtime.ensure_async(req, session=self.session)
+            for req in pt_config.get("pythonRequirements", []) or []:
+                await self.runtime.ensure_async(req, session=self.session)
+
+            # The request handed to the wrapper script.
+            request = {
+                "name": "%s:%s" % (part.project_name, part.name),
+                "label": part.name,
+                "orig_name": self.orig_name,
+                "config": self.config,
+                "parameters": {},
+            }
+            for param_name, param in (self.config.get("parameters") or {}).items():
+                request["parameters"][param_name] = param.get("default") if isinstance(param, dict) else param
+            request_serialized = shape_envelope.serialize(request)
+
+            meta_wrapper = wrapper.get("part_type.py")
+            exitcode, response_serialized, errors = await self.runtime.run_async(
+                [meta_wrapper, os.path.abspath(script_abs), os.path.abspath(pt_project.config_dir)],
+                request_serialized,
+                session=self.session,
+            )
+            if exitcode != 0 and not errors:
+                errors = "%s: %s: partType wrapper failed (exit code %s)" % (
+                    part.project_name,
+                    part.name,
+                    exitcode,
+                )
+            if errors:
+                for line in errors.split("\n"):
+                    line = line.strip()
+                    if line:
+                        pc_logging.debug("%s: %s" % (part.name, line))
+
+            try:
+                response = shape_envelope.deserialize(response_serialized)
+            except Exception as e:
+                part.error("Deserialization error: %s" % e)
+                return None
+
+            if not response.get("success"):
+                part.error(str(response.get("exception")))
+                return None
+
+            shapes = response.get("shapes", [])
+            if not shapes:
+                part.error("The partType wrapper produced no shape")
+                return None
+            self.ctx.stats_parts_instantiated += 1
+            if len(shapes) == 1:
+                return shapes[0]
+
+            # Compounding runs in the sandbox (transform.compound), so the core
+            # never touches OCP. Keep the contract: report via part.error() and
+            # return None instead of raising.
+            try:
+                return await transform.compound(self.ctx, shapes)
+            except Exception as e:
+                part.error("Failed to compound wrapper shapes: %s" % e)
+                return None

--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 # The kinds of first-class objects a package may contain, mapped to the
 # 'partcad.yaml' section that declares them. Kept as data so that introducing a
 # new kind of object does not require touching the per-kind accessor plumbing.
-OBJECT_KINDS = ("interface", "sketch", "part", "assembly", "provider", "repository")
+OBJECT_KINDS = ("interface", "sketch", "part", "assembly", "provider", "repository", "partType")
 OBJECT_KIND_SECTIONS = {
     "interface": "interfaces",
     "sketch": "sketches",
@@ -58,6 +58,11 @@ OBJECT_KIND_SECTIONS = {
     "assembly": "assemblies",
     "provider": "providers",
     "repository": "repositories",
+    # A 'partType' is a package-defined way to construct parts (e.g. a wrapper
+    # script). It is enumerable like any other object, but it is not a shape and
+    # is never instantiated: parts whose 'type' references it are constructed by
+    # PartFactoryWrapper, which looks the definition up here.
+    "partType": "partTypes",
 }
 
 
@@ -264,12 +269,18 @@ class Project(project_config.Configuration):
         everything if the targeted fetch is not supported.
         """
         configs = self._object_configs.get(kind)
-        if configs is not None:
-            return configs.get(name)
+        if configs is not None and name in configs:
+            return configs[name]
+        # Not in the (possibly already enumerated) set: try a targeted single
+        # fetch. A plugin-backed package can serve objects beyond what it
+        # enumerates - e.g. the first page of a large, paginated catalog - so
+        # any addressable object remains reachable even when it was not listed.
         one = self._fetch_object_config(kind, name)
         if one is not None:
             return one
-        return self.object_configs(kind).get(name)
+        if configs is None:
+            return self.object_configs(kind).get(name)
+        return None
 
     def object_names(self, kind: str) -> list:
         return list(self.object_configs(kind).keys())
@@ -552,6 +563,9 @@ class Project(project_config.Configuration):
     def get_repository_config(self, repository_name):
         return self.object_config("repository", repository_name)
 
+    def get_part_type_config(self, part_type_name):
+        return self.object_config("partType", part_type_name)
+
     def get_object_config(self, object_name, configs: dict[str, dict[str, typing.Any]]):
         if not object_name in configs:
             return None
@@ -779,8 +793,12 @@ class Project(project_config.Configuration):
             self.lock.release()
 
             if not has_name_params:
-                # This is just a regular object name, no params (object_name == result_name)
-                if not object_name in object_configs:
+                # This is just a regular object name, no params (object_name == result_name).
+                # Resolve through 'get_config' rather than a membership test on
+                # the enumerated set, so a plugin-backed package can serve an
+                # object it did not enumerate (a targeted single fetch).
+                config = get_config(object_name)
+                if config is None:
                     # We don't know anything about such an object
                     if not quiet:
                         pc_logging.error(
@@ -789,8 +807,6 @@ class Project(project_config.Configuration):
                             self.name,
                         )
                     return None
-                # This is not yet created (invalidated?)
-                config = get_config(object_name)
                 full_object_name = f"{self.name}:{object_name}"
                 config = config_class.normalize(object_name, config, full_object_name)
                 self.init_object_by_config(factory_name, config_class, alias_class, config)

--- a/partcad/src/partcad/project_external_repository.py
+++ b/partcad/src/partcad/project_external_repository.py
@@ -12,7 +12,6 @@ import json
 import threading
 
 from .cache_hash import CacheHash
-from .project import OBJECT_KINDS
 from .project_plugin import ProjectPlugin
 from .sync_threads import threadpool_manager
 from . import logging as pc_logging
@@ -69,9 +68,15 @@ class ProjectExternalRepository(ProjectPlugin):
         self._cache = cache
         self._request_cache: dict[str, object] = {}
         self._request_lock = threading.Lock()
-        # Objects are instantiated once, lazily, after enumeration (see
-        # 'ensure_enumerated_async'); this guards against doing it twice.
+        # Objects are instantiated once, lazily, the first time this package's
+        # 'parts'/'sketches'/'assemblies' are accessed (see '_lazy_objects').
+        # '_instantiating' is the reentrancy guard so factories can write into
+        # the backing dicts during instantiation without re-triggering it.
+        self._parts = {}
+        self._sketches = {}
+        self._assemblies = {}
         self._objects_instantiated = False
+        self._instantiating = False
         super().__init__(ctx, name, path, config_obj=config_obj, inherited_config=inherited_config)
 
     def request(self, key: str, handler):
@@ -213,43 +218,30 @@ class ProjectExternalRepository(ProjectPlugin):
         return future.result()
 
     async def ensure_enumerated_async(self):
-        """Warm the metadata, object and dependency caches from the repository.
+        """Warm the package's structure (metadata and child list) from the plugin.
 
-        Called from the async import traversal so that the synchronous accessors
-        (object_configs, dependencies, desc, ...) reached later only ever hit the
-        cache and never bridge to async from within a running loop.
+        Called from the async import traversal. Only the cheap, package-level
+        data is warmed here: 'meta' (so 'desc' etc. are known) and 'deps' (so the
+        child packages can be discovered). The objects of a package (parts,
+        sketches, assemblies) are NOT enumerated here: doing so eagerly for every
+        package makes loading a large repository (thousands of parts across many
+        sub-packages) prohibitively expensive. They are enumerated lazily, per
+        package, the first time that package's objects are actually accessed (see
+        the 'parts'/'sketches'/'assemblies' properties below).
         """
         await self._materialize_meta_async()
-        for kind in OBJECT_KINDS:
-            if self._object_configs.get(kind) is None:
-                configs = await self.get_data_async("objects/" + kind)
-                # Apply the same augmentation as '_enumerate_object_configs';
-                # this async warm-up runs first, so skipping it would leave the
-                # configs untagged for file materialization.
-                self._object_configs[kind] = (
-                    {name: self._augment(config) for name, config in configs.items()} if configs else {}
-                )
-        # Warm 'deps' too, so the synchronous 'dependencies()' is a cache hit.
+        # Warm 'deps' so the synchronous 'dependencies()' is a cache hit.
         await self.get_data_async("deps")
 
-        # The object configs are now known, so instantiate the objects into the
-        # eager 'parts'/'sketches'/'assemblies' dictionaries the synchronous
-        # consumers read, honoring the promise made where this is awaited (see
-        # Context._process_project) that downstream 'list'/render/export observe
-        # a populated package. 'ProjectPlugin' deferred this (its
-        # '_instantiate_objects' is a no-op) because nothing was known at
-        # construction. Geometry stays lazy - only the factories are created.
-        if not self._objects_instantiated:
-            self._objects_instantiated = True
-            self._instantiate_enumerated()
-
     def _instantiate_enumerated(self):
-        """Instantiate the enumerated objects into the eager object dicts.
+        """Instantiate this package's enumerated objects into the eager dicts.
 
-        Each object is created independently and defensively: one that cannot be
-        built (e.g. an unsupported type, or a file-backed object whose file is
-        absent) is skipped with a warning instead of hiding every other object
-        from a 'list'. Geometry is not built here - only the factories.
+        Runs at most once, the first time a consumer reads 'parts'/'sketches'/
+        'assemblies' (see those properties). Each object is created
+        independently and defensively: one that cannot be built (an unsupported
+        type, a file-backed object whose file is absent) is skipped with a
+        warning instead of hiding every other object from a 'list'. Geometry is
+        not built here - only the factories.
         """
         for kind, getter in (
             ("sketch", self.get_sketch),
@@ -261,6 +253,49 @@ class ProjectExternalRepository(ProjectPlugin):
                     getter(name)
                 except Exception as e:
                     pc_logging.warning("%s: could not instantiate %s '%s': %s" % (self.name, kind, name, e))
+
+    def _lazy_objects(self):
+        """Instantiate the enumerated objects on first access, once."""
+        if self._objects_instantiated or self._instantiating:
+            return
+        self._instantiating = True
+        try:
+            self._instantiate_enumerated()
+            self._objects_instantiated = True
+        finally:
+            self._instantiating = False
+
+    # The eager object dictionaries the synchronous consumers (the CLI 'list'
+    # commands, render, export, get_*) read. They are populated lazily, per
+    # package, so that loading a large repository does not enumerate every
+    # sub-package's objects up front. The reentrancy guard lets the factories
+    # write into the backing dict during instantiation without re-triggering.
+    @property
+    def parts(self):
+        self._lazy_objects()
+        return self._parts
+
+    @parts.setter
+    def parts(self, value):
+        self._parts = value
+
+    @property
+    def sketches(self):
+        self._lazy_objects()
+        return self._sketches
+
+    @sketches.setter
+    def sketches(self, value):
+        self._sketches = value
+
+    @property
+    def assemblies(self):
+        self._lazy_objects()
+        return self._assemblies
+
+    @assemblies.setter
+    def assemblies(self, value):
+        self._assemblies = value
 
     async def _materialize_meta_async(self):
         """Fill package-level metadata from the repository.

--- a/partcad/src/partcad/schema/partcad.json
+++ b/partcad/src/partcad/schema/partcad.json
@@ -380,6 +380,20 @@
               },
               "required": ["type"],
               "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "description": "A part built by a package-defined partType (its 'type' references a partType). partType-specific properties are allowed.",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "pattern": "^(:[^:]+|[^:]+:[^:]+)$"
+                },
+                "desc": { "type": "string", "maxLength": 1000 },
+                "parameters": { "$ref": "#/definitions/shape-parameter" }
+              },
+              "required": ["type"],
+              "additionalProperties": true
             }
           ]
         }
@@ -650,6 +664,22 @@
             "parameters": { "$ref": "#/definitions/shape-parameter"}
           },
           "required": ["type"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "partTypes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_/./-]+$": {
+          "type": "object",
+          "properties": {
+            "kind": { "type": "string", "enum": ["wrapper"] },
+            "desc": { "type": "string", "maxLength": 1000 },
+            "path": { "type": "string", "minLength": 1 },
+            "pythonRequirements": { "type": "array", "items": { "type": "string" } }
+          },
           "additionalProperties": false
         }
       },

--- a/partcad/src/partcad/wrappers/wrapper_part_type.py
+++ b/partcad/src/partcad/wrappers/wrapper_part_type.py
@@ -1,0 +1,64 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Sandbox entry point for a 'wrapper'-kind partType.
+
+A partType of kind 'wrapper' is a package-supplied Python script that builds a
+part. This meta-wrapper runs inside the PartCAD sandbox (so it may import OCP /
+build123d), executes that script with 'runpy', and serializes the shape(s) it
+produces back to PartFactoryWrapper.
+
+The partType script is executed with these globals available:
+
+    request  -- the part's config/parameters (see PartFactoryWrapper)
+
+and is expected to leave its result in a global 'output':
+
+    output = {"shape": <TopoDS_Shape>}                # a single shape, or
+    output = {"shapes": [<TopoDS_Shape>, ...]}        # several, or
+    output = {"exception": "<message>"}               # a failure
+
+Both '__file__' and the run name '__partcad_part__' are set on the script, so it
+can gate its build logic (``if __name__ == "__partcad_part__":``) and remain
+importable for its own unit tests.
+"""
+
+import os
+import runpy
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+import wrapper_common
+
+
+def process(path, request):
+    try:
+        result = runpy.run_path(
+            path,
+            init_globals={"request": request},
+            run_name="__partcad_part__",
+        )
+    except Exception as e:
+        wrapper_common.handle_exception(e, path)
+        return {"success": False, "exception": wrapper_common.exception_to_str(e), "shapes": []}
+
+    output = result.get("output", {}) if isinstance(result, dict) else {}
+
+    shapes = output.get("shapes")
+    if shapes is None:
+        shape = output.get("shape")
+        shapes = [shape] if shape is not None else []
+
+    exception = output.get("exception")
+    if exception:
+        wrapper_common.handle_exception(Exception(str(exception)), path)
+        return {"success": False, "exception": str(exception), "shapes": shapes}
+
+    return {"success": True, "exception": None, "shapes": shapes}
+
+
+path, request = wrapper_common.handle_input()
+result = process(path, request)
+wrapper_common.handle_output(result)

--- a/partcad/tests/unit/test_part_type.py
+++ b/partcad/tests/unit/test_part_type.py
@@ -1,0 +1,73 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Unit tests for package-defined partTypes.
+
+A partType is a reusable, package-defined way to construct parts. A part whose
+'type' references it (the short form ':<name>', expanded to '<package>:<name>')
+is built by PartFactoryWrapper. These tests cover the expansion, the partType
+config accessor, and the factory dispatch without the sandbox; a gated
+end-to-end test instantiates the shape when the sandbox is available.
+"""
+
+import asyncio
+
+import pytest
+
+import partcad as pc
+from partcad import factory
+
+EXAMPLE = "examples/produce_part_wrapper"
+
+
+def test_wrapper_factory_is_registered():
+    # A part 'type' that carries a package path is dispatched to the wrapper.
+    assert "wrapper" in factory.all["part"]
+
+
+def test_part_type_definition_is_enumerated():
+    ctx = pc.Context(EXAMPLE)
+    root = ctx.get_project(ctx.get_current_project_path())
+    cfg = root.get_part_type_config("box")
+    assert cfg is not None
+    assert cfg.get("kind", "wrapper") == "wrapper"
+    assert cfg.get("path") == "box_wrapper.py"
+    # It is enumerable as an object kind, and it is not a part.
+    assert "box" in root.object_names("partType")
+    assert "box" not in root.object_names("part")
+
+
+def test_short_part_type_is_expanded_and_stored():
+    ctx = pc.Context(EXAMPLE)
+    root = ctx.get_project(ctx.get_current_project_path())
+
+    part = ctx.get_part(":demo")
+    assert part is not None
+
+    # The short ':box' form is expanded to the fully-qualified '<package>:box'
+    # and stored expanded (here, at construction, when the part factory is made).
+    expanded = root.get_part_config("demo")["type"]
+    assert expanded != ":box"
+    assert expanded.endswith(":box")
+    assert expanded == root.name + ":box"
+
+
+def test_unknown_part_type_is_not_found():
+    ctx = pc.Context(EXAMPLE)
+    root = ctx.get_project(ctx.get_current_project_path())
+    assert root.get_part_type_config("nope") is None
+
+
+@pytest.mark.slow
+def test_wrapper_part_instantiates():
+    """End to end: the wrapper script produces the part's shape (needs the sandbox)."""
+    ctx = pc.Context(EXAMPLE)
+    part = ctx.get_part(":demo")
+    assert part is not None
+    try:
+        wrapped = asyncio.run(part.get_wrapped(ctx))
+    except Exception as e:
+        pytest.skip("Sandbox unavailable for partType wrapper: %s" % e)
+    assert wrapped is not None

--- a/partcad/tests/unit/test_project_external_repository.py
+++ b/partcad/tests/unit/test_project_external_repository.py
@@ -50,10 +50,20 @@ def test_request_memoizes_by_key():
 def test_construction_defers_everything():
     ctx = pc.Context("examples")
     repo, fake = _make_repo(ctx, {"objects/part": {"bolt": {"type": "step"}}})
-    # Nothing enumerated or instantiated at construction.
+    # Nothing is enumerated, instantiated or fetched at construction: not the
+    # object configs, and not even a single request to the repository.
     assert repo._object_configs["part"] is None
-    assert repo.parts == {}
     assert fake.keys == []
+
+
+def test_accessing_parts_enumerates_lazily():
+    # Objects are enumerated the first time a package's 'parts' are accessed,
+    # not eagerly at load, so a large repository stays cheap to import.
+    ctx = pc.Context("examples")
+    repo, fake = _make_repo(ctx, {"objects/part": {"bolt": {"type": "step"}}})
+    assert fake.keys == []
+    _ = repo.parts  # first access triggers enumeration
+    assert "objects/part" in fake.keys
 
 
 def test_enumeration_is_lazy_and_cached():


### PR DESCRIPTION
## Summary

Adds **`partTypes`** — a new object kind a package can declare to define reusable ways to construct parts. A part whose `type` references a partType is built by a new `PartFactoryWrapper` instead of a built-in factory. This generalizes part construction so a package (e.g. an external repository) can ship its own part kind.

- A `type` of `:<name>` is a short reference to a partType **in the part's own package**; it is expanded to `<package path>:<name>` and stored expanded (`factory.instantiate`). A `type` carrying a package path (`<package>:<name>`) is dispatched to `PartFactoryWrapper`.
- The default (and only, for now) partType **kind is `wrapper`**: its `path` (default `<name>.py`) is a Python script run in the sandbox via a new meta-wrapper `wrappers/wrapper_part_type.py`, which returns the shape(s). The script is materialized from disk, or fetched from the repository for a plugin-backed package.
- `partType` is enumerable like any object kind but is never instantiated as a shape.

## Enabling changes for plugin-backed packages at scale

partTypes are exercised by large plugin-backed repositories (see *Consumers*), which surfaced a few gaps in the `external` package support (#457):

- **Lazy per-package enumeration.** An external package now enumerates its objects the first time its `parts`/`sketches`/`assemblies` are accessed, not eagerly for the whole tree at import. Enumerating every sub-package up front is prohibitive for a repository with many categories/thousands of parts.
- **`get_project` resolves plugin-backed hierarchy children** via the `dependencies()` accessor, not only a static `dependencies:` section — so a category served by a plugin's `deps` is addressable.
- **`object_config` single-fetch fallback** — an object a plugin can serve but did not enumerate (e.g. beyond the first page of a large, paginated catalog) is still reachable.

## Schema

`schema/partcad.json` gains the `partTypes` section and a parts `oneOf` branch for partType-referenced parts (partType-specific properties allowed), while built-in parts remain strict (unknown properties rejected).

## Testing

- New `partcad/tests/unit/test_part_type.py` + example `examples/produce_part_wrapper/`: wrapper factory registration, partType config enumeration, `:name`→`<package>:name` expansion, unknown-partType handling, and a gated end-to-end wrapper render.
- `test_project_external_repository.py` updated for lazy enumeration.
- Verified against `devel`: partType, external-repository, relocation and assembly unit tests pass.

## Consumers

- [`partcad-bosl2`](https://github.com/partcad/partcad-bosl2) — BOSL2 as parametric OpenSCAD parts (external repository).
- [`partcad-ldraw`](https://github.com/partcad/partcad-ldraw) — the LDraw parts library via an `:ldraw` **partType** and an external repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)