### PR TITLE
feat(external): add cacheVersion to invalidate stale plugin caches

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -62,6 +62,7 @@ Besides the package properties and, optionally, a list of imported dependencies,
           revision: <(git only) the exact revision to import>
           plugin: <(external only) reference to the repository plugin that serves this package>
           subfolder: <(external only) location within the repository, for hierarchies>
+          cacheVersion: <(external only) integer; bump to invalidate the on-disk cache>
           includePaths: <(optional) Jinja2 include path>
 
   parts:
@@ -172,6 +173,15 @@ package backed by the same plugin, with a ``subfolder`` that scopes its
 requests within the repository. In this way one plugin can serve an entire tree
 of packages, each with its own sketches, parts, assemblies, providers and
 further children.
+
+Everything a plugin returns is cached on disk, keyed by the plugin reference and
+the request. The cache does not know when the plugin's code changes, so a plugin
+that starts returning a new shape of data (for example, adding a field to every
+part it serves) would keep being served the stale, pre-change entries. Set
+``cacheVersion`` to an integer and bump it whenever the plugin's output format
+changes: it is folded into the cache location, so bumping it moves the whole
+repository (and every child in its hierarchy) to a fresh cache namespace at once,
+invalidating the old entries. It defaults to ``0`` (unversioned).
 
 See ``examples/plugin_repository_basic`` (a package backed by a local file),
 ``examples/plugin_repository_full`` (backed by an HTTP endpoint) and

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -62,7 +62,7 @@ Besides the package properties and, optionally, a list of imported dependencies,
           revision: <(git only) the exact revision to import>
           plugin: <(external only) reference to the repository plugin that serves this package>
           subfolder: <(external only) location within the repository, for hierarchies>
-          cacheVersion: <(external only) integer; bump to invalidate the on-disk cache>
+          cacheVersion: <(external only) non-negative integer; bump to invalidate the on-disk cache>
           includePaths: <(optional) Jinja2 include path>
 
   parts:
@@ -174,14 +174,17 @@ requests within the repository. In this way one plugin can serve an entire tree
 of packages, each with its own sketches, parts, assemblies, providers and
 further children.
 
-Everything a plugin returns is cached on disk, keyed by the plugin reference and
-the request. The cache does not know when the plugin's code changes, so a plugin
-that starts returning a new shape of data (for example, adding a field to every
-part it serves) would keep being served the stale, pre-change entries. Set
-``cacheVersion`` to an integer and bump it whenever the plugin's output format
-changes: it is folded into the cache location, so bumping it moves the whole
-repository (and every child in its hierarchy) to a fresh cache namespace at once,
-invalidating the old entries. It defaults to ``0`` (unversioned).
+Non-null responses from a plugin are cached on disk, keyed by the plugin
+reference and the request; a request the plugin has no answer for is remembered
+only for the run that made it, and is put to the plugin again after a restart.
+The cache does not know when the plugin's code changes, so a plugin that starts
+returning a new shape of data (for example, adding a field to every part it
+serves) would keep being served the stale, pre-change entries. Set
+``cacheVersion`` to a non-negative integer and bump it whenever the plugin's
+output format changes: it is folded into the cache location, so bumping it moves
+the whole repository (and every child in its hierarchy) to a fresh cache
+namespace at once, invalidating the old entries. It defaults to ``0``
+(unversioned).
 
 See ``examples/plugin_repository_basic`` (a package backed by a local file),
 ``examples/plugin_repository_full`` (backed by an HTTP endpoint) and

--- a/partcad/src/partcad/project_external_repository.py
+++ b/partcad/src/partcad/project_external_repository.py
@@ -51,6 +51,7 @@ class ProjectExternalRepository(ProjectPlugin):
         subfolder: str = "",
         repository=None,
         cache=None,
+        cache_version: int = 0,
         config_obj=None,
         inherited_config=None,
     ):
@@ -66,6 +67,9 @@ class ProjectExternalRepository(ProjectPlugin):
         self._subfolder = subfolder
         self._repository = repository
         self._cache = cache
+        # Carried so that child packages served by the same plugin inherit it and
+        # land in the same versioned cache namespace (see 'dependencies()').
+        self._cache_version = cache_version
         self._request_cache: dict[str, object] = {}
         self._request_lock = threading.Lock()
         # Objects are instantiated once, lazily, the first time this package's
@@ -363,4 +367,8 @@ class ProjectExternalRepository(ProjectPlugin):
                 "plugin": self._plugin_ref,
                 "subfolder": self._scope(child),
             }
+            # Propagate the cache version so a child computes the same versioned
+            # cache namespace as its parent (the whole hierarchy shares one cache).
+            if self._cache_version:
+                deps[child]["cacheVersion"] = self._cache_version
         return deps

--- a/partcad/src/partcad/project_factory_external.py
+++ b/partcad/src/partcad/project_factory_external.py
@@ -25,6 +25,13 @@ class ExternalImportConfiguration:
         # A child of a plugin-backed hierarchy carries the subfolder that scopes
         # its requests within the repository. Empty for a top-level package.
         self.subfolder = self.config_obj.get("subfolder", "")
+        # An optional integer the plugin author bumps whenever the *shape* of the
+        # data the plugin returns changes (e.g. a new field is added to every
+        # part config). It is mixed into the on-disk cache location, so bumping it
+        # invalidates every entry cached by an older version of the plugin - which
+        # a key derived from the plugin reference and the request alone would keep
+        # serving. See 'docs/source/configuration.rst' (external dependencies).
+        self.cache_version = int(self.config_obj.get("cacheVersion", 0) or 0)
 
 
 @telemetry.instrument()
@@ -41,8 +48,11 @@ class ProjectFactoryExternal(pf.ProjectFactory, ExternalImportConfiguration):
 
         # Find a place to store all temporary artifacts if any. The hash of the
         # resolved plugin reference identifies this repository instance, so two
-        # vendored copies backed by different plugins get separate caches.
-        repo_hash = hashlib.sha256(self.plugin.encode()).hexdigest()[:16]
+        # vendored copies backed by different plugins get separate caches. The
+        # optional 'cacheVersion' is folded in too, so bumping it moves every
+        # child of this repository to a fresh cache namespace at once.
+        repo_key = self.plugin if not self.cache_version else "%s@v%d" % (self.plugin, self.cache_version)
+        repo_hash = hashlib.sha256(repo_key.encode()).hexdigest()[:16]
         self.path = os.path.join(ctx.user_config.internal_state_dir, "external", repo_hash)
         # The package is served by a plugin and has no source tree of its own,
         # but it still needs a real directory: it is the base into which
@@ -67,5 +77,6 @@ class ProjectFactoryExternal(pf.ProjectFactory, ExternalImportConfiguration):
             plugin_ref=self.plugin,
             subfolder=self.subfolder,
             cache=self.cache,
+            cache_version=self.cache_version,
             inherited_config=self.inherited_config,
         )

--- a/partcad/src/partcad/schema/partcad.json
+++ b/partcad/src/partcad/schema/partcad.json
@@ -226,6 +226,7 @@
             "revision": { "type": "string", "minLength": 1 },
             "plugin": { "type": "string", "minLength": 1 },
             "subfolder": { "type": "string" },
+            "cacheVersion": { "type": "integer", "minimum": 0 },
             "includePaths": {
               "type": "array",
               "items": { "type": "string", "minLength": 1 },

--- a/partcad/tests/unit/test_project_external_repository.py
+++ b/partcad/tests/unit/test_project_external_repository.py
@@ -173,6 +173,28 @@ def test_metadata_materializes_from_the_repository():
     assert repo.name == "//ext"  # identity is never overridden by metadata
 
 
+def test_cache_version_propagates_to_children():
+    """The cache version is inherited by every child of a plugin-backed
+    hierarchy, so the whole tree shares one versioned cache namespace."""
+    ctx = pc.Context("examples")
+    top = ProjectExternalRepository(
+        ctx, "//ext", "/tmp/ext", plugin_ref="//ext:remote", cache_version=3
+    )
+    top._repository = FakeRepository({"deps": ["motors"]})
+    child = top.dependencies()["motors"]
+    assert child["cacheVersion"] == 3
+    assert child["plugin"] == "//ext:remote"
+
+
+def test_no_cache_version_leaves_children_unversioned():
+    """Without a cache version (the default), children carry no cacheVersion,
+    preserving the pre-existing cache namespace."""
+    ctx = pc.Context("examples")
+    top = ProjectExternalRepository(ctx, "//ext", "/tmp/ext", plugin_ref="//ext:remote")
+    top._repository = FakeRepository({"deps": ["motors"]})
+    assert "cacheVersion" not in top.dependencies()["motors"]
+
+
 def test_hierarchy_forwards_under_a_subfolder():
     """A child of the hierarchy scopes its requests to its subfolder."""
     ctx = pc.Context("examples")


### PR DESCRIPTION
## Problem

An external (plugin-backed) package caches everything its plugin returns on disk, keyed only by the plugin reference and the request key (`ProjectExternalRepository` + `Cache("external/<sha(plugin)>")`). Nothing in that key reflects the plugin's **output format**. So when a plugin starts returning a new *shape* of data — e.g. it begins adding a field to every part config — the entries cached by the older plugin are still served, silently, until the cache is manually wiped.

We hit exactly this in `partcad-ldraw`: after the `ldraw_repo` plugin began attaching `implements:` (LEGO stud/anti-stud interfaces) to every part, the previously-cached catalogs (without `implements`) kept being served, and assemblies could not find the interfaces until `~/.partcad/cache/external` was deleted by hand.

## Change

Add an optional integer **`cacheVersion`** to an `external` dependency:

```yaml
dependencies:
  ldraw:
    type: external
    plugin: :ldraw_repo
    cacheVersion: 1     # bump when the plugin's output format changes
```

It is folded into the repository's cache location (`sha(plugin@vN)`), and propagated to every child of a plugin-backed hierarchy so the whole tree shares one versioned namespace. Bumping it moves the repository to a fresh cache namespace, invalidating the stale entries in one step. It defaults to `0` (unversioned), so existing packages are unaffected.

## Tests

`partcad/tests/unit/test_project_external_repository.py`:
- `test_cache_version_propagates_to_children` — a versioned repo passes `cacheVersion` down to its children.
- `test_no_cache_version_leaves_children_unversioned` — the default leaves children unversioned (no behavior change).

Full external-repo unit suite passes (13 tests). Verified end to end against `partcad-ldraw`: with `cacheVersion: 1`, the cache relocates from `sha(...:ldraw_repo)` to `sha(...:ldraw_repo@v1)` and the fresh catalog carries the interfaces.

Also documented under external dependencies in `docs/source/configuration.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)