### PR TITLE
fix(test): wait for listen(), not for the socket file, before connecting

### DIFF
--- a/partcad-service-json-rpc/tests/test_client.py
+++ b/partcad-service-json-rpc/tests/test_client.py
@@ -51,8 +51,13 @@ def _serve(socket_dir, registry):
     path = str(socket_dir / "socket")
     server = SocketServer(Session(), registry)
     threading.Thread(target=server.serve_unix, args=(path,), daemon=True).start()
-    for _ in range(200):
-        if os.path.exists(path):
+    # Wait until the server is *accepting*, not merely until the socket file
+    # exists. serve_unix() binds -- which creates the file -- and only then
+    # calls listen(); a client that connects in between gets ECONNREFUSED.
+    # `_server_sock` is assigned after listen() returns, so it is the first
+    # observable moment at which a connection can succeed.
+    for _ in range(500):
+        if server._server_sock is not None:
             break
         time.sleep(0.01)
     return server, path

--- a/partcad-service-json-rpc/tests/test_daemon.py
+++ b/partcad-service-json-rpc/tests/test_daemon.py
@@ -73,8 +73,13 @@ def test_determine_root_path_without_partcad_yaml_is_the_directory_itself(tmp_pa
 def _serve(path, registry):
     server = SocketServer(Session(), registry)
     threading.Thread(target=server.serve_unix, args=(path,), daemon=True).start()
-    for _ in range(200):
-        if os.path.exists(path):
+    # Wait until the server is *accepting*, not merely until the socket file
+    # exists. serve_unix() binds -- which creates the file -- and only then
+    # calls listen(); a client that connects in between gets ECONNREFUSED.
+    # `_server_sock` is assigned after listen() returns, so it is the first
+    # observable moment at which a connection can succeed.
+    for _ in range(500):
+        if server._server_sock is not None:
             break
         time.sleep(0.01)
     return server

--- a/partcad-service-json-rpc/tests/test_socket_server.py
+++ b/partcad-service-json-rpc/tests/test_socket_server.py
@@ -52,8 +52,13 @@ def _serve(socket_dir, registry, session=None):
     server = SocketServer(session or Session(), registry)
     thread = threading.Thread(target=server.serve_unix, args=(path,), daemon=True)
     thread.start()
-    for _ in range(200):
-        if os.path.exists(path):
+    # Wait until the server is *accepting*, not merely until the socket file
+    # exists. serve_unix() binds -- which creates the file -- and only then
+    # calls listen(); a client that connects in between gets ECONNREFUSED.
+    # `_server_sock` is assigned after listen() returns, so it is the first
+    # observable moment at which a connection can succeed.
+    for _ in range(500):
+        if server._server_sock is not None:
             break
         time.sleep(0.01)
     return server, path, thread


### PR DESCRIPTION
## What & why

The `partcad-service-json-rpc` socket tests fail intermittently with `ConnectionRefusedError`, on unrelated PRs. #494 hit it on 5 of its 16 `Pytest` cells:

```
FAILED partcad-service-json-rpc/tests/test_client.py::test_client_call_returns_result
    ConnectionRefusedError: [Errno 61] Connection refused
FAILED partcad-service-json-rpc/tests/test_client.py::test_client_raises_daemon_error_on_error_response
    ConnectionRefusedError: [Errno 111] Connection refused
```

Their `_serve()` helpers treated *the socket file appearing* as "the server is ready", but `SocketServer.serve_unix()` creates the file before it can accept:

```python
server.bind(path)      # <- the file appears here
os.chmod(path, 0o600)
server.listen(64)      # <- only now will connect() succeed
```

A client that connects in between is refused. The window widens exactly when a CI runner is loaded, which is why it never reproduced locally and looks flaky — a different subset of cells fails each run.

## The fix

Wait for `SocketServer._server_sock`, which `serve_unix()` assigns *after* `listen()` returns, making it the first observable moment a connection can succeed. Applied to the three helpers that had the race (`test_client.py`, `test_socket_server.py`, `test_daemon.py`).

**Tests only — no product change.**

## Verification

The window is too small to hit reliably on an idle machine, so it was widened deliberately (patching `socket.socket.listen` to sleep) to make the race deterministic:

| readiness condition | result |
|---|---|
| old — socket file exists | `ECONNREFUSED`, `ECONNREFUSED`, `ECONNREFUSED` |
| new — after `listen()` | `connected`, `connected`, `connected` |

Then: 172 service tests pass, and the three socket suites ran 10× consecutively with no failures.

## Not addressed here

The other CI failures on #494 and #469 are unrelated to this:

- `Examples … via bundle` and `Behave` shard 2 (`docs.feature:103/118`) — external `partcad-index` packages still declaring `ai-cadquery` parts, retired in #486. These are red on `devel` itself.
- #469's 17 `Pytest` failures — its own new `part_factory_wrapper.py` pins `cadquery-ocp`/`build123d`/`ocpsvg`/`ocp-tessellate`, which the guard added in #493 rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
