### PR TITLE
fix(parts): source the pinned CAD stack in the wrapper factory

### DIFF
--- a/partcad/src/partcad/part_factory_wrapper.py
+++ b/partcad/src/partcad/part_factory_wrapper.py
@@ -19,21 +19,11 @@ import os
 from .part_factory import PartFactory
 from .utils import resolve_resource_path
 from . import logging as pc_logging
+from . import sandbox_versions
 from . import shape_envelope
 from . import telemetry
 from . import transform
 from . import wrapper
-
-# The geometry stack the sandbox needs so a wrapper can build and serialize
-# shapes. Matches the other Python-backed part factories. The core itself never
-# imports OCP: shapes cross the boundary as BREP envelopes (see shape_envelope).
-_SANDBOX_REQUIREMENTS = (
-    "ocp-tessellate==3.0.9",
-    "typing_extensions==4.12.2",
-    "cadquery-ocp==7.7.2",
-    "ocpsvg==0.3.4",
-    "build123d==0.8.0",
-)
 
 
 @telemetry.instrument()
@@ -48,9 +38,7 @@ class PartFactoryWrapper(PartFactory):
                 target_project.name, self.part_type_ref
             )
 
-            python_version = self.project.python_version or "3.11"
-            if python_version in ("3.10", "3.12"):
-                python_version = "3.11"
+            python_version = self.project.python_version or sandbox_versions.DEFAULT_PYTHON_VERSION
             self.runtime = self.ctx.get_python_runtime(python_version)
             self.session = self.runtime.get_session(source_project.name)
 
@@ -110,14 +98,26 @@ class PartFactoryWrapper(PartFactory):
                 part.error(str(e))
                 return None
 
-            # Prepare the sandbox: the partType's package dependencies plus the
-            # geometry stack, plus any requirements the partType declares.
+            # Prepare the sandbox: the partType's package dependencies, then
+            # whatever the partType itself declares, then the geometry stack.
             await self.runtime.prepare_for_package(pt_project, session=self.session)
             await self.runtime.prepare_for_shape(self.config, session=self.session)
-            for req in _SANDBOX_REQUIREMENTS:
-                await self.runtime.ensure_async(req, session=self.session)
             for req in pt_config.get("pythonRequirements", []) or []:
                 await self.runtime.ensure_async(req, session=self.session)
+
+            # The geometry stack the sandbox needs so a wrapper can build and
+            # serialize shapes. The versions come from sandbox_versions: a
+            # session v-env is shared by every part of a package, so a factory
+            # that pins its own version corrupts it for all the others. The
+            # core itself never imports OCP - shapes cross the boundary as
+            # BREP envelopes (see shape_envelope).
+            await self.runtime.ensure_async(sandbox_versions.OCP_TESSELLATE, session=self.session)
+            await self.runtime.ensure_async(sandbox_versions.TYPING_EXTENSIONS, session=self.session)
+            await self.runtime.ensure_async(sandbox_versions.OCPSVG, session=self.session)
+            await self.runtime.ensure_async(sandbox_versions.BUILD123D, session=self.session)
+            # Last: re-asserts the VTK-enabled OCP that build123d's
+            # 'cadquery-ocp-novtk' dependency has just replaced.
+            await self.runtime.ensure_async(sandbox_versions.CADQUERY_OCP, session=self.session)
 
             # The request handed to the wrapper script.
             request = {


### PR DESCRIPTION
## Copilot Summary

`PartFactoryWrapper` (#469) declared its own copy of the geometry stack:

```python
_SANDBOX_REQUIREMENTS = (
    "ocp-tessellate==3.0.9",
    "typing_extensions==4.12.2",
    "cadquery-ocp==7.7.2",
    "ocpsvg==0.3.4",
    "build123d==0.8.0",
)
```

which is exactly what the guard added in #491/#493 exists to prevent. A session v-env is shared by every part of a package, so a factory that pins its own version of the co-dependent CAD stack corrupts that environment for the other parts. `test_no_factory_pins_its_own_version_of_the_shared_cad_stack` has been red on `devel` ever since #469 landed.

The literals were also stale (build123d is pinned at `0.11.1`, not `0.8.0`), and `reconcile_requirement()` was already overriding them at install time — once per runtime, with a warning nobody asked for. This change takes the versions from `sandbox_versions` instead, like every other factory.

### Changes

- **Source the geometry stack from `sandbox_versions`** instead of a hardcoded tuple, so the wrapper factory installs the same pinned generation as every other factory and stops corrupting the shared session v-env.
- **Fix the install order.** `build123d` pulls `cadquery-ocp-novtk`, which writes the same OCP native module as `cadquery-ocp` and replaces it with a build compiled without VTK, so `CADQUERY_OCP` has to be re-asserted **last** (see `PythonRuntime.once()` and `SketchFactorySvg.instantiate()`). The old tuple installed it third, before `ocpsvg` and `build123d`. The partType's own `pythonRequirements` move above the stack for the same reason.
- **Drop the interpreter-version special case** that silently rewrote a package's declared `3.10`/`3.12` to `3.11`. Nothing else in the tree rewrites a package's declared Python version. It now falls back to `sandbox_versions.DEFAULT_PYTHON_VERSION` and otherwise honors what the package asked for.

Net diff is 18 insertions / 18 deletions in `partcad/src/partcad/part_factory_wrapper.py`.

### Testing

Ran directly via `poetry run pytest` (Docker/dev-container was unavailable in this environment):

- `partcad/tests/unit/test_runtime_python_deps.py` — **26 passed**, including the two guards that were previously red:
  - `test_no_factory_pins_its_own_version_of_the_shared_cad_stack`
  - `test_cadquery_ocp_is_installed_after_build123d_everywhere`
- `partcad/tests/unit/test_part_type.py`, `partcad/tests/unit/test_import_part.py` — pass (the 2 skips are the sandbox-requiring cases that skip when no CAD sandbox is present).
- `flake8` clean at the project's `max-line-length=120`.

### Note for reviewers

Unlike `PartFactoryCadquery`/`SketchFactorySvg`, this factory does not clamp the interpreter with `at_least(python_version, MIN_PYTHON_VERSION_CADQUERY)`. The removed `3.10/3.12→3.11` hack partially masked that; a package declaring `3.10` now gets `3.10`. The wrapper installs `build123d` + `cadquery-ocp` but not the `cadquery` package itself, so `MIN_PYTHON_VERSION_CADQUERY` may not strictly apply — flagging it in case parity with the sibling factories is preferred.

Also worth confirming: this factory reads the interpreter version from `self.project.python_version` (matching #469), whereas `SketchFactorySvg` reads `source_project.python_version`. For a partType-backed part these resolve to the same object — `PartFactory.__init__` passes `source_project` as `project` to `ShapeFactory`, which stores it as `self.project` — so there is no divergence, but noting it since the two factories spell it differently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3VmGLm4tk1teGBuBFJyjN)_