### PR TITLE
test(lint): match the anyOf part-type schema error in lint.feature

### DIFF
--- a/features/lint.feature
+++ b/features/lint.feature
@@ -59,7 +59,9 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.parts.part1.type: 'unknown_type' is not one of"
+    # A part 'type' is now anyOf {built-in enum, a '<package>:<partType>' reference},
+    # so an unknown type fails the whole part schema rather than just the enum.
+    And STDOUT should contain "$.parts.part1: {'type': 'unknown_type'} is not valid under any of the given schemas"
 
   @failure
   Scenario: Invalid enum in shape parameters
@@ -80,7 +82,9 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "'nonsense' is not one of ['string', 'int', 'bool', 'float']"
+    # Same anyOf part schema: a bad parameter 'type' surfaces as the parameter
+    # object failing its schemas, not as a bare enum error.
+    And STDOUT should contain "{'type': 'nonsense'} is not valid under any of the given schemas"
 
   @success
   Scenario: Fully valid configuration with deeply nested parameters


### PR DESCRIPTION
## Copilot Summary

Two `pc lint` Behave scenarios have been red on `devel` since #469, in Behave **shard 2** on every OS/Python combination (not flaky, not version-specific):

- `features/lint.feature:51` — *Invalid enum value in part type*
- `features/lint.feature:65` — *Invalid enum in shape parameters*

### Root cause

#469 (package-defined partTypes) changed the part schema in `partcad/src/partcad/schema/partcad.json` so a part is now an `anyOf` of two branches: the built-in part (with the `type` enum) **and** a package-defined partType whose `type` matches the resource-path pattern `^(:[^:]+|[^:]+:[^:]+)$`. An invalid `type` now fails the whole part schema, so the linter reports:

```
$.parts.part1: {'type': 'unknown_type'} is not valid under any of the given schemas
  (["'unknown_type' does not match '^(:[^:]+|[^:]+:[^:]+)$'",
    "'unknown_type' is not one of ['cadquery', 'build123d', ...]"])
```

instead of the pre-#469 `$.parts.part1.type: 'unknown_type' is not one of [...]`. The two scenarios still asserted the old wording, so they failed even though the linter behaves correctly. The schema change is intended behaviour; the feature assertions simply hadn't caught up.

### Change

Update the two `STDOUT should contain` assertions to the current output, and add a one-line comment on each explaining why the message shape changed:

| Scenario | Was | Now |
|---|---|---|
| Invalid enum value in part type | `$.parts.part1.type: 'unknown_type' is not one of` | `$.parts.part1: {'type': 'unknown_type'} is not valid under any of the given schemas` |
| Invalid enum in shape parameters | `'nonsense' is not one of ['string', 'int', 'bool', 'float']` | `{'type': 'nonsense'} is not valid under any of the given schemas` |

Exit codes are unchanged (both still assert `1`); only the substrings move. For the second scenario the deepest `'nonsense' is not one of [...]` message is no longer surfaced — the `anyOf` collapses it to the parameter object failing its schemas — so the assertion targets that stable message instead.

### Testing

Reproduced both scenarios' current CLI output locally to derive the exact substrings, then ran the whole feature:

```
behave features/lint.feature
1 feature passed, 0 failed, 0 skipped
25 scenarios passed, 0 failed, 0 skipped
```

Only `features/lint.feature` changes; no product code is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3VmGLm4tk1teGBuBFJyjN)_