### PR TITLE
fix(test): poll for the socket unlink after daemon.stop, not the thread join

### DIFF
--- a/partcad-service-json-rpc/tests/test_socket_server.py
+++ b/partcad-service-json-rpc/tests/test_socket_server.py
@@ -108,6 +108,17 @@ def test_daemon_stop_responds_then_shuts_down_and_unlinks(socket_dir):
     c.close()
     thread.join(timeout=3)
     assert not thread.is_alive()
+    # The socket is unlinked by stop(), which the daemon.stop handler runs on
+    # the *connection* thread -- not the accept-loop `thread` joined above. And
+    # stop() sets the stop flag before it unlinks, so the accept loop can see
+    # the flag and exit (ending `thread`) in the window before the unlink runs.
+    # Joining `thread` therefore does not imply the file is gone; poll for it.
+    # Mirror image of the startup race #496 fixed by waiting for listen()
+    # rather than for the socket file to appear.
+    for _ in range(300):
+        if not os.path.exists(path):
+            break
+        time.sleep(0.01)
     assert not os.path.exists(path)
 
 


### PR DESCRIPTION
## Copilot Summary

`partcad-service-json-rpc/tests/test_socket_server.py::test_daemon_stop_responds_then_shuts_down_and_unlinks` fails intermittently — observed on the `Pytest (macos-latest, 3.10)` / `Pytest (macos-26, 3.10)` CI cells, which run with `-x` so this one flake reddens the whole job:

```
AssertionError: assert not True
  where True = exists('/tmp/pcsx2ooqinb/socket')
```

### Root cause — a cross-thread ordering gap, not a shutdown bug

The test joins the **accept-loop** thread (`serve_unix`) and then asserts the socket file is already unlinked:

```python
thread.join(timeout=3)
assert not thread.is_alive()
assert not os.path.exists(path)   # <-- races the unlink
```

But the unlink is performed by `SocketServer.stop()`, which the `daemon.stop` handler runs on the **connection** thread (`_handle_connection`), *not* the accept-loop thread being joined. And `stop()` runs `_stop.set()` **before** `os.unlink(path)`:

```python
def stop(self):
    ...
    self._stop.set()                     # 1. lets the accept loop exit
    if self._path and os.path.exists(self._path):
        os.unlink(self._path)            # 2. done on the connection thread
    self._server_sock.close()
```

The accept loop exits as soon as it observes `_stop` on its 0.5 s `accept()` timeout tick (`while not self._stop.is_set()`). That can happen in the window between step 1 and step 2, so the joined `thread` dies — satisfying `thread.join()` — while the socket file has not yet been unlinked. Under a slow/loaded runner (macOS 3.10) the connection thread gets preempted right there and the assertion sees the file still present. Reproduced locally at ~4/30.

The server's shutdown itself is correct — `stop()` unlinks promptly, and real clients (`pc daemon stop`) never join these threads. The defect is purely that the test proxies "socket gone" through an unrelated thread's exit.

### Fix

Poll for the file to disappear after the join, with the same timeout budget:

```python
thread.join(timeout=3)
assert not thread.is_alive()
for _ in range(300):
    if not os.path.exists(path):
        break
    time.sleep(0.01)
assert not os.path.exists(path)
```

### Note — prior related attempt (#496)

This is the **teardown-side mirror** of #496 (`fix(test): wait for listen(), not for the socket file, before connecting`), which fixed the *startup* race in the same file's `_serve` helper by waiting for `listen()` (`_server_sock is not None`) instead of for the socket file to appear. #496 addressed a connect-before-listen `ECONNREFUSED`; this addresses the symmetric unlink-after-stop race on shutdown. Same class of test-synchronization bug, opposite end of the socket's lifecycle — so the earlier fix did not (and was not meant to) cover this case.

### Testing

- Reproduced the flake on Linux: **4/30** failures before the change.
- After the change: **0/60** failures, and the full `test_socket_server.py` module passes.

Test-only change; no product code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3VmGLm4tk1teGBuBFJyjN)_