### PR TITLE
perf(runtime): proposal — scope the sandbox lock so runs can overlap

### DIFF
--- a/openspec/changes/sandbox-run-concurrency/.openspec.yaml
+++ b/openspec/changes/sandbox-run-concurrency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/sandbox-run-concurrency/design.md
+++ b/openspec/changes/sandbox-run-concurrency/design.md
@@ -1,0 +1,179 @@
+## Context
+
+This document is written for an implementer picking the work up cold. It records what was found, how it was
+found, and what has *not* been verified, so the implementer can tell the two apart.
+
+### How a sandbox run reaches the lock
+
+1. A factory calls `await self.runtime.run_async(cmd, stdin, session=...)`. Call sites:
+   `part_factory_step.py:44`, `part_factory_brep.py:51`, `part_factory_3mf.py:68`, `part_factory_sdf.py:84`,
+   `part_factory_extrude.py:80`, `part_factory_sweep.py:95`, `part_factory_scad.py:246`,
+   `part_factory_wrapper.py:135`, `transform.py:47`, `shape.py:617` (SVG), `shape.py:842` (all render formats),
+   `actions/assembly/import_assy.py:39`, `test/cam_analysis.py:28`.
+2. `run_async()` (`runtime_python.py:506`) calls `once_async()`, then `run_async_onced()`.
+3. `run_async_onced()` (`runtime_python.py:510`) enters `async with self.async_lock(session)` at line 524 and
+   holds it until it returns at line 618 — spanning `create_subprocess_exec` (561) and `communicate` (571).
+
+### The three primitives, and what each actually guards
+
+| Primitive | Where | Scope | What it really does |
+|---|---|---|---|
+| `asyncio.Lock` | `get_async_lock()`, `runtime_python.py:247` | per (thread, event loop, runtime) — stored in `self.tls`, keyed by `id(self)` and `id(loop)` | Serializes every sandbox operation issued from the *same* thread/loop. This is what makes `Project.render_async`'s `asyncio.gather` serial. |
+| `threading.RLock` | `self.lock`, created at `runtime_python.py:173` | one per `PythonRuntime` instance ⇒ effectively one per process | Serializes every sandbox operation across *all* threads. Acquired blocking, inside a coroutine, held across `await`. |
+| `FileLock` (`VenvLock`) | `runtime_python.py:131-149` | one file per (sandbox, venv) | Cross-**process** guard. Constructed with `thread_local=False` (line 146). |
+
+**A claim to verify before relying on it (task 1.4):** with `thread_local=False`, `filelock` keeps its
+reentrancy counter shared across threads rather than thread-local, which means a second thread calling
+`acquire()` on an already-held lock object increments the counter and returns immediately instead of waiting.
+If that reading is right, `VenvLock` provides *no* intra-process mutual exclusion today — all of the
+intra-process exclusion comes from the `RLock` — and the new design must not assume otherwise. Confirm against
+the pinned `filelock` version before building on it.
+
+### Why the lock is there
+
+`runtime_python.py:511-523` documents the hazard, and it is genuine:
+
+> Two parts of the same package (e.g. a CadQuery part and a build123d part) share a session v-env; if the
+> install loop is left outside this lock, a build123d install — which pulls `cadquery-ocp-novtk` and overwrites
+> the shared OCP native module — can slip in between another part's `CADQUERY_OCP` re-assertion and the moment
+> that part actually runs `import cadquery` […]
+
+Supporting machinery for the same hazard: `sandbox_versions.GUARD_INVALIDATED_BY`,
+`invalidate_dependent_guards()` (`runtime_python.py:83`), `needs_reassert()`/`clear_reassert()`, and the
+`FORCE_REINSTALL_FLAGS` comment at `runtime_python.py:62-68`. Read all of it before changing the locking; the
+guard/reassert bookkeeping is what makes the VTK-enabled build win *eventually*, and the lock is what makes it
+win *at the instant a run starts*.
+
+### What is not the problem
+
+- It is not `FileLock` contention: that is cross-process and the bottleneck reproduces in a single process.
+- It is not the thread pool sizing: the pool is correctly sized (`sync_threads.py:44-70`), it is simply blocked.
+- It is not `Shape.get_wrapped`'s own lock (`shape.py:209`), though that method has the same
+  blocking-lock-across-`await` shape and is worth fixing in passing (task 5.3). Its scope is one shape, so it
+  does not serialize unrelated work.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Independent sandbox operations run concurrently, bounded by an explicit cap.
+- Mutual exclusion is scoped to the environment being mutated (a sandbox path or a v-env path), not to the
+  runtime object.
+- No sandbox operation blocks an event loop while waiting for a lock.
+- The install/run race that motivated the current lock remains impossible, and a test proves it.
+
+**Non-Goals**
+
+- Fewer or cheaper sandbox invocations (sibling proposal: `sandbox-process-reuse`).
+- Cross-process concurrency policy. The `FileLock` layer stays as the cross-process guard for installs.
+- Any change to what a wrapper receives or returns.
+
+## Decisions
+
+### D1 — Readers/writer, keyed by environment path
+
+Model the environment (`self.path` for the sandbox, `session["path"]` for a v-env) as a resource with:
+
+- **Writers** — anything that mutates it: `ensure*` when the install guard is absent, and v-env creation
+  (`python -m venv`). Exclusive against every other holder of the same key.
+- **Readers** — a run that only executes an interpreter in an environment already known good. Shared.
+
+A run against a v-env implicitly depends on the parent sandbox as well, so a run must hold a read on *both* the
+sandbox key and (if a session is in play) the v-env key. Acquire in a fixed order — sandbox first, then v-env —
+so no cycle is possible. Note `runtime_python_conda.py` overrides `sync_lock_install`/`async_lock_install` with
+a conda-global lock; keep it outermost so the ordering stays total.
+
+### D2 — Never block an event loop
+
+`asyncio.Lock` cannot be used for cross-thread coordination (it is bound to one loop, which is exactly why the
+current code needs the `RLock` alongside it). Two viable approaches:
+
+- **D2a (recommended, smallest diff):** keep `threading`-level primitives for cross-thread coordination, but
+  acquire them off-loop — `await asyncio.to_thread(gate.acquire_read, key)` — so waiting parks the coroutine
+  instead of freezing the thread. Release is non-blocking and can stay inline.
+- **D2b:** route every sandbox run through one dedicated owner loop and use `asyncio` primitives throughout.
+  Cleaner in the long run, much larger blast radius.
+
+Take D2a unless something during implementation makes it untenable; record the reason if you switch.
+
+### D3 — An explicit concurrency cap
+
+Removing the lock uncovers unbounded fan-out: `Project.render_async` can gather hundreds of coroutines. Add a
+process-wide semaphore around sandbox *execution* sized from `user_config.threads_max` (fall back to
+`ThreadPoolManager`'s `constrained` count, `sync_threads.py:60`). Each sandbox process is CPU-heavy and can be
+memory-heavy, so this cap is a correctness-of-resource-use concern, not a nicety.
+
+### D4 — Keep the guard/reassert bookkeeping untouched
+
+`invalidate_dependent_guards()`, `needs_reassert()` and `FORCE_REINSTALL_FLAGS` are orthogonal to *when* things
+may run concurrently. Do not restructure them in this change; a diff that touches both is very hard to review.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Reintroducing the OCP-clobbering race, which manifests as a native crash with **no traceback and no stderr** | Task 4 is a dedicated regression test. Note the existing diagnostic at `runtime_python.py:601-616` — a non-zero exit with no output is the signature; make the test assert on it. |
+| A deadlock from mixed lock ordering with `runtime_python_conda.py`'s global conda lock | D1's fixed acquisition order; task 3.5 audits every acquisition site. |
+| Memory exhaustion once many OCP interpreters run at once | D3's semaphore, plus task 6.4 records peak RSS in the benchmark. |
+| Flaky tests that only fail under load | Task 4.3 runs the regression test repeatedly (≥20 iterations) under `-n` parallelism. |
+
+## How to measure
+
+There is no benchmark in the repo today; build one first (task 2) so the "before" number is real rather than
+inferred. A self-contained recipe that needs no telemetry backend:
+
+```python
+# dev-tools/perf/measure_sandbox_concurrency.py  (throwaway, do not ship)
+import asyncio, time
+import partcad as pc
+from partcad.runtime_python import PythonRuntime
+
+spans = []
+orig = PythonRuntime.run_async_onced
+
+async def traced(self, *a, **kw):
+    t0 = time.monotonic()
+    try:
+        return await orig(self, *a, **kw)
+    finally:
+        spans.append((t0, time.monotonic()))
+
+PythonRuntime.run_async_onced = traced
+
+t0 = time.monotonic()
+ctx = pc.init("examples")            # or a package with several parts
+ctx.render(project_path="//examples/produce_part_step", format="stl")
+wall = time.monotonic() - t0
+
+busy = sum(e - s for s, e in spans)
+# Max overlap: how many sandbox processes were ever in flight at once.
+events = sorted([(s, 1) for s, _ in spans] + [(e, -1) for _, e in spans])
+cur = peak = 0
+for _, d in events:
+    cur += d
+    peak = max(peak, cur)
+print(f"wall={wall:.1f}s  sandbox_busy={busy:.1f}s  runs={len(spans)}  peak_overlap={peak}")
+```
+
+**Today's expected reading:** `peak_overlap == 1` and `busy ≈ wall`. That is the signature of full
+serialization and is the "before" number to record in the PR.
+
+**Acceptance:** with the change, `peak_overlap` reaches `min(len(spans), cap)`, and on a multi-core machine
+wall-clock for N independent parts drops toward `busy / peak_overlap` plus overhead. State the machine's core
+count alongside the numbers — the result is meaningless without it.
+
+Use the packages under `examples/` for the workload (`produce_part_step`, `produce_part_cadquery_primitive`,
+`produce_part_build123d_primitive`, `produce_assembly_assy`). A mixed-flavour package is the interesting case
+for both performance and the race.
+
+## Open questions for the implementer
+
+1. Should the concurrency cap be shared with, or independent of, `ThreadPoolManager`'s constrained pool? A part
+   instantiation occupies a pool thread *and* a sandbox slot; if the two counts are equal, the pool thread is
+   simply the thing that waits. Independent counts may be better once renders (which do not use the pool) are
+   also concurrent.
+2. Should a run against a v-env whose install guards are all present skip the sandbox-level read entirely? It
+   would reduce contention but weakens the "sandbox is not being mutated under me" guarantee.
+3. Is per-**package** install serialization worth keeping as a simplification, given every part of a package
+   shares one session v-env (`get_session()`, `runtime_python.py:918`)? It would make writers coarse but
+   simple, and installs are already the rare path once guards exist.

--- a/openspec/changes/sandbox-run-concurrency/proposal.md
+++ b/openspec/changes/sandbox-run-concurrency/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+Every piece of CAD work PartCAD does happens in a sandboxed Python subprocess, and today **no two of those
+subprocesses ever run at the same time**, on any machine, no matter how many cores it has.
+
+`PythonRuntime.async_lock()` (`partcad/src/partcad/runtime_python.py:265`) acquires two mutual-exclusion
+primitives before yielding:
+
+```python
+async def async_lock(self, session=None):
+    async with self.get_async_lock():        # asyncio.Lock, per (thread, loop, runtime)
+        with self.lock:                      # threading.RLock, ONE per runtime instance
+            venv = session["hash"] if session is not None else None
+            with VenvLock(self, venv):
+                yield
+```
+
+`run_async_onced()` (`runtime_python.py:510`) wraps that context manager around the *entire* subprocess
+lifetime — provisioning, `asyncio.create_subprocess_exec` (line 561), `await p.communicate()` (line 571), and
+the output handling that follows — returning only at line 618.
+
+There is effectively **one** `PythonRuntime` instance per process. `Context.get_python_runtime()`
+(`context.py:1028`) memoizes by `python_runtime + "-" + version`, and virtually every call site asks for
+`"3.11"` / `sandbox_versions.DEFAULT_PYTHON_VERSION`. One instance means one `self.lock`, and that single
+`threading.RLock` gates every sandbox execution in the process.
+
+Two distinct consequences follow, and both are load-bearing:
+
+1. **The thread pool is inert.** `ThreadPoolManager` sizes a pool at `cpu_count - 1` (`sync_threads.py:44`) and
+   `Part.get_shape()` dispatches each part's instantiation onto it (`part.py:34`). Every one of those threads
+   then blocks on the same `RLock` while some other thread's subprocess runs. Worse: a *blocking* lock acquired
+   inside a coroutine stalls the whole OS thread, and therefore that thread's entire event loop — so pending
+   `aiofiles` cache I/O and any other async work scheduled there stalls too. The slowdown is not confined to
+   sandbox runs.
+
+2. **Gathered renders are serial.** `Project.render_async()` (`project.py:1179`) builds a coroutine for every
+   shape × format combination and `asyncio.gather`s them on one loop (`project.py:1220`). They all share that
+   thread's single `asyncio.Lock` from `get_async_lock()`, so `gather` executes them strictly one at a time.
+
+The lock is not gratuitous. The comment at `runtime_python.py:511-523` documents a real hazard: installing
+`build123d` pulls `cadquery-ocp-novtk`, which overwrites the very same OCP native module `cadquery-ocp`
+installs, so an install slipping in between another part's `CADQUERY_OCP` re-assertion and its actual run
+leaves that run importing a half-installed OCP and dying with an unrelated-looking `ImportError`. That hazard
+is real and must survive this change. But the mutual exclusion it motivates is *(venv, install-vs-run)*, while
+what is implemented is *(runtime, any run)* — and sessionless runs, which install nothing at that point, are
+serialized along with everything else.
+
+## What Changes
+
+- Replace the blanket runtime-wide lock around sandbox execution with a **readers/writer gate keyed on the
+  environment being mutated**: package installs and v-env creation take the gate exclusively; interpreter runs
+  that install nothing share it.
+- Stop acquiring a blocking `threading` primitive inside a coroutine, so a waiting sandbox operation no longer
+  stalls its thread's event loop.
+- Bound the resulting parallelism with an explicit, process-wide concurrency cap derived from
+  `user_config.threads_max`, so lifting the lock does not replace "one interpreter at a time" with "two hundred
+  at once".
+- Preserve the OCP-clobbering invariant exactly, and add a regression test that would fail if it were lost.
+- Record concurrent sandbox execution as a specified capability, so the property is asserted by tests rather
+  than left as an accident of how the locks happen to nest.
+
+Not a user-visible behavior change: the same shapes are produced, from the same inputs, with the same contents.
+
+## Capabilities
+
+### New Capabilities
+
+- `sandbox-concurrency`: The requirement that independent sandboxed CAD operations execute concurrently up to a
+  configured bound; that mutual exclusion is scoped to the environment actually being mutated rather than to
+  the runtime as a whole; that no sandbox operation blocks an event loop while waiting; and that concurrent
+  execution never allows a package install to corrupt an environment another operation is already running in.
+
+## Impact
+
+- **Modified**: `partcad/src/partcad/runtime_python.py` — `async_lock()`/`sync_lock()`, `run_async_onced()`,
+  `run_onced()`, and the `ensure*` family's locking.
+- **Modified (possibly)**: `partcad/src/partcad/runtime_python_conda.py` — it overrides
+  `sync_lock_install`/`async_lock_install`; confirm the new scheme composes with its global conda lock without
+  inverting lock order.
+- **New tests**: concurrency regression coverage alongside `partcad/tests/unit/test_runtime_python.py`.
+- **New specs**: `openspec/specs/sandbox-concurrency/spec.md`.
+- **Unchanged**: the wire protocol, the wrapper scripts, the shape cache, and every factory. This change is
+  confined to *when* sandbox processes are allowed to run, not *what* they do.
+
+## Non-Goals
+
+- Reducing the *number* of sandbox invocations, or making them cheaper to start. That is a separate, larger
+  change; see the sibling proposal `sandbox-process-reuse`.
+- Reducing the cost of a cache hit; see the sibling proposal `shape-cache-efficiency`.
+- Changing `ThreadPoolManager`'s sizing heuristics.

--- a/openspec/changes/sandbox-run-concurrency/specs/sandbox-concurrency/spec.md
+++ b/openspec/changes/sandbox-run-concurrency/specs/sandbox-concurrency/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Independent sandbox operations execute concurrently
+Sandboxed CAD operations that do not mutate the same environment SHALL be able to execute concurrently, up to a
+configured concurrency bound. No single lock SHALL serialize every sandbox execution in a process.
+
+#### Scenario: Several parts are instantiated at once
+- **WHEN** a package containing several independent parts is built on a machine with more than one core
+- **THEN** more than one sandbox process is in flight at the same time, up to the configured bound
+
+#### Scenario: Several formats are rendered from one shape
+- **WHEN** rendering work is gathered onto a single event loop, as `Project.render_async` does
+- **THEN** those render operations execute concurrently rather than one at a time
+
+### Requirement: Mutual exclusion is scoped to the environment being mutated
+Mutual exclusion between sandbox operations SHALL be keyed on the environment being mutated — a sandbox path or
+a v-env path — and not on the runtime object. An operation that installs nothing SHALL NOT exclude an
+unrelated operation that installs nothing.
+
+#### Scenario: A sessionless run overlaps another sessionless run
+- **WHEN** two sandbox operations run in environments whose dependencies are already provisioned
+- **THEN** neither operation waits for the other
+
+#### Scenario: An install excludes runs in the same environment
+- **WHEN** a package is being installed into an environment
+- **THEN** no sandbox process executes in that environment until the install has completed
+
+### Requirement: Waiting for a sandbox lock does not block an event loop
+Acquiring the right to execute a sandbox operation SHALL NOT block the thread running an event loop. A
+sandbox operation that is waiting SHALL leave its event loop free to make progress on other work.
+
+#### Scenario: Unrelated async work proceeds while a sandbox operation waits
+- **WHEN** a sandbox operation is waiting for another operation to release an environment
+- **THEN** other coroutines scheduled on the same event loop, such as cache file I/O, continue to run
+
+### Requirement: Concurrency is explicitly bounded
+The number of sandbox processes running simultaneously SHALL be bounded by an explicit limit derived from the
+user's thread configuration, so that lifting serialization does not permit unbounded process fan-out.
+
+#### Scenario: A package declares more shapes than the bound
+- **WHEN** more sandbox operations are requested at once than the configured bound allows
+- **THEN** the excess operations queue, and the number in flight never exceeds the bound
+
+### Requirement: Concurrent execution preserves environment integrity
+Concurrent sandbox execution SHALL NOT permit a package install to replace files in an environment while a
+sandbox process is executing in that environment. In particular, installing a distribution that overwrites the
+OCP native module SHALL NOT be able to interleave with another operation's use of that module.
+
+#### Scenario: A CadQuery part and a build123d part are built together
+- **WHEN** two parts sharing one session v-env, one requiring CadQuery and one requiring build123d, are built
+  concurrently from a freshly provisioned sandbox
+- **THEN** both parts instantiate successfully, and neither sandbox process terminates abnormally with no
+  output — the signature of two incompatible OCP builds loaded into one process

--- a/openspec/changes/sandbox-run-concurrency/tasks.md
+++ b/openspec/changes/sandbox-run-concurrency/tasks.md
@@ -1,0 +1,92 @@
+## 1. Confirm the finding before changing anything
+
+- [ ] 1.1 Read `partcad/src/partcad/runtime_python.py` lines 131-160 (`VenvLock`), 160-200 (`__init__`),
+      247-283 (the lock helpers) and 506-618 (`run_async_onced`) end to end
+- [ ] 1.2 Confirm `Context.get_python_runtime()` (`context.py:1028-1043`) returns a single memoized instance for
+      the version every call site asks for, by logging the `id()` of the runtime at each `run_async` call site
+      during an `examples/` render
+- [ ] 1.3 Confirm `self.lock` (`runtime_python.py:173`) is held across `await p.communicate()`
+      (`runtime_python.py:571`) — e.g. by logging acquire/release with thread ids
+- [ ] 1.4 Settle the `VenvLock` question from `design.md`: does `FileLock(..., thread_local=False)`
+      (`runtime_python.py:146`) provide intra-process mutual exclusion, or only cross-process? Check the pinned
+      `filelock` version's source; write the answer into `design.md` before designing around it
+- [ ] 1.5 Confirm the same serialization applies to the synchronous path (`sync_lock()`,
+      `runtime_python.py:257`, used by `run_onced()` at line 364), so the fix covers both
+
+## 2. Establish the baseline
+
+- [ ] 2.1 Bring up the dev container (root `AGENTS.md`, "Where commands run") — all of the below runs inside it
+- [ ] 2.2 Write the throwaway measurement script from `design.md` ("How to measure") under `dev-tools/perf/`
+- [ ] 2.3 Pick a workload with several independent parts. Suggested: a scratch package importing
+      `examples/produce_part_step`, `examples/produce_part_cadquery_primitive` and
+      `examples/produce_part_build123d_primitive`; the mixed CadQuery/build123d flavour is also the race case
+- [ ] 2.4 Record, on a warm cache-free run: wall clock, sandbox busy time, run count, peak overlap, core count,
+      peak RSS. Expect `peak_overlap == 1`
+- [ ] 2.5 Record the same numbers for `pc --no-ansi render` over a package with several shapes and formats, to
+      capture the `Project.render_async` gather path (`project.py:1220`) specifically
+- [ ] 2.6 Paste both baselines into the PR description before writing any implementation code
+
+## 3. Implement the readers/writer gate
+
+- [ ] 3.1 Add the gate: a keyed readers/writer lock over environment paths, with non-blocking-for-the-loop
+      acquisition (`design.md` D1, D2a). Put it in a new module rather than growing `runtime_python.py`
+- [ ] 3.2 Unit-test the gate in isolation first: readers share, a writer excludes, ordering is FIFO enough not
+      to starve writers, and acquisition never blocks a running event loop
+- [ ] 3.3 Convert `async_lock()`/`sync_lock()` (`runtime_python.py:257-272`) to take a *read* on the sandbox key
+      and, when a session is given, on the v-env key — in that order
+- [ ] 3.4 Convert the `ensure*` family and v-env creation to take a *write* on the key they mutate. Note there
+      are four near-duplicate `ensure` variants (`ensure_onced` 678, `ensure_onced_locked` 719,
+      `ensure_async_onced` 761, `ensure_async_onced_locked` 803) — treat their duplication as pre-existing and
+      do not refactor it here
+- [ ] 3.5 Audit every lock acquisition site for ordering against `runtime_python_conda.py`'s
+      `sync_lock_install`/`async_lock_install` global conda lock; keep the conda lock outermost
+- [ ] 3.6 Remove `self.lock` (the `threading.RLock`) once nothing acquires it, or document precisely what it
+      still guards if something does
+- [ ] 3.7 Confirm no blocking lock acquisition remains inside a coroutine anywhere in `runtime_python.py`
+
+## 4. Prove the install/run race did not come back
+
+- [ ] 4.1 Read `runtime_python.py:36-68` and `sandbox_versions.GUARD_INVALIDATED_BY` so the hazard is
+      understood before testing for it
+- [ ] 4.2 Add a regression test next to `partcad/tests/unit/test_runtime_python.py`: a package with both a
+      CadQuery-flavoured and a build123d-flavoured part, built concurrently from a cold sandbox, asserting both
+      shapes come out valid
+- [ ] 4.3 Run it ≥20 times (and under `pytest -n 4`) to shake out a load-dependent failure; a race that
+      reproduces one time in ten will otherwise land green
+- [ ] 4.4 Assert specifically on the crash signature the existing code already diagnoses: non-zero exit with
+      empty stdout *and* empty stderr (`runtime_python.py:601-616`). That is what an OCP collision looks like
+- [ ] 4.5 Mark the test `slow` if it provisions sandboxes, so the pre-commit hook's `-m "not slow"` still runs
+      fast, and confirm CI (which does not exclude `slow`) still picks it up
+
+## 5. Concurrency cap and adjacent cleanups
+
+- [ ] 5.1 Add the process-wide sandbox-execution semaphore (`design.md` D3), sized from
+      `user_config.threads_max` with `ThreadPoolManager`'s `constrained` count as the fallback
+- [ ] 5.2 Verify the cap is honoured by re-running the measurement script and checking
+      `peak_overlap <= cap`
+- [ ] 5.3 Optional, same failure mode, different object: `Shape.get_wrapped()` (`shape.py:208-210`) also holds a
+      blocking `threading.RLock` across `await`s, including across a whole sandbox run. Its scope is one shape
+      so it does not serialize unrelated work, but it does stall the loop. Fix it here or file it separately —
+      do not leave it unmentioned
+
+## 6. Validate
+
+- [ ] 6.1 `poetry run pytest partcad partcad-cli -x -p no:error-for-skips -p no:warnings --dist no`
+- [ ] 6.2 `poetry run behave` (integration tests under `./features`; `render.feature` and `test.feature` are the
+      relevant ones)
+- [ ] 6.3 Re-run the measurement script and record the "after" numbers next to the baseline from task 2.6
+- [ ] 6.4 Record peak RSS before and after — concurrency multiplies OCP-sized processes and this is the most
+      likely unpleasant surprise
+- [ ] 6.5 Confirm rendered artifacts are byte-identical (or geometrically equivalent, where an exporter embeds a
+      timestamp) to the ones produced before the change
+- [ ] 6.6 Sanity-check a single-core / `threadsMax: 1` configuration still works and does not regress
+
+## 7. Land it
+
+- [ ] 7.1 Delete the throwaway measurement script, or promote it to a maintained benchmark under `dev-tools/`
+      with a short README — do not leave it half-committed
+- [ ] 7.2 Move the delta spec into `openspec/specs/sandbox-concurrency/spec.md`
+- [ ] 7.3 Run `pre-commit run --config dev-tools/pre-commit-config.yaml` inside the container and re-stage
+      anything the formatting hooks rewrote
+- [ ] 7.4 Commit inside the container; verify with `git log -1 --stat` that the hooks ran and the file set is
+      what you intended


### PR DESCRIPTION
## Copilot Summary

**This PR contains a proposal only — no behavior change.** It adds an OpenSpec change under
`openspec/changes/sandbox-run-concurrency/` (`proposal.md`, `design.md`, `tasks.md`, and a delta spec) recording
a performance finding in `partcad/` together with a design, a measurement recipe, and the regression coverage
the fix needs. It is one of three sibling proposals from the same read-through; see "Relationship to the other
two" below.

The implementation is deliberately not included: the finding should be measured on real hardware before code is
written, and `tasks.md` starts with exactly that. **Work through `tasks.md` in order — it is the handoff.**

---

## The finding

Every piece of CAD work PartCAD does happens in a sandboxed Python subprocess, and today **no two of those
subprocesses ever run at the same time**, on any machine, regardless of core count.

`PythonRuntime.async_lock()` (`partcad/src/partcad/runtime_python.py:265`) acquires two mutual-exclusion
primitives before yielding:

```python
async def async_lock(self, session=None):
    async with self.get_async_lock():        # asyncio.Lock, per (thread, loop, runtime)
        with self.lock:                      # threading.RLock, ONE per runtime instance
            venv = session["hash"] if session is not None else None
            with VenvLock(self, venv):
                yield
```

`run_async_onced()` (`runtime_python.py:510`) wraps that context manager around the **entire** subprocess
lifetime — provisioning, `asyncio.create_subprocess_exec` (line 561), `await p.communicate()` (line 571), and
the output handling — returning only at line 618.

There is effectively **one** `PythonRuntime` instance per process: `Context.get_python_runtime()`
(`context.py:1028`) memoizes by `python_runtime + "-" + version`, and virtually every call site asks for
`"3.11"` / `sandbox_versions.DEFAULT_PYTHON_VERSION`. One instance ⇒ one `self.lock` ⇒ one `threading.RLock`
gating every sandbox execution in the process.

### Two consequences, both load-bearing

**1. The thread pool is inert.** `ThreadPoolManager` sizes a pool at `cpu_count - 1` (`sync_threads.py:44`) and
`Part.get_shape()` dispatches each part's instantiation onto it (`part.py:34`). Every one of those threads then
blocks on the same `RLock` while another thread's subprocess runs. Worse: a *blocking* lock acquired inside a
coroutine stalls the whole OS thread, and therefore that thread's entire event loop — so pending `aiofiles`
cache I/O and any other async work scheduled there stalls too. The slowdown is not confined to sandbox runs.

**2. Gathered renders are serial.** `Project.render_async()` (`project.py:1179`) builds a coroutine for every
shape × format combination and `asyncio.gather`s them on one loop (`project.py:1220`). They all share that
thread's single `asyncio.Lock` from `get_async_lock()`, so `gather` executes them strictly one at a time.

### The lock is not gratuitous

`runtime_python.py:511-523` documents a real hazard: installing `build123d` pulls `cadquery-ocp-novtk`, which
overwrites the very same OCP native module `cadquery-ocp` installs. An install slipping in between another
part's `CADQUERY_OCP` re-assertion and its actual run leaves that run importing a half-installed OCP and dying
with an unrelated-looking `ImportError`. **That hazard must survive this change.**

But the mutual exclusion it motivates is *(venv, install-vs-run)*, while what is implemented is *(runtime, any
run)* — and sessionless runs, which install nothing at that point, are serialized along with everything else.

### What is *not* the problem

- Not `FileLock` contention: that is cross-process, and this reproduces in a single process.
- Not thread-pool sizing: the pool is sized correctly (`sync_threads.py:44-70`), it is simply blocked.
- Not `Shape.get_wrapped()`'s own lock (`shape.py:209`), though it has the same blocking-lock-across-`await`
  shape and is worth fixing in passing (task 5.3). Its scope is one shape, so it does not serialize unrelated
  work.

---

## One claim that is unverified

`VenvLock` builds its `FileLock` with `thread_local=False` (`runtime_python.py:146`). Reading `filelock`'s
semantics, that keeps the reentrancy counter shared across threads rather than thread-local, which would mean a
second thread's `acquire()` on an already-held lock object increments the counter and returns immediately —
i.e. `VenvLock` provides **no intra-process mutual exclusion today**, and all of it comes from the `RLock`.

That reading was not verified against the pinned `filelock` version. **Task 1.4 settles it before anything is
designed around it.** It is called out here so it is not mistaken for an established fact.

---

## Proposed direction (details in `design.md`)

- **D1** — a readers/writer gate keyed on the environment being mutated. Writers: `ensure*` when the install
  guard is absent, and v-env creation. Readers: runs that install nothing. A run holds a read on the sandbox
  key and, when a session is in play, on the v-env key — in that order, so no cycle is possible. Keep
  `runtime_python_conda.py`'s global conda lock outermost.
- **D2a** (recommended) — keep `threading` primitives for cross-thread coordination but acquire them off-loop
  (`await asyncio.to_thread(...)`), so waiting parks the coroutine instead of freezing the thread. D2b (one
  owner loop, `asyncio` primitives throughout) is cleaner long-term but a much larger blast radius.
- **D3** — an explicit process-wide concurrency cap from `user_config.threads_max`. Removing the lock uncovers
  unbounded fan-out; each sandbox process is CPU- and memory-heavy, so this is resource correctness, not polish.
- **D4** — leave the guard/reassert bookkeeping (`invalidate_dependent_guards()`, `needs_reassert()`,
  `FORCE_REINSTALL_FLAGS`) alone. A diff touching both is very hard to review.

Three open questions are recorded at the end of `design.md` for whoever implements this.

---

## How to measure

No benchmark exists in the repo, so **task 2 builds the baseline before any code is written**. `design.md`
carries a self-contained recipe needing no telemetry backend: monkeypatch `PythonRuntime.run_async_onced` to
record `(start, end)` spans, then report wall clock, total sandbox busy time, run count, and peak overlap.

- **Expected reading today:** `peak_overlap == 1` and `busy ≈ wall`. That is the signature of full
  serialization, and it is the "before" number to paste into this PR.
- **Acceptance:** `peak_overlap` reaches `min(runs, cap)`, and wall clock for N independent parts drops toward
  `busy / peak_overlap` plus overhead. **State the machine's core count** — the result is meaningless without
  it.

Workload: packages under `examples/` (`produce_part_step`, `produce_part_cadquery_primitive`,
`produce_part_build123d_primitive`, `produce_assembly_assy`). A mixed CadQuery/build123d package is both the
interesting performance case and the race case.

---

## Risks the implementer must handle

| Risk | Mitigation |
|---|---|
| Reintroducing the OCP-clobbering race — it manifests as a native crash with **no traceback and no stderr** | Task 4 is a dedicated regression test; assert on that exact signature, which `runtime_python.py:601-616` already diagnoses |
| Deadlock from mixed ordering with `runtime_python_conda.py`'s global conda lock | D1's fixed acquisition order; task 3.5 audits every acquisition site |
| Memory exhaustion once many OCP interpreters run at once | D3's semaphore; task 6.4 records peak RSS |
| A race that reproduces one time in ten lands green | Task 4.3 runs the regression ≥20 times, under `pytest -n 4` |

---

## Relationship to the other two proposals

Three independent findings, three independent PRs, no ordering dependency between them:

- **This one** lets sandbox work spread across cores.
- **`sandbox-process-reuse`** reduces how much sandbox work there is (7 interpreter starts for one transformed
  part rendered to 4 formats). It is complementary — this PR is a prerequisite for its benefit being visible on
  a multi-core machine, but neither subsumes the other.
- **`shape-cache-efficiency`** lowers the incremental-rebuild floor (a cache hit currently reads and MD5s the
  whole source model).

---

## Validation status

Only markdown under `openspec/changes/` is added — no Python is touched, so `pytest`/`behave` outcomes are
unaffected. **The pre-commit hooks did not run locally:** this session's container has no working Docker daemon,
so the dev container documented in the root `AGENTS.md` could not be started, and host-level `pre-commit` is
deliberately not used (host tool versions are not the pinned ones). CI will run the gates. Everything in
`tasks.md` is written to be run inside the dev container.


---
_Generated by [Claude Code](https://claude.ai/code/session_018enkjjYJCdP34QJKxDVSbt)_