### PR TITLE
perf(sandbox): proposal — amortize the cost of starting a CAD interpreter

### DIFF
--- a/openspec/changes/sandbox-process-reuse/.openspec.yaml
+++ b/openspec/changes/sandbox-process-reuse/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/sandbox-process-reuse/design.md
+++ b/openspec/changes/sandbox-process-reuse/design.md
@@ -1,0 +1,174 @@
+## Context
+
+This document is written for an implementer picking the work up cold. It records what was found, how the pieces
+fit together, and which claims are estimates rather than measurements.
+
+### The invocation protocol as it exists today
+
+Every wrapper is a standalone script run as `python -sOOIu wrapper_<x>.py <path> [<cwd>]`, whose stdin carries
+one serialized request and whose stdout carries one serialized response. `wrapper_common.handle_input()`
+(`partcad/src/partcad/wrappers/wrapper_common.py:26`) reads stdin **to EOF** and deserializes the whole thing;
+`handle_output()` writes the response and flushes. `deserialize()` takes the *last non-empty line* of the
+output (`shape_envelope.py`, `deserialize`), which is how stray wrapper stdout is tolerated.
+
+Two properties of that protocol matter here:
+
+- It is one-shot and EOF-terminated. Reuse requires framing, because a warm host cannot read to EOF.
+- The core never holds a live OCP object. `shape_envelope.py` (core side) keeps shapes as opaque
+  `{"name", "label", "brep"}` dicts; only `wrappers/ocp_serialize.py` (sandbox side) turns them back into
+  geometry. That invariant is the point of the split and must survive any change here.
+
+### Where the invocations come from
+
+| Operation | Site | Notes |
+|---|---|---|
+| Instantiate a part | `part_factory_{step,brep,3mf,sdf,extrude,sweep,scad,wrapper}.py` | One per part |
+| `offset` | `shape.py:252` via `transform.py:33` | Separate process, *after* instantiation |
+| `scale` | `shape.py:254` via `transform.py:33` | Another separate process |
+| `compound` | `part_factory_wrapper.py:174` via `transform.py:33` | Another |
+| Render, per format | `shape.py:842`, inside the loop at `shape.py:765` | One process **per format** |
+| Render SVG (thumbnail path) | `shape.py:617` | Yet another |
+
+`Shape.render_async()` is worth reading closely (`shape.py:702-875`): `obj = await self.get_wrapped(ctx)` is
+fetched **once** at line 757, and then the loop re-serializes that same `obj` at line 828 and ships it to a new
+interpreter at line 842 for each format. Note also the latent bug at line 832 — `dependencies =
+WRAPPER_FORMATS[format_name]` uses the *outer* `format_name`, not the loop's `format`, so the multi-format path
+(`format_name=None`) would raise `KeyError: None`. In practice only the single-format path is exercised. Batching
+removes this footgun rather than fixing it in place; say so in the PR so it is not mistaken for an unrelated
+drive-by.
+
+### The per-invocation preamble
+
+Each invocation re-walks the dependency-assurance chain — five `ensure_async` calls in
+`part_factory_3mf.py:54-60`, `part_factory_scad.py:232-238` and `part_factory_wrapper.py:114-120`, and the
+per-format list in `shape.py:836-837`. Each of those re-enters `once_async()` (`runtime_python.py:331`), which
+re-takes the runtime locks and stats guard files. Individually cheap (a few stats and a lock cycle); the point
+is that it is paid once per operation, and the whole thrust of this change is to have fewer operations.
+
+The installs are correctly *ordered* rather than gathered, and the comments explaining why
+(`shape.py:833-835`, `runtime_python.py:36-68`) are load-bearing: build123d pulls `cadquery-ocp-novtk`, which
+overwrites the OCP native module `cadquery-ocp` installs, so `CADQUERY_OCP` must be re-asserted last. Do not
+"optimize" that into an `asyncio.gather`.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One sandbox invocation per shape for all of its exports.
+- No dedicated invocation for a transform that the producing invocation could have applied itself.
+- A supported way to keep an interpreter warm and serve many requests from it, with the daemon as its owner.
+- Every step independently measurable, and independently revertable.
+
+**Non-Goals**
+
+- Overlapping sandbox operations (sibling proposal: `sandbox-run-concurrency`).
+- Cheaper cache hits (sibling proposal: `shape-cache-efficiency`).
+- Any relaxation of the "core never imports OCP" rule.
+- Changing pinned CAD-stack versions.
+
+## Decisions
+
+### D1 — Step 1: batch the formats (do this first)
+
+Change `Shape.render_async()` to collect `(format, filepath, options)` for every requested format, install the
+union of the formats' dependency lists **in a dependency-safe order**, and issue one invocation carrying the
+list. A new `wrapper_render.py` dispatches to the existing per-format exporters, which stay where they are.
+
+Two details that will bite:
+
+- **Dependency ordering across a union.** `WRAPPER_FORMATS` (`shape.py:714-747`) is per-format and each list is
+  already ordered so `CADQUERY_OCP` lands last. Unioning them naively can break that. Compute the union, then
+  re-impose the invariant explicitly rather than relying on iteration order.
+- **Partial failure.** Today one format failing leaves the others unaffected because they are separate
+  processes. After batching, the response must report per-format success/failure, and a failure in one exporter
+  must not abort the rest. Mirror the existing error surface: `result["success"]` plus `result["exception"]`,
+  now per format.
+
+Expected win: for a shape rendered to N formats, N cold CAD-stack imports and N BREP decodes collapse to one.
+
+### D2 — Step 2: fold transforms into the producing invocation
+
+`Shape.get_wrapped()` applies `offset`/`scale` at `shape.py:248-254` by round-tripping the shape through
+`transform.offset` and then `transform.scale` — two extra processes, each of which decodes and re-encodes the
+whole payload.
+
+Add an optional `transform` field to the instantiation request that a wrapper applies before it serializes its
+result. Keep `transform.py` intact as the fallback for the cases where there is no producing invocation to fold
+into: a shape served from the cache, and any factory not yet updated. Guard the fold behind a per-factory
+capability flag so factories can be converted one at a time instead of in one large diff.
+
+**Cache-key warning.** `Shape.__init__` already folds `offset` and `scale` into the cache hash
+(`shape.py:144-149`), so a shape's cached entry is keyed on its transform. Applying the transform earlier does
+not change the key — but verify it, because getting this wrong silently serves untransformed geometry.
+
+### D3 — Step 3: warm wrapper hosts
+
+A host process per (runtime, v-env) that imports the CAD stack once, then loops: read one framed request,
+dispatch it to the same wrapper entry points used today, write one framed response.
+
+- **Framing.** The current protocol is EOF-terminated and cannot be reused as-is. Use length-prefixed frames.
+  Keep the *body* encoding exactly as it is (`shape_envelope` / `ocp_serialize`) so only the transport changes.
+- **Ownership and lifetime.** The daemon (`partcad-service-json-rpc`) already owns the runtimes and the warm
+  PartCAD context (root `CLAUDE.md`), so hosts kept there survive across `pc` commands. A non-daemon `pc` run
+  must keep working, with hosts scoped to that process's lifetime — do not make the daemon a hard requirement.
+- **Invalidation.** A host must be retired when the environment beneath it changes: any install into its
+  sandbox or v-env, in particular one that trips `invalidate_dependent_guards()` (`runtime_python.py:83`).
+  A host holding an OCP module that has since been overwritten on disk is exactly the failure the guard
+  bookkeeping exists to prevent. This interacts directly with the sibling `sandbox-run-concurrency` proposal's
+  readers/writer gate — a host is a long-lived *reader*.
+- **Crash isolation.** A wrapper that segfaults today kills one operation. In a warm host it kills every
+  queued request on that host. Detect the death, restart the host, and retry the in-flight request **once**;
+  a second failure is a genuine error and must surface as one.
+- **State bleed.** Wrappers today get a fresh interpreter each time and may rely on it. `wrapper_common`
+  keeps module-level `_request_name`/`_request_label` (`wrapper_common.py:22-23`); `ocp_serialize` keeps
+  `_zstd_warned` and the lazily-built `downcast_LUT`. Audit every wrapper for module-level mutable state and
+  reset per request. `os.chdir()` in `handle_input()` (`wrapper_common.py:43`) is process-global and a
+  particularly sharp edge.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Batching changes error semantics: one bad format takes down the others | D1's per-format result reporting; a test that renders a good and a deliberately failing format together |
+| The frozen PyInstaller bundle misses a new wrapper file | Read `dev-tools/pyinstaller/README.md` first; task 6.5 tests the built bundle, not just the wheels |
+| A warm host serves a request against a clobbered OCP | D3's invalidation rule, tied to the install guards |
+| Cross-request state bleed produces wrong geometry rather than an error | D3's audit; task 5.4 asserts identical output for a request run alone vs. run after others on the same host |
+| Step 3 balloons and blocks steps 1-2 from shipping | Ship 1 and 2 first, each with its own measurement |
+
+## How to measure
+
+Same harness as the sibling proposal — monkeypatch `PythonRuntime.run_async_onced` to record spans — but the
+headline number here is the **count**, not the overlap:
+
+```python
+print(f"wall={wall:.1f}s  sandbox_busy={busy:.1f}s  runs={len(spans)}")
+```
+
+Also measure the fixed cost each of those runs pays, inside a provisioned sandbox:
+
+```bash
+# path from ctx.get_python_runtime("3.11").path
+<sandbox>/bin/python -X importtime -c "import build123d, cadquery" 2>&1 | tail -1
+```
+
+Multiply the two. That product is the budget this change is going after.
+
+**Expected today** for one part with `offset` + `scale`, rendered to svg + step + stl + 3mf: `runs == 7`.
+**After step 1:** 4. **After step 2:** 2. **After step 3:** the CAD-stack import is paid once per host, not per
+run.
+
+Report the run count and wall clock at each step separately. A single before/after number spanning all three
+steps hides which one actually paid off.
+
+## Open questions for the implementer
+
+1. Should batching extend across *shapes* as well as formats — one invocation exporting many parts? It would
+   amortize further, but it couples unrelated shapes' failures and complicates progress reporting. Probably a
+   later step; note the decision either way.
+2. How long should a warm host live when idle, and how many should exist per v-env? One is simplest; a small
+   pool interacts better with `sandbox-run-concurrency`'s cap.
+3. Should `wrapper_common.handle_input()` grow the framed mode, or should a new host module wrap the existing
+   entry points without touching them? The latter keeps one-shot invocation working unchanged and is likely the
+   safer path.
+4. Does the daemon's existing lifecycle (`pc daemon start`/`stop`) need new surface to report or reset warm
+   hosts, e.g. for `pc status`?

--- a/openspec/changes/sandbox-process-reuse/proposal.md
+++ b/openspec/changes/sandbox-process-reuse/proposal.md
@@ -1,0 +1,84 @@
+## Why
+
+PartCAD does its geometry work in sandboxed Python subprocesses, and it starts a **brand new interpreter for
+every individual operation**. Each one imports the CAD stack (OCP, and usually build123d and/or CadQuery) from
+cold before it does any work. For anything but a very large model, that import dominates the wall clock.
+
+There is more than one such operation per shape. Counting the invocation sites:
+
+- **Instantiation** — one subprocess per part: `part_factory_step.py:44`, `part_factory_brep.py:51`,
+  `part_factory_3mf.py:68`, `part_factory_sdf.py:84`, `part_factory_extrude.py:80`,
+  `part_factory_sweep.py:95`, `part_factory_scad.py:246`, `part_factory_wrapper.py:135`.
+- **Transforms** — `offset`, `scale` and `compound` each spawn their own subprocess through `transform._run()`
+  (`transform.py:33-55`). `Shape.get_wrapped()` calls `offset` and `scale` as two separate invocations
+  (`shape.py:252` and `shape.py:254`), *after* instantiation has already finished in a third.
+  `PartFactoryWrapper.instantiate()` adds a `compound` call (`part_factory_wrapper.py:174`).
+- **Rendering** — one subprocess **per format**. `Shape.render_async()` loops over formats
+  (`shape.py:765`) and inside the loop re-serializes the same payload (`shape.py:828`) and spawns a fresh
+  interpreter (`shape.py:842`). `render_svg_somewhere()` (`shape.py:617`) is another.
+
+So one file-backed part carrying `offset` and `scale`, rendered to svg + step + stl + 3mf, costs **seven**
+interpreter starts — seven cold imports of OCP, seven trips through the `ensure_async` chain, and seven
+serializations of the same BREP payload. The render loop is the most obviously wasteful of these: the wrapper
+decodes the shape, exports one format, exits, and the next invocation decodes the identical bytes again.
+
+Each invocation also re-walks the dependency-assurance chain. `part_factory_3mf.py:54-60` issues five
+`ensure_async` calls before its single run; every one of them re-enters `once_async()`
+(`runtime_python.py:331`), which re-takes the runtime locks and stats guard files. The same five-call preamble
+appears in `part_factory_scad.py:232-238`, `part_factory_wrapper.py:114-120` and `shape.py:836-837`.
+
+This is the largest remaining cost after sandbox runs are allowed to overlap at all (see the sibling proposal
+`sandbox-run-concurrency`, which is a prerequisite for the benefit here being visible on a multi-core machine).
+
+## What Changes
+
+Three steps, deliberately ordered so each is independently shippable and independently measurable:
+
+1. **Batch the render formats.** One wrapper invocation per shape that exports every requested format, instead
+   of one per format. The wrapper already holds the decoded shape; today that decode is discarded and redone.
+2. **Fold the transforms into the producing invocation.** Carry `offset`/`scale` in the request that produces
+   the shape rather than spawning two further processes to post-process it, keeping `transform.py` as the
+   fallback for shapes that arrive from the cache or from a factory that cannot apply them inline.
+3. **Reuse warm interpreters.** A persistent wrapper host per (runtime, v-env): a process that imports the CAD
+   stack once and then serves length-prefixed requests over its stdin/stdout for as long as it is useful.
+   `partcad-service-json-rpc` already owns the runtimes for the daemon's lifetime, so warm hosts kept there
+   survive across `pc` commands, not merely within one.
+
+Steps 1 and 2 are contained and low-risk. Step 3 is the large one and should not start until 1 and 2 have
+landed and been measured.
+
+Not a user-visible behavior change: the same shapes and the same exported files, from the same inputs.
+
+## Capabilities
+
+### New Capabilities
+
+- `sandbox-process-reuse`: The requirement that the cost of starting a sandbox interpreter and importing the CAD
+  stack is amortized rather than paid per operation — that a shape's exports share one invocation, that
+  transformations do not each require their own, and that interpreters may be kept warm and reused across
+  operations without weakening the isolation the sandbox provides.
+
+## Impact
+
+- **Modified**: `partcad/src/partcad/shape.py` — `render_async()`'s per-format loop, and the `offset`/`scale`
+  application in `get_wrapped()`.
+- **Modified**: `partcad/src/partcad/wrappers/wrapper_render_*.py` — accept a list of output formats in one
+  request. Check `dev-tools/pyinstaller/README.md` before adding or renaming any wrapper file: the frozen
+  bundle collects them explicitly and a new file can be invisible to it while the wheels stay fine.
+- **Modified**: `partcad/src/partcad/transform.py` — remains the fallback path; gains no new responsibilities.
+- **Modified (step 3)**: `partcad/src/partcad/runtime_python.py`, plus a new wrapper-host module and its
+  counterpart in `partcad-service-json-rpc`.
+- **New specs**: `openspec/specs/sandbox-process-reuse/spec.md`.
+- **Unchanged**: the envelope format itself (`shape_envelope.py` / `wrappers/ocp_serialize.py`) — the request
+  and response bodies grow fields, but the encoding is untouched.
+
+## Non-Goals
+
+- Allowing sandbox operations to overlap. That is the sibling proposal `sandbox-run-concurrency`; this change
+  reduces the amount of work, that one lets the work spread across cores. They are complementary and neither
+  subsumes the other.
+- Reducing the cost of a cache hit; see the sibling proposal `shape-cache-efficiency`.
+- Weakening sandbox isolation, or letting the core process import OCP. The core carries opaque BREP envelopes
+  and must keep doing so (`shape_envelope.py` header).
+- Changing which packages get installed into a sandbox, or their pinned versions
+  (`sandbox_versions.PINNED_REQUIREMENTS`).

--- a/openspec/changes/sandbox-process-reuse/specs/sandbox-process-reuse/spec.md
+++ b/openspec/changes/sandbox-process-reuse/specs/sandbox-process-reuse/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: A shape's exports share one sandbox invocation
+Exporting a shape to several formats SHALL require one sandbox invocation, not one per format. The shape's
+geometry SHALL be decoded once per export request regardless of how many formats it produces.
+
+#### Scenario: One shape is rendered to several formats
+- **WHEN** a shape is rendered to more than one format in a single request
+- **THEN** exactly one sandbox process is started for that shape's exports
+
+#### Scenario: One exporter fails among several
+- **WHEN** one requested format fails to export and the others succeed
+- **THEN** the successful outputs are written, and the failure is reported for that format alone rather than
+  aborting the remaining formats
+
+### Requirement: Transformations do not require dedicated sandbox invocations
+Applying a shape's configured `offset` or `scale` SHALL NOT require a sandbox invocation separate from the one
+that produced the shape, where a producing invocation exists.
+
+#### Scenario: A part declares both an offset and a scale
+- **WHEN** a part configured with both `offset` and `scale` is instantiated
+- **THEN** no additional sandbox process is started to apply either transformation
+
+#### Scenario: A transformed shape is served from the cache
+- **WHEN** a shape carrying a transformation is served from the cache, so no producing invocation runs
+- **THEN** the transformation is still applied correctly
+
+#### Scenario: A transformation changes
+- **WHEN** a shape's `offset` or `scale` configuration changes
+- **THEN** its cached entry is invalidated, and the newly configured transformation is reflected in the result
+
+### Requirement: Sandbox interpreters may be reused across operations
+The system SHALL support serving more than one operation from a single sandbox interpreter, so that the cost of
+starting the interpreter and importing the CAD stack is amortized rather than paid per operation.
+
+#### Scenario: Several operations run in one environment
+- **WHEN** several sandbox operations are requested against the same provisioned environment
+- **THEN** they may be served by the same interpreter without it being restarted between them
+
+#### Scenario: No daemon is running
+- **WHEN** an operation runs without the background daemon
+- **THEN** it still completes correctly, with any reuse scoped to the lifetime of the process that requested it
+
+### Requirement: A reused interpreter does not observe another operation's state
+An interpreter serving more than one operation SHALL produce, for any given request, the same result it would
+produce as the first request that interpreter served.
+
+#### Scenario: The same request is repeated on a warm interpreter
+- **WHEN** a request is served by an interpreter that has already served other, unrelated requests
+- **THEN** its output is identical to the output of the same request served by a freshly started interpreter
+
+### Requirement: A reused interpreter is retired when its environment changes
+An interpreter SHALL NOT continue serving requests after the environment it was started in has been modified by
+a package install, so that it can never execute against files that have since been replaced on disk.
+
+#### Scenario: A package is installed into an environment with a live interpreter
+- **WHEN** a package is installed into a sandbox or v-env that a reused interpreter was started in
+- **THEN** that interpreter is retired, and subsequent operations are served by an interpreter started after the
+  install
+
+### Requirement: An interpreter crash does not silently lose an operation
+If a reused interpreter terminates unexpectedly, the system SHALL restart it and retry the interrupted
+operation once. A second failure SHALL be reported as an error rather than retried indefinitely or ignored.
+
+#### Scenario: An interpreter dies mid-request
+- **WHEN** an interpreter serving a request terminates abnormally
+- **THEN** the request is retried once on a fresh interpreter, and a repeated failure is surfaced to the caller
+
+### Requirement: The core process still holds no live geometry
+Reusing interpreters SHALL NOT change where geometry lives: the core process SHALL continue to carry shapes as
+opaque BREP envelopes and SHALL NOT import the OCP library.
+
+#### Scenario: A full render completes in the core process
+- **WHEN** a package is rendered from a process that imported PartCAD
+- **THEN** the OCP library is never imported into that process

--- a/openspec/changes/sandbox-process-reuse/tasks.md
+++ b/openspec/changes/sandbox-process-reuse/tasks.md
@@ -1,0 +1,97 @@
+## 1. Confirm the finding and establish the baseline
+
+- [ ] 1.1 Bring up the dev container (root `AGENTS.md`, "Where commands run") — everything below runs inside it
+- [ ] 1.2 Instrument `PythonRuntime.run_async_onced` to count and time invocations (recipe in `design.md`,
+      "How to measure"); confirm a part with `offset` + `scale` rendered to four formats costs seven runs
+- [ ] 1.3 Measure the fixed per-run cost: `python -X importtime -c "import build123d, cadquery"` inside a
+      provisioned sandbox. Record the number and the machine
+- [ ] 1.4 Record the baseline (`runs`, `sandbox_busy`, `wall`) for two workloads: a single multi-format part,
+      and a whole package (`pc --no-ansi render`)
+- [ ] 1.5 Confirm the latent bug at `shape.py:832` — `WRAPPER_FORMATS[format_name]` inside a loop over `format`
+      — by calling `render_async` with `format_name=None` and observing `KeyError: None`. Note it in the PR;
+      step 2 removes the loop rather than patching it
+- [ ] 1.6 Paste the baselines into the PR description before writing implementation code
+
+## 2. Step 1 — batch the render formats
+
+- [ ] 2.1 Read `Shape.render_async()` (`shape.py:702-875`) in full, including `render_getopts()`
+      (`shape.py:642`), so per-format path and option resolution is understood before it moves
+- [ ] 2.2 Restructure `render_async` to resolve every requested format up front into
+      `(format, final_filepath, request_options)` and issue a single invocation
+- [ ] 2.3 Compute the union of `WRAPPER_FORMATS` dependency lists, then **re-impose** the ordering invariant so
+      `CADQUERY_OCP` is asserted last (`shape.py:714-747` and the note at `shape.py:833-835`)
+- [ ] 2.4 Add `wrapper_render.py` dispatching to the existing `wrapper_render_<format>.py` exporters; do not
+      rewrite the exporters themselves
+- [ ] 2.5 Define the multi-format response: per-format `success` / `exception`, so one failing exporter does not
+      abort the others. Keep the single-format response shape backward compatible
+- [ ] 2.6 Update the callers: `Project.render_async()` (`project.py:1179-1220`) currently creates one coroutine
+      per shape *per format* — it should now create one per shape
+- [ ] 2.7 Leave `render_svg_somewhere()` (`shape.py:565-640`) alone in this step; fold it in only if it falls
+      out cleanly
+- [ ] 2.8 Read `dev-tools/pyinstaller/README.md` and make whatever entry it requires for the new wrapper file
+- [ ] 2.9 Re-measure: run count for the four-format part should drop from 7 to 4
+
+## 3. Step 2 — fold transforms into the producing invocation
+
+- [ ] 3.1 Read `Shape.get_wrapped()` (`shape.py:208-270`) and `transform.py` in full
+- [ ] 3.2 Add an optional `transform` field to the instantiation request, applied inside the wrapper before it
+      serializes its result
+- [ ] 3.3 Add a per-factory capability flag so factories convert one at a time; unconverted factories keep using
+      `transform.py`
+- [ ] 3.4 Keep `transform.py` as the fallback for shapes served from the cache, where there is no producing
+      invocation to fold into
+- [ ] 3.5 **Verify the cache key is unaffected.** `Shape.__init__` folds `offset`/`scale` into the hash
+      (`shape.py:144-149`). Add a test that a part with a transform and the same part without one produce
+      different cache entries, and that changing the transform value invalidates the entry
+- [ ] 3.6 Convert `PartFactoryWrapper`'s `compound` call (`part_factory_wrapper.py:162-177`) so a multi-shape
+      wrapper result is compounded in the invocation that produced it
+- [ ] 3.7 Re-measure: run count for the four-format part should drop from 4 to 2
+
+## 4. Step 3 — warm wrapper hosts (do not start before 2 and 3 have landed)
+
+- [ ] 4.1 Design the framing (`design.md` D3): length-prefixed frames, body encoding unchanged
+- [ ] 4.2 Add the host process and a client that speaks to it, keeping one-shot invocation working unchanged as
+      the fallback
+- [ ] 4.3 Audit every wrapper for module-level mutable state and reset it per request. Known instances:
+      `wrapper_common._request_name` / `_request_label` (`wrapper_common.py:22-23`),
+      `ocp_serialize._zstd_warned` and `downcast_LUT`, and the process-global `os.chdir()` at
+      `wrapper_common.py:43`
+- [ ] 4.4 Implement host invalidation: retire a host on any install into its sandbox or v-env, especially one
+      that trips `invalidate_dependent_guards()` (`runtime_python.py:83`)
+- [ ] 4.5 Implement crash handling: detect host death, restart, retry the in-flight request **once**, and
+      surface a second failure as a real error
+- [ ] 4.6 Wire host ownership into `partcad-service-json-rpc` so hosts survive across `pc` commands; confirm a
+      non-daemon `pc` run still works with hosts scoped to its own lifetime
+- [ ] 4.7 Coordinate with `sandbox-run-concurrency` if it has landed: a warm host is a long-lived *reader* of
+      its environment and must participate in that gate
+
+## 5. Correctness
+
+- [ ] 5.1 Golden-output test: for each supported format, the file produced by the batched path is byte-identical
+      to the one produced today (or geometrically equivalent where an exporter embeds a timestamp)
+- [ ] 5.2 A render where one format fails and the others succeed still writes the successful outputs and reports
+      the failure
+- [ ] 5.3 A shape with `offset` and `scale` produces identical geometry through the folded path and the
+      `transform.py` fallback
+- [ ] 5.4 State-bleed test for step 3: a request run alone and the same request run after several others on the
+      same warm host produce identical output
+- [ ] 5.5 Confirm the core still never imports OCP: `import partcad` followed by a full render must leave `OCP`
+      absent from `sys.modules` in the core process
+
+## 6. Validate
+
+- [ ] 6.1 `poetry run pytest partcad partcad-cli -x -p no:error-for-skips -p no:warnings --dist no`
+- [ ] 6.2 `poetry run behave` — `features/render.feature` and `features/export.feature` are the relevant ones
+- [ ] 6.3 Re-run the measurement harness and record run count and wall clock **per step**, next to the baseline
+- [ ] 6.4 Record peak RSS: warm hosts hold the CAD stack resident between requests, which is the trade being made
+- [ ] 6.5 Build and smoke-test the PyInstaller bundle (`dev-tools/pyinstaller/README.md`). A missing wrapper file
+      breaks the frozen bundle while the wheels stay green — this is the failure mode that will not show up in CI
+      unless it is tested for
+
+## 7. Land it
+
+- [ ] 7.1 Remove or promote the measurement harness — do not leave it half-committed
+- [ ] 7.2 Move the delta spec into `openspec/specs/sandbox-process-reuse/spec.md`
+- [ ] 7.3 Run `pre-commit run --config dev-tools/pre-commit-config.yaml` inside the container and re-stage
+      anything the formatting hooks rewrote
+- [ ] 7.4 Commit inside the container; verify with `git log -1 --stat`


### PR DESCRIPTION
## Copilot Summary

**This PR contains a proposal only — no behavior change.** It adds an OpenSpec change under
`openspec/changes/sandbox-process-reuse/` (`proposal.md`, `design.md`, `tasks.md`, and a delta spec) recording a
performance finding in `partcad/` together with a three-step design, a measurement recipe, and the correctness
work each step needs. It is one of three sibling proposals from the same read-through; see "Relationship to the
other two" below.

The implementation is deliberately not included: the finding should be measured on real hardware before code is
written, and `tasks.md` starts with exactly that. **Work through `tasks.md` in order — it is the handoff.**

---

## The finding

PartCAD starts a **brand new interpreter for every individual geometry operation**, and each one imports the CAD
stack (OCP, usually build123d and/or CadQuery) from cold before doing any work. For anything but a very large
model, that import dominates the wall clock.

There is more than one such operation per shape:

| Operation | Site | Notes |
|---|---|---|
| Instantiate a part | `part_factory_{step,brep,3mf,sdf,extrude,sweep,scad,wrapper}.py` | One per part |
| `offset` | `shape.py:252` via `transform.py:33` | Separate process, **after** instantiation |
| `scale` | `shape.py:254` via `transform.py:33` | Another separate process |
| `compound` | `part_factory_wrapper.py:174` via `transform.py:33` | Another |
| Render, per format | `shape.py:842`, inside the loop at `shape.py:765` | One process **per format** |
| Render SVG (thumbnail path) | `shape.py:617` | Yet another |

So one file-backed part carrying `offset` and `scale`, rendered to svg + step + stl + 3mf, costs **seven**
interpreter starts — seven cold OCP imports, seven trips through the `ensure_async` chain, and seven
serializations of the same BREP payload.

The render loop is the most visibly wasteful. `Shape.render_async()` fetches the shape **once** at
`shape.py:757`, then re-serializes that same object at `shape.py:828` and ships it to a **new** interpreter at
`shape.py:842` for each format. The wrapper decodes the shape, exports one format, exits — and the next
invocation decodes the identical bytes again.

Each invocation also re-walks the dependency-assurance chain: five `ensure_async` calls in
`part_factory_3mf.py:54-60`, `part_factory_scad.py:232-238` and `part_factory_wrapper.py:114-120`, plus the
per-format list at `shape.py:836-837`. Each re-enters `once_async()` (`runtime_python.py:331`), re-taking the
runtime locks and stat'ing guard files. Individually cheap; the point is that it is paid *per operation*.

### A latent bug found in the same code

`shape.py:832` reads `dependencies = WRAPPER_FORMATS[format_name]` — the **outer** `format_name`, not the loop
variable `format`. With `format_name=None` (the "render every format" path) this raises `KeyError: None`. In
practice only the single-format path is exercised, where the two are equivalent. Step 1 removes the loop rather
than patching the line; flagged here so it is not mistaken for an unrelated drive-by. Task 1.5 reproduces it
first.

### Constraints that must not be broken

- **The core never holds live geometry.** `shape_envelope.py` (core side) keeps shapes as opaque
  `{"name", "label", "brep"}` dicts; only `wrappers/ocp_serialize.py` turns them back into geometry. That split
  is the point and must survive.
- **Install ordering is load-bearing, not incidental.** `shape.py:833-835` and `runtime_python.py:36-68`
  explain why `CADQUERY_OCP` must be re-asserted **last**: build123d pulls `cadquery-ocp-novtk`, which
  overwrites the OCP native module. Do not "optimize" the ordered installs into an `asyncio.gather`.
- **The protocol is one-shot and EOF-terminated.** `wrapper_common.handle_input()`
  (`wrappers/wrapper_common.py:26`) reads stdin to EOF. Reuse therefore requires framing.

---

## Proposed direction — three steps, each independently shippable

Ordered so each ships and measures on its own. **Do not start step 3 until 1 and 2 have landed and been
measured.**

### Step 1 — batch the render formats
One invocation per shape exporting every requested format, with a new `wrapper_render.py` dispatching to the
existing per-format exporters (which stay put). Two details that will bite:
- **Dependency ordering across a union.** `WRAPPER_FORMATS` (`shape.py:714-747`) is ordered per format so
  `CADQUERY_OCP` lands last. Unioning naively breaks that — compute the union, then re-impose the invariant.
- **Partial failure.** Today one failing format cannot affect the others because they are separate processes.
  After batching, the response needs per-format `success`/`exception`, and one exporter failing must not abort
  the rest.

### Step 2 — fold transforms into the producing invocation
An optional `transform` field on the instantiation request, applied inside the wrapper before it serializes.
`transform.py` stays as the fallback for shapes served from the cache and for factories not yet converted; a
per-factory capability flag lets them convert one at a time.

**Cache-key warning:** `Shape.__init__` already folds `offset`/`scale` into the hash (`shape.py:144-149`).
Applying the transform earlier should not change the key — but verify it (task 3.5), because getting this wrong
silently serves untransformed geometry.

### Step 3 — warm wrapper hosts
A host per (runtime, v-env) that imports the CAD stack once, then serves length-prefixed frames. Body encoding
stays exactly as it is; only the transport changes. Four things to get right:
- **Ownership** — `partcad-service-json-rpc` already owns runtimes and the warm context, so hosts kept there
  survive across `pc` commands. A non-daemon `pc` run must still work, with hosts scoped to its lifetime.
- **Invalidation** — retire a host on any install into its environment, especially one tripping
  `invalidate_dependent_guards()` (`runtime_python.py:83`). A host holding an OCP module since overwritten on
  disk is exactly the failure the guard bookkeeping exists to prevent.
- **Crash isolation** — a segfault today kills one operation; on a warm host it kills everything queued. Detect,
  restart, retry **once**; a second failure is a real error.
- **State bleed** — wrappers currently get a fresh interpreter and may rely on it. Known module-level state:
  `wrapper_common._request_name`/`_request_label` (`wrapper_common.py:22-23`), `ocp_serialize._zstd_warned` and
  the lazily-built `downcast_LUT`, and the process-global `os.chdir()` at `wrapper_common.py:43`.

Four open questions are recorded at the end of `design.md`.

---

## How to measure

Same harness as the sibling concurrency proposal — monkeypatch `PythonRuntime.run_async_onced` — but the
headline number here is the **count**, not the overlap. Also measure the fixed cost each run pays, inside a
provisioned sandbox:

```bash
<sandbox>/bin/python -X importtime -c "import build123d, cadquery" 2>&1 | tail -1
```

Multiply the two: that product is the budget this change goes after.

- **Expected today** for one part with `offset` + `scale` rendered to four formats: `runs == 7`
- **After step 1:** 4 &nbsp;·&nbsp; **After step 2:** 2 &nbsp;·&nbsp; **After step 3:** the CAD-stack import is
  paid once per host, not per run

**Report run count and wall clock per step.** A single before/after number spanning all three hides which one
actually paid off.

---

## Risks the implementer must handle

| Risk | Mitigation |
|---|---|
| Batching changes error semantics — one bad format takes down the others | Per-format result reporting; test a good and a deliberately failing format together (task 5.2) |
| **The frozen PyInstaller bundle misses the new wrapper file** — breaks the bundle while the wheels stay green, and CI will not catch it | Read `dev-tools/pyinstaller/README.md` first (task 2.8); task 6.5 smoke-tests the built bundle |
| A warm host serves a request against a clobbered OCP | Invalidation tied to the install guards (task 4.4) |
| Cross-request state bleed produces wrong geometry rather than an error | Audit (task 4.3) plus an identical-output test, alone vs. after others (task 5.4) |
| Step 3 balloons and blocks steps 1-2 from shipping | Ship 1 and 2 first, each with its own measurement |

---

## Relationship to the other two proposals

Three independent findings, three independent PRs, no ordering dependency between them:

- **This one** reduces how much sandbox work there is.
- **`sandbox-run-concurrency`** lets sandbox work spread across cores — every sandbox subprocess in a process is
  currently serialized on one `threading.RLock`. Complementary: it is what makes this PR's win visible on a
  multi-core machine, but neither subsumes the other.
- **`shape-cache-efficiency`** lowers the incremental-rebuild floor.

---

## Validation status

Only markdown under `openspec/changes/` is added — no Python is touched, so `pytest`/`behave` outcomes are
unaffected. **The pre-commit hooks did not run locally:** this session's container has no working Docker daemon,
so the dev container documented in the root `AGENTS.md` could not be started, and host-level `pre-commit` is
deliberately not used (host tool versions are not the pinned ones). CI will run the gates. Everything in
`tasks.md` is written to be run inside the dev container.


---
_Generated by [Claude Code](https://claude.ai/code/session_018enkjjYJCdP34QJKxDVSbt)_