### PR TITLE
perf(cache): proposal — make a cache hit cost metadata, not content

### DIFF
--- a/openspec/changes/shape-cache-efficiency/.openspec.yaml
+++ b/openspec/changes/shape-cache-efficiency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/shape-cache-efficiency/design.md
+++ b/openspec/changes/shape-cache-efficiency/design.md
@@ -1,0 +1,177 @@
+## Context
+
+This document is written for an implementer picking the work up cold. It records what was found, the trade-off
+that decides the design, and which claims are measurements rather than estimates.
+
+### The hot path
+
+`Shape.get_wrapped()` (`shape.py:208-270`) is the single entry point for "give me this shape's geometry". On a
+cache hit it does, in order:
+
+1. `ctx.cache_shapes.read_async(cache_hash, keys)` (`shape.py:219`), which calls `hash.get()`
+   (`cache_shape.py:83`) — and `CacheHash.get()` (`cache_hash.py:141-151`) first walks `self.dependencies`,
+   reading and MD5-ing **every byte** of each one (`cache_hash.py:127-128`).
+2. Reads the cached files (`cache.py:90-99`).
+3. Deserializes: `.decode("utf-8")` → `json.loads` → the envelope dict (`cache_shape.py:110` via
+   `shape_envelope.loads`).
+
+Step 1 is the expensive one, and it is unavoidable in the current design: the hash *is* the cache key, so
+nothing can be looked up until every dependency has been read.
+
+`hash.get()` is guarded by `is_used` (`cache_hash.py:142`), so the dependency read happens once per `Shape`
+object per process — not once per lookup. The cost is therefore per shape per run, which is exactly the
+incremental-build floor this change is about.
+
+### What `cache_dependencies_ignore` actually does
+
+Do not mistake this for a hashing switch. `Shape.get_cache_dependencies_broken()` (`shape.py:167-170`) uses it
+to decide whether a *broken* dependency disables caching for that shape. Dependencies are hashed either way,
+via `set_dependencies()` at `shape.py:142`. The user-level knob is at
+`partcad-utils/src/partcad_utils/user_config.py:386` and is threaded into child configs at
+`assembly_factory_assy.py:195`. A new knob is needed for hashing mode; this one cannot be reused.
+
+### Measured serialization overhead
+
+On the analysis machine, an 8 MB payload: `hashlib.md5` 14 ms, `base64.b64encode` 30 ms, `json.dumps` 35 ms,
+`json.loads` 14 ms, `.encode("utf-8")` 10 ms; on-disk size 1.33× the raw payload. These are real numbers from a
+throwaway script, not estimates. The MD5 figure is for data already in memory — the file read that precedes it
+is the larger cost for a model that is not in the page cache.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A cache hit's cost is proportional to metadata consulted, not to the size of the source model.
+- A cached payload is not re-encoded on its way to or from disk.
+- Cache entries remain **content-addressed**, so an entry produced on one machine is still valid on another.
+- Existing entries are never misread under new rules.
+
+**Non-Goals**
+
+- Changing what is cached, or the size-threshold policy.
+- Changing BREP compression (`wrappers/ocp_serialize.py:186-191`).
+- The sibling proposals' territory: sandbox concurrency, sandbox invocation count.
+
+## Decisions
+
+### D1 — Memoize the content digest; do not replace it
+
+The obvious move is to key a dependency on `(size, mtime_ns)` instead of its content. **Do not do that as the
+default.** It breaks a property the current design quietly has: because the key is a content hash, an entry
+produced on one machine is valid on any other. A CI job that restores a warm cache directory, or a team sharing
+one, gets hits today and would stop getting them if the key embedded local mtimes. That is a real regression
+traded for a real speedup, and it is the wrong side of the trade.
+
+Instead, keep the digest a **content** digest and make computing it cheap:
+
+- Maintain a small local index in `user_config.internal_state_dir` mapping
+  `(absolute path, size, mtime_ns, inode)` → content digest.
+- `add_filename()` stats the file; on an index hit it uses the stored digest and never opens the file. On a
+  miss it reads, hashes, and records.
+- The cache key is unchanged in meaning: it is still the content digest. Cross-machine sharing keeps working;
+  the index is a local accelerator that can be deleted at any time with no correctness consequence.
+
+Hot-path cost: one `stat()` and one index lookup per dependency, against a full read and MD5 today.
+
+**Offer metadata-only hashing as an opt-in**, for users who want the last stat's worth of speed and do not
+share caches. `cache_hash.py:130`'s TODO points at this; make it a documented user-config option with the
+trade-off written down, not the silent default.
+
+### D2 — Hash dependencies concurrently, preserving digest order
+
+`cache_hash.py:143` already asks for this. The constraint is that the digest depends on the order in which
+dependencies contribute. Compute each file's digest independently (on `threadpool_manager`), then fold the
+per-file digests into the running hasher in the original list order. With D1 in place this matters mainly for
+the cold path, where files must actually be read.
+
+### D3 — Store the payload raw
+
+`Cache.write_data_async()` already writes one file per key (`cache.py:63`) and reads one file per key
+(`cache.py:92`). So the change is confined to `ShapeCache`: split the envelope into
+
+- a small JSON metadata file (name, label, location, assembly structure), and
+- the payload as raw bytes in its own file,
+
+instead of `shape_envelope.dumps(value).encode("utf-8")` (`cache_shape.py:44`). A write becomes one `write()`
+of bytes already in hand; a read becomes one `read()` with no `json.loads` over a multi-megabyte string.
+
+Two things to get right:
+
+- **Assemblies are trees.** `Shape.get_cache_value()` is overridden by `Assembly` to store a nested structure
+  (`shape.py:303-317` documents why: a flat compound would lose names, labels and sub-assemblies). The split
+  must handle a tree with many payloads, not just one. Either store one payload file per leaf, or keep the tree
+  in the metadata file with payload references.
+- **The `"cmps"` key.** `get_wrapped()` caches components under `"cmps"` alongside the shape
+  (`shape.py:218`, `shape.py:259-260`), and components can be nested lists (`shape.py:297-301`). Same treatment.
+
+Whether the base64 layer can be dropped entirely — storing the zstd-compressed BREP bytes directly — depends on
+nothing but the cache's own format, since the cache is not the wire. Dropping it saves the 1.33× inflation and
+the encode/decode. Do it if the split lands cleanly; it is the whole point of storing raw bytes.
+
+### D4 — Bump `cache_hash.VERSION`
+
+`VERSION` (`cache_hash.py:24`) is mixed into every hash precisely so a change in what the bytes mean moves every
+entry to a new key rather than letting an old entry be read under new rules. D1 does not change the digest's
+meaning, but D3 changes the stored format. Bump it, and extend the comment block at `cache_hash.py:16-23` with
+the reason, following the existing style. Old files are not deleted; they simply stop being looked up.
+
+### D5 — Replace the `total_size()` calls
+
+`cache_shape.py:56` and `cache_shape.py:61` walk the object graph to get a size that is already available as
+`len(serialized_items[key])`. `read_async()` already does it that way (`cache_shape.py:121`). One-line change;
+do it first, on its own commit, so it is trivially reviewable.
+
+Note the two calls are not quite equivalent: `total_size(value)` measures the in-memory object, while
+`len(serialized)` measures the encoded form. The thresholds they feed
+(`cacheMemoryMaxEntrySize`, `cacheMemoryDoubleCacheMaxEntrySize`) are documented in terms of cache entries, and
+`read_async` already compares against the encoded length — so the encoded length is the consistent choice.
+Confirm the user-facing documentation of those settings matches before changing the semantics.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Serving a stale cache entry — the one failure that produces *wrong output* rather than a slow run | D1 keeps a content digest, so staleness requires the index to be wrong, not the key. Include inode and size, not just mtime; verify behavior across a `git checkout` that rewrites a file |
+| Losing cross-machine cache validity | D1 is chosen specifically to preserve it; task 4.4 tests it explicitly |
+| The metadata-only opt-in gets enabled by default later without the trade-off being re-read | Document it in the user config docs with the caveat inline, not just in this proposal |
+| Assembly trees or `"cmps"` lists mishandled by the payload split | Tasks 3.4-3.6; `partcad/tests/unit/test_assembly_serialize.py` is the closest existing coverage |
+| Existing digest tests break | Expected: `partcad/tests/unit/test_cache_hash.py` asserts exact digests and pins `VERSION` into them. Update them deliberately, do not loosen them |
+
+## How to measure
+
+Two distinct numbers; report both.
+
+**Cache-hit floor.** Build a package once to warm the cache, then time a second, fully-cached run:
+
+```bash
+poetry run pc --no-ansi render <package>     # warm
+time poetry run pc --no-ansi render <package>  # measure this one
+```
+
+Use a package with a large file-backed part — `examples/produce_part_step` with a deliberately large STEP file
+is the clearest case. Drop the OS page cache between runs where the platform allows it, and say whether you
+did: a warm page cache hides most of the read cost and makes the "before" number look better than it is.
+
+**Per-payload overhead.** Instrument `ShapeCache.write_async`/`read_async` with timers around the
+serialize/deserialize steps and report total time and total bytes written for a full package build.
+
+**Expected direction.** The cache-hit floor should drop by roughly the time it takes to read and MD5 every
+dependency file — which is why the large-part case is the one to measure. Payload overhead should drop by the
+`json.dumps` + `encode` + `json.loads` time and, if base64 goes, by 1.33× on bytes written.
+
+## Related, out of scope
+
+`Shape.matches()` (`shape.py:151-165`) reads whole files for `pc search`. Same class of problem, different
+command, no cache involved. Not part of this change; worth a separate issue.
+
+## Open questions for the implementer
+
+1. Should the digest index live per-user (`internal_state_dir`) or per-project? Per-user shares work across
+   projects that reference the same vendored files; per-project is easier to reason about and to discard.
+2. Should the index be a single file (read once per process) or a directory of small entries? A single file
+   needs concurrency handling across the daemon and concurrent `pc` runs.
+3. Is there a case where a dependency file is *expected* to change without its mtime changing — a generated
+   file written by a tool that preserves timestamps? If so, D1's index needs a way to opt a path out.
+4. Should `add_filename()`'s `FileNotFoundError` path (`cache_hash.py:132-135`, silently skipping a file that is
+   "not yet downloaded") also participate in the index, or stay a plain miss? It currently makes a
+   not-yet-downloaded dependency contribute nothing to the hash, which is worth a second look on its own.

--- a/openspec/changes/shape-cache-efficiency/proposal.md
+++ b/openspec/changes/shape-cache-efficiency/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+The point of the shape cache is that an unchanged shape costs nearly nothing. Today it costs a full read and
+hash of its source model, plus several full copies of its cached payload. That sets the floor on every
+incremental run — the case users hit most often, and the one where the cache is supposed to be the whole story.
+
+### 1. The cache cannot be consulted until every dependency has been read end to end
+
+`CacheHash.get()` (`partcad/src/partcad/cache_hash.py:141`) walks `self.dependencies` and calls
+`add_filename()` on each, which does:
+
+```python
+with open(filename, "rb") as f:
+    self.hasher.update(f.read())
+```
+
+(`cache_hash.py:127-128`) — the **entire file**, read into memory and hashed. For a file-backed shape that file
+*is* the source model: `PartFactoryFile.post_create()` appends `self.path` to `cache_dependencies`
+(`part_factory_file.py:56`), as do `assembly_factory_file.py:39` and `sketch_factory_file.py:58`.
+`PartFactoryPython` and `PartFactoryScad` add each declared `dependencies:` entry on top
+(`part_factory_python.py:48`, `part_factory_scad.py:156`).
+
+`Shape.get_wrapped()` needs that hash *before* it can look anything up (`shape.py:216-219`), so a cache hit on a
+200 MB STEP part still pays a full read plus MD5 of it — serially, on the event loop. The code already carries
+the TODOs: "optionally, track changes by file modification time only" (`cache_hash.py:130`) and "make I/O
+asynchronous and parallel, but maintain the order of hashing" (`cache_hash.py:143`).
+
+### 2. The payload is base64 inside JSON, re-encoded on every hop
+
+A shape envelope's `"brep"` value is *already* a base64 string (`wrappers/ocp_serialize.py:265-266`, which
+base64-encodes the zstd-compressed BREP). `ShapeCache.write_async()` then calls
+`shape_envelope.dumps(value).encode("utf-8")` (`cache_shape.py:44`), so `json.dumps` re-scans and re-escapes
+that entire string into a new one, and `.encode()` copies it again. Reads reverse all of it
+(`cache_shape.py:110`). Each render then re-serializes the same payload once more (`shape.py:828`).
+
+Measured on the analysis machine with an 8 MB payload: ~30 ms base64 + ~35 ms `json.dumps` + ~10 ms UTF-8
+encode, at 1.33× on-disk inflation. Modest per shape; it multiplies by shape count and by format count.
+
+### 3. A deep object-graph walk where a length is already in hand
+
+`ShapeCache.write_async()` calls `total_size(value)` (`cache_shape.py:56` and `cache_shape.py:61`) — a
+`gc.get_referents` breadth-first walk of the object graph (`partcad-utils/src/partcad_utils/utils.py:63`) —
+purely to compare against the size thresholds. The serialized length is sitting in the same scope, in
+`serialized_items[key]`. `read_async()` already does it the cheap way: `data_len = len(data)`
+(`cache_shape.py:121`). This one is free to fix.
+
+## What Changes
+
+- **Hash dependencies by metadata, not content, by default.** Key a dependency's contribution on
+  `(size, mtime_ns)`, falling back to content hashing when metadata is unavailable, and keep full content
+  hashing available for callers that need it. Bump `cache_hash.VERSION` so no existing entry is ever read back
+  under the new rules.
+- **Hash dependencies concurrently**, as `cache_hash.py:143` already asks for, while preserving the order in
+  which they contribute to the digest.
+- **Store the BREP payload as raw bytes.** Write the payload to its own cache file and keep the JSON envelope
+  for metadata only, so a cache write is one `write()` with no re-encode and a read is one `read()`.
+- **Replace the two `total_size()` calls** in `ShapeCache.write_async()` with the serialized length already
+  computed.
+
+## Capabilities
+
+### New Capabilities
+
+- `shape-cache-efficiency`: The requirement that the cost of a cache hit is proportional to the metadata
+  consulted rather than to the size of the source model or the cached payload; that dependency freshness is
+  determined without reading file contents in the common case; and that a cached payload is not re-encoded on
+  its way to or from disk.
+
+## Impact
+
+- **Modified**: `partcad/src/partcad/cache_hash.py` — `add_filename()`, `get()`, `set_dependencies()`, and
+  `VERSION`.
+- **Modified**: `partcad/src/partcad/cache_shape.py` — `write_async()`/`read_async()` payload handling and the
+  size checks.
+- **Modified (possibly)**: `partcad/src/partcad/cache.py` — `write_data_async`/`read_data_async` already write
+  one file per key (`cache.py:63`, `cache.py:92`), so a raw-bytes payload may need no new file layout at all.
+- **Modified**: `partcad/tests/unit/test_cache_hash.py` — the existing tests assert exact digests and will need
+  updating alongside the `VERSION` bump.
+- **New specs**: `openspec/specs/shape-cache-efficiency/spec.md`.
+- **Unchanged**: the wire envelope between core and wrappers. This change is about what the *cache* stores and
+  how freshness is decided, not about what crosses the sandbox boundary.
+
+## Non-Goals
+
+- Changing what is cached, or the cache's eviction and size-threshold policy
+  (`cacheFilesMinEntrySize`, `cacheMemoryMaxEntrySize`, `cacheMemoryDoubleCacheMaxEntrySize`).
+- Overlapping sandbox operations (sibling proposal: `sandbox-run-concurrency`).
+- Reducing the number of sandbox invocations (sibling proposal: `sandbox-process-reuse`).
+- Changing the compression of BREP payloads. zstd at level 3 is already a considered choice
+  (`wrappers/ocp_serialize.py:186-191`).

--- a/openspec/changes/shape-cache-efficiency/specs/shape-cache-efficiency/spec.md
+++ b/openspec/changes/shape-cache-efficiency/specs/shape-cache-efficiency/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: A cache hit does not read its dependencies' contents
+Determining whether a shape's cached entry is still valid SHALL NOT require reading the contents of that
+shape's dependency files, in the common case where those files are unchanged since they were last hashed.
+
+#### Scenario: An unchanged package is built twice
+- **WHEN** a package whose source files have not changed is built a second time
+- **THEN** the contents of its dependency files are not read
+
+#### Scenario: A dependency's content changes
+- **WHEN** a dependency file's content changes
+- **THEN** the shape's cached entry is invalidated and the shape is rebuilt
+
+#### Scenario: A dependency is touched without being changed
+- **WHEN** a dependency file's timestamp changes but its content does not
+- **THEN** the shape's cached entry remains valid and is reused
+
+### Requirement: Cache entries stay content-addressed
+A cache entry's key SHALL be derived from the content of the shape's inputs, not from machine-local file
+metadata, so that an entry produced on one machine remains valid on another.
+
+#### Scenario: A warmed cache is moved between machines
+- **WHEN** a cache directory warmed on one machine is used on another, where the same source files have
+  different timestamps
+- **THEN** the entries in it are still found and reused
+
+#### Scenario: The local acceleration data is discarded
+- **WHEN** any local index used to avoid re-reading file contents is deleted
+- **THEN** results are unchanged, and only performance is affected
+
+### Requirement: Cached payloads are stored without re-encoding
+A cached geometry payload SHALL be written to and read from disk without being re-encoded into a text format on
+the way. The bytes written SHALL NOT be materially larger than the payload they represent.
+
+#### Scenario: A shape is written to the cache
+- **WHEN** a shape's geometry is stored in the cache
+- **THEN** its payload is written as bytes, without being embedded into a text document that must be escaped
+  and re-parsed
+
+#### Scenario: A shape is read from the cache
+- **WHEN** a shape's geometry is read from the cache
+- **THEN** its payload is read as bytes, without parsing a text document containing it
+
+### Requirement: Cached structure survives the payload split
+Storing payloads separately from metadata SHALL preserve everything the cache records today, including an
+assembly's nested tree of names, labels and sub-assemblies, and a shape's cached components.
+
+#### Scenario: An assembly is cached and restored
+- **WHEN** an assembly with sub-assemblies is cached and then read back
+- **THEN** its hierarchy, names and labels are identical to what was stored
+
+#### Scenario: A shape with components is cached and restored
+- **WHEN** a shape whose components were cached is read back
+- **THEN** its components, including nested lists, are identical to what was stored
+
+### Requirement: A cache format change never reinterprets old entries
+When the meaning of the bytes behind a cache key changes, the cache format version SHALL be advanced so that
+entries written under the previous format are never read back under the new rules.
+
+#### Scenario: A cache written by a previous version is present
+- **WHEN** a cache directory contains entries written before a format change
+- **THEN** those entries are not read, and the affected shapes are rebuilt rather than misinterpreted
+
+### Requirement: Entry size decisions use the size actually stored
+The cache's size thresholds SHALL be applied to the size of the data being stored, consistently on the write
+and read paths, and determining that size SHALL NOT require traversing an in-memory object graph.
+
+#### Scenario: An entry is checked against the size thresholds
+- **WHEN** the cache decides whether an entry is too large to keep in memory
+- **THEN** it uses the length of the serialized data it already holds

--- a/openspec/changes/shape-cache-efficiency/tasks.md
+++ b/openspec/changes/shape-cache-efficiency/tasks.md
@@ -1,0 +1,99 @@
+## 1. Confirm the finding and establish the baseline
+
+- [ ] 1.1 Bring up the dev container (root `AGENTS.md`, "Where commands run") — everything below runs inside it
+- [ ] 1.2 Read `cache_hash.py` in full, `cache.py` in full, `cache_shape.py` in full, and `Shape.get_wrapped()`
+      (`shape.py:208-270`)
+- [ ] 1.3 Confirm the cache-hit path reads dependency files end to end: instrument `CacheHash.add_filename()`
+      (`cache_hash.py:117`) to log bytes read, then run a fully-cached build and check the total against the
+      sum of the source model sizes
+- [ ] 1.4 Confirm `hash.get()`'s `is_used` guard (`cache_hash.py:142`) means this is paid once per shape per
+      run, not once per lookup — so the cost scales with shape count, not access count
+- [ ] 1.5 Time a fully-cached run with and without the OS page cache dropped, on a package with a large
+      file-backed part. Record both, and record which is which
+- [ ] 1.6 Instrument `ShapeCache.write_async`/`read_async` to report serialize/deserialize time and bytes
+      written for a full build
+- [ ] 1.7 Paste both baselines into the PR description before writing implementation code
+
+## 2. The free win first (separate commit)
+
+- [ ] 2.1 Replace `total_size(value)` at `cache_shape.py:56` and `cache_shape.py:61` with
+      `len(serialized_items[key])`, matching what `read_async` already does at `cache_shape.py:121`
+- [ ] 2.2 Confirm the semantic shift is the right one: the thresholds
+      (`cacheMemoryMaxEntrySize`, `cacheMemoryDoubleCacheMaxEntrySize`) should compare against the encoded
+      length, as `read_async` does. Check the user-facing documentation of those settings agrees
+- [ ] 2.3 Handle the `not user_config.cache` branch, where `serialized_items` was never built — it currently
+      falls through to `total_size` at line 61 and still needs a size
+- [ ] 2.4 Confirm `total_size` has no remaining hot-path callers that matter; note that
+      `Shape.shape_info()` (`shape.py:550`) still uses it, which is fine — it is a diagnostic command
+- [ ] 2.5 Commit this on its own so it is trivially reviewable
+
+## 3. Cheap dependency freshness
+
+- [ ] 3.1 Read `design.md` D1 in full before writing code. The decision to keep a **content** digest and
+      memoize it — rather than switching the key to `(size, mtime)` — is the load-bearing one, and reversing it
+      silently breaks cross-machine cache validity
+- [ ] 3.2 Implement the digest index: `(absolute path, size, mtime_ns, inode)` → content digest, stored under
+      `user_config.internal_state_dir`
+- [ ] 3.3 Rework `add_filename()` (`cache_hash.py:117`) to stat first and consult the index; read and hash only
+      on a miss, recording the result
+- [ ] 3.4 Make the index safe to delete at any time, and prove it: deleting it must change performance only,
+      never results
+- [ ] 3.5 Decide and document the index's scope and file layout (`design.md`, open questions 1 and 2), including
+      concurrent access from the daemon and from parallel `pc` runs
+- [ ] 3.6 Add the opt-in metadata-only hashing mode as a documented user-config setting, with its trade-off
+      stated inline in the docs. It must not be the default
+- [ ] 3.7 Implement concurrent dependency hashing (`design.md` D2), folding per-file digests into the hasher in
+      the original list order. Add a test that reordering the input list changes the digest, so the ordering
+      guarantee is pinned
+
+## 4. Raw payload storage
+
+- [ ] 4.1 Split `ShapeCache` storage into a small JSON metadata file plus raw payload bytes, replacing
+      `shape_envelope.dumps(value).encode("utf-8")` at `cache_shape.py:44`
+- [ ] 4.2 Drop the base64 layer for the cache if the split lands cleanly — the cache is not the wire, so it can
+      store the zstd-compressed BREP bytes directly. This is where the 1.33× and the encode/decode time go
+- [ ] 4.3 Bump `cache_hash.VERSION` (`cache_hash.py:24`) and extend the comment block at `cache_hash.py:16-23`
+      with the reason, in the existing style
+- [ ] 4.4 Verify an entry written on one machine is readable on another — copy a warmed cache directory to a
+      different machine (or a container with different mtimes) and confirm hits. This is the property D1 exists
+      to protect
+- [ ] 4.5 Handle assembly trees: `Assembly` overrides `get_cache_value()` to store a nested structure
+      (`shape.py:303-317`). Either one payload file per leaf, or payload references inside the metadata file
+- [ ] 4.6 Handle the `"cmps"` key and its nested component lists (`shape.py:218`, `shape.py:259-260`,
+      `shape.py:297-301`)
+- [ ] 4.7 Confirm a cache file written by the previous format is never read under the new rules — it should miss
+      cleanly on the bumped `VERSION`, not raise
+
+## 5. Tests
+
+- [ ] 5.1 Update `partcad/tests/unit/test_cache_hash.py` — it asserts exact digests and pins `VERSION` into
+      them. Update deliberately; do not loosen the assertions to make them pass
+- [ ] 5.2 Add: modifying a dependency's content invalidates the entry, whether or not the index has an entry for
+      the old version
+- [ ] 5.3 Add: touching a file without changing its content produces the **same** digest (the index misses, the
+      content hash is recomputed, the key is unchanged) — this is the property that keeps cache hits after a
+      fresh `git clone`
+- [ ] 5.4 Add: a fully-cached build reads no dependency file content (assert via an instrumented `open`, or by
+      making the file unreadable after the first build)
+- [ ] 5.5 Round-trip tests for the new payload storage: plain shape, assembly tree, components, and an entry
+      large enough to exercise the size thresholds
+- [ ] 5.6 Check `partcad/tests/unit/test_assembly_serialize.py` still passes and extend it if the assembly tree
+      layout changed
+
+## 6. Validate
+
+- [ ] 6.1 `poetry run pytest partcad partcad-cli -x -p no:error-for-skips -p no:warnings --dist no`
+- [ ] 6.2 `poetry run behave`
+- [ ] 6.3 Re-run both baseline measurements from task 1 and record the after numbers next to them, stating
+      whether the page cache was dropped
+- [ ] 6.4 Confirm geometry is unchanged: rendered outputs from a cached build match those from a cold build
+- [ ] 6.5 Confirm on-disk cache size before and after
+
+## 7. Land it
+
+- [ ] 7.1 Remove the instrumentation added in task 1
+- [ ] 7.2 Document the new user-config setting wherever the other cache settings are documented
+- [ ] 7.3 Move the delta spec into `openspec/specs/shape-cache-efficiency/spec.md`
+- [ ] 7.4 Run `pre-commit run --config dev-tools/pre-commit-config.yaml` inside the container and re-stage
+      anything the formatting hooks rewrote
+- [ ] 7.5 Commit inside the container; verify with `git log -1 --stat`


### PR DESCRIPTION
## Copilot Summary

**This PR contains a proposal only — no behavior change.** It adds an OpenSpec change under
`openspec/changes/shape-cache-efficiency/` (`proposal.md`, `design.md`, `tasks.md`, and a delta spec) recording
a performance finding in `partcad/` together with a design, a measurement recipe, and the tests it needs. It is
one of three sibling proposals from the same read-through; see "Relationship to the other two" below.

The implementation is deliberately not included: the finding should be measured on real hardware before code is
written, and `tasks.md` starts with exactly that. **Work through `tasks.md` in order — it is the handoff.**

---

## The finding

The point of the shape cache is that an unchanged shape costs nearly nothing. Today it costs a full read and
hash of its source model, plus several full copies of its cached payload. That sets the floor on every
incremental run — the case users hit most often, and the one where the cache is supposed to be the whole story.

### 1. The cache cannot be consulted until every dependency has been read end to end

`CacheHash.get()` (`partcad/src/partcad/cache_hash.py:141`) walks `self.dependencies` and calls
`add_filename()` on each, which does:

```python
with open(filename, "rb") as f:
    self.hasher.update(f.read())
```

(`cache_hash.py:127-128`) — the **entire file**, read into memory and hashed. For a file-backed shape that file
*is* the source model: `PartFactoryFile.post_create()` appends `self.path` to `cache_dependencies`
(`part_factory_file.py:56`), as do `assembly_factory_file.py:39` and `sketch_factory_file.py:58`.
`PartFactoryPython` and `PartFactoryScad` add each declared `dependencies:` entry on top
(`part_factory_python.py:48`, `part_factory_scad.py:156`).

`Shape.get_wrapped()` needs that hash **before** it can look anything up (`shape.py:216-219`), so a cache hit on
a 200 MB STEP part still pays a full read plus MD5 of it — serially, on the event loop. The code already carries
the TODOs: "optionally, track changes by file modification time only" (`cache_hash.py:130`) and "make I/O
asynchronous and parallel, but maintain the order of hashing" (`cache_hash.py:143`).

`hash.get()` is guarded by `is_used` (`cache_hash.py:142`), so this is paid once per `Shape` per process — the
cost scales with shape count, not access count. That is exactly the incremental-build floor.

### 2. The payload is base64 inside JSON, re-encoded on every hop

A shape envelope's `"brep"` value is **already** a base64 string (`wrappers/ocp_serialize.py:265-266`, which
base64-encodes the zstd-compressed BREP). `ShapeCache.write_async()` then calls
`shape_envelope.dumps(value).encode("utf-8")` (`cache_shape.py:44`), so `json.dumps` re-scans and re-escapes
that entire string into a new one, and `.encode()` copies it again. Reads reverse all of it
(`cache_shape.py:110`). Each render re-serializes the same payload once more (`shape.py:828`).

Measured on the analysis machine, 8 MB payload: **~30 ms** base64 + **~35 ms** `json.dumps` + **~10 ms** UTF-8
encode, at **1.33×** on-disk inflation. (`hashlib.md5` on the same data: 14 ms — but that figure is for data
already in memory; the file read preceding it is the larger cost when the model is not in the page cache.)

### 3. A deep object-graph walk where a length is already in hand

`ShapeCache.write_async()` calls `total_size(value)` (`cache_shape.py:56` and `cache_shape.py:61`) — a
`gc.get_referents` breadth-first walk (`partcad-utils/src/partcad_utils/utils.py:63`) — purely to compare
against the size thresholds. The serialized length is in the same scope, as `serialized_items[key]`.
`read_async()` already does it the cheap way: `data_len = len(data)` (`cache_shape.py:121`). Free to fix, and
task 2 does it first as its own commit.

### Correcting one thing about `cache_dependencies_ignore`

It is **not** a hashing switch. `Shape.get_cache_dependencies_broken()` (`shape.py:167-170`) uses it to decide
whether a *broken* dependency disables caching for that shape; dependencies are hashed either way, via
`set_dependencies()` at `shape.py:142`. A new knob is needed for hashing mode — this one cannot be reused.

---

## The load-bearing design decision

The obvious fix is to key a dependency on `(size, mtime_ns)` instead of its content. **The proposal explicitly
rejects that as the default**, and an implementer should not quietly reverse it.

Because the key is a *content* hash today, an entry produced on one machine is valid on any other. A CI job that
restores a warm cache directory, or a team sharing one, gets hits — and would stop getting them if the key
embedded local mtimes. That is a real regression traded for a real speedup, on the wrong side of the trade.

**Instead: keep the digest a content digest, and make computing it cheap.**

- A local index in `user_config.internal_state_dir` maps `(absolute path, size, mtime_ns, inode)` → content
  digest.
- `add_filename()` stats the file; on an index hit it uses the stored digest and never opens the file. On a miss
  it reads, hashes, and records.
- The cache key's *meaning* is unchanged. Cross-machine sharing keeps working. The index is a local accelerator
  that can be deleted at any time with **no correctness consequence** — a property task 3.4 tests directly.

Hot-path cost: one `stat()` and one index lookup per dependency, against a full read and MD5 today.

Metadata-only hashing is still offered, as a **documented opt-in** with its trade-off stated inline in the
docs — never the default (task 3.6).

---

## The rest of the proposed direction (details in `design.md`)

- **D2** — hash dependencies concurrently (as `cache_hash.py:143` asks), folding per-file digests into the
  hasher in the original list order. A test pins the ordering guarantee.
- **D3** — store the payload raw: a small JSON metadata file plus payload bytes in their own file. `Cache`
  already writes and reads one file per key (`cache.py:63`, `cache.py:92`), so this is confined to `ShapeCache`.
  Since the cache is not the wire, the base64 layer can be dropped entirely — that is where the 1.33× and the
  encode/decode time go.
- **D4** — bump `cache_hash.VERSION` (`cache_hash.py:24`) so no entry written under the old format is ever read
  under the new rules, and extend the comment block at `cache_hash.py:16-23` in the existing style.

Two structures the payload split must not break:
- **Assembly trees.** `Assembly` overrides `get_cache_value()` to store a nested structure — `shape.py:303-317`
  documents that a flat compound would lose names, labels and sub-assemblies.
- **The `"cmps"` key.** Components are cached alongside the shape (`shape.py:218`, `shape.py:259-260`) and can
  be nested lists (`shape.py:297-301`).

Four open questions are recorded at the end of `design.md`.

---

## How to measure

Two distinct numbers; report both (task 1).

**Cache-hit floor** — build once to warm, then time a fully-cached second run, on a package with a large
file-backed part:

```bash
poetry run pc --no-ansi render <package>       # warm
time poetry run pc --no-ansi render <package>  # measure this one
```

Drop the OS page cache between runs where the platform allows, and **say whether you did** — a warm page cache
hides most of the read cost and makes the "before" number look better than it is.

**Per-payload overhead** — instrument `ShapeCache.write_async`/`read_async` and report serialize/deserialize
time and total bytes written for a full package build.

Expected direction: the cache-hit floor drops by roughly the time to read and MD5 every dependency (hence the
large-part case); payload overhead drops by the `json.dumps` + `encode` + `json.loads` time and, if base64 goes,
by 1.33× on bytes written.

---

## Risks the implementer must handle

| Risk | Mitigation |
|---|---|
| **Serving a stale entry** — the one failure mode that produces *wrong output* rather than a slow run | Keeping a content digest means staleness requires the index to be wrong, not the key. Include inode and size, not just mtime; verify across a `git checkout` that rewrites a file |
| Losing cross-machine cache validity | The design is chosen specifically to preserve it; task 4.4 tests it by moving a warmed cache between machines |
| The opt-in metadata mode later becomes the default without the trade-off being re-read | Document the caveat inline in the user config docs, not only in the proposal |
| Assembly trees or `"cmps"` lists mishandled by the payload split | Tasks 3.4-3.6 and 4.5-4.6; `partcad/tests/unit/test_assembly_serialize.py` is the closest existing coverage |
| Existing digest tests break | **Expected.** `partcad/tests/unit/test_cache_hash.py` asserts exact digests and pins `VERSION` into them. Update deliberately — do not loosen the assertions to make them pass |

---

## Related, out of scope

`Shape.matches()` (`shape.py:151-165`) reads whole files for `pc search`. Same class of problem, different
command, no cache involved. Worth a separate issue.

---

## Relationship to the other two proposals

Three independent findings, three independent PRs, no ordering dependency between them:

- **This one** lowers the incremental-rebuild floor.
- **`sandbox-run-concurrency`** — every sandbox subprocess in a process is serialized on one `threading.RLock`,
  so the thread pool never runs two at once.
- **`sandbox-process-reuse`** — a transformed part rendered to four formats costs seven cold interpreter starts.

---

## Validation status

Only markdown under `openspec/changes/` is added — no Python is touched, so `pytest`/`behave` outcomes are
unaffected. **The pre-commit hooks did not run locally:** this session's container has no working Docker daemon,
so the dev container documented in the root `AGENTS.md` could not be started, and host-level `pre-commit` is
deliberately not used (host tool versions are not the pinned ones). CI will run the gates. Everything in
`tasks.md` is written to be run inside the dev container.


---
_Generated by [Claude Code](https://claude.ai/code/session_018enkjjYJCdP34QJKxDVSbt)_