### PR TITLE
feat(cli): add `pc bom` to print an assembly's bill of materials

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -72,6 +72,18 @@ Object commands
 ``pc info``
   Show detailed information about a part, assembly, or scene, including its parameters.
 
+``pc bom``
+  Print the bill of materials of an assembly: every part it is made of, recursively, with how many of each
+  are needed and, where the object says so, the vendor and the SKU to order it by. Use ``-P`` to name the
+  package the assembly comes from, ``-p <name>=<value>`` to set parameters, and ``-j``/``--json`` to produce
+  JSON on standard output instead of a table.
+
+  ``-s``/``--stop-at-purchasable`` stops the recursion at a sub-assembly that can be bought ready-made — one
+  that declares both a ``vendor`` and an ``sku``, and that a supplier of its package reports as available.
+  Such a sub-assembly is listed as a single line item and its own contents are left out: it is one thing to
+  order, not a list of parts to source and assemble. A sub-assembly that names a vendor and an SKU nobody
+  supplies is still expanded.
+
 ``pc convert``
   Convert parts or sketches to another format and update their type in the package. Subcommands: ``part`` and
   ``sketch``.

--- a/features/bom.feature
+++ b/features/bom.feature
@@ -1,0 +1,88 @@
+@cli @pc-bom
+Feature: `pc bom` command
+
+  Background: A package with an assembly of assemblies
+    Given I am in "/tmp/sandbox/behave" directory
+    And I have temporary $HOME in "/tmp/sandbox/home"
+    And a file named "partcad.yaml" with content:
+      """
+      parts:
+        cube:
+          type: cadquery
+          desc: A cube
+
+      assemblies:
+        unit:
+          type: assy
+          desc: A pair of cubes, also sold assembled
+          vendor: partcad
+          sku: UNIT-1
+        top:
+          type: assy
+          desc: The top level assembly
+      """
+    And a file named "cube.py" with content:
+      """
+      import cadquery as cq
+
+      shape = cq.Workplane("XY").box(1, 1, 1)
+      show_object(shape)
+      """
+    And a file named "unit.assy" with content:
+      """
+      links:
+        - part: cube
+          name: cube1
+          location: [[0,0,0], [0,0,1], 0]
+        - part: cube
+          name: cube2
+          location: [[0,0,1], [0,0,1], 0]
+      """
+    And a file named "top.assy" with content:
+      """
+      links:
+        - assembly: unit
+          name: unit1
+          location: [[0,0,0], [0,0,1], 0]
+        - assembly: unit
+          name: unit2
+          location: [[0,0,10], [0,0,1], 0]
+        - part: cube
+          location: [[0,0,20], [0,0,1], 0]
+      """
+
+  @success @pc-bom
+  Scenario: The bill of materials counts the whole tree
+    When I run "pc bom :top"
+    Then the command should exit with a status code of "0"
+    And STDOUT should contain "Bill of materials of //:top:"
+    # Two units of two cubes each, plus the one the top level assembly holds.
+    And STDOUT should contain "//:cube"
+    And STDOUT should contain "Total: 5"
+    And STDOUT should contain "DONE: BoM: //: top"
+
+  @success @pc-bom
+  Scenario: The bill of materials in JSON
+    When I run "pc -q bom --json :top"
+    Then the command should exit with a status code of "0"
+    And STDOUT should contain '"assembly": "//:top"'
+    And STDOUT should contain '"name": "//:cube"'
+    And STDOUT should contain '"kind": "part"'
+    And STDOUT should contain '"count": 5'
+    And STDOUT should contain '"total": 5'
+
+  @success @pc-bom
+  Scenario: A sub-assembly nobody supplies is expanded even when it names an SKU
+    # The unit declares a vendor and an SKU, but the package declares no
+    # supplier, so there is nowhere to buy it: it is still an assembly to build.
+    When I run "pc bom --stop-at-purchasable :top"
+    Then the command should exit with a status code of "0"
+    And STDOUT should contain "Total: 5"
+    # A purchased line item is the only thing that prints an SKU to order by.
+    And STDOUT should not contain "UNIT-1"
+
+  @success @pc-bom
+  Scenario: A part is not an assembly
+    When I run "pc bom :cube"
+    Then the command should exit with a non-zero status code
+    And STDOUT should contain "Assembly //:cube is not found"

--- a/partcad-cli/src/partcad_cli/click/command.py
+++ b/partcad-cli/src/partcad_cli/click/command.py
@@ -122,7 +122,7 @@ command_groups = [
     },
     {
         "name": "Object commands",
-        "commands": ["list", "add", "import", "test", "inspect", "info", "convert", "export", "render"],
+        "commands": ["list", "add", "import", "test", "inspect", "info", "bom", "convert", "export", "render"],
     },
     {
         "name": "Workflow commands",

--- a/partcad-cli/src/partcad_cli/click/commands/bom.py
+++ b/partcad-cli/src/partcad_cli/click/commands/bom.py
@@ -1,0 +1,74 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import json
+import sys
+
+import rich_click as click
+
+from ..service import run
+
+
+@click.command(help="Print the bill of materials of an assembly")
+@click.option(
+    "-P",
+    "--package",
+    "package",
+    type=str,
+    help="Package to retrieve the object from",
+    default=None,
+    show_envvar=True,
+)
+@click.option(
+    "-j",
+    "--json",
+    "api",
+    is_flag=True,
+    help="Produce JSON output",
+    show_envvar=True,
+)
+@click.option(
+    "-s",
+    "--stop-at-purchasable",
+    "stop_at_purchasable",
+    is_flag=True,
+    help="Do not expand a sub-assembly that can be purchased as a whole "
+    "(it declares a vendor and an SKU, and a supplier has it available); "
+    "list it as a single line item instead",
+    show_envvar=True,
+)
+@click.option(
+    "-p",
+    "--param",
+    "params",
+    type=str,
+    multiple=True,
+    metavar="<name>=<value>",
+    help="Assign a value to the parameter",
+    show_envvar=True,
+)
+@click.argument("object", type=str, required=True)  # help="Assembly to print the bill of materials of"
+@click.pass_obj
+def cli(cli_ctx, package: str, api: bool, stop_at_purchasable: bool, params: tuple[str, ...], object: str) -> None:
+    result = run(
+        cli_ctx,
+        "bom",
+        {
+            "package": package,
+            "object": object,
+            "params": list(params),
+            "stop_at_purchasable": stop_at_purchasable,
+            "json": api,
+        },
+        needs_context=True,
+    )
+
+    # The human-readable table is rendered by the daemon, through the same
+    # logging path as `pc list`. JSON goes to stdout instead, so it can be piped
+    # into `jq` no matter where the logs are sent.
+    if api and result is not None:
+        sys.stdout.write(json.dumps(result, indent=4) + "\n")
+        sys.stdout.flush()

--- a/partcad-service-json-rpc/src/partcad_service_json_rpc/core/operations.py
+++ b/partcad-service-json-rpc/src/partcad_service_json_rpc/core/operations.py
@@ -1317,6 +1317,100 @@ def list_mates(session, params):
     return None
 
 
+def bom(session, params):
+    """Print the bill of materials of an assembly.
+
+    Returns the line items so the CLI can render them as JSON; the human-readable
+    table is emitted here, through PartCAD logging, the way `pc list` renders its
+    own. ``stop_at_purchasable`` keeps sub-assemblies that can be bought whole
+    from being expanded into their contents.
+    """
+    import asyncio
+
+    ctx = _ctx(session, params)
+    if ctx is None:
+        return None
+    pc = session.partcad
+
+    object_name = params.get("object")
+    if not object_name:
+        raise JsonRpcError(USAGE_ERROR, "No assembly is given")
+
+    package = ctx.resolve_package_path(params.get("package") or ".")
+    package_obj = ctx.get_project(package)
+    if not package_obj:
+        pc.logging.error("Package %s is not found" % package)
+        return None
+
+    package, object_name = pc.utils.resolve_resource_path(package_obj.name, object_name)
+    path = "%s:%s" % (package, object_name)
+
+    param_dict = {}
+    for kv in params.get("params") or []:
+        if "=" in kv:
+            k, v = kv.split("=", 1)
+            param_dict[k] = v
+
+    with pc.logging.Process("BoM", package, object_name):
+        assembly = ctx.get_assembly(path, params=param_dict)
+        if assembly is None:
+            pc.logging.error("Assembly %s is not found" % path)
+            return None
+
+        bom_items = asyncio.run(
+            assembly.get_bom_detailed_async(ctx, stop_at_purchasable=bool(params.get("stop_at_purchasable")))
+        )
+
+        items = [{"name": name, **entry} for name, entry in sorted(bom_items.items())]
+        result = {
+            "assembly": path,
+            "items": items,
+            "total": sum(item["count"] for item in items),
+        }
+
+        if not params.get("json"):
+            pc.logging.info(_bom_output(result))
+    return result
+
+
+def _bom_output(result: dict) -> str:
+    """The human-readable rendering of a BoM: one line item per line.
+
+    The columns are sized from the content, not fixed the way `pc list` sizes
+    its own: every name here carries the package it comes from, so the names are
+    long and their length varies a lot from one BoM to the next.
+    """
+    items = result["items"]
+    output = "Bill of materials of %s:\n" % result["assembly"]
+    if not items:
+        return output + "\t<none>\n"
+
+    rows = []
+    for item in items:
+        # What to order, for the items that say so: buying one needs the vendor
+        # and the SKU, not the name PartCAD knows it by.
+        if item.get("vendor") and item.get("sku"):
+            source = "%s %s" % (item["vendor"], item["sku"])
+        else:
+            source = ""
+        rows.append((item["name"], str(item["count"]), source, item.get("desc") or ""))
+
+    name_width = max(len(row[0]) for row in rows)
+    count_width = max(len(row[1]) for row in rows)
+    source_width = max(len(row[2]) for row in rows)
+
+    # Where a folded description continues, counting the leading tab as one.
+    indent = 1 + name_width + 2 + count_width + 2 + (source_width + 2 if source_width else 0)
+    for name, count, source, desc in rows:
+        line = "\t%s  %s" % (name.ljust(name_width), count.rjust(count_width))
+        if source_width:
+            line += "  %s" % source.ljust(source_width)
+        line += "  " + desc.replace("\n", "\n" + " " * indent)
+        output += line.rstrip() + "\n"
+    output += "Total: %d\n" % result["total"]
+    return output
+
+
 def search_objects(session, params):
     """Search parts/sketches/assemblies/interfaces/packages by keyword."""
     ctx = _ctx(session, params)

--- a/partcad-service-json-rpc/src/partcad_service_json_rpc/rpc/methods.py
+++ b/partcad-service-json-rpc/src/partcad_service_json_rpc/rpc/methods.py
@@ -37,6 +37,7 @@ _OPERATIONS = {
     "list.packages": operations.list_packages,
     "list.providers": operations.list_providers,
     "list.mates": operations.list_mates,
+    "bom": operations.bom,
     "search.objects": operations.search_objects,
     "render.objects": operations.render_objects,
     "convert.object": operations.convert_object,

--- a/partcad/src/partcad/assembly.py
+++ b/partcad/src/partcad/assembly.py
@@ -12,6 +12,7 @@ import typing
 from . import telemetry
 from . import shape_envelope
 from .geom import Location
+from .plugin_provider_data_cart import ProviderCartItem
 from .shape import Shape
 from .sync_threads import threadpool_manager
 from . import logging as pc_logging
@@ -224,6 +225,55 @@ class Assembly(Shape):
                 _bom_grouped_add(grouped["parts"], item)
         return grouped
 
+    async def get_bom_detailed_async(self, ctx=None, stop_at_purchasable: bool = False):
+        """The flattened BoM of this assembly, one entry per line item.
+
+        Like 'get_bom()', the tree is flattened into a map keyed by the object's
+        full name, counting how many times each occurs. Unlike it, every entry
+        also carries what a bill of materials is read for: whether the item is a
+        part or an assembly, its description, and the store data that says what
+        to order.
+
+            {"//package:name": {"kind": "part", "count": 2, "desc": "...",
+                                "vendor": None, "sku": None, "count_per_sku": 1}}
+
+        With 'stop_at_purchasable', a sub-assembly that can be bought whole -- it
+        declares a vendor and an SKU, and a supplier of its package has it
+        available -- becomes a line item of its own instead of being expanded
+        into its contents. It is then one thing to order rather than a list of
+        parts to source and assemble, and nothing below it appears in the BoM.
+        Querying the suppliers needs 'ctx'; without one, nothing is purchasable.
+        """
+        with pc_logging.Action("BoMDetailed", self.project_name, self.name):
+            return await self._get_bom_detailed_locked(ctx, stop_at_purchasable, {})
+
+    def get_bom_detailed(self, ctx=None, stop_at_purchasable: bool = False):
+        return asyncio.run(self.get_bom_detailed_async(ctx, stop_at_purchasable))
+
+    async def _get_bom_detailed_locked(self, ctx, stop_at_purchasable, purchasable: dict):
+        with self.lock:
+            async with self.get_async_lock():
+                await self.do_instantiate()
+                return await self._get_bom_detailed_real(ctx, stop_at_purchasable, purchasable)
+
+    async def _get_bom_detailed_real(self, ctx, stop_at_purchasable, purchasable: dict):
+        bom = {}
+        for child in self.children:
+            item = child.item
+            if isinstance(item, Assembly):
+                # An assembly embedded in the parent's source file belongs to no
+                # package, so there is no name to order it by; it can only ever be
+                # expanded, exactly as the grouped BoM treats it.
+                embedded = bool(item.config.get("child", False))
+                if stop_at_purchasable and not embedded and await _is_purchasable(ctx, item, purchasable):
+                    _bom_detailed_add(bom, item, "assembly")
+                    continue
+                child_bom = await item._get_bom_detailed_locked(ctx, stop_at_purchasable, purchasable)
+                _bom_detailed_merge(bom, child_bom)
+            else:
+                _bom_detailed_add(bom, item, "part")
+        return bom
+
 
 def _bom_grouped_add(section: dict, item):
     """Account for one more instance of 'item' in a grouped BoM section."""
@@ -242,3 +292,68 @@ def _bom_grouped_merge(grouped: dict, other: dict):
                     target[name]["count"] += entry["count"]
                 else:
                     target[name] = dict(entry)
+
+
+def _bom_detailed_add(bom: dict, item, kind: str):
+    """Account for one more instance of 'item' in a detailed BoM."""
+    name = "%s:%s" % (item.project_name, item.name)
+    entry = bom.get(name)
+    if entry is None:
+        store_data = item.get_store_data()
+        entry = bom[name] = {
+            "kind": kind,
+            "count": 0,
+            "desc": getattr(item, "desc", None),
+            "vendor": store_data.vendor,
+            "sku": store_data.sku,
+            "count_per_sku": store_data.count_per_sku,
+        }
+    entry["count"] += 1
+
+
+def _bom_detailed_merge(bom: dict, other: dict):
+    """Add the counts of another detailed BoM into 'bom'."""
+    for name, entry in other.items():
+        if name in bom:
+            bom[name]["count"] += entry["count"]
+        else:
+            bom[name] = dict(entry)
+
+
+async def _is_purchasable(ctx, assembly, cache: dict) -> bool:
+    """Whether 'assembly' can be bought whole instead of being assembled.
+
+    Both halves are required: the store data that says what to order (a vendor
+    and an SKU), and a supplier of the assembly's own package that has it
+    available. Either half on its own is not something a buyer can act on.
+
+    The answer is cached per assembly, so a sub-assembly used many times costs
+    one supplier query rather than one per instance.
+    """
+    if ctx is None:
+        return False
+
+    name = "%s:%s" % (assembly.project_name, assembly.name)
+    if name in cache:
+        return cache[name]
+
+    def answer(value: bool) -> bool:
+        cache[name] = value
+        return value
+
+    store_data = assembly.get_store_data()
+    if not store_data.vendor or not store_data.sku:
+        return answer(False)
+
+    # Whether the package declares any supplier at all is asked here rather than
+    # left to 'find_part_suppliers()': that reports the absence as an error, and
+    # a package that simply does not sell anything is not one.
+    project = ctx.get_project(assembly.project_name)
+    if project is None or not project.get_suppliers():
+        return answer(False)
+
+    item = ProviderCartItem()
+    item.set_shape(assembly)
+    # 'find_part_suppliers()' keeps only the providers that report the item as
+    # available, so a non-empty result is the availability answer.
+    return answer(bool(await ctx.find_part_suppliers(item)))

--- a/partcad/src/partcad/plugin_provider_data_cart.py
+++ b/partcad/src/partcad/plugin_provider_data_cart.py
@@ -62,6 +62,18 @@ class ProviderCartItem:
         self.sku = store_data.sku
         self.count_per_sku = store_data.count_per_sku
 
+    def set_shape(self, shape, count: int = 1):
+        """Populate the item from a shape object the caller already holds.
+
+        'set_spec()' resolves a part by name through the context; this is for the
+        callers that have the object at hand, including the assemblies that the
+        context's part lookup would never find. Only the store data is filled in:
+        an assembly has no material, color or finish of its own.
+        """
+        self.name = "%s:%s" % (shape.project_name, shape.name)
+        self.count = count
+        self._set_store_data(shape)
+
     async def set_spec(self, ctx, spec: str):
         self.name, self.count = resolve_cart_item(spec)
 

--- a/partcad/src/partcad/schema/partcad.json
+++ b/partcad/src/partcad/schema/partcad.json
@@ -431,7 +431,9 @@
                   "uniqueItems": true
                 },
                 "offset": { "$ref": "#/definitions/OCCTLocation" },
-                "render": { "$ref": "#/definitions/render" }
+                "render": { "$ref": "#/definitions/render" },
+                "vendor": { "type": "string", "minLength": 1 },
+                "sku": { "type": "string", "minLength": 1 }
               },
               "required": ["type"],
               "additionalProperties": false

--- a/partcad/tests/unit/data/assembly_bom_store/partcad.yaml
+++ b/partcad/tests/unit/data/assembly_bom_store/partcad.yaml
@@ -1,0 +1,11 @@
+desc: An assembly built out of sub-assemblies that can also be bought ready-made
+
+dependencies:
+  sub:
+    type: local
+    path: ./sub
+
+assemblies:
+  top:
+    type: assy
+    desc: The top level assembly

--- a/partcad/tests/unit/data/assembly_bom_store/sub/cube.py
+++ b/partcad/tests/unit/data/assembly_bom_store/sub/cube.py
@@ -1,0 +1,5 @@
+import cadquery as cq
+
+# The geometry is never built: these tests only walk the assembly tree.
+shape = cq.Workplane("XY").box(1, 1, 1)
+show_object(shape)  # noqa: F821

--- a/partcad/tests/unit/data/assembly_bom_store/sub/myStore.py
+++ b/partcad/tests/unit/data/assembly_bom_store/sub/myStore.py
@@ -1,0 +1,25 @@
+"""A minimal store provider: what it has in stock is what 'stock.csv' lists.
+
+Only the 'avail' API is implemented, which is all that finding a supplier for a
+bill of materials asks for.
+"""
+
+import csv
+
+if "request" not in globals():
+    request = {"api": "avail"}
+
+if __name__ == "avail":
+    stock = {}
+    with open(request["parameters"]["file"], newline="\n") as csvfile:
+        for row in csv.DictReader(csvfile, lineterminator="\n"):
+            stock[(row["vendor"], row["sku"])] = int(row["count"])
+
+    in_stock = stock.get((request["vendor"], request["sku"]), 0)
+    output = {
+        "available": in_stock * request["count_per_sku"] >= request["count"],
+        "count": in_stock,
+    }
+
+else:
+    raise Exception("Unknown API: {}".format(__name__))

--- a/partcad/tests/unit/data/assembly_bom_store/sub/panel.assy
+++ b/partcad/tests/unit/data/assembly_bom_store/sub/panel.assy
@@ -1,0 +1,10 @@
+links:
+  - part: cube
+    name: cube1
+    location: [[0, 0, 0], [0, 0, 1], 0]
+  - part: cube
+    name: cube2
+    location: [[1, 0, 0], [0, 0, 1], 0]
+  - part: cube
+    name: cube3
+    location: [[2, 0, 0], [0, 0, 1], 0]

--- a/partcad/tests/unit/data/assembly_bom_store/sub/partcad.yaml
+++ b/partcad/tests/unit/data/assembly_bom_store/sub/partcad.yaml
@@ -1,0 +1,29 @@
+desc: The package the top level assembly is built out of, and the store that sells it
+
+providers:
+  myStore:
+    type: store
+    parameters:
+      file:
+        type: string
+        default: stock.csv
+
+suppliers:
+  myStore:
+
+parts:
+  cube:
+    type: cadquery
+    desc: A cube
+
+assemblies:
+  unit:
+    type: assy
+    desc: A pair of cubes, also sold assembled
+    vendor: partcad
+    sku: UNIT-1
+  panel:
+    type: assy
+    desc: A row of cubes, sold assembled but out of stock
+    vendor: partcad
+    sku: PANEL-1

--- a/partcad/tests/unit/data/assembly_bom_store/sub/stock.csv
+++ b/partcad/tests/unit/data/assembly_bom_store/sub/stock.csv
@@ -1,0 +1,2 @@
+vendor,sku,count
+partcad,UNIT-1,10

--- a/partcad/tests/unit/data/assembly_bom_store/sub/unit.assy
+++ b/partcad/tests/unit/data/assembly_bom_store/sub/unit.assy
@@ -1,0 +1,7 @@
+links:
+  - part: cube
+    name: cube1
+    location: [[0, 0, 0], [0, 0, 1], 0]
+  - part: cube
+    name: cube2
+    location: [[0, 0, 1], [0, 0, 1], 0]

--- a/partcad/tests/unit/data/assembly_bom_store/top.assy
+++ b/partcad/tests/unit/data/assembly_bom_store/top.assy
@@ -1,0 +1,15 @@
+links:
+  - assembly: unit
+    package: sub
+    name: unit1
+    location: [[0, 0, 0], [0, 0, 1], 0]
+  - assembly: unit
+    package: sub
+    name: unit2
+    location: [[0, 0, 10], [0, 0, 1], 0]
+  - assembly: panel
+    package: sub
+    location: [[0, 0, 20], [0, 0, 1], 0]
+  - part: cube
+    package: sub
+    location: [[0, 0, 30], [0, 0, 1], 0]

--- a/partcad/tests/unit/test_assembly_bom.py
+++ b/partcad/tests/unit/test_assembly_bom.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The detailed bill of materials an assembly reports.
+
+The fixture package ('data/assembly_bom_store') is a top level assembly built out
+of two sub-assemblies and a loose part. Both sub-assemblies declare a vendor and
+an SKU, so both look purchasable; only one of them is in the store's stock, which
+is what tells the two halves of the purchasability rule apart.
+"""
+
+import asyncio
+
+import pytest
+
+import partcad as pc
+
+DATA = "partcad/tests/unit/data/assembly_bom_store"
+
+CUBE = "//sub:cube"
+UNIT = "//sub:unit"
+PANEL = "//sub:panel"
+
+# What 'sub/stock.csv' has: the unit, and nothing else.
+IN_STOCK = {("partcad", "UNIT-1")}
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """Answer the store's availability queries without the Python sandbox.
+
+    What the assembly's store data turns into, and how the answer is read back,
+    is the path these tests are about; running 'sub/myStore.py' in a sandbox is
+    not, and features/bom.feature covers that end to end. The request is checked
+    here rather than merely answered: a provider that is asked about the wrong
+    item would otherwise still report it as available.
+    """
+    from partcad.plugin_factory_python import PluginFactoryPython
+
+    async def query_script(self, plugin, script_name, request):
+        assert script_name == "avail"
+        # An availability request names the item by its store data alone, so
+        # this is also where a cart item built from an assembly is checked.
+        assert (request["vendor"], request["sku"]) in IN_STOCK | {("partcad", "PANEL-1")}
+        assert request["count"] == 1 and request["count_per_sku"] == 1
+        return {"available": (request["vendor"], request["sku"]) in IN_STOCK}
+
+    monkeypatch.setattr(PluginFactoryPython, "query_script", query_script)
+
+
+def _bom(stop_at_purchasable=False, with_context=True):
+    ctx = pc.Context(DATA)
+    top = ctx._get_assembly(":top")
+    assert top is not None
+    return asyncio.run(
+        top.get_bom_detailed_async(ctx if with_context else None, stop_at_purchasable=stop_at_purchasable)
+    )
+
+
+def test_bom_detailed_flattens_the_whole_tree():
+    """Without the option, every sub-assembly is expanded into its parts."""
+    bom = _bom()
+
+    # Two units of two cubes, one panel of three, and one loose cube.
+    assert sorted(bom.keys()) == [CUBE]
+    assert bom[CUBE]["count"] == 8
+    assert bom[CUBE]["kind"] == "part"
+    assert bom[CUBE]["desc"] == "A cube"
+
+
+def test_bom_detailed_carries_the_store_data(store):
+    """A line item says what to order, not only how many are needed."""
+    bom = _bom(stop_at_purchasable=True)
+
+    assert bom[UNIT]["vendor"] == "partcad"
+    assert bom[UNIT]["sku"] == "UNIT-1"
+    assert bom[UNIT]["count_per_sku"] == 1
+    # The cube is not sold on its own, so it carries no store data.
+    assert bom[CUBE]["vendor"] is None
+    assert bom[CUBE]["sku"] is None
+
+
+def test_bom_detailed_stops_at_a_purchasable_sub_assembly(store):
+    """A sub-assembly that can be bought whole is a line item, not a parts list."""
+    bom = _bom(stop_at_purchasable=True)
+
+    assert sorted(bom.keys()) == [CUBE, UNIT]
+    # The unit is bought twice; the cubes inside it are not listed at all.
+    assert bom[UNIT]["count"] == 2
+    assert bom[UNIT]["kind"] == "assembly"
+    # Three cubes from the panel, which is not in stock, plus the loose one.
+    assert bom[CUBE]["count"] == 4
+
+
+def test_bom_detailed_expands_what_no_supplier_has(store):
+    """A vendor and an SKU alone do not make a sub-assembly purchasable.
+
+    The panel declares both, but the store has none in stock, so it is still
+    something to assemble: it is expanded, and is not a line item of its own.
+    """
+    bom = _bom(stop_at_purchasable=True)
+
+    assert PANEL not in bom
+
+
+def test_bom_detailed_without_a_context_buys_nothing(store):
+    """Suppliers cannot be queried without a context, so nothing is purchasable."""
+    bom = _bom(stop_at_purchasable=True, with_context=False)
+
+    assert sorted(bom.keys()) == [CUBE]
+    assert bom[CUBE]["count"] == 8
+
+
+def test_bom_detailed_matches_the_flat_bom():
+    """The counts are the ones 'get_bom()' has always reported."""
+    ctx = pc.Context(DATA)
+    top = ctx._get_assembly(":top")
+    flat = asyncio.run(top.get_bom())
+    detailed = asyncio.run(top.get_bom_detailed_async(ctx))
+
+    assert {name: entry["count"] for name, entry in detailed.items()} == flat


### PR DESCRIPTION
## Copilot Summary

Adds `pc bom`, a command that prints the bill of materials of an assembly.

```console
$ pc bom //pub/examples/partcad/produce_assembly_assy:logo
INFO:  Bill of materials of //pub/examples/partcad/produce_assembly_assy:logo:
	//pub/examples/partcad/produce_part_cadquery_logo:bone       2  Plate used as one of the bones on PartCAD logo
	//pub/examples/partcad/produce_part_cadquery_logo:head_half  2  Bracket used as one side of the head on PartCAD logo
	//pub/examples/partcad/produce_part_step:bolt                1  M8x30-screw
Total: 5
```

Every part the assembly is made of, recursively, with how many of each are needed and — where the object says so — the vendor and the SKU to order it by.

### Options

- `-j`/`--json` writes the same data to stdout as JSON, so it can be piped into other tooling. `pc list` has no JSON option to copy, so this mirrors `pc supply find --json` / `pc supply quote --json`: same `-j`/`--json` spelling, JSON on stdout while the logs go through the usual renderer.
- `-s`/`--stop-at-purchasable` stops the recursion at a sub-assembly that can be bought ready-made: one that declares both a `vendor` and an `sku`, **and** that a supplier of its own package reports as available. Such a sub-assembly becomes a single line item and its contents are left out of the BoM — it is one thing to order, not a list of parts to source and assemble. Both halves are required, so a sub-assembly that names an SKU nobody supplies is still expanded. The answer is cached per assembly, so a sub-assembly used many times costs one supplier query rather than one per instance.
- `-P`/`--package` and `-p <name>=<value>` behave as they do in `pc info`.

### Implementation notes

- `Assembly.get_bom_detailed_async()` is the core half. It flattens the tree the way `get_bom()` always has — the counts are asserted to be identical — but each entry also carries the kind of object, its description, and its store data (`vendor`, `sku`, `count_per_sku`). Assemblies embedded in a parent's `links:` belong to no package, so there is no name to order them by; they are always expanded, exactly as the grouped BoM treats them.
- `ProviderCartItem.set_shape()` builds a cart item from an object the caller already holds. `set_spec()` resolves a *part* by name through the context, which would never find an assembly.
- Whether the package declares any supplier at all is checked before calling `find_part_suppliers()`, which reports the absence as an error — a package that simply does not sell anything is not one, and an error there would abort the command.
- The command is a thin daemon client, as the command boundary requires: it reads the package graph and drives the provider plugins, both of which live in the daemon's environment. Method `bom` is registered in the daemon's registry; the human-readable table is rendered daemon-side through PartCAD logging, like `pc list`.
- Assemblies could already carry `vendor`/`sku` as far as the code was concerned (`partcad/test/cam.py` reads them for the manufacturability test), but the package schema rejected them. They are now declarable on an assembly exactly as on a part.

### Testing

- `partcad/tests/unit/test_assembly_bom.py` (6 tests) over a new fixture package: a top level assembly of two sub-assemblies (one in the store's stock, one not) and a loose part. Covers full flattening, the store data on a line item, stopping at the purchasable sub-assembly, expanding the one nobody supplies, no context ⇒ nothing purchasable, and agreement with `get_bom()`. The provider's sandboxed script is stubbed at `query_script`, and the stub asserts the request it is handed, so a cart item built from an assembly is checked rather than assumed.
- `features/bom.feature` (4 scenarios) exercises the CLI end to end: the table, `--json`, `--stop-at-purchasable` where no supplier exists, and the error when the named object is not an assembly.
- `pytest partcad-cli` (11 passed, includes the command-boundary contract) and `pytest partcad-service-json-rpc` (172 passed).

The `partcad` unit suite could not be run in full in this environment: importing `build123d`/OCP segfaults here and the Python sandbox is absent, which fails `test_render.py`'s SVG tests and `test_provider.py` (needs the `//pub` clone) regardless of this change. The BoM-related render tests and the new BoM tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_015aWVZnNGhCQzpKW42cd4PH)_