### PR TITLE
fix(build): bump the partcad-utils pin in partcad/requirements.txt

### DIFF
--- a/dev-tools/bumpversion.toml
+++ b/dev-tools/bumpversion.toml
@@ -70,6 +70,11 @@ search = "__version__ = \"{current_version}\""
 replace = "__version__ = \"{new_version}\""
 
 [[tool.bumpversion.files]]
+filename = "partcad/requirements.txt"
+search = "partcad-utils=={current_version}"
+replace = "partcad-utils=={new_version}"
+
+[[tool.bumpversion.files]]
 filename = "partcad-service-json-rpc/requirements.txt"
 search = "partcad-utils=={current_version}"
 replace = "partcad-utils=={new_version}"

--- a/partcad/requirements.txt
+++ b/partcad/requirements.txt
@@ -6,7 +6,7 @@
 # things that need a CAD library present in this process are handing back live
 # build123d/cadquery objects (convert("build123d"/"cadquery")) and show(); both
 # are opt-in, import their library lazily, and warn if it is not installed.
-partcad-utils==0.7.158
+partcad-utils==0.7.162
 # sdf-fork  # installed on demand into the sandbox runtime (see part_factory_sdf.py)
 pyyaml>=6.0.1
 # Pinned, not floored. pygit2 follows libgit2 and drops deprecated API across


### PR DESCRIPTION
`devel` has not installed since the `0.7.158` → `0.7.159` version bump. Every CI job fails at `Run ./.github/actions/setup-all`, on every OS and Python version, before a single test executes:

```
ERROR: Could not find a version that satisfies the requirement
partcad-utils==0.7.158 (from partcad) (from versions: none)
ERROR: No matching distribution found for partcad-utils==0.7.158
```

## Cause

`partcad/requirements.txt` was never added to `dev-tools/bumpversion.toml`. Its `partcad-utils==` pin therefore froze at `0.7.158` — the version it happened to carry when it was written — while the sibling pins in `partcad-cli/`, `partcad-client/` and `partcad-service-json-rpc/` all advanced. As of `141083d` the repo is at `0.7.162` and that one file still asked for `0.7.158`, which is not on any index.

This is precisely the failure mode the existing comment in `bumpversion.toml` warns about for `partcad-utils` and `partcad-service-json-rpc`. `partcad-cli/tests/unit/test_versions.py` is the guard written to catch it, but it never had the chance to run — the job dies during install, several steps earlier.

## Fix

- Correct the pin in `partcad/requirements.txt` to `0.7.162`.
- Add the missing `[[tool.bumpversion.files]]` entry for `partcad/requirements.txt` so it tracks from here on.

Verified that all 30 entries in `bumpversion.toml` now match text actually present in the files they name, so no other pin has silently drifted.

## Scope

This is not part of any feature branch — it is a pre-existing break on `devel`, present before the current batch of merges (`ddab7536`, the commit preceding them, already failed). It is separated out so it can land, and be reverted, on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJUdN3k39YTAL1rrofSzs)_