### PR TITLE
test(lint): find the fileFrom enum error underneath the parts 'oneOf'

### DIFF
--- a/partcad/tests/unit/test_lint_schema.py
+++ b/partcad/tests/unit/test_lint_schema.py
@@ -31,6 +31,26 @@ def failure(config):
     return err.value
 
 
+def failures(config):
+    """Every error raised for 'config', including those nested inside 'oneOf'.
+
+    'jsonschema.validate' surfaces a single best-match error. Where a branch of
+    a 'oneOf' is what failed -- 'parts' is the only kind wrapped in one -- the
+    best match is the 'oneOf' itself, and the error that names the offending
+    keyword sits underneath it in '.context'. Flatten the tree so a test can
+    assert on that error wherever it ended up.
+    """
+    schema = get_partcad_schema()
+    validator = jsonschema.validators.validator_for(schema)(schema)
+
+    def walk(errors):
+        for error in errors:
+            yield error
+            yield from walk(error.context or [])
+
+    return list(walk(validator.iter_errors(config)))
+
+
 # An object of each kind that carries a source file, in the shortest form that
 # declares where to pull that file from.
 FILE_BACKED = {
@@ -71,6 +91,9 @@ def test_schema_unsupported_file_from(kind):
     """'url' is the only source a file can be pulled from so far"""
     name, config = next(iter(FILE_BACKED[kind].items()))
     config = dict(config, fileFrom="ftp", fileUrl="https://example.com/vendor/%s" % name)
-    error = failure({kind: {name: config}})
-    assert error.json_path == "$.%s.%s.fileFrom" % (kind, name)
-    assert "'ftp' is not one of ['url']" in error.message
+    errors = failures({kind: {name: config}})
+    assert any(
+        error.json_path == "$.%s.%s.fileFrom" % (kind, name)
+        and "'ftp' is not one of ['url']" in error.message
+        for error in errors
+    ), [(error.json_path, error.message) for error in errors]


### PR DESCRIPTION
`test_schema_unsupported_file_from[parts]` fails on `devel` under the pinned `jsonschema` 4.26.0.

```
parts       FAIL  best_match path=$.parts.bolt              expected=$.parts.bolt.fileFrom
sketches    PASS  best_match path=$.sketches.outline.fileFrom
assemblies  PASS  best_match path=$.assemblies.rig.fileFrom
```

## Cause

The test asserts that the best-match error for an unsupported `fileFrom` points at the key itself. That holds for `sketches` and `assemblies`, whose objects are validated directly. `parts` is the only kind wrapped in a `oneOf`: when no branch validates, the best match is the `oneOf` at `$.parts.bolt`, and the error naming the enum lives underneath it in `.context`.

This is not a regression from any recent change — it is a property of the `parts` schema shape. It has simply never been observable, because every CI job on `devel` was dying during install (fixed separately in #524), several steps before the tests ran.

## Fix

Add a `failures()` helper that flattens the error tree, including errors nested inside `oneOf` branches, and assert the enum violation is present wherever it landed.

This checks the property more precisely than before, not less: it asserts both the path (`$.parts.bolt.fileFrom`) and the message (`'ftp' is not one of ['url']`), rather than depending on which error the best-match heuristic surfaces. On failure it prints every error found, so a future regression reports what it actually got.

## Verification

Against the real schema on `devel`, all three kinds now pass, and valid `fileFrom: url` configurations still produce zero errors for every kind — so the assertion was not loosened into one that cannot fail.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJUdN3k39YTAL1rrofSzs)_