### PR TITLE
fix(ci): unbreak Pytest on Python 3.10 and stop the extras pins going stale

### DIFF
--- a/dev-tools/bumpversion.toml
+++ b/dev-tools/bumpversion.toml
@@ -104,6 +104,28 @@ filename = "partcad-cli/requirements.txt"
 search = "partcad-service-json-rpc=={current_version}"
 replace = "partcad-service-json-rpc=={new_version}"
 
+# The CLI's pass-through extras. Each one re-states the `partcad` pin that
+# `partcad-cli/requirements.txt` above already carries, so leaving them out of
+# this file does not merely make them stale -- it makes them contradict it.
+# `pip install partcad-cli[lint]` then resolves `partcad==<current>` and
+# `partcad[lint]==<whatever it froze at>` from the same install and fails. All
+# three had frozen this way (0.7.146, 0.7.158, 0.7.158) before they were added
+# here.
+[[tool.bumpversion.files]]
+filename = "partcad-cli/requirements-lint.txt"
+search = "partcad[lint]=={current_version}"
+replace = "partcad[lint]=={new_version}"
+
+[[tool.bumpversion.files]]
+filename = "partcad-cli/requirements-memcache.txt"
+search = "partcad[memcache]=={current_version}"
+replace = "partcad[memcache]=={new_version}"
+
+[[tool.bumpversion.files]]
+filename = "partcad-cli/requirements-aws.txt"
+search = "partcad[aws]=={current_version}"
+replace = "partcad[aws]=={new_version}"
+
 [[tool.bumpversion.files]]
 filename = "partcad/src/partcad/__init__.py"
 search = "__version__: str = \"{current_version}\""

--- a/partcad-cli/requirements-aws.txt
+++ b/partcad-cli/requirements-aws.txt
@@ -1,1 +1,1 @@
-partcad[aws]==0.7.158
+partcad[aws]==0.7.177

--- a/partcad-cli/requirements-lint.txt
+++ b/partcad-cli/requirements-lint.txt
@@ -1,1 +1,1 @@
-partcad[lint]==0.7.146
+partcad[lint]==0.7.177

--- a/partcad-cli/requirements-memcache.txt
+++ b/partcad-cli/requirements-memcache.txt
@@ -1,1 +1,1 @@
-partcad[memcache]==0.7.158
+partcad[memcache]==0.7.177

--- a/partcad-cli/tests/unit/test_versions.py
+++ b/partcad-cli/tests/unit/test_versions.py
@@ -17,8 +17,17 @@ added later is covered the moment it is declared there, and is caught if it is
 not.
 """
 
-import tomllib
+import re
 from pathlib import Path
+
+# `tomllib` is only in the standard library from Python 3.11. This repo still
+# supports 3.10 (`requires-python = ">=3.10,<3.15"`, and the CI matrix runs it),
+# and pytest is run with `-x`, so a bare `import tomllib` here is not one failing
+# test -- it is a collection error that aborts the entire run on every 3.10 job.
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
 import partcad_cli
 import partcad_client
@@ -78,3 +87,98 @@ def test_every_bumpversion_search_string_still_matches():
         if entry["search"].replace("{current_version}", current) not in text:
             unmatched.append("%s: %s" % (entry["filename"], entry["search"]))
     assert not unmatched, "bumpversion entries that match nothing:\n  " + "\n  ".join(unmatched)
+
+
+# Every distribution this monorepo publishes under the one version. Scoped
+# deliberately: an unrelated third-party dependency that happens to sit at the
+# same version number today must not be swept in and then start failing on the
+# day it makes a release of its own.
+PARTCAD_DISTRIBUTIONS = (
+    "partcad",
+    "partcad-cli",
+    "partcad-client",
+    "partcad-utils",
+    "partcad-service-json-rpc",
+    "partcad-ide-client",
+)
+
+# "partcad[lint]==0.7.146" and friends: a pin on ourselves, with or without extras.
+SELF_PIN = re.compile(
+    r"^(?P<name>%s)(?P<extras>\[[a-z,]+\])?==(?P<version>[^\s;#]+)" % "|".join(PARTCAD_DISTRIBUTIONS),
+    re.MULTILINE,
+)
+
+# Vendored, installed or generated trees. Nothing under them is ours to bump:
+# "bundled" is where the VS Code extension packages third-party wheels, and the
+# rest are dependency and build directories.
+SKIPPED_DIRS = frozenset({".git", ".venv", ".nox", ".tox", "node_modules", "bundled", "build", "dist"})
+
+
+def _self_pins():
+    """Every PartCAD self-pin in the tree, as (relative path, "name[extras]==", version)."""
+    found = []
+    for path in sorted(REPO_ROOT.rglob("*requirements*.txt")):
+        relative = path.relative_to(REPO_ROOT)
+        if SKIPPED_DIRS.intersection(relative.parts):
+            continue
+        for match in SELF_PIN.finditer(path.read_text(encoding="utf-8")):
+            token = "%s%s==" % (match.group("name"), match.group("extras") or "")
+            found.append((relative.as_posix(), token, match.group("version")))
+    return found
+
+
+def test_no_partcad_self_pin_is_stale():
+    """A pin on ourselves that stopped moving is a broken install, not a typo.
+
+    `partcad-cli/requirements.txt` pins `partcad=={current_version}`, and the
+    pass-through extras re-state that same pin as `partcad[lint]==...` and so on.
+    Both are requirements of one install, so the moment the two disagree
+    `pip install partcad-cli[lint]` is unsatisfiable. That is what had happened:
+    the three `partcad-cli` extras files sat at 0.7.146, 0.7.158 and 0.7.158 while
+    everything around them moved, because none of them was named in
+    `dev-tools/bumpversion.toml`.
+
+    The tests above are all driven either by the hardcoded `PACKAGES` map or by
+    what `bumpversion.toml` already declares, so none of them can see a file that
+    file does not mention. This one reads the tree instead.
+    """
+    current = _bumpversion()["current_version"]
+    stale = [
+        "%s: %s%s (expected %s)" % (filename, token, version, current)
+        for filename, token, version in _self_pins()
+        if version != current
+    ]
+    assert not stale, "PartCAD self-pins left behind by the version bump:\n  " + "\n  ".join(stale)
+
+
+def test_every_partcad_self_pin_is_declared_in_bumpversion():
+    """Undeclared is how they go stale; the release after is when it shows.
+
+    `dev-tools/bumpversion.toml` warns about exactly this in its own comment: a
+    thing added to the monorepo without being added there keeps whatever version
+    it was created with while everything else moves. It has now happened four
+    times -- `partcad/requirements.txt`, the three `partcad-cli` extras files,
+    the FreeCAD addon's two constants, and `partcad-ide-client`.
+
+    A new file is correct on the day it is written, so the staleness test above
+    only starts failing one release later, in a commit that touches nothing near
+    it. This checks the declaration rather than the value, so it fails while the
+    author is still looking at the file they just added.
+    """
+    current = _bumpversion()["current_version"]
+    declared = {
+        (entry["filename"], entry["search"].replace("{current_version}", current)) for entry in _bumpversion()["files"]
+    }
+    undeclared = [
+        "%s: %s%s" % (filename, token, version)
+        for filename, token, version in _self_pins()
+        if not any(
+            entry_filename == filename and "%s%s" % (token, current) in entry_search
+            for entry_filename, entry_search in declared
+        )
+    ]
+    assert not undeclared, (
+        "PartCAD self-pins that no [[tool.bumpversion.files]] entry moves:\n  "
+        + "\n  ".join(undeclared)
+        + "\nAdd an entry naming the file to dev-tools/bumpversion.toml."
+    )

--- a/partcad-cli/tests/unit/test_versions.py
+++ b/partcad-cli/tests/unit/test_versions.py
@@ -113,11 +113,17 @@ SELF_PIN = re.compile(
 # rest are dependency and build directories.
 SKIPPED_DIRS = frozenset({".git", ".venv", ".nox", ".tox", "node_modules", "bundled", "build", "dist"})
 
+# The pinned files and the pip-compile inputs alike. The inputs are not merely
+# scanned early: `partcad/requirements-dev.in` has no compiled counterpart at
+# all -- CI installs it with `pip install -r` directly -- so a pin added there
+# would be read by nothing here if only ".txt" were globbed.
+REQUIREMENTS_GLOBS = ("*requirements*.txt", "*requirements*.in")
+
 
 def _self_pins():
     """Every PartCAD self-pin in the tree, as (relative path, "name[extras]==", version)."""
     found = []
-    for path in sorted(REPO_ROOT.rglob("*requirements*.txt")):
+    for path in sorted(candidate for glob in REQUIREMENTS_GLOBS for candidate in REPO_ROOT.rglob(glob)):
         relative = path.relative_to(REPO_ROOT)
         if SKIPPED_DIRS.intersection(relative.parts):
             continue

--- a/partcad/requirements-dev.in
+++ b/partcad/requirements-dev.in
@@ -13,6 +13,12 @@ coverage==7.15.2
 # depended on 'ocp_vscode', which pulled 'flask-sock', which pulled Flask.
 flask==3.1.3
 pyhamcrest==2.1.0
+# 'partcad-cli/tests/unit/test_versions.py' parses 'dev-tools/bumpversion.toml'.
+# 'tomllib' is only in the standard library from Python 3.11, so on 3.10 - which
+# this repo supports and the CI matrix runs - the test falls back to 'tomli'.
+# Declared here because until now it arrived only by accident, through
+# 'partcad-ide-vscode/src/test/python_tests/requirements.txt'.
+tomli==2.4.1; python_version < "3.11"
 pytest==9.1.1
 pytest-cov==7.1.0
 pytest-durations==1.7.0


### PR DESCRIPTION
## Summary

Three related version-hygiene problems, one of which is currently red on every Python 3.10 job.

### 1. Python 3.10 CI is broken (urgent)

`partcad-cli/tests/unit/test_versions.py` did `import tomllib` at module level. `tomllib` is only in the standard library from Python 3.11, but the repo declares `requires-python = ">=3.10,<3.15"` and the CI matrix runs 3.10. Because pytest runs with `-x`, this was not one failing test — it was a collection error that aborted the entire run:

```
ERROR collecting partcad-cli/tests/unit/test_versions.py
E   ModuleNotFoundError: No module named 'tomllib'
```

Fixed with a fallback to `tomli`, and `tomli==2.4.1; python_version < "3.11"` is now declared in `partcad/requirements-dev.in` (the file the CI test environment installs, and where `flask` is declared for the same reason). It was already reaching the environment on 3.10 — from `poetry.lock` in the dev container, and from `partcad-ide-vscode/src/test/python_tests/requirements.txt` in CI — but only by accident, which is exactly the arrangement that stops holding without warning. It is a test dependency only; no shipped package gained a runtime dependency.

This breakage was introduced by #520 and was invisible until #524 fixed the install break that was masking it.

### 2. Three stale PartCAD self-pins

| file | was | now |
| --- | --- | --- |
| `partcad-cli/requirements-lint.txt` | `partcad[lint]==0.7.146` | `partcad[lint]==0.7.177` |
| `partcad-cli/requirements-memcache.txt` | `partcad[memcache]==0.7.158` | `partcad[memcache]==0.7.177` |
| `partcad-cli/requirements-aws.txt` | `partcad[aws]==0.7.158` | `partcad[aws]==0.7.177` |

They were stale because none of them was named in `dev-tools/bumpversion.toml`. Each now has a `[[tool.bumpversion.files]]` entry, so they move with every future bump.

This was a real bug for wheel users, not just untidiness: `partcad-cli/requirements.txt` pins `partcad==<current>` while the extra pinned `partcad[lint]==0.7.146`, and both are requirements of the same install — so `pip install partcad-cli[lint]` was unsatisfiable.

### 3. Tests that would have caught the whole class

`test_versions.py` already had three tests, but every one is driven either by a hardcoded `PACKAGES` map or by entries **already declared** in `bumpversion.toml`. Nothing scanned the filesystem for version-bearing files that are *not* declared — which is precisely how these slipped through. This is the fourth recurrence of the same shape: `partcad/requirements.txt`, these three extras files, `partcad-cad-freecad`'s two constants, and `partcad-ide-client`.

Two new tests:

* **`test_no_partcad_self_pin_is_stale`** — scans `*requirements*.txt` across the tree for `^(partcad|partcad-cli|partcad-client|partcad-utils|partcad-service-json-rpc|partcad-ide-client)(\[extras\])?==` and asserts every matched version equals `current_version`. The pattern is scoped to PartCAD's own distribution names, so an unrelated dependency that happens to sit at the same version cannot false-positive.
* **`test_every_partcad_self_pin_is_declared_in_bumpversion`** — asserts every such pin is moved by some `[[tool.bumpversion.files]]` entry. This catches a newly added file at introduction, while it is still correct, rather than one release later in a commit that touches nothing near it. It is the failure `bumpversion.toml`'s own comment already warns about.

## Verification

* `pytest partcad-cli/tests/unit/test_versions.py` — **13 passed** (11 existing + 2 new).
* Staleness check, before/after. Reverting fix 2 and re-running flags exactly the three files and nothing else:
  ```
  PartCAD self-pins left behind by the version bump:
    partcad-cli/requirements-aws.txt: partcad[aws]==0.7.158 (expected 0.7.177)
    partcad-cli/requirements-lint.txt: partcad[lint]==0.7.146 (expected 0.7.177)
    partcad-cli/requirements-memcache.txt: partcad[memcache]==0.7.158 (expected 0.7.177)
  ```
  The coverage check flags the same three. With fix 2 applied, both pass.
* `dev-tools/bumpversion.toml` still parses, and all **37** entries' search strings still match text in the files they name (the invariant `test_every_bumpversion_search_string_still_matches` guards).
* Simulated a bump 0.7.177 → 0.7.178 across every declared file: the three new entries move the extras pins, and the staleness scan afterwards reports nothing left behind.
* The 3.10 import path was exercised by hiding `tomllib` and confirming the module imports through the `tomli` fallback.
* `python3 -m compileall`, `black --check` and `flake8` clean on the touched Python.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJUdN3k39YTAL1rrofSzs)_