### PR TITLE
docs: correct why the URDF format declares 'decode: false'

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1858,6 +1858,42 @@ the object's value wins:
         step:
           comment: Revision C.
 
+Two names are not entirely the package's own.
+
+``decode`` is not a parameter at all. It is one of the fields PartCAD reads
+itself -- it says whether the sandbox rebuilds the shape and assembly envelopes
+into live geometry before the implementation sees them (see ``urdf`` under
+`Built-in implementations`_) -- so no package can declare an export parameter
+named ``decode``: a ``decode:`` in a file type's configuration is always that
+flag.
+
+``properties`` is the other way round, and it is a parameter -- with a caveat. A
+file type that declares ``properties: true`` is handed, in place of the flag, an
+index of what the shapes being written declare about themselves: their
+``physics``, ``material`` and ``color``, keyed by the full ``<package>:<name>``
+of each shape, so an implementation given a whole assembly tree can look up the
+properties belonging to each node of it. Only shapes that declare at least one
+appear.
+
+.. code-block:: yaml
+
+  export:
+    urdf:
+      properties: true
+
+It is opt-in because building the index instantiates the whole assembly tree,
+which defeats the shape cache for that subtree: an assembly whose geometry could
+have been served from the cache has to be built anyway, so that its children
+exist to be walked. An implementation with no use for the properties should not
+pay for that. ``urdf`` is the one built-in file type that asks.
+
+The caveat is that ``properties``, unlike ``decode``, is *not* a reserved field
+name, and PartCAD intercepts it by value rather than by declaration: a package
+that declares an ordinary export parameter of its own named ``properties`` and
+gives it the value ``true`` will find that value replaced by the index before
+its implementation sees it. Any other value is passed through untouched, but the
+name is best avoided for anything else.
+
 Custom implementations
 ----------------------
 
@@ -1939,6 +1975,8 @@ declares and the images the other file types leave behind (see ``pc render`` in
 ``urdf`` is the one built-in file type that is not a single file: it writes a
 ``.urdf`` plus the directory of mesh files it references, which is why
 ``Shape.convert()`` refuses it (there is no single payload to hand back) and why
-it declares ``decode: false`` - it is handed the assembly *tree*, one URDF link
-per node, rather than the single compound the tree decodes to. See
-:doc:`simulation`.
+it declares ``decode: false`` - it is handed the assembly *tree* itself, one
+URDF link per node, rather than the geometry the tree decodes to. Decoding keeps
+the shape of the tree but nothing else about it: every node's ``name`` and
+``label`` is dropped, and its placement is baked into the geometry instead of
+staying readable as the joint origin. See :doc:`simulation`.

--- a/partcad/src/partcad/builtin/export/export_urdf.py
+++ b/partcad/src/partcad/builtin/export/export_urdf.py
@@ -7,14 +7,16 @@
 
 Writes a PartCAD shape or assembly as a URDF file plus its mesh files.
 
-Unlike the other exporters, this one is handed the assembly *tree* rather than
-the compound it decodes to - which is what 'decode: false' on this format's
-declaration asks for, see wrapper_export.DECODE_KEY: URDF is a tree of links
-joined by joints, and one link per node is exactly what makes the export
-reversible. Each node becomes a link, each parent/child edge a
-fixed joint carrying that child's placement, and each node that has geometry
-gets a mesh written next to the URDF and referenced from its ``<visual>`` and
-``<collision>``.
+Unlike the other exporters, this one is handed the assembly *tree* itself
+rather than the geometry it decodes to - which is what 'decode: false' on this
+format's declaration asks for, see wrapper_export.DECODE_KEY. Decoding would
+keep the tree's shape, and nothing else about it: every node's 'name' and
+'label' is dropped and its placement is baked into the geometry rather than
+staying readable as data. This exporter needs all three - the link names, the
+mesh names, the properties lookup and every joint origin come from them. Each
+node becomes a link, each parent/child edge a fixed joint carrying that child's
+placement, and each node that has geometry gets a mesh written next to the URDF
+and referenced from its ``<visual>`` and ``<collision>``.
 
 The URDF is built with ROS's own 'urdf_parser_py' and serialized by it, so what
 lands on disk is what the ROS toolchain itself would write and reads back

--- a/partcad/src/partcad/builtin/export/partcad.yaml
+++ b/partcad/src/partcad/builtin/export/partcad.yaml
@@ -114,13 +114,15 @@ export:
     desc: |
       Unified Robot Description Format: a URDF file plus the mesh files it
       references. Unlike every other format here it is handed the assembly
-      *tree* rather than the compound it decodes to (`decode: false`), because
-      one URDF link per assembly node is what makes the export reversible.
+      *tree* itself rather than the geometry it decodes to (`decode: false`),
+      because one URDF link per assembly node - named, placed and looked up by
+      what the tree says - is what makes the export reversible.
     path: export_urdf.py
     extension: urdf
     # 'decode: false' -- see wrappers/wrapper_export.py. The exporter walks the
-    # assembly envelopes itself; decoding them into live geometry would collapse
-    # the tree into a single compound and there would be no links left to write.
+    # assembly envelopes itself; decoding them into live geometry would keep the
+    # tree's shape but drop every node's name and label and bake its placement
+    # in, leaving nothing to name, group or joint the links by.
     decode: false
     pythonRequirements:
       - cadquery-ocp==7.9.3.1.1

--- a/partcad/src/partcad/output.py
+++ b/partcad/src/partcad/output.py
@@ -105,7 +105,11 @@ SCRIPT_KEY = "__script__"
 # The request key that says whether the sandbox rebuilds the shape and assembly
 # envelopes into live OCCT geometry before the implementation sees them. It
 # travels beside the script path for the same reason: the wrapper has to know
-# before it deserializes anything. Declared on a file type as 'decode: false'.
+# before it deserializes anything. Declared on a file type as 'decode: false',
+# which is what an implementation asks for when it needs what an envelope says
+# *about* a node: decoding mirrors the assembly tree in nested compounds, but
+# geometry is all it keeps - every node's 'name' and 'label' is dropped, and its
+# placement is baked into the shape instead of staying readable as data.
 DECODE_KEY = "__decode__"
 
 # A parameter, not a reserved key: a file type declares 'properties: true' to be

--- a/partcad/src/partcad/shape.py
+++ b/partcad/src/partcad/shape.py
@@ -915,9 +915,10 @@ class Shape(ShapeConfiguration):
         request = await self._output_request(obj, impl, kwargs)
         request[output.SCRIPT_KEY] = os.path.abspath(script)
         # Whether the sandbox rebuilds the envelopes into live geometry before
-        # the implementation sees them. Off for an implementation that walks the
-        # assembly *tree* (the URDF exporter turns each node into a link of its
-        # own), which decoding would have collapsed into one compound.
+        # the implementation sees them. Off for an implementation that needs what
+        # the envelopes say about each node (the URDF exporter names every link
+        # and places every joint from that), none of which decoding carries over
+        # into the geometry it builds.
         request[output.DECODE_KEY] = impl.decode
         request_serialized = shape_envelope.serialize(request)
 

--- a/partcad/src/partcad/wrappers/ocp_serialize.py
+++ b/partcad/src/partcad/wrappers/ocp_serialize.py
@@ -495,7 +495,9 @@ def deserialize_raw(data) -> object:
 
     The counterpart of the core-side 'shape_envelope.deserialize()', for the
     wrappers that need the *structure* of an assembly envelope rather than the
-    compound it decodes to: the URDF exporter turns each node of the tree into a
-    link of its own, which the flattening in 'decode()' would have thrown away.
+    geometry it decodes to: the URDF exporter names each link and places each
+    joint from what the envelope says about a node, and 'decode()' keeps none of
+    that - the compound it builds mirrors the tree, but the names and labels are
+    gone and the placements are baked into the geometry.
     """
     return json.loads(_payload_line(data))

--- a/partcad/src/partcad/wrappers/wrapper_common.py
+++ b/partcad/src/partcad/wrappers/wrapper_common.py
@@ -27,8 +27,10 @@ def handle_input(decode=True):
 
     'decode' off keeps the request exactly as it travelled, with shape and
     assembly envelopes left as their dicts instead of being rebuilt into live
-    OCCT geometry. A wrapper that walks an assembly *tree* needs that, because
-    decoding collapses the tree into one compound (see ocp_serialize.decode).
+    OCCT geometry. A wrapper that needs a node's 'name' or 'label', or its
+    location as separate data, needs that: decoding mirrors the tree in nested
+    compounds but keeps geometry alone, dropping the names and baking the
+    placements in (see ocp_serialize.decode_shape).
     """
     if len(sys.argv) < 2:
         sys.stderr.write("Usage: %s <path>\n" % sys.argv[0])

--- a/partcad/src/partcad/wrappers/wrapper_common.py
+++ b/partcad/src/partcad/wrappers/wrapper_common.py
@@ -30,7 +30,8 @@ def handle_input(decode=True):
     OCCT geometry. A wrapper that needs a node's 'name' or 'label', or its
     location as separate data, needs that: decoding mirrors the tree in nested
     compounds but keeps geometry alone, dropping the names and baking the
-    placements in (see ocp_serialize.decode_shape).
+    placements in (see ocp_serialize.decode, which hands each envelope it finds
+    to decode_shape - the per-node walk that does this).
     """
     if len(sys.argv) < 2:
         sys.stderr.write("Usage: %s <path>\n" % sys.argv[0])

--- a/partcad/src/partcad/wrappers/wrapper_export.py
+++ b/partcad/src/partcad/wrappers/wrapper_export.py
@@ -52,9 +52,11 @@ SCRIPT_KEY = "__script__"
 # The key that says whether the envelopes are rebuilt into live OCCT geometry
 # before the implementation sees them. It has to travel in the request and be
 # read before anything is decoded, which is why the request is always read raw
-# here and decoded afterwards. An implementation that walks an assembly *tree*
-# (the URDF exporter turns each node into a link of its own) declares
-# 'decode: false', because decoding collapses the tree into one compound.
+# here and decoded afterwards. An implementation that needs what an envelope
+# says *about* a node (the URDF exporter names each link after the node and
+# reads its location as a joint origin) declares 'decode: false', because
+# decoding keeps the tree's shape but only its geometry: names and labels are
+# gone and placements are baked in rather than left as data.
 DECODE_KEY = "__decode__"
 
 

--- a/partcad/tests/unit/test_output.py
+++ b/partcad/tests/unit/test_output.py
@@ -456,10 +456,11 @@ def test_parameters_exclude_the_reserved_fields():
 def test_a_format_decodes_its_envelopes_unless_it_declares_otherwise(ctx):
     """'decode' is off for URDF alone, and nothing else may lose it silently.
 
-    The URDF exporter is handed the assembly tree, one link per node; decoding
-    would collapse it into a single compound and the export would quietly write
-    a one-link robot. It is the only built-in format that asks for that, so this
-    also guards the other direction.
+    The URDF exporter is handed the assembly tree, one link per node; decoded
+    geometry carries no node names, labels or separate placements to build those
+    links from, so 'export_urdf.process()' rejects it outright and the export
+    fails with "needs a shape or an assembly to export". It is the only built-in
+    format that asks for that, so this also guards the other direction.
     """
     off = set()
     for section in output.SECTIONS:


### PR DESCRIPTION
## What this changes

`decode: false` on the `urdf` file type is correct and load-bearing. Nothing about the flag changes here. Only the *reason* given for it was wrong, in eight comments that all repeated the same false claim.

**The false claim.** Those comments said that `ocp_serialize.decode()` "collapses the tree into a single compound", and gave that as why URDF opts out. It does not. `decode_shape()` (`partcad/src/partcad/wrappers/ocp_serialize.py`) calls `compound_of` **per assembly node**, so the result is a *nested* compound whose topology mirrors the assembly tree exactly. Grouping survives, and placements survive — fused in via `Located`.

**The real reason.** What decoding actually destroys is:

- every node's `name` and `label` — OCCT `TopoDS_*` has no such attribute, and `decode_shape` never reads those fields; and
- the placement as *separate data* — it is baked into the geometry rather than remaining readable as `KEY_LOCATION`.

That is exactly what `builtin/export/export_urdf.py` needs. Its URDF link names, its mesh file names, its multi-`<visual>` grouping rule (a `label` prefix convention) and its properties lookup all come from `name`/`label`, and it reads each node's `KEY_LOCATION` as the joint origin. None of that is recoverable from decoded geometry, however faithfully the compound mirrors the tree.

## Sites corrected

- `partcad/src/partcad/output.py` — `DECODE_KEY`
- `partcad/src/partcad/wrappers/wrapper_export.py` — `DECODE_KEY`
- `partcad/src/partcad/wrappers/wrapper_common.py` — `handle_input()` docstring
- `partcad/src/partcad/builtin/export/export_urdf.py` — module docstring
- `partcad/src/partcad/builtin/export/partcad.yaml` — the `urdf` `desc:` and the comment above `decode: false`
- `docs/source/configuration.rst` — the `urdf` paragraph under *Built-in implementations*
- `partcad/src/partcad/shape.py` — the comment above `request[output.DECODE_KEY] = impl.decode`
- `partcad/src/partcad/wrappers/ocp_serialize.py` — `deserialize_raw()`, which attributed the same non-existent behaviour to "the flattening in `decode()`"

The last two were found while making the pass rather than being part of the original list.

## The cross-reference in `handle_input()`

An earlier revision of this branch changed that docstring's pointer from `ocp_serialize.decode` to `decode_shape`, justified in the commit message by the claim that `decode` did not exist. **That claim was false** and the second commit corrects it. Both functions exist: `decode()` is the public entry point, and it dispatches any dict carrying `brep` or `assembly` to `decode_shape()`. `handle_input()` reaches the latter only through the former — `deserialize` → `loads` → `decode` → `decode_shape`.

The docstring now names both, since each answers a different question: `decode` is what this function actually calls, and `decode_shape` is where the per-node walk the surrounding sentence describes actually lives.

## A second false claim, in a test docstring

`test_a_format_decodes_its_envelopes_unless_it_declares_otherwise` said that dropping the flag would mean "the export would quietly write a one-link robot". It would not. `export_urdf.process()` fails its `isinstance(root, dict)` guard and raises `ValueError("The URDF exporter needs a shape or an assembly to export")`, which `wrapper_export.process()` turns into `{"success": False, ...}`. The failure is loud. The docstring now says so; the test body is untouched and still passes.

## Newly documented: `properties: true`

`docs/source/configuration.rst` documented `decode: false` but never mentioned `properties: true`. It is now documented alongside, under *Export parameters*:

- what it hands the implementation — an index of the shapes' declared `physics`, `material` and `color`, keyed by full `<package>:<name>`;
- why it is opt-in — building the index instantiates the whole assembly tree, which defeats the shape cache for that subtree;
- the caveat that `PROPERTIES_KEY` is **not** in `RESERVED_KEYS`, so a package declaring an ordinary export parameter named `properties` with the value `true` will have it intercepted and replaced by the core.

The same section now also notes that `decode` **is** in `IMPLEMENTATION_KEYS`, so no package can have an export parameter by that name.

## Verification

- `python3 -m compileall` clean on every touched Python file; no line over 120 chars.
- `partcad.yaml` parses; `decode: false` and `properties: true` unchanged.
- `configuration.rst` parses under docutils with no new messages (the one pre-existing title-style error at line 1488 is present on `devel` too, and is untouched).
- `partcad/tests/unit/test_output.py`: 45 passed, 2 skipped.
- `git diff` touches comments, docstrings and documentation only — no executable line moved.