### PR TITLE
fix: repair the two post-merge regressions on `devel` (cache round-trip test, docs build)

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1143,7 +1143,7 @@ The ``manufacturing.method`` field says how a part is made:
 
 These are ways of making a **part**, and apply to parts only. An assembly is put
 together rather than made, and has a single method of its own -- see
-:ref:`assembly-manufacturing` below.
+:ref:`manufacturing an assembly <assembly-manufacturing>` below.
 
 A part that is bought rather than made carries ``vendor`` and ``sku`` instead of
 a method.
@@ -1486,7 +1486,7 @@ by its URL and downloaded the first time it is used:
       fileUrl: https://example.com/vendor/catalog/gearbox.step
 
 Compared to ``pc import assembly``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``pc import assembly`` reads the very same file with the very same reader, but
 it is a one-shot conversion: it writes a STEP file per component and an

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -61,7 +61,7 @@ The commands and options supported by PartCAD CLI:
 
   Package commands:
     init         Create a new PartCAD package in the current directory
-    install      Download and set up all imported packages
+    install      Download everything the package needs to be built
     update       Force update all imported packages to their latest versions
     lint         Run linting checks on files within packages
 

--- a/features/lint.feature
+++ b/features/lint.feature
@@ -415,7 +415,10 @@ Feature: `pc lint` command
       """
     And a file named "main.assy" with content:
       """
-      This is a assembly file for main.assy
+      links:
+        - part: bone
+          package: //pub/examples
+          location: [[0, 0, 0], [0, 0, 1], 0]
       """
     When I run "pc lint"
     Then the command should exit with a status code of "0"

--- a/features/pc.feature
+++ b/features/pc.feature
@@ -23,7 +23,7 @@ Feature: `pc` command
     # TODO-61: Due to different terminal size in CI' (YAML file or directory with 'partcad.yaml')' is wrapped to the next line
     And STDOUT should contain "Specify the package path"
     And STDOUT should contain "Create a new PartCAD package in the current directory "
-    And STDOUT should contain "Download and set up all imported packages "
+    And STDOUT should contain "Download everything the package needs to be built."
     And STDOUT should contain "List components"
 
   @pc-verbose @pc-status

--- a/partcad-cli/README.md
+++ b/partcad-cli/README.md
@@ -23,7 +23,7 @@ Run `pc --help` to see all commands, and `pc <command> --help` for the options o
 a specific command. The most common commands are:
 
 - `pc init` — Create a new PartCAD package in the current directory.
-- `pc install` — Download and set up all imported packages.
+- `pc install` — Download everything the package needs to be built.
 - `pc list` — List parts, sketches, assemblies, interfaces, and packages.
 - `pc add` / `pc import` — Add or import a part, sketch, or assembly.
 - `pc inspect` — View a part, assembly, or scene visually.

--- a/partcad/src/partcad/adhoc/convert.py
+++ b/partcad/src/partcad/adhoc/convert.py
@@ -83,14 +83,17 @@ def convert_cad_file(input_filename: str, input_type: str, output_filename: str,
                 raise RuntimeError("Failed to load the input part: no part returned")
 
             shape = asyncio.run(part.get_wrapped(ctx))
+            # Errors first: when the factory failed - a missing module, a
+            # sandbox that would not install - that is the reason there is no
+            # shape, and it is the one worth reporting. "No shape returned" is
+            # what is left to say when nothing was recorded.
+            if part.errors:
+                raise RuntimeError(f"Failed to load the input part: {part.errors}")
             if not shape:
                 raise RuntimeError("Failed to load the input part: no shape returned")
 
             pc_logging.info(f"Loaded input part: {input_path}")
             pc_logging.info(f"Shape: {type(shape)}")
-
-            if part.errors:
-                raise RuntimeError(f"Failed to load the input part: {part.errors}")
 
             part.render(ctx=ctx, format_name=output_type, project=project, filepath=output_filename)
 
@@ -124,13 +127,13 @@ def convert_sketch_file(input_filename: str, input_type: str, output_filename: s
                 raise RuntimeError("Failed to load the input sketch: no sketch returned")
 
             shape = asyncio.run(sketch.get_wrapped(ctx))
+            # Errors first, for the same reason as in convert_cad_file().
+            if sketch.errors:
+                raise RuntimeError(f"Failed to load the input sketch: {sketch.errors}")
             if not shape:
                 raise RuntimeError("Failed to load the input sketch: no shape returned")
 
             pc_logging.debug(f"Loaded input sketch: {input_path}")
-
-            if sketch.errors:
-                raise RuntimeError(f"Failed to load the input sketch: {sketch.errors}")
 
             sketch.render(ctx=ctx, format_name=output_type, project=project, filepath=output_filename)
 

--- a/partcad/src/partcad/adhoc/convert.py
+++ b/partcad/src/partcad/adhoc/convert.py
@@ -98,7 +98,7 @@ def convert_cad_file(input_filename: str, input_type: str, output_filename: str,
             part.render(ctx=ctx, format_name=output_type, project=project, filepath=output_filename)
 
     except Exception as e:
-        raise RuntimeError(f"Failed to convert: {e}")
+        raise RuntimeError(f"Failed to convert: {e}") from e
     finally:
         shutil.rmtree(temp_dir)
 
@@ -138,6 +138,8 @@ def convert_sketch_file(input_filename: str, input_type: str, output_filename: s
             sketch.render(ctx=ctx, format_name=output_type, project=project, filepath=output_filename)
 
     except Exception as e:
-        raise RuntimeError("Failed to convert sketch") from e
+        # The cause belongs in the message, not only in __cause__: this is what
+        # the CLI prints, and without it every sketch failure reads the same.
+        raise RuntimeError(f"Failed to convert sketch: {e}") from e
     finally:
         shutil.rmtree(temp_dir)

--- a/partcad/tests/unit/test_adhoc_convert_error_order.py
+++ b/partcad/tests/unit/test_adhoc_convert_error_order.py
@@ -1,0 +1,119 @@
+#
+# PartCAD, 2025
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""
+Which failure `pc adhoc convert` reports when a factory fails.
+
+A factory that fails records the reason in `errors` and returns no shape, so
+both conditions are true at once and only the order of the checks decides what
+the user is told. These tests pin that order: the recorded reason wins, and
+"no shape returned" is reserved for the case where nothing was recorded.
+
+They stub the context rather than converting a real file, so they need no CAD
+runtime and no sandbox -- the ordering is the whole subject.
+"""
+
+import pytest
+
+from partcad.adhoc import convert as adhoc_convert
+
+
+class _FakeShape:
+    """Stands in for whatever the factory would have produced."""
+
+
+class _FakeObject:
+    def __init__(self, errors, shape):
+        self.errors = errors
+        self._shape = shape
+        self.rendered = False
+
+    async def get_wrapped(self, ctx):
+        return self._shape
+
+    def render(self, **kwargs):
+        self.rendered = True
+
+
+class _FakeProject:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def get_part(self, name):
+        return self._obj
+
+    def get_sketch(self, name):
+        return self._obj
+
+
+class _FakeContext:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def get_project(self, name):
+        return _FakeProject(self._obj)
+
+
+@pytest.fixture
+def stub_context(monkeypatch):
+    """Point `convert.Context` at a fake built from the object under test."""
+
+    def install(obj):
+        monkeypatch.setattr(adhoc_convert, "Context", lambda *a, **kw: _FakeContext(obj))
+        return obj
+
+    return install
+
+
+@pytest.mark.parametrize(
+    "convert, kind",
+    [
+        (adhoc_convert.convert_cad_file, "part"),
+        (adhoc_convert.convert_sketch_file, "sketch"),
+    ],
+)
+def test_a_recorded_error_is_reported_instead_of_the_missing_shape(stub_context, tmp_path, convert, kind):
+    """A failed factory records why; that reason is what reaches the user."""
+    obj = stub_context(_FakeObject(errors=["sandbox install failed: no cadquery wheel"], shape=None))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        convert(str(tmp_path / "in.step"), "step", str(tmp_path / "out.stl"), "stl")
+
+    message = str(excinfo.value)
+    assert "sandbox install failed: no cadquery wheel" in message
+    assert "no shape returned" not in message
+    assert not obj.rendered
+
+
+@pytest.mark.parametrize(
+    "convert, kind",
+    [
+        (adhoc_convert.convert_cad_file, "part"),
+        (adhoc_convert.convert_sketch_file, "sketch"),
+    ],
+)
+def test_no_shape_and_no_recorded_error_still_says_no_shape(stub_context, tmp_path, convert, kind):
+    """With nothing recorded, the fallback message is all there is to say."""
+    obj = stub_context(_FakeObject(errors=[], shape=None))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        convert(str(tmp_path / "in.step"), "step", str(tmp_path / "out.stl"), "stl")
+
+    assert "no shape returned" in str(excinfo.value)
+    assert not obj.rendered
+
+
+@pytest.mark.parametrize(
+    "convert",
+    [adhoc_convert.convert_cad_file, adhoc_convert.convert_sketch_file],
+)
+def test_a_shape_with_no_errors_is_rendered(stub_context, tmp_path, convert):
+    """The success path is unchanged: no errors and a shape means render."""
+    obj = stub_context(_FakeObject(errors=[], shape=_FakeShape()))
+
+    convert(str(tmp_path / "in.step"), "step", str(tmp_path / "out.stl"), "stl")
+
+    assert obj.rendered

--- a/partcad/tests/unit/test_assembly_serialize.py
+++ b/partcad/tests/unit/test_assembly_serialize.py
@@ -14,6 +14,8 @@ import sys
 import partcad as pc
 from partcad import shape_envelope
 
+from OCP.Bnd import Bnd_Box
+from OCP.BRepBndLib import BRepBndLib
 from OCP.BRepGProp import BRepGProp
 from OCP.GProp import GProp_GProps
 
@@ -25,6 +27,14 @@ def _volume(shape):
     props = GProp_GProps()
     BRepGProp.VolumeProperties_s(shape, props)
     return props.Mass()
+
+
+def _bbox(shape):
+    """The assembled bounding box, as the two corners in world coordinates."""
+    box = Bnd_Box()
+    BRepBndLib.Add_s(shape, box)
+    lo, hi = box.CornerMin(), box.CornerMax()
+    return (lo.X(), lo.Y(), lo.Z(), hi.X(), hi.Y(), hi.Z())
 
 
 def _first_leaf(tree):
@@ -98,4 +108,16 @@ def test_assembly_tree_round_trips_to_the_same_geometry():
     # And it comes back as the same geometry. get_wrapped() returns a BREP
     # envelope too, so decode that as well before measuring.
     rebuilt = ocp_serialize.decode_shape(shape_envelope.loads(text))
-    assert abs(_volume(rebuilt) - _volume(ocp_serialize.decode_shape(compound))) < 1e-6
+    original = ocp_serialize.decode_shape(compound)
+    assert abs(_volume(rebuilt) - _volume(original)) < 1e-6
+
+    # Volume alone is placement-blind: a child that came back at the origin, or
+    # anywhere else, displaces exactly as much as one in its right place, so the
+    # assertion above would not notice. The bounding box does - it is the cheap
+    # invariant that moves when a child does. Both sides are measured the same
+    # way, so Bnd_Box's own gap cancels out.
+    rebuilt_bbox = _bbox(rebuilt)
+    original_bbox = _bbox(original)
+    assert all(abs(a - b) < 1e-6 for a, b in zip(rebuilt_bbox, original_bbox)), (
+        "the assembly does not occupy the same space: %r vs %r" % (rebuilt_bbox, original_bbox)
+    )

--- a/partcad/tests/unit/test_assembly_serialize.py
+++ b/partcad/tests/unit/test_assembly_serialize.py
@@ -118,6 +118,6 @@ def test_assembly_tree_round_trips_to_the_same_geometry():
     # way, so Bnd_Box's own gap cancels out.
     rebuilt_bbox = _bbox(rebuilt)
     original_bbox = _bbox(original)
-    assert all(abs(a - b) < 1e-6 for a, b in zip(rebuilt_bbox, original_bbox)), (
+    assert all(abs(a - b) < 1e-6 for a, b in zip(rebuilt_bbox, original_bbox, strict=True)), (
         "the assembly does not occupy the same space: %r vs %r" % (rebuilt_bbox, original_bbox)
     )

--- a/partcad/tests/unit/test_assembly_serialize.py
+++ b/partcad/tests/unit/test_assembly_serialize.py
@@ -12,6 +12,7 @@ import os
 import sys
 
 import partcad as pc
+from partcad import shape_envelope
 
 from OCP.BRepGProp import BRepGProp
 from OCP.GProp import GProp_GProps
@@ -60,13 +61,41 @@ def test_assembly_cache_value_is_a_nested_tree():
     assert leaf is not None and leaf["name"] and leaf["label"] and leaf["brep"]
 
 
+def _brep_payloads(tree):
+    """Every "brep" field in the tree, the root's own first."""
+    if isinstance(tree, list):
+        for item in tree:
+            yield from _brep_payloads(item)
+        return
+    if not isinstance(tree, dict):
+        return
+    if "brep" in tree:
+        yield tree["brep"]
+    for child in tree.get("assembly", []):
+        yield from _brep_payloads(child)
+
+
 def test_assembly_tree_round_trips_to_the_same_geometry():
     ctx = pc.init("examples")
     asm = ctx._get_assembly("//produce_assembly_assy:logo_embedded")
     compound = asyncio.run(asm.get_wrapped(ctx))
     tree = asyncio.run(asm.get_cache_value(ctx, compound))
 
-    # Through the JSON the cache stores, the tree decodes to the same geometry.
-    # get_wrapped() returns a BREP envelope now, so decode it before measuring.
-    rebuilt = ocp_serialize.decode_shape(json.loads(json.dumps(tree)))
+    # In memory a BREP payload is the compressed bytes themselves; base64 is
+    # applied only where the value has to become JSON text. That boundary is
+    # shape_envelope.dumps()/loads(), which is what the shape cache serializes
+    # through - so the round trip goes through it, not through bare json, which
+    # has no byte type to carry the payload in the first place.
+    text = shape_envelope.dumps(tree)
+
+    # What it produced really is JSON, and every payload in it really is text:
+    # nothing bytes-shaped is left for the cache - or a wrapper - to choke on.
+    raw = json.loads(text)
+    payloads = list(_brep_payloads(raw))
+    assert payloads, "the encoded tree carries no BREP payload at all"
+    assert all(isinstance(payload, str) for payload in payloads), "a BREP payload survived as non-text"
+
+    # And it comes back as the same geometry. get_wrapped() returns a BREP
+    # envelope too, so decode that as well before measuring.
+    rebuilt = ocp_serialize.decode_shape(shape_envelope.loads(text))
     assert abs(_volume(rebuilt) - _volume(ocp_serialize.decode_shape(compound))) < 1e-6


### PR DESCRIPTION
## The regression

`partcad/tests/unit/test_assembly_serialize.py::test_assembly_tree_round_trips_to_the_same_geometry`
fails on Python 3.11, 3.12 and 3.13 with:

```
TypeError: Object of type bytes is not JSON serializable
```

It passed on 3.13 as recently as **2026-08-20**. The test itself has not changed since #478.

The origin is **#521** ("fix(cache): store shapes without the outer envelope layer", 7b7722b), which
deliberately made the in-process `"brep"` payload the raw zstd frame rather than base64. The test does
`json.loads(json.dumps(tree))` on the result of `get_cache_value()`, and bare `json` has no byte type.

## Which side was wrong: the test

**#521 is right; the test was over-specific.** The evidence is the caller set — `get_cache_value()` has
exactly three callers in the whole tree:

| Caller | Needs JSON-native? |
| --- | --- |
| `partcad/src/partcad/shape.py:368` (`Shape.get_wrapped()` → `ctx.cache_shapes.write_async()`) | No |
| `test_assembly_serialize.py:43` (`..._is_a_nested_tree`) | No — it only reads `name`/`label`/`brep` truthiness |
| `test_assembly_serialize.py:67` (this test) | It assumed so |

The only production caller hands the value to `ShapeCache.write_async()`, which serializes through
`cache_shape._serialize()` → `shape_envelope.strip_metadata()` + `shape_envelope.encode()`. That is where
base64 is applied, and it is the only place it is applied: a lone shape does not even get JSON around it,
its compressed frame goes to the storage tier byte for byte.

Nothing else touches the value. It is not returned by any JSON-RPC method (`partcad-service-json-rpc`
never mentions `get_cache_value`), it is not read by the IDE client, and it is never written to disk as
bare JSON. So **no caller requires a JSON-safe structure**, and making the producer re-encode to keep bare
`json.dumps()` working would put back exactly the base64 round trip #521 removed from the hot cache path —
`ocp_serialize.compressed_brep()` says as much: *"Base64 is applied on top of this only where the payload
has to travel as JSON; the core keeps the bytes."*

## The fix

The test now round-trips through `shape_envelope.dumps()`/`loads()` — the boundary the cache itself
serializes through — instead of bare `json`. It has not been weakened:

* The geometry assertion its name promises is unchanged: decode the round-tripped tree and compare its
  volume against the freshly built compound.
* It additionally asserts what the old bare `json.dumps()` was implicitly asserting — that the encoded
  form really is JSON text (`json.loads()` on it), and that **every** `"brep"` in it, at every level of
  the tree, came out as `str`. A payload that leaked through as bytes fails that assertion rather than
  silently riding along.

No production code was changed for this, so the on-disk cache format, the cache key version and the
JSON-RPC wire format are all untouched.

## Also: surface the real error in `pc adhoc convert`

`partcad/src/partcad/adhoc/convert.py` checked `if not shape:` before `if part.errors:`, so when the
underlying factory failed — a missing module, a sandbox that would not install — the user got
"no shape returned" and the actual cause stayed in the captured logs. The two checks are swapped so the
recorded error is what reaches the exception; "no shape returned" remains the fallback for when there
genuinely are no recorded errors. `convert_sketch_file()` had the identical ordering and got the same
treatment.

Both conditions already raised before reaching `render()`, so this changes the message and nothing else.
The existing assertions (`test_convert_invalid_file`, `test_convert_invalid_sketch_file`, and the
`features/adhoc/convert/*.feature` scenarios) all match on the outer `"Failed to convert"` wrapper and are
unaffected.

## Verification

Honest accounting of what ran here versus what was reasoned about:

* **Could not run** `test_assembly_serialize.py` — this environment has no OCP and no installed `partcad`
  (`ModuleNotFoundError: No module named 'OCP'`; `partcad` resolves to the source directory, not a
  package). Same for the `adhoc/convert.py` error-path tests. **CI is the real check for both.**
* **Ran** an offline reproduction of the codec contract against `partcad/src/partcad/shape_envelope.py`
  with a hand-built assembly tree shaped like `Assembly._get_shape_real()`'s output: bare `json.dumps()`
  fails with exactly the reported `TypeError`; `shape_envelope.dumps()` yields JSON whose every `"brep"`
  is `str`; and `loads(dumps(tree)) == tree`.
* **Ran** `python3 -m compileall` on both touched files (clean), `flake8 --max-line-length 120` (clean),
  and `black --check --line-length 120`. Black flags one block in `test_assembly_serialize.py` that this
  branch does not touch and that is flagged identically on `devel` — a local black 24.10.0 vs. the pinned
  version, left alone rather than reformatted into the diff.
* **Grepped** for other consumers of everything touched: `get_cache_value` (3 call sites, listed above),
  `convert_cad_file`/`convert_sketch_file` (the JSON-RPC `operations.py`, `actions/part/import_part.py`,
  and tests), and the literal strings `"no shape returned"` / `"no part returned"` / `"no sketch returned"`
  (nothing asserts on them).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJUdN3k39YTAL1rrofSzs)_