### PR TITLE
fix: tolerate the generative-AI object types retired in 0.7.153

### DIFF
--- a/partcad/src/partcad/factory.py
+++ b/partcad/src/partcad/factory.py
@@ -11,14 +11,22 @@
 # The object types this PartCAD used to support and deliberately removed, each
 # mapped to the release that removed it.
 #
-# All four are the built-in generative-AI part types retired by #486 ("retire
-# the built-in generative-AI functionality"), which deleted the
-# 'part_factory_ai_*' modules together with their 'register()' calls. The public
-# index is a separate repository and still declares them, as does every package
-# published while they existed - so this is not something the user of such a
-# package can correct. That is why naming one of these is a warning and the
-# object is skipped, while any other unknown type stays an error (see
-# 'Project.record_broken_object').
+# These are 'part' types, and only 'part' types. All four are the built-in
+# generative-AI part types retired by #486 ("retire the built-in generative-AI
+# functionality"), which deleted the 'part_factory_ai_*' modules together with
+# their 'register()' calls - every one of which was a
+# 'factory.register("part", ...)'. The public index is a separate repository and
+# still declares them, as does every package published while they existed - so
+# this is not something the user of such a package can correct. That is why
+# naming one of these is a warning and the object is skipped, while any other
+# unknown type stays an error (see 'Project.record_broken_object').
+#
+# Because the scope is 'part', 'instantiate' consults this only for that kind.
+# The same name on a sketch, an assembly, a provider or a repository was never a
+# type PartCAD had, so it is not a retirement and must not be forgiven as one -
+# and calling it retired would name a release that never supported it. Should a
+# non-part type ever be retired, this map has to grow a kind before that entry
+# can be added to it.
 #
 # Nothing else belongs in here. A type that never existed, or a typo in the
 # user's own package, must keep failing loudly.
@@ -122,7 +130,10 @@ def instantiate(kind: str, t: str, ctx, source_project, target_project, config):
     # the retired 'ai-*' types carry - into the log for every occurrence.
     #
     # Checked after the lookups above, not before them, so that a type which is
-    # somehow registered again is served rather than reported as retired.
-    if isinstance(t, str) and t in RETIRED_TYPES:
+    # somehow registered again is served rather than reported as retired. Gated
+    # on 'part' because that is what every retired type was: naming one of them
+    # on any other kind is a broken declaration, not a retirement (see
+    # 'RETIRED_TYPES').
+    if kind == "part" and isinstance(t, str) and t in RETIRED_TYPES:
         raise RetiredTypeException(kind, t, config.get("name"))
     raise UnknownTypeException(kind, t, config.get("name"))

--- a/partcad/src/partcad/factory.py
+++ b/partcad/src/partcad/factory.py
@@ -8,23 +8,72 @@
 #
 
 
+# The object types this PartCAD used to support and deliberately removed, each
+# mapped to the release that removed it.
+#
+# All four are the built-in generative-AI part types retired by #486 ("retire
+# the built-in generative-AI functionality"), which deleted the
+# 'part_factory_ai_*' modules together with their 'register()' calls. The public
+# index is a separate repository and still declares them, as does every package
+# published while they existed - so this is not something the user of such a
+# package can correct. That is why naming one of these is a warning and the
+# object is skipped, while any other unknown type stays an error (see
+# 'Project.record_broken_object').
+#
+# Nothing else belongs in here. A type that never existed, or a typo in the
+# user's own package, must keep failing loudly.
+RETIRED_TYPES = {
+    "ai-build123d": "0.7.153",
+    "ai-cadquery": "0.7.153",
+    "ai-openscad": "0.7.153",
+    "ai-sdf": "0.7.153",
+}
+
+
 class UnknownTypeException(Exception):
     """A declared object names a type this PartCAD has no factory for.
 
-    Most often a package written against an older PartCAD that used a feature
-    since retired - the 'ai-cadquery'/'ai-build123d' part types, for instance.
     Nothing can be done with such an object, but the package it lives in is
     otherwise fine, so this is per object and never fails a whole package.
+
+    A type PartCAD used to have and dropped raises the 'RetiredTypeException'
+    subclass below instead, which is reported more gently.
     """
 
-    def __init__(self, kind: str, t: str, name=None):
+    def __init__(self, kind: str, t: str, name=None, message: str = None):
         self.kind = kind
         self.type = t
         self.name = name
-        known = ", ".join(sorted(all[kind])) if kind in all else ""
+        if message is None:
+            known = ", ".join(sorted(all[kind])) if kind in all else ""
+            message = "unknown %s type '%s'%s. This PartCAD supports: %s" % (
+                kind,
+                t,
+                "" if name is None else " for '%s'" % name,
+                known,
+            )
+        super().__init__(message)
+
+
+class RetiredTypeException(UnknownTypeException):
+    """A declared object names a type this PartCAD removed on purpose.
+
+    What separates it from a plain unknown type is whose problem it is. An
+    unknown type is a broken declaration - a typo, or a package to fix. A
+    retired type is a declaration that was correct when it was written, in a
+    package the user most often only depends on and cannot edit; PartCAD is the
+    side that changed. Reporting it as an error would make every command that
+    merely walks such a package exit non-zero, with nothing to act on.
+    """
+
+    def __init__(self, kind: str, t: str, name=None):
+        self.release = RETIRED_TYPES[t]
         super().__init__(
-            "unknown %s type '%s'%s. This PartCAD supports: %s"
-            % (kind, t, "" if name is None else " for '%s'" % name, known)
+            kind,
+            t,
+            name,
+            message="the %s type '%s'%s was retired in PartCAD %s; the object is skipped"
+            % (kind, t, "" if name is None else " of '%s'" % name, self.release),
         )
 
 
@@ -71,4 +120,9 @@ def instantiate(kind: str, t: str, ctx, source_project, target_project, config):
     # It used to be logged here instead, which dropped the object silently and
     # printed the whole configuration - including the multi-page descriptions
     # the retired 'ai-*' types carry - into the log for every occurrence.
+    #
+    # Checked after the lookups above, not before them, so that a type which is
+    # somehow registered again is served rather than reported as retired.
+    if isinstance(t, str) and t in RETIRED_TYPES:
+        raise RetiredTypeException(kind, t, config.get("name"))
     raise UnknownTypeException(kind, t, config.get("name"))

--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -650,9 +650,19 @@ class Project(project_config.Configuration):
         *package* requires a newer PartCAD, which is not a per-object condition
         and which the caller turns into its own "update PartCAD" prompt. Filing
         it against one object would swallow that prompt.
+
+        A type PartCAD itself retired ('factory.RetiredTypeException') is
+        reported at WARNING instead of ERROR. The object is still recorded as
+        broken and still skipped, but nothing the user of that package can do
+        would make it work - PartCAD dropped the feature - so it must not fail
+        the command. The public index, a separate repository, still declares the
+        generative-AI part types retired in 0.7.153. Every other reason stays an
+        error: an unknown type is a mistake somebody can fix.
         """
         if isinstance(reason, NeedsUpdateException):
             raise reason
+
+        retired = isinstance(reason, factory.RetiredTypeException)
 
         reason = str(reason) or type(reason).__name__
         # One line, and short: some of these configurations embed multi-page
@@ -662,7 +672,10 @@ class Project(project_config.Configuration):
             reason = reason[:197] + "..."
 
         self.broken_objects.setdefault(kind, {})[name] = reason
-        pc_logging.error("Failed to create the %s '%s:%s': %s" % (kind, self.name, name, reason))
+        if retired:
+            pc_logging.warning("Skipping the %s '%s:%s': %s" % (kind, self.name, name, reason))
+        else:
+            pc_logging.error("Failed to create the %s '%s:%s': %s" % (kind, self.name, name, reason))
 
     def get_broken_object_reason(self, kind: str, name: str):
         """Why an object could not be created, or None if it was not one of them."""

--- a/partcad/tests/unit/test_project_resilience.py
+++ b/partcad/tests/unit/test_project_resilience.py
@@ -82,17 +82,27 @@ def test_getting_an_object_that_was_never_declared_still_returns_none(package):
 
 
 def test_unknown_type_exception_lists_what_is_supported():
+    # Deliberately a type nobody ever had rather than a retired one.
+    # 'RetiredTypeException' subclasses this and hands its own message to
+    # super(), so the supported-type list is never built for a retired type -
+    # asking 'ai-cadquery' here asserted nothing, and 'cadquery' matched only
+    # the substring inside the bad type's own name. The retired path has its
+    # own tests further down.
     with pytest.raises(factory.UnknownTypeException) as excinfo:
-        factory.instantiate("part", "ai-cadquery", None, None, None, {"name": "some_part"})
+        factory.instantiate("part", "nonsense", None, None, None, {"name": "some_part"})
+
+    assert not isinstance(excinfo.value, factory.RetiredTypeException)
 
     message = str(excinfo.value)
-    assert "ai-cadquery" in message
+    assert "nonsense" in message
     assert "some_part" in message
     # The supported types are listed, because "unknown type" on its own leaves
-    # the user with nothing to do about it.
+    # the user with nothing to do about it. Asserted on the sentence that
+    # introduces the list, and on a type name the bad type cannot supply itself.
+    assert "supports" in message
     assert "cadquery" in message
     assert excinfo.value.kind == "part"
-    assert excinfo.value.type == "ai-cadquery"
+    assert excinfo.value.type == "nonsense"
 
 
 def test_a_parametrized_instance_of_an_unusable_declaration_returns_none(tmp_path):

--- a/partcad/tests/unit/test_project_resilience.py
+++ b/partcad/tests/unit/test_project_resilience.py
@@ -313,3 +313,64 @@ def test_an_unknown_type_is_reported_at_error_level(unknown_type_package, monkey
     pc.Context(str(unknown_type_package)).get_project("//")
 
     assert not any("nonsense" in message for message in recorded), recorded
+
+
+# ...and the retirement is scoped to the kind that was actually retired.
+#
+# Every 'ai-*' registration #486 removed was a 'factory.register("part", ...)';
+# there never was an 'ai-cadquery' sketch, assembly, provider or repository. So
+# the name only means "retired" on a part. Anywhere else it is a typo in a
+# package somebody can fix, and forgiving it would both hide that and claim a
+# release had a type it never had.
+
+
+@pytest.fixture
+def retired_part_type_on_a_sketch_package(tmp_path):
+    """A sketch declared with a type only ever registered for parts."""
+    config = {
+        "name": "//test",
+        "sketches": {"not_a_sketch_type": {"type": "ai-cadquery"}},
+    }
+    (tmp_path / "partcad.yaml").write_text(yaml.safe_dump(config))
+    return tmp_path
+
+
+def test_a_retired_part_type_on_a_sketch_is_unknown_rather_than_retired(
+    retired_part_type_on_a_sketch_package,
+):
+    """It has to fail the command, exactly as any other unknown sketch type does."""
+    pc.logging.reset_errors()
+
+    project = pc.Context(str(retired_part_type_on_a_sketch_package)).get_project("//")
+
+    assert pc.logging.had_errors is True
+    reason = project.get_broken_object_reason("sketch", "not_a_sketch_type")
+    assert "unknown sketch type 'ai-cadquery'" in reason
+    # And it must not claim a release that never had such a sketch type.
+    assert "retired" not in reason
+    assert "0.7.153" not in reason
+
+
+def test_a_retired_part_type_on_a_sketch_is_not_reported_as_a_warning(
+    retired_part_type_on_a_sketch_package, monkeypatch
+):
+    recorded = _record_warnings(monkeypatch)
+
+    pc.Context(str(retired_part_type_on_a_sketch_package)).get_project("//")
+
+    assert not any("ai-cadquery" in message for message in recorded), recorded
+
+
+@pytest.mark.parametrize("kind", ["sketch", "assembly", "provider", "repository"])
+def test_a_retired_part_type_raises_a_plain_unknown_type_for_other_kinds(kind):
+    with pytest.raises(factory.UnknownTypeException) as excinfo:
+        factory.instantiate(kind, "ai-cadquery", None, None, None, {"name": "some_object"})
+
+    assert not isinstance(excinfo.value, factory.RetiredTypeException)
+    assert "unknown %s type 'ai-cadquery'" % kind in str(excinfo.value)
+
+
+def test_a_retired_part_type_is_still_retired_on_a_part():
+    """The guard above must not have cost the case the retirement is for."""
+    with pytest.raises(factory.RetiredTypeException):
+        factory.instantiate("part", "ai-cadquery", None, None, None, {"name": "some_part"})

--- a/partcad/tests/unit/test_project_resilience.py
+++ b/partcad/tests/unit/test_project_resilience.py
@@ -198,3 +198,118 @@ def test_a_factory_that_produces_nothing_is_recorded_rather_than_indexed(tmp_pat
             del factory.all["part"]["test-silent"]
         else:
             factory.register("part", "test-silent", saved)
+
+
+# A type PartCAD itself retired is not the same as a type nobody ever had.
+#
+# The public index is a separate repository, and it still declares the
+# generative-AI part types removed in 0.7.153. Reporting those as errors makes
+# every command that so much as walks the index exit non-zero, over declarations
+# the user cannot edit and cannot fix. Reporting a genuine typo as anything less
+# than an error would be worse, so the two have to stay apart.
+
+
+def _record_warnings(monkeypatch):
+    """Collect pc_logging.warning() calls.
+
+    The 'partcad' logger sets propagate=False, so the caplog fixture (which
+    attaches to the root logger) sees nothing on the pytest version used in CI.
+    """
+    recorded = []
+    monkeypatch.setattr(pc.logging, "warning", lambda *args, **kwargs: recorded.append(" ".join(str(a) for a in args)))
+    return recorded
+
+
+@pytest.fixture
+def unknown_type_package(tmp_path):
+    """The same package, but the unusable type is a typo rather than a retirement."""
+    config = {
+        "name": "//test",
+        "parts": {
+            "good_before": {"type": "cadquery", "path": "cube.py"},
+            "typo": {"type": "nonsense"},
+            "good_after": {"type": "cadquery", "path": "cube.py"},
+        },
+    }
+    (tmp_path / "partcad.yaml").write_text(yaml.safe_dump(config))
+    (tmp_path / "cube.py").write_text("import cadquery as cq\nshow_object(cq.Workplane('front').box(1, 1, 1))\n")
+    return tmp_path
+
+
+def test_the_retired_types_are_the_ones_that_were_removed():
+    """The set is closed, and comes from what #486 actually deleted.
+
+    Those four are the 'part_factory_ai_*' modules that PR removed along with
+    their 'factory.register()' calls. Anything else added here would quietly
+    downgrade a real error.
+    """
+    assert set(factory.RETIRED_TYPES) == {"ai-build123d", "ai-cadquery", "ai-openscad", "ai-sdf"}
+    assert set(factory.RETIRED_TYPES.values()) == {"0.7.153"}
+    # And none of them is registered, which is what makes them retired.
+    for kind in factory.all:
+        assert not set(factory.RETIRED_TYPES) & set(factory.all[kind])
+
+
+def test_a_retired_type_does_not_make_the_command_fail(package):
+    """pc_logging.error() sets the flag the CLI turns into a non-zero exit code.
+
+    This is the whole point: 'pc list -r //pub/examples' walked the index, hit
+    the retired declarations it carries, and aborted on them.
+    """
+    pc.logging.reset_errors()
+
+    ctx = pc.Context(str(package))
+    project = ctx.get_project("//")
+
+    assert pc.logging.had_errors is False
+    # Still skipped, and still recorded as broken - only the severity changed.
+    assert sorted(project.parts.keys()) == ["good_after", "good_before"]
+    assert list(project.broken_objects["part"]) == ["obsolete"]
+
+
+def test_a_retired_type_says_it_was_retired_and_when(package, monkeypatch):
+    recorded = _record_warnings(monkeypatch)
+
+    project = pc.Context(str(package)).get_project("//")
+
+    reason = project.get_broken_object_reason("part", "obsolete")
+    assert "retired in PartCAD 0.7.153" in reason
+    assert "ai-cadquery" in reason
+    assert any("ai-cadquery" in message and "retired" in message for message in recorded), recorded
+
+
+def test_a_retired_type_raises_a_retired_type_exception():
+    with pytest.raises(factory.RetiredTypeException) as excinfo:
+        factory.instantiate("part", "ai-openscad", None, None, None, {"name": "some_part"})
+
+    # Still an unknown type, so every caller that handles those keeps working.
+    assert isinstance(excinfo.value, factory.UnknownTypeException)
+    assert excinfo.value.release == "0.7.153"
+    assert "retired" in str(excinfo.value)
+    assert "some_part" in str(excinfo.value)
+
+
+def test_an_unknown_type_is_still_an_error(unknown_type_package):
+    """The property that must not regress along with the above.
+
+    A type nobody retired is a mistake in the package being loaded, and it has
+    to keep failing the command that found it.
+    """
+    pc.logging.reset_errors()
+
+    project = pc.Context(str(unknown_type_package)).get_project("//")
+
+    assert pc.logging.had_errors is True
+    reason = project.get_broken_object_reason("part", "typo")
+    assert "unknown part type 'nonsense'" in reason
+    assert "retired" not in reason
+    # ...and it costs the caller that one object, exactly as before.
+    assert sorted(project.parts.keys()) == ["good_after", "good_before"]
+
+
+def test_an_unknown_type_is_reported_at_error_level(unknown_type_package, monkeypatch):
+    recorded = _record_warnings(monkeypatch)
+
+    pc.Context(str(unknown_type_package)).get_project("//")
+
+    assert not any("nonsense" in message for message in recorded), recorded


### PR DESCRIPTION
## The problem

`pc list all -r //pub/examples/partcad` aborts. It lists the parts, the assemblies and the providers, and then exits 1 on Click's `Aborted.`, because the CLI treats "at least one error was logged" as a failed run:

```
ERROR:partcad:Failed to create the part '//pub/examples/competition/tootalltobby:tier01-24-01-01':
  unknown part type 'ai-cadquery' for 'tier01-24-01-01'. This PartCAD supports: 3mf, alias, brep, ...
```

The declarations are not ours. #486 ("retire the built-in generative-AI functionality", released in **0.7.153**) deleted the `part_factory_ai_*` modules and their `factory.register()` calls. The public index is a **separate repository** and still declares those types, as does every package published while they existed. Nobody loading such a package can edit them.

### CI impact

* **`Examples (PartCAD)`** — 21 jobs in the full matrix (`40 -> 21 combinations`, per `test.yml`). Its first step is exactly `pc --no-ansi list all -r //pub/examples/partcad`, and unlike `Examples (All)` it is **not** `continue-on-error`, so all 21 cells go red.
* **Behave** — `features/docs.feature:105` and `:120` run `pc list ... -r //pub/examples` and assert an exit code of `0`.

## The change

A *retired* type is now a category of its own, distinct from an unknown one.

* `factory.RETIRED_TYPES` names the four part types #486 removed — `ai-build123d`, `ai-cadquery`, `ai-openscad`, `ai-sdf` — each mapped to the release that removed it (`0.7.153`). The set was taken from the PR itself (the deleted `part_factory_ai_*` modules and the `register()` calls that went with them), not from guesswork; a test asserts it, and asserts that none of them is registered.
* `factory.instantiate()` raises `RetiredTypeException` for them. It is a **subclass** of `UnknownTypeException`, so every caller that already handles unknown types keeps working — this composes with #495 rather than replacing it. The check sits after the factory lookups, so a type that ever comes back is served rather than reported as retired.
* `Project.record_broken_object()` reports that one exception at `WARNING` instead of `ERROR`. The object is still skipped and still recorded in `broken_objects` (so `pc list` and the PartCAD Explorer still show it, and still say why); only the severity changes. `pc_logging.error()` is what sets the `had_errors` flag the CLI turns into an exit code, so that is the whole fix.

What a package that names one now produces:

```
WARNING:partcad:Skipping the part '//pub/...:tier01-24-01-01': the part type 'ai-cadquery'
  of 'tier01-24-01-01' was retired in PartCAD 0.7.153; the object is skipped
```

## Unknown types are still errors

This is deliberately **not** a general softening of error handling, and the property is asserted rather than assumed:

* `type: nonsense` still logs `ERROR`, still sets `had_errors`, still aborts the command, and still reports `unknown part type 'nonsense'. This PartCAD supports: ...`. A typo in a package somebody is writing has to keep failing loudly.
* Only the four names above are tolerated, and only because PartCAD — not the package — is the side that changed.

## Tests

New in `partcad/tests/unit/test_project_resilience.py`, next to the existing broken-object tests:

| test | asserts |
| --- | --- |
| `test_the_retired_types_are_the_ones_that_were_removed` | the set is exactly the four #486 removed, all at `0.7.153`, and none is registered |
| `test_a_retired_type_does_not_make_the_command_fail` | `pc.logging.had_errors is False`; the object is skipped and recorded as broken |
| `test_a_retired_type_says_it_was_retired_and_when` | the reason and the log line name the type, say "retired", and give the release |
| `test_a_retired_type_raises_a_retired_type_exception` | still an `UnknownTypeException`, and carries `.release` |
| `test_an_unknown_type_is_still_an_error` | `type: nonsense` sets `had_errors`; the reason is `unknown part type 'nonsense'` |
| `test_an_unknown_type_is_reported_at_error_level` | it does not come out as a warning |

`partcad/tests/unit/test_project_resilience.py` passes in full (16 tests, the 10 pre-existing ones included). `black` is clean on the three touched files. The CAD stack is not installed in the environment this was written in, so the suites that import `build123d`/`cadquery` could not run here; the whole `partcad/tests/unit` run has an identical failure set before and after the change (196 failed / 829 passed before, 196 failed / 835 passed after — the six added are the six above).

`features/lint.feature`'s unknown-type scenario is schema validation (`$.parts.part1: {'type': 'unknown_type'} is not valid under any of the given schemas`) and is unaffected, so no behave expectation needed changing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJUdN3k39YTAL1rrofSzs)_