### PR TITLE
feat(shape): parameters are inputs, properties are outputs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -726,32 +726,34 @@ Parts are declared in ``partcad.yaml`` using the following syntax:
           location: <OCCT Location object> # e.g. [[x_off,y_off,z_off], [x_rot,y_rot,z_rot], rot_angle]
           sketch: <(optional) name of the sketch used for visualization>
 
-      material: <(optional) the name of the material this shape is made of>
-      color: <(optional) "#RRGGBB" or "#RRGGBBAA">
+      # What the shape this part produces reports about itself. See "Properties".
+      properties: # (optional)
+        material: <(optional) the name of the material this shape is made of>
+        color: <(optional) "#RRGGBB" or "#RRGGBBAA">
 
-      physics: # (optional) physical properties
-        mass: ... # kg
-        centerOfMass: [<x>, <y>, <z>] # mm, in the shape's own frame
-        inertiaOrientation: [<roll>, <pitch>, <yaw>] # (optional) degrees
-        inertia: # kg*m^2, about 'centerOfMass'
-          ixx: ...
-          ixy: ...
-          ixz: ...
-          iyy: ...
-          iyz: ...
-          izz: ...
-        friction: ...        # coefficient, along 'frictionDirection'
-        friction2: ...       # coefficient, across it
-        frictionDirection: [<x>, <y>, <z>]
-        contactStiffness: ... # N/m
-        contactDamping: ...   # N*s/m
-        minContactDepth: ...  # mm
-        maxContactVelocity: ... # mm/s
-        restitution: ...     # 0 is a dead stop, 1 a perfect bounce
-        maxContacts: ...
-        velocityDamping: ...
-        selfCollide: <true|false>
-        gravity: <true|false>
+        physics: # (optional) physical properties
+          mass: ... # kg
+          centerOfMass: [<x>, <y>, <z>] # mm, in the shape's own frame
+          inertiaOrientation: [<roll>, <pitch>, <yaw>] # (optional) degrees
+          inertia: # kg*m^2, about 'centerOfMass'
+            ixx: ...
+            ixy: ...
+            ixz: ...
+            iyy: ...
+            iyz: ...
+            izz: ...
+          friction: ...        # coefficient, along 'frictionDirection'
+          friction2: ...       # coefficient, across it
+          frictionDirection: [<x>, <y>, <z>]
+          contactStiffness: ... # N/m
+          contactDamping: ...   # N*s/m
+          minContactDepth: ...  # mm
+          maxContactVelocity: ... # mm/s
+          restitution: ...     # 0 is a dead stop, 1 a perfect bounce
+          maxContacts: ...
+          velocityDamping: ...
+          selfCollide: <true|false>
+          gravity: <true|false>
 
       # What this part contributes to every connection it takes part in.
       connect: # (optional)
@@ -772,20 +774,9 @@ The fields of the ``connect`` section are the defaults for the ``holdWith*`` and
 ``holdTo*`` fields of the ``how`` section of an Assembly YAML
 ``connect``/``connectPorts`` node. See :doc:`assy`.
 
-Every ``physics`` property has a PartCAD name and a PartCAD unit, and the set of
-them is closed. Lengths are millimetres and angles degrees, as everywhere else
-in PartCAD; everything else is SI, so a mass is kilograms and an inertia tensor
-kg·m². Nothing is stored under the name of the format it came from: a URDF
-import reads ``<inertial>`` and the friction and contact settings of a
-``<gazebo>`` block into these properties one value at a time, and a URDF export
-writes each of them back into the element that states it. A URDF that says
-something PartCAD has no property for stops the import instead of being carried
-opaquely, and a property PartCAD holds that URDF cannot state is reported when
-it is exported.
-
-``physics`` does not take part in the shape cache - it says nothing about the
-geometry - which also means nothing notices when an edit to the CAD invalidates
-it. See :doc:`simulation`.
+The ``properties`` section says what the shape this part produces is, as opposed
+to ``parameters``, which say what is asked of the type that produces it. See
+:ref:`properties` below.
 
 See :ref:`location` for more information on the OCCT Location object.
 
@@ -1055,8 +1046,21 @@ Other methods to define parts are coming soon (e.g. `SDF <https://github.com/fog
 Please, express your interest in support for other formats by filing a corresponding issue on GitHub
 or sending an email to `support@partcad.org <mailto:support@partcad.org>`_.
 
+.. _parameters:
+
 Parameters
 ----------
+
+Parameters are **inputs**. They are a request made of the object type that
+produces the part - the ``width`` a CadQuery script extrudes to, the
+``tolerance`` a mesh is faceted at - and they only mean anything if that type
+accepts them. Two parts that differ in a parameter are different shapes, so a
+parameter is part of what the shape cache is keyed on.
+
+What comes back out is :ref:`properties`, and the two are not the same thing
+even where they share a name: ``parameters.material`` asks for a part to be made
+of something, and ``properties.material`` states what the part that came out is
+made of.
 
 Each part may have a list of parameters that are passed into the scripts to
 modify the part.
@@ -1123,6 +1127,62 @@ and have received corresponding manufacturing instructions out-of-band.
 The MCFTT parameters are not required and have no impact on parts that have
 ``vendor`` and ``sku`` set and that are procured using providers of the type
 ``store``.
+
+The MCFTT parameters are a request, and the request is a manufacturing one: they
+say what the part should be made of, and how well, for the provider that will
+make it. They are not a claim about a shape that exists. A part read from a STEP
+file that already states its material does not answer them, and the answer is
+not what an exporter writes into a file. That is :ref:`properties`, below.
+
+.. _properties:
+
+Properties
+----------
+
+Properties are **outputs**. They are what instantiating the object produced -
+what the resulting shape reports about itself - and they are declared where the
+shape cannot report them on its own. A mesh has no material and no mass, so the
+only way a part read from an STL has either is to say so; a URDF import fills
+this section in from what the file already stated.
+
+.. code-block:: yaml
+
+  parts:
+    <part name>:
+      # ...
+      properties:
+        material: <(optional) the name of the material this shape is made of>
+        color: <(optional) "#RRGGBB" or "#RRGGBBAA">
+        physics: # (optional)
+          mass: ... # kg
+          # ... see the full list under "Parts" above
+
+Assemblies take the same section. Nothing in it takes part in the shape cache -
+it says nothing about the geometry - which also means nothing notices when an
+edit to the CAD invalidates it. It does travel with the shape: a property
+declared on a part is carried on the shape that part produces, through the cache
+and through every assembly that embeds it, so an export of a whole robot finds
+each link's properties on the link. That is also where the properties inherit
+the caching a name and a placement already have: an object's own are stamped on
+from its configuration every time it is read, but the ones on the parts *inside*
+a cached assembly are part of that assembly's cached tree, and editing them does
+not invalidate it any more than renaming a part does. ``pc system reset``, or a
+change to something the assembly does hash, is what picks them up.
+
+Every ``physics`` property has a PartCAD name and a PartCAD unit, and the set of
+them is closed. Lengths are millimetres and angles degrees, as everywhere else
+in PartCAD; everything else is SI, so a mass is kilograms and an inertia tensor
+kg·m². Nothing is stored under the name of the format it came from: a URDF
+import reads ``<inertial>`` and the friction and contact settings of a
+``<gazebo>`` block into these properties one value at a time, and a URDF export
+writes each of them back into the element that states it. A URDF that says
+something PartCAD has no property for stops the import instead of being carried
+opaquely, and a property PartCAD holds that URDF cannot state is reported when
+it is exported. See :doc:`simulation`.
+
+A file type that has a way to state these declares ``properties: true`` in its
+``export:`` section, and is handed them keyed by the full name of the shape they
+belong to. URDF is the one built-in format that does.
 
 Manufacturing methods
 ---------------------

--- a/docs/source/simulation.rst
+++ b/docs/source/simulation.rst
@@ -114,18 +114,17 @@ density turns those into a mass. Since PartCAD still has nowhere to record what
 a part is *made of*, that density is a parameter of the export with a default
 rather than a property of the part - the first gap this page proposes to close.
 
-A link's name, and the properties looked up under it, come from the label on the
-shape the exporter is handed - and there is one way that goes wrong today. The
-shape cache is keyed by geometry, deliberately, so that two parts reading the
-same mesh file do not compute it twice; but the entry carries the name and label
-of whichever part wrote it, and the other part reads back wearing a name that is
-not its own. Every consumer of a cached shape has that problem, and the URDF
-export is simply the first to key on the answer. The fix belongs in the cache,
-which should hand a shape back under the name it was asked for, so it is left
-for a change of its own. Until it lands, exporting parts that share geometry
-with other parts in the package can name a link after the wrong one and miss the
-properties declared on it; ``test_export_reports_properties_urdf_cannot_state``
-is marked ``xfail`` for exactly that reason.
+A link's name, and the properties written under it, come from the shape the
+exporter is handed, and both travel on that shape together. This used to be the
+one place the shape cache showed through: the cache is keyed by geometry,
+deliberately, so that two parts reading the same mesh file do not compute it
+twice, and the entry used to carry the name of whichever part wrote it - so the
+other part read back wearing a name that was not its own, and the properties
+looked up under that name were the wrong part's or nobody's. The cache no longer
+stores any of it. What identifies a shape - its name, its label, its placement,
+and what it reports about itself - is stamped onto the payload from the asking
+object's own configuration every time an entry is read, so parts that share
+geometry each get themselves back.
 
 Converting between the two
 ==========================
@@ -707,9 +706,10 @@ round trip nearly lossless while the rest of the proposal is still being
 designed, and it is the difference between PartCAD being usable in a robotics
 workflow and being a one-way trip out of one.
 
-A part carries ``physics:``, ``material:`` and ``color:``; an interface carries
-``motion:`` and ``physics:``. Every property in them is a PartCAD property with
-a PartCAD unit and a closed definition in the schema. A URDF import reads its
+A part carries a ``properties:`` section holding ``material``, ``color`` and
+``physics``; an interface carries ``motion:`` and ``physics:``. Every property
+in them is a PartCAD property with a PartCAD unit and a closed definition in the
+schema. A URDF import reads its
 values into them one at a time and the URDF export writes each one back into the
 element that states it. The two rules that keep the list honest are the loud
 failures: URDF that no property covers stops the import, and a property URDF
@@ -719,13 +719,13 @@ What is still missing:
 
 - **``<ros2_control>`` and ``<transmission>``**, which are robot-level rather
   than link-level, and so have nowhere to attach yet. The assembly needs a
-  ``physics:`` of its own - which it deliberately does not have today, because
-  an assembly is a container and every property so far belongs to something
-  inside it.
+  place to attach robot-level physics - an assembly takes the same
+  ``properties:`` section a part does, but nothing yet reads one there, because
+  every property so far belongs to something inside the container.
 - **Properties that are not a link's or a joint's.** A URDF's ``<gazebo>``
   blocks also carry sensors and simulator plugins, which items 7 and 8 cover;
   until then they are counted and reported, not carried.
-- **Any check at all that a declared property still applies.** ``physics:`` does
+- **Any check at all that a declared property still applies.** ``properties:`` does
   not take part in the shape cache, which is right - it says nothing about the
   geometry - but it also means nothing notices when the geometry moves out from
   under it. A mass read from a URDF survives an edit to the CAD that invalidates

--- a/docs/source/simulation.rst
+++ b/docs/source/simulation.rst
@@ -120,11 +120,19 @@ one place the shape cache showed through: the cache is keyed by geometry,
 deliberately, so that two parts reading the same mesh file do not compute it
 twice, and the entry used to carry the name of whichever part wrote it - so the
 other part read back wearing a name that was not its own, and the properties
-looked up under that name were the wrong part's or nobody's. The cache no longer
-stores any of it. What identifies a shape - its name, its label, its placement,
-and what it reports about itself - is stamped onto the payload from the asking
-object's own configuration every time an entry is read, so parts that share
-geometry each get themselves back.
+looked up under that name were the wrong part's or nobody's. The entry no longer
+stores that outer layer at all. What identifies the shape being asked for - its
+name, its label, its placement, and what it reports about itself - is stamped
+onto the payload from the asking object's own configuration every time an entry
+is read, so parts that share geometry each get themselves back.
+
+The stamp reaches the shape that was asked for and no further. Inside a cached
+assembly the children sit in the entry with the names, labels and properties
+they were built with, because down there they are not who is asking - they are
+what the tree is made of, as much a part of the answer as the geometry. So a
+link exported from a part is that part; a link exported from a child of a cached
+assembly is whatever that child was when the tree was cached, and it takes a
+change the assembly actually hashes, or ``pc system reset``, to build it again.
 
 Converting between the two
 ==========================

--- a/docs/source/simulation.rst
+++ b/docs/source/simulation.rst
@@ -134,6 +134,16 @@ link exported from a part is that part; a link exported from a child of a cached
 assembly is whatever that child was when the tree was cached, and it takes a
 change the assembly actually hashes, or ``pc system reset``, to build it again.
 
+What a shape reports about itself is cached too, in an entry of its own beside
+the geometry - the geometry's key with ``-props`` appended. Both are filled by
+the one run that actually instantiates the shape, and they are read apart: a
+consumer after a part's material need not pull its BREP back out of the cache,
+and a cache written before that entry existed is a miss for the properties and
+not for the geometry. It is not what the stamp above is made of, though: that
+entry is keyed on the geometry, so what sits in it belongs to the geometry -
+which is where a *derived* property (item 2 below) would land. What the object
+asking reports is its own ``properties:`` section, and only that.
+
 Converting between the two
 ==========================
 
@@ -733,12 +743,12 @@ What is still missing:
 - **Properties that are not a link's or a joint's.** A URDF's ``<gazebo>``
   blocks also carry sensors and simulator plugins, which items 7 and 8 cover;
   until then they are counted and reported, not carried.
-- **Any check at all that a declared property still applies.** ``properties:`` does
-  not take part in the shape cache, which is right - it says nothing about the
-  geometry - but it also means nothing notices when the geometry moves out from
-  under it. A mass read from a URDF survives an edit to the CAD that invalidates
-  it, silently. ``pc lint`` is where that belongs, and it needs item 2 to have
-  something to compare against.
+- **Any check at all that a declared property still applies.** ``properties:``
+  does not take part in the shape cache *key*, which is right - it says nothing
+  about the geometry - but it also means nothing notices when the geometry moves
+  out from under it. A mass read from a URDF survives an edit to the CAD that
+  invalidates it, silently. ``pc lint`` is where that belongs, and it needs
+  item 2 to have something to compare against.
 
 10. Units
 =========

--- a/partcad/src/partcad/actions/assembly/convert.py
+++ b/partcad/src/partcad/actions/assembly/convert.py
@@ -280,7 +280,7 @@ def urdf_to_assy(project: Project, assembly_name: str, config: dict, out_dir: Pa
     """Turn a URDF assembly into an ASSY one, with parts and interfaces.
 
     Every link becomes an ``stl`` part written into ``<assembly>/`` inside the
-    package, carrying whatever the URDF said about it in its ``physics``
+    package, carrying whatever the URDF said about it in its ``properties``
     section. Every joint becomes an interface pair, and the ``.assy`` connects
     the parts through them.
     """
@@ -332,11 +332,16 @@ def urdf_to_assy(project: Project, assembly_name: str, config: dict, out_dir: Pa
         entry["type"] = "stl"
         entry["path"] = relative
         entry["desc"] = "Link '%s' of '%s'" % (link_name, assembly_name)
-        for key, value in (links[link_name].get("appearance") or {}).items():
-            entry[key] = value
+        # What the link reports about itself, all under one 'properties:'
+        # section: the appearance of its shape and its physics. Not
+        # 'parameters:' - nothing here is asked of the 'stl' type below, it is
+        # what the shape that type produces turns out to be made of.
+        properties = _section(links[link_name].get("appearance"))
         physics = _section(links[link_name].get("physics"))
         if physics:
-            entry["physics"] = physics
+            properties["physics"] = physics
+        if properties:
+            entry["properties"] = properties
         parts["%s/%s" % (assembly_name, link_name)] = entry
 
     # Which interface each link implements, and where.

--- a/partcad/src/partcad/assembly.py
+++ b/partcad/src/partcad/assembly.py
@@ -157,10 +157,14 @@ class Assembly(Shape):
         indistinguishable from one just built. Besides the name and the label
         that every shape carries, an assembly carries its own placement: two
         assemblies of the same children in different places share the cached
-        children but must not inherit each other's location.
+        children but must not inherit each other's location. It carries what it
+        reports about itself for the same reason.
         """
         name = ("%s:%s" % (self.project_name, self.name)) if self.name else self.project_name
         metadata = {"name": name, "label": self.name}
+        properties = self._shape_properties()
+        if properties:
+            metadata[shape_envelope.KEY_PROPERTIES] = properties
         root = self._root_location()
         if root is not None:
             metadata[shape_envelope.KEY_LOCATION] = root.as_packed()

--- a/partcad/src/partcad/assembly_factory_urdf.py
+++ b/partcad/src/partcad/assembly_factory_urdf.py
@@ -61,6 +61,17 @@ DROPPED_LABELS = {
     "calibration": "joint calibration references",
 }
 
+# What a node of the wrapper's tree may say about the shape it becomes. The
+# wrapper speaks URDF's vocabulary and keeps these side by side; a PartCAD
+# configuration groups them under 'properties:', which is where every consumer
+# of a shape - the export above all - looks for them.
+NODE_PROPERTIES = ("physics", "material", "color")
+
+
+def node_properties(node):
+    """The 'properties:' section for one node of the wrapper's tree."""
+    return {key: node[key] for key in NODE_PROPERTIES if node.get(key)}
+
 
 @telemetry.instrument()
 class AssemblyFactoryUrdf(AssemblyFactoryFile):
@@ -288,8 +299,9 @@ class AssemblyFactoryUrdf(AssemblyFactoryFile):
             }
             # A sub-assembly that *is* a URDF link carries what the link said
             # about itself, so the export finds it where it expects to.
-            if node.get("physics"):
-                config["physics"] = node["physics"]
+            properties = node_properties(node)
+            if properties:
+                config[shape_envelope.KEY_PROPERTIES] = properties
             item = Assembly(assembly.project_name, config)
             # Keep it uncacheable before the parts info is in the hashing context
             item.cacheable = False
@@ -349,9 +361,9 @@ class AssemblyFactoryUrdf(AssemblyFactoryFile):
             config["scale"] = scale
         # What the link states about itself, as named PartCAD properties: the
         # physical ones on the link, the appearance on the shape that has it.
-        for key in ("physics", "material", "color"):
-            if node.get(key):
-                config[key] = node[key]
+        properties = node_properties(node)
+        if properties:
+            config[shape_envelope.KEY_PROPERTIES] = properties
 
         full_name = "%s:%s" % (self.project.name, part_name)
         config = PartConfiguration.normalize(part_name, config, full_name)

--- a/partcad/src/partcad/builtin/export/partcad.yaml
+++ b/partcad/src/partcad/builtin/export/partcad.yaml
@@ -141,7 +141,9 @@ export:
     # mesh_dir: <directory>
     # mesh_prefix: <prefix>
     # density: 2700.0
-    # Hand the exporter what the parts state about themselves - mass, inertia,
+    # Hand the exporter what the parts report about themselves - mass, inertia,
     # friction, colour - so that it writes those rather than recomputing them or
-    # losing them. See 'output.PROPERTIES_KEY'.
+    # losing them. The properties travel on the shape envelopes; this asks for
+    # the index that looks one up by name, which costs a walk of the tree that
+    # is already in hand. See 'wrappers/wrapper_export.properties_index()'.
     properties: true

--- a/partcad/src/partcad/cache_backend.py
+++ b/partcad/src/partcad/cache_backend.py
@@ -37,6 +37,13 @@ from . import logging as pc_logging
 # repository index - is small by construction and always worth storing.
 SIZED_KEYS = ("shape", "sketch", "part", "assembly", "cmps")
 
+# What a shape reports about itself is cached under the key of the geometry it
+# describes plus this suffix (see cache_shape.properties_key). Being named after
+# a geometry key is what makes it look like one here, and it is not: a handful
+# of declared values, small by construction like everything else the window
+# exempts. The window is there to keep trivial *geometry* out.
+PROPERTIES_SUFFIX = "-props"
+
 
 class CacheBackend:
     """One storage tier: flat names in, bytes out.
@@ -62,7 +69,7 @@ class CacheBackend:
 
     def accepts(self, key: str, size: int) -> bool:
         """Whether an entry of this size belongs in this tier."""
-        if not key.startswith(SIZED_KEYS):
+        if not key.startswith(SIZED_KEYS) or key.endswith(PROPERTIES_SUFFIX):
             return True
         # One-byte entries are how a test result is stored, and they are exempt
         # from the minimum: the point of the minimum is to keep small geometry

--- a/partcad/src/partcad/cache_shape.py
+++ b/partcad/src/partcad/cache_shape.py
@@ -10,6 +10,7 @@
 import json
 
 from .cache import Cache
+from .cache_backend import PROPERTIES_SUFFIX
 from .cache_hash import CacheHash
 from .utils import total_size
 from . import shape_envelope
@@ -53,6 +54,20 @@ def _deserialize(data: bytes):
     if data.startswith(_BREP_PREFIXES):
         return {shape_envelope.KEY_BREP: data}
     return shape_envelope.decode(json.loads(data.decode("utf-8")))
+
+
+def properties_key(kind: str) -> str:
+    """The key holding what the shape cached under 'kind' reports about itself.
+
+    Beside the geometry rather than inside it, because the two go stale on
+    different occasions: the hash covers 'parameters', 'offset' and 'scale'
+    only, so editing a 'properties:' section leaves the geometry entry valid,
+    and properties buried in that entry would go on being answered with the ones
+    it happened to be written with. An entry of its own is written, read and
+    missed on its own - and a shape's properties can be had without pulling its
+    geometry back out of the cache.
+    """
+    return kind + PROPERTIES_SUFFIX
 
 
 @telemetry.instrument()

--- a/partcad/src/partcad/output.py
+++ b/partcad/src/partcad/output.py
@@ -108,12 +108,6 @@ SCRIPT_KEY = "__script__"
 # before it deserializes anything. Declared on a file type as 'decode: false'.
 DECODE_KEY = "__decode__"
 
-# A parameter, not a reserved key: a file type declares 'properties: true' to be
-# handed what the shapes state about themselves ('physics', 'material',
-# 'color'), keyed by full name, instead of the flag. Named here so the core and
-# the implementations agree on the spelling.
-PROPERTIES_KEY = "properties"
-
 
 class Implementation:
     """Who writes a file of a given type, and with what.

--- a/partcad/src/partcad/schema/partcad.json
+++ b/partcad/src/partcad/schema/partcad.json
@@ -63,7 +63,7 @@
           "pattern": "^#([0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$",
           "description": "The colour of this shape, as #RRGGBB or #RRGGBBAA."
         },
-        "physics": { "$ref": "#/definitions/physics" }
+        "physics": { "$ref": "#/definitions/shape-physics" }
       },
       "additionalProperties": false
     },
@@ -129,6 +129,32 @@
         "provideFeedback": { "type": "boolean", "description": "Whether the simulator reports the forces at this connection." }
       },
       "additionalProperties": false
+    },
+    "shape-physics": {
+      "description": "The physical properties a shape may state about itself: 'physics' without the ones that describe a connection rather than a body. An effort limit, a joint damping or a spring belongs to the interface a connection is made through, not to the part that connection moves, so a part that states one has made a mistake rather than said something to carry. Stated as the whole vocabulary minus the connection-only names, so that a body property added to 'physics' is available here without being written down twice, and so that the two lists cannot drift apart.",
+      "allOf": [
+        { "$ref": "#/definitions/physics" },
+        {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "description": "The properties of a connection, which only an interface may state. See 'motion' and 'physics' on an interface.",
+              "enum": [
+                "maxEffort",
+                "maxVelocity",
+                "damping",
+                "springStiffness",
+                "springReference",
+                "stopCfm",
+                "stopErp",
+                "fudgeFactor",
+                "implicitSpringDamper",
+                "provideFeedback"
+              ]
+            }
+          }
+        }
+      ]
     },
     "motion": {
       "type": "object",

--- a/partcad/src/partcad/schema/partcad.json
+++ b/partcad/src/partcad/schema/partcad.json
@@ -53,6 +53,20 @@
       "type": "string",
       "pattern": "((http|https)://)(www.)?[a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)"
     },
+    "shape-properties": {
+      "type": "object",
+      "description": "What the shape this object produces reports about itself, as opposed to 'parameters', which are what is asked of the object type that produces it. Every entry here is an output: it describes the instantiated shape, and an exporter that has a way to state one writes it out rather than recomputing or losing it.",
+      "properties": {
+        "material": { "type": "string", "minLength": 1, "description": "The name of the material this shape is made of." },
+        "color": {
+          "type": "string",
+          "pattern": "^#([0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$",
+          "description": "The colour of this shape, as #RRGGBB or #RRGGBBAA."
+        },
+        "physics": { "$ref": "#/definitions/physics" }
+      },
+      "additionalProperties": false
+    },
     "physics": {
       "type": "object",
       "description": "Physical properties, each with a documented name and unit. Lengths are millimetres and angles are degrees, as everywhere else in PartCAD; everything else is SI. A property that has no entry here is not carried: a format that states one PartCAD does not support fails the import, and a property PartCAD holds that the target format cannot state is reported on export.",
@@ -481,12 +495,7 @@
                   "items": { "type": "string", "minLength": 1 },
                   "uniqueItems": true
                 },
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "length": { "type": "number" }
-                  }
-                },
+                "properties": { "$ref": "#/definitions/shape-properties" },
                 "path": { "type": "string", "minLength": 1 },
                 "fileFrom": { "type": "string", "enum": ["url"] },
                 "fileUrl": { "$ref": "#/definitions/url" },
@@ -617,14 +626,7 @@
                   "additionalProperties": false
                 },
                 "manufacturable": { "type": "boolean" },
-                "connect": { "$ref": "#/definitions/connect" },
-                "physics": { "$ref": "#/definitions/physics" },
-                "material": { "type": "string", "minLength": 1, "description": "The name of the material this shape is made of." },
-                "color": {
-                  "type": "string",
-                  "pattern": "^#([0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$",
-                  "description": "The colour of this shape, as #RRGGBB or #RRGGBBAA."
-                }
+                "connect": { "$ref": "#/definitions/connect" }
               },
               "required": ["type"],
               "additionalProperties": false
@@ -716,7 +718,8 @@
                 "render": { "$ref": "#/definitions/render" },
                 "export": { "$ref": "#/definitions/output-section" },
                 "manufacturable": { "type": "boolean" },
-                "connect": { "$ref": "#/definitions/connect" }
+                "connect": { "$ref": "#/definitions/connect" },
+                "properties": { "$ref": "#/definitions/shape-properties" }
               },
               "required": ["type"],
               "additionalProperties": false

--- a/partcad/src/partcad/shape.py
+++ b/partcad/src/partcad/shape.py
@@ -379,40 +379,22 @@ class Shape(ShapeConfiguration):
                     self._wrapped = shape
                 return shape
 
-    # The properties an exporter may need that are declared rather than derived
-    # from the geometry. 'physics' is the physical ones (mass, inertia,
-    # friction); the other two are appearance.
-    EXPORTED_PROPERTIES = ("physics", "material", "color")
+    def _shape_properties(self):
+        """What this shape reports about itself, or None if it reports nothing.
 
-    async def _property_index(self):
-        """The declared properties of this shape and everything under it.
-
-        Keyed by the full name ("<package>:<name>") an exporter sees on the
-        envelope, so a wrapper that is handed a whole assembly tree can find the
-        properties belonging to each node of it. Only shapes that declare at
-        least one appear.
-
-        An assembly is built first: its geometry may well have come from the
-        cache, in which case its children have never been instantiated and there
-        would be nothing to walk.
+        The 'properties:' section of the configuration - 'material', 'color' and
+        'physics'. They are outputs, not inputs: 'parameters:' is what is asked
+        of the object type that produces the shape, while these describe the
+        shape that came out. Nothing here takes part in the cache hash, which is
+        why a cached entry can be shared by objects that state different ones.
         """
-        instantiate = getattr(self, "do_instantiate", None)
-        if instantiate is not None:
-            await instantiate()
-
-        index = {}
-
-        def walk(shape):
-            config = getattr(shape, "config", None)
-            if isinstance(config, dict):
-                declared = {key: config[key] for key in self.EXPORTED_PROPERTIES if config.get(key)}
-                if declared:
-                    index["%s:%s" % (shape.project_name, shape.name)] = declared
-            for child in getattr(shape, "children", None) or []:
-                walk(child.item)
-
-        walk(self)
-        return index
+        if not isinstance(self.config, dict):
+            return None
+        properties = self.config.get(shape_envelope.KEY_PROPERTIES)
+        if not isinstance(properties, dict):
+            return None
+        properties = {key: value for key, value in properties.items() if value not in (None, {}, [], "")}
+        return properties or None
 
     def _shape_metadata(self):
         """The (full_name, label) stamped onto this shape's envelope."""
@@ -465,10 +447,16 @@ class Shape(ShapeConfiguration):
 
         A cache entry is keyed on the geometry, so several shapes with identical
         geometry share one. Everything that says which shape this is therefore
-        lives here rather than in the cache - see ShapeCache.
+        lives here rather than in the cache - see ShapeCache. That includes what
+        the shape reports about itself: two parts cut from the same solid may
+        well be made of different materials, and each has to get its own back.
         """
         full_name, label = self._shape_metadata()
-        return {"name": full_name, "label": label}
+        metadata = {"name": full_name, "label": label}
+        properties = self._shape_properties()
+        if properties:
+            metadata[shape_envelope.KEY_PROPERTIES] = properties
+        return metadata
 
     async def convert(self, part_type: str, ctx=None, **kwargs):
         """Convert this shape to 'part_type' and return the result in memory.
@@ -887,16 +875,11 @@ class Shape(ShapeConfiguration):
         # arguments defaulting to None by several callers.
         request.update({key: value for key, value in kwargs.items() if value is not None})
 
-        # A format that has a way to state what the parts say about themselves -
-        # mass, inertia, friction, colour - asks for it with 'properties: true'
-        # in its declaration, and is handed the index instead of the flag. It is
-        # built only on request: collecting it instantiates the whole assembly
-        # tree, which an exporter that has no use for the properties should not
-        # pay for. URDF is the one built-in format that asks (see
-        # '//builtin/export').
-        if request.get(output.PROPERTIES_KEY) is True:
-            request[output.PROPERTIES_KEY] = await self._property_index()
-
+        # 'properties: true' is left in the request as it is. What the shapes
+        # report about themselves travels on the envelopes, so the index an
+        # exporter looks them up in is built in the sandbox, out of the request
+        # that arrives there - see wrappers/wrapper_export.py. Nothing has to be
+        # collected here, and nothing has to be instantiated to collect it.
         return request
 
     async def _render_one_async(self, ctx, obj, format_name, project, filepath, options_project, output_dir, kwargs):

--- a/partcad/src/partcad/shape.py
+++ b/partcad/src/partcad/shape.py
@@ -19,6 +19,7 @@ import warnings
 from typing import Optional
 
 from .cache_hash import CacheHash
+from .cache_shape import properties_key
 from . import output
 from .shape_config import ShapeConfiguration
 from .utils import total_size
@@ -368,6 +369,15 @@ class Shape(ShapeConfiguration):
                         to_cache = {self.kind: await self.get_cache_value(ctx, shape)}
                         if self.components and len(self.components) > 0:
                             to_cache["cmps"] = self.components
+                        properties = self._shape_properties()
+                        if properties:
+                            # Both entries are filled here and nowhere else:
+                            # this is the one path that has actually
+                            # instantiated the shape, and so the one that knows
+                            # what came out of it. They are materialized apart
+                            # (see 'get_cached_properties_async()'), and a shape
+                            # that reports nothing leaves no entry to read.
+                            to_cache[properties_key(self.kind)] = properties
                         to_cache_in_memory = await ctx.cache_shapes.write_async(cache_hash, to_cache)
                         do_cache_in_memory = to_cache_in_memory.get(self.kind, False)
                     else:
@@ -395,6 +405,30 @@ class Shape(ShapeConfiguration):
             return None
         properties = {key: value for key, value in properties.items() if value not in (None, {}, [], "")}
         return properties or None
+
+    async def get_cached_properties_async(self, ctx):
+        """What the cache recorded beside this shape's geometry, or None.
+
+        The other half of 'get_wrapped()'. The two entries are filled together,
+        as the shape is instantiated, and materialized apart: the properties can
+        be had without pulling a BREP out of the cache, and the BREP without
+        them. A shape that has never been built, an entry written before
+        properties were cached at all, and a shape that reports nothing all mean
+        the same thing here - nothing recorded - which is an answer rather than
+        a failure, and never a reason to build the geometry again.
+
+        What comes back describes the geometry, which every object hashing to
+        the same key shares. What identifies *this* object is its own
+        'properties:' section, which is why 'get_cache_metadata()' - and so
+        everything stamped onto an envelope - reads the configuration and never
+        comes here.
+        """
+        if not ctx or await self.get_cache_key_async() is None:
+            return None
+        key = properties_key(self.kind)
+        cached, _ = await ctx.cache_shapes.read_async(self.hash, [key])
+        properties = cached.get(key)
+        return properties if isinstance(properties, dict) and properties else None
 
     def _shape_metadata(self):
         """The (full_name, label) stamped onto this shape's envelope."""

--- a/partcad/src/partcad/shape_envelope.py
+++ b/partcad/src/partcad/shape_envelope.py
@@ -20,8 +20,10 @@ point of the split:
     dict on 'decode' - the core only ever moves the bytes around.
 
 A single shape is '{"name", "label", "brep"}'; an assembly is
-'{"name", "label", "assembly": [...]}'. Requests/responses are ordinary JSON
-objects that carry such shape objects under keys like "shape" or "wrapped".
+'{"name", "label", "assembly": [...]}'. Either may also carry an optional
+"location" and an optional "properties" (see the keys below).
+Requests/responses are ordinary JSON objects that carry such shape objects
+under keys like "shape" or "wrapped".
 
 The "brep" payload is zstd-compressed BREP. Which Python type holds it depends
 on the layer, and that is the whole reason this module exists:
@@ -44,6 +46,12 @@ KEY_BYTES = "__bytes__"
 # Optional placement on a shape/assembly object, carried opaquely by the core
 # and turned into a real location by the geometry-side codec (ocp_serialize).
 KEY_LOCATION = "location"
+# Optional properties on a shape/assembly object: what the shape reports about
+# itself ("material", "color", "physics"), as opposed to the parameters it was
+# built from. One key rather than three, so that the envelope's key space stays
+# small and everything that identifies an object travels beside its name. Like
+# the placement, it is data the core carries opaquely and never interprets.
+KEY_PROPERTIES = "properties"
 
 
 def is_shape_object(obj) -> bool:

--- a/partcad/src/partcad/wrappers/wrapper_export.py
+++ b/partcad/src/partcad/wrappers/wrapper_export.py
@@ -33,6 +33,10 @@ Both '__file__' and the run name '__partcad_export__' are set on the script, so
 it can gate any top-level work ("if __name__ == '__partcad_export__':") and
 remain importable by its siblings - which is how the PNG and DXF renderers
 reuse the SVG one.
+
+A format that declared 'properties: true' finds 'request["properties"]' holding
+what each shape reports about itself - its material, its colour, its physics -
+keyed by the full name the shape carries. See 'properties_index()'.
 """
 
 import os
@@ -56,6 +60,53 @@ SCRIPT_KEY = "__script__"
 # (the URDF exporter turns each node into a link of its own) declares
 # 'decode: false', because decoding collapses the tree into one compound.
 DECODE_KEY = "__decode__"
+
+# The parameter a file type sets to 'true' to be handed what the shapes it is
+# given report about themselves, keyed by the full name ("<package>:<name>")
+# those shapes carry on their envelopes. It is a plain export parameter, not a
+# reserved key: a format that has no way to state a material or a mass never
+# declares it and never sees the index.
+PROPERTIES_KEY = "properties"
+
+
+def properties_index(request):
+    """Full name -> what that shape reports about itself, over the whole request.
+
+    Built from the request as it arrives, before anything is decoded, and that
+    ordering is the point. The properties ride on the envelopes, beside the very
+    name an exporter looks a node up by, so they are here for an implementation
+    that walks the tree ('decode: false') *and* for one that is handed live
+    geometry ('decode: true'), whose decoding throws every envelope away.
+
+    Only shapes that report something appear. A shape with no name cannot be
+    looked up and is skipped, but its children are still walked.
+    """
+    index = {}
+
+    def walk(obj):
+        if isinstance(obj, list):
+            for item in obj:
+                walk(item)
+            return
+        if not isinstance(obj, dict):
+            return
+        is_envelope = ocp_serialize.KEY_BREP in obj or ocp_serialize.KEY_ASSEMBLY in obj
+        if is_envelope:
+            properties = obj.get(PROPERTIES_KEY)
+            name = obj.get("name")
+            if name and isinstance(properties, dict) and properties:
+                index[name] = properties
+            for child in obj.get(ocp_serialize.KEY_ASSEMBLY) or []:
+                walk(child)
+            return
+        for key, value in obj.items():
+            # Never the index itself: it is keyed by name, not by anything that
+            # holds an envelope, and walking it would be pointless.
+            if key != PROPERTIES_KEY:
+                walk(value)
+
+    walk(request)
+    return index
 
 
 def _failed(exception):
@@ -109,6 +160,10 @@ if __name__ == "__main__":
     # choice travels inside the request itself.
     path, request = wrapper_common.handle_input(decode=False)
     script = request.pop(SCRIPT_KEY, None)
+    # Before the decode, while the envelopes - and so the properties they carry
+    # - are still there to be read.
+    if request.get(PROPERTIES_KEY) is True:
+        request[PROPERTIES_KEY] = properties_index(request)
     if request.pop(DECODE_KEY, True) is not False:
         request = ocp_serialize.decode(request)
     if script is None:

--- a/partcad/tests/unit/test_assembly_urdf.py
+++ b/partcad/tests/unit/test_assembly_urdf.py
@@ -233,7 +233,7 @@ def test_urdf_physics_becomes_named_partcad_properties():
     is the URDF file itself.
     """
     ctx = pc.Context(EXAMPLES)
-    shoulder = ctx.get_part("//produce_assembly_urdf:robot/shoulder").config
+    shoulder = ctx.get_part("//produce_assembly_urdf:robot/shoulder").config["properties"]
 
     assert shoulder["physics"]["mass"] == pytest.approx(0.32)
     # 0.03 m up in the URDF, in millimetres here.
@@ -248,9 +248,9 @@ def test_urdf_physics_becomes_named_partcad_properties():
     # link became, the robot's root link included, and are there exactly once.
     robot = ctx._get_assembly(URDF_EXAMPLE)
     asyncio.run(robot.do_instantiate())
-    assert "physics" not in robot.config
+    assert "properties" not in robot.config
 
-    base = ctx.get_part("//produce_assembly_urdf:robot/base_link").config["physics"]
+    base = ctx.get_part("//produce_assembly_urdf:robot/base_link").config["properties"]["physics"]
     assert base["mass"] == pytest.approx(0.78)
     assert base["inertia"]["izz"] == pytest.approx(1.87e-3)
     # The Gazebo block was read into properties too, one value at a time.
@@ -385,7 +385,7 @@ def test_an_unknown_gazebo_setting_is_reported_and_can_be_fatal(tmp_path):
     robot = ctx._get_assembly(":robot")
     asyncio.run(robot.do_instantiate())
     # What it did understand became a property; what it did not was reported.
-    assert ctx.get_part(":robot/a").config["physics"]["friction"] == pytest.approx(0.4)
+    assert ctx.get_part(":robot/a").config["properties"]["physics"]["friction"] == pytest.approx(0.4)
     assert any("stormFactor" in warning for warning in robot.urdf_factory.urdf_info["warnings"])
 
     strict = _urdf_package(tmp_path / "strict", body, options="    strict: true\n")
@@ -494,22 +494,20 @@ def test_export_states_the_properties_a_part_carries(tmp_path):
     assert float(gazebo[0].find("mu1").text) == pytest.approx(0.9)
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Depends on the shape cache handing back a shape under its own name. The cache is keyed by "
-        "geometry, so this part shares an entry with every other part that reads the same mesh, and "
-        "the entry carries whichever name was stamped on it first - so the declared 'mass' is only "
-        "found when this test happens to be the one that wrote it. Expected to pass once the cache "
-        "stamps on read; see the URDF section of docs/source/simulation.rst."
-    ),
-)
 def test_export_reports_properties_urdf_cannot_state(tmp_path, caplog):
     """The mirror image of refusing unknown URDF: what URDF cannot say is said out loud.
 
     'damping' is a PartCAD property of a connection, and URDF has no place for
     one on a link. The export writes what it can and reports the rest at info
     level - the file is correct, it just says less than the package does.
+
+    This used to be xfail'd: the properties were looked up in a side index built
+    from the configuration tree, and the shape they belonged to came back from a
+    geometry-keyed cache entry under whichever name was stamped on it first, so
+    the declared 'mass' was only found when this test happened to be the one
+    that filled the entry. The properties now ride on the envelope beside the
+    name they are looked up by, and both are stamped from this part's own
+    configuration every time the entry is read, so the two cannot disagree.
     """
     root = sandbox(tmp_path, ("produce_part_stl",))
     package = root / "produce_part_stl"
@@ -518,7 +516,11 @@ def test_export_reports_properties_urdf_cannot_state(tmp_path, caplog):
         .read_text()
         .replace(
             "    desc: A cube defined in STL\n",
-            "    desc: A cube defined in STL\n    physics:\n      mass: 2.0\n      damping: 0.5\n",
+            "    desc: A cube defined in STL\n"
+            "    properties:\n"
+            "      physics:\n"
+            "        mass: 2.0\n"
+            "        damping: 0.5\n",
         )
     )
     (package / "partcad.yaml").write_text(config)
@@ -595,9 +597,9 @@ def test_convert_urdf_to_assy(tmp_path):
         assert entry["type"] == "stl"
         assert (package / entry["path"]).is_file()
     # What the URDF said about a link travelled with it, as named properties.
-    assert config["parts"]["robot/base_link"]["physics"]["mass"] == pytest.approx(0.78)
-    assert config["parts"]["robot/base_link"]["physics"]["friction"] == pytest.approx(0.9)
-    assert config["parts"]["robot/shoulder"]["color"] == "#E6801A"
+    assert config["parts"]["robot/base_link"]["properties"]["physics"]["mass"] == pytest.approx(0.78)
+    assert config["parts"]["robot/base_link"]["properties"]["physics"]["friction"] == pytest.approx(0.9)
+    assert config["parts"]["robot/shoulder"]["properties"]["color"] == "#E6801A"
 
     # One interface pair per distinct joint, reused where the joints agree: the
     # two fixed joints share a pair, the revolute one gets its own.
@@ -730,7 +732,7 @@ def test_import_assembly_from_a_urdf(tmp_path):
         entry = config["parts"]["robot/%s" % link]
         assert entry["type"] == "stl"
         assert (package / entry["path"]).is_file()
-    assert config["parts"]["robot/base_link"]["physics"]["mass"] == pytest.approx(0.78)
+    assert config["parts"]["robot/base_link"]["properties"]["physics"]["mass"] == pytest.approx(0.78)
     assert set(config["interfaces"]) == {
         "robot/fixed-socket",
         "robot/fixed-plug",

--- a/partcad/tests/unit/test_shape_properties.py
+++ b/partcad/tests/unit/test_shape_properties.py
@@ -30,7 +30,7 @@ import partcad as pc
 from partcad import shape_envelope
 from partcad.assembly import Assembly
 from partcad.cache_hash import CacheHash
-from partcad.cache_shape import ShapeCache
+from partcad.cache_shape import ShapeCache, properties_key
 from partcad.lint.all import get_partcad_schema
 from partcad.shape import Shape
 
@@ -45,8 +45,8 @@ STEEL = {"material": "steel", "color": "#8899AA"}
 BRASS = {"material": "brass", "physics": {"mass": 0.25}}
 
 
-def _cache(tmp_path):
-    return ShapeCache(user_config=CacheUserConfig(tmp_path))
+def _cache(tmp_path, **overrides):
+    return ShapeCache(user_config=CacheUserConfig(tmp_path, **overrides))
 
 
 def _hash():
@@ -56,9 +56,14 @@ def _hash():
     return cache_hash
 
 
+def _entry(tmp_path, cache_hash, key):
+    """The file one cache entry is stored in, whether or not it is there."""
+    return tmp_path / "cache" / "shapes" / ("%s.%s" % (cache_hash.get(), key))
+
+
 class _Ctx:
-    def __init__(self, tmp_path):
-        self.cache_shapes = _cache(tmp_path)
+    def __init__(self, tmp_path, **overrides):
+        self.cache_shapes = _cache(tmp_path, **overrides)
 
 
 class _Part(Shape):
@@ -248,7 +253,7 @@ def test_the_cache_stores_no_properties_of_its_own_but_keeps_a_child_s(tmp_path)
     tree = {"name": "pkg:first", "label": "first", "properties": BRASS, "assembly": [child]}
     asyncio.run(cache.write_async(cache_hash, {"assembly": tree}))
 
-    stored = json.loads((tmp_path / "cache" / "shapes" / ("%s.assembly" % cache_hash.get())).read_bytes())
+    stored = json.loads(_entry(tmp_path, cache_hash, "assembly").read_bytes())
     assert stored == {"assembly": [shape_envelope.encode(child)]}
     assert "brass" not in json.dumps(stored)
 
@@ -293,6 +298,106 @@ def test_composition_carries_a_child_s_properties_into_the_parent(tmp_path):
 
     assert "properties" not in tree
     assert tree["assembly"][0]["properties"] == BRASS
+
+
+# In an entry of their own
+# ------------------------
+
+
+def test_instantiating_a_shape_fills_the_geometry_entry_and_the_properties_one(tmp_path):
+    """Both, and by the one path that actually built the shape.
+
+    The key is the geometry's with a suffix, so the two sit side by side in
+    whatever tier took them and neither can be mistaken for the other.
+    """
+    ctx = _Ctx(tmp_path)
+    part = _Part("bolt", STEEL)
+    asyncio.run(part.get_wrapped(ctx))
+
+    assert properties_key("part") == "part-props"
+    assert _entry(tmp_path, part.hash, "part").read_bytes() == BREP
+    assert json.loads(_entry(tmp_path, part.hash, properties_key("part")).read_bytes()) == STEEL
+
+
+def test_the_properties_are_materialized_without_the_geometry(tmp_path):
+    """Asking what a shape is made of does not pull its BREP out of the cache."""
+    ctx = _Ctx(tmp_path)
+    part = _Part("bolt", STEEL)
+    asyncio.run(part.get_wrapped(ctx))
+    _entry(tmp_path, part.hash, "part").unlink()
+
+    # A later run of the same part, with no geometry left to read.
+    assert asyncio.run(_Part("bolt", STEEL).get_cached_properties_async(ctx)) == STEEL
+
+
+def test_the_geometry_is_materialized_without_the_properties(tmp_path):
+    """A cache from before the properties had an entry is not a miss for the geometry.
+
+    The two go stale on different occasions and are read on different ones, so
+    the absence of either has to leave the other alone.
+    """
+    ctx = _Ctx(tmp_path)
+    first = _Part("first", STEEL)
+    asyncio.run(first.get_wrapped(ctx))
+    _entry(tmp_path, first.hash, properties_key("part")).unlink()
+
+    second = asyncio.run(_Part("second", BRASS).get_wrapped(ctx))
+
+    assert second == {"name": "pkg:second", "label": "second", "properties": BRASS, "brep": BREP}
+    assert asyncio.run(_Part("second", BRASS).get_cached_properties_async(ctx)) is None
+
+
+def test_a_shape_that_reports_nothing_leaves_no_properties_entry(tmp_path):
+    """One entry or none, the way one stamped key or none is."""
+    ctx = _Ctx(tmp_path)
+    plain = _Part("plain")
+    asyncio.run(plain.get_wrapped(ctx))
+
+    assert not _entry(tmp_path, plain.hash, properties_key("part")).exists()
+    assert asyncio.run(_Part("plain").get_cached_properties_async(ctx)) is None
+
+
+def test_the_properties_entry_is_not_filtered_out_by_the_geometry_size_window(tmp_path):
+    """It is named after a geometry key without being geometry.
+
+    A tier drops entries below its minimum to keep trivial geometry out of the
+    cache - 100 bytes for the files tier by default. A handful of declared
+    values is always under that, so applying the window to them would leave the
+    entry never written at all.
+    """
+    ctx = _Ctx(tmp_path, cache_min_entry_size=100)
+    part = _Part("bolt", STEEL)
+    asyncio.run(part.get_wrapped(ctx))
+
+    # The window really is on: the geometry below it was dropped.
+    assert len(BREP) < 100 and not _entry(tmp_path, part.hash, "part").exists()
+    assert json.loads(_entry(tmp_path, part.hash, properties_key("part")).read_bytes()) == STEEL
+
+
+def test_an_assembly_s_own_go_to_its_entry_and_its_children_s_stay_in_the_tree(tmp_path):
+    """The split, end to end: the root's are the asking object's, a child's are the tree's."""
+    ctx = _Ctx(tmp_path)
+    rig = _Assembly("rig", BRASS, child_properties=STEEL)
+    asyncio.run(rig.get_wrapped(ctx))
+
+    stored = json.loads(_entry(tmp_path, rig.hash, "assembly").read_bytes())
+    assert [child["properties"] for child in stored["assembly"]] == [STEEL]
+    assert "brass" not in json.dumps(stored)
+    assert json.loads(_entry(tmp_path, rig.hash, properties_key("assembly")).read_bytes()) == BRASS
+
+
+def test_a_properties_entry_is_carried_as_the_plain_dict_it_is(tmp_path):
+    """It has no payload, so there is no outer layer to strip or to stamp back on."""
+    cache = _cache(tmp_path)
+    cache_hash = _hash()
+    key = properties_key("part")
+    asyncio.run(cache.write_async(cache_hash, {key: BRASS}))
+
+    assert json.loads(_entry(tmp_path, cache_hash, key).read_bytes()) == BRASS
+
+    read, _ = asyncio.run(cache.read_async(cache_hash, [key], {"name": "pkg:x", "label": "x"}))
+
+    assert read[key] == BRASS
 
 
 # And into the exporter

--- a/partcad/tests/unit/test_shape_properties.py
+++ b/partcad/tests/unit/test_shape_properties.py
@@ -118,6 +118,71 @@ def test_the_schema_refuses_the_flat_form_and_an_unknown_property():
         _validate({"parts": {"bolt": {"type": "step", "properties": {"smell": "burnt"}}}})
 
 
+# What a connection costs, which an interface states and a shape must not: these
+# describe moving a joint, not being a body. Values of the type each is declared
+# with, so that a rejection below is about the name and nothing else.
+CONNECTION_ONLY_PHYSICS = {
+    "maxEffort": 12.0,
+    "maxVelocity": 30.0,
+    "damping": 0.5,
+    "springStiffness": 100.0,
+    "springReference": 0.0,
+    "stopCfm": 0.1,
+    "stopErp": 0.2,
+    "fudgeFactor": 0.5,
+    "implicitSpringDamper": True,
+    "provideFeedback": True,
+}
+
+
+def _errors(config):
+    """Every error raised for 'config', including those nested inside a 'oneOf'.
+
+    'parts' and 'assemblies' are each wrapped in one, so the best-match error
+    names the 'oneOf' and the error that names the offending property sits
+    underneath it in '.context'. Draft 7 explicitly because that is what
+    '$schema' says: a later validator reads this schema's tuple-form 'items' as
+    a single subschema and misjudges the OCCT locations.
+    """
+    validator = jsonschema.Draft7Validator(get_partcad_schema())
+
+    def walk(errors):
+        for error in errors:
+            yield error
+            yield from walk(error.context or [])
+
+    return list(walk(validator.iter_errors(config)))
+
+
+def test_the_schema_takes_a_body_property_on_a_shape():
+    """What a body is: mass, where it balances, how it rubs and how it bounces."""
+    _validate({"parts": {"bolt": {"type": "step", "properties": {"physics": {"mass": 0.01, "friction": 0.4}}}}})
+    _validate({"assemblies": {"rig": {"type": "assy", "properties": {"physics": {"restitution": 0.2}}}}})
+
+
+@pytest.mark.parametrize("name,value", sorted(CONNECTION_ONLY_PHYSICS.items()))
+@pytest.mark.parametrize("kind,declaration", [("parts", {"type": "step"}), ("assemblies", {"type": "assy"})])
+def test_the_schema_refuses_a_connection_property_on_a_shape(kind, declaration, name, value):
+    """A part is not a joint, so it has no effort limit, no damping, no spring.
+
+    The shape's vocabulary is the body half of 'physics'. Stating the other half
+    on a shape is a mistake about where the property lives rather than metadata
+    to carry, and the error names the property so it can be moved.
+    """
+    config = {kind: {"thing": dict(declaration, properties={"physics": {name: value}})}}
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        _validate(config)
+    assert any(
+        error.json_path == "$.%s.thing.properties.physics" % kind and name in error.message for error in _errors(config)
+    )
+
+
+def test_the_schema_still_takes_a_connection_property_on_an_interface():
+    """Only the shape's vocabulary narrowed - the connection's is untouched."""
+    _validate({"interfaces": {"hinge": {"physics": dict(CONNECTION_ONLY_PHYSICS)}}})
+    _validate({"interfaces": {"hinge": {"physics": {"damping": 0.5, "friction": 0.4}}}})
+
+
 def test_declaring_properties_does_not_move_the_cache_key():
     """They say nothing about the geometry, so they must not rehash it.
 

--- a/partcad/tests/unit/test_shape_properties.py
+++ b/partcad/tests/unit/test_shape_properties.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""What a shape reports about itself, from the configuration to the exporter.
+
+'parameters:' are inputs - a request made of the object type that produces the
+shape. 'properties:' are outputs - what the instantiated shape turns out to be.
+This file follows one of those outputs the whole way: onto the envelope, through
+the shape cache, through the composition of an assembly, and into the index an
+export implementation looks it up in.
+
+Everything here is pure Python: envelopes, JSON and dicts. No CAD kernel and no
+sandbox is involved, which is the point - the properties travel as data beside
+the geometry rather than being collected from the object graph.
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+import jsonschema
+import pytest
+from cache_config import CacheUserConfig
+
+import partcad as pc
+from partcad import shape_envelope
+from partcad.assembly import Assembly
+from partcad.cache_hash import CacheHash
+from partcad.cache_shape import ShapeCache
+from partcad.lint.all import get_partcad_schema
+from partcad.shape import Shape
+
+sys.path.append(os.path.join(os.path.dirname(pc.__file__), "wrappers"))
+import wrapper_export  # noqa: E402
+
+# Not a real BREP, but it starts the way an uncompressed payload does, which is
+# all the cache uses to tell a raw payload from a JSON one.
+BREP = b"CASCADE Topology V3, (c) Open Cascade\n\nLocations 0\n"
+
+STEEL = {"material": "steel", "color": "#8899AA"}
+BRASS = {"material": "brass", "physics": {"mass": 0.25}}
+
+
+def _cache(tmp_path):
+    return ShapeCache(user_config=CacheUserConfig(tmp_path))
+
+
+def _hash():
+    cache_hash = CacheHash("geometry", cache=True)
+    # Every shape below builds the same geometry, and so shares one entry.
+    cache_hash.add_string("identical-geometry")
+    return cache_hash
+
+
+class _Ctx:
+    def __init__(self, tmp_path):
+        self.cache_shapes = _cache(tmp_path)
+
+
+class _Part(Shape):
+    """A part whose factory hands back an envelope, with no sandbox involved."""
+
+    def __init__(self, name, properties=None):
+        config = {"name": name}
+        if properties is not None:
+            config["properties"] = properties
+        super().__init__("pkg", config)
+        self.name = name
+        self.kind = "part"
+        self.hash.add_string("identical-geometry")
+
+    async def get_shape(self, ctx):
+        return {"name": None, "label": None, "brep": BREP}
+
+
+class _Assembly(Assembly):
+    def __init__(self, name, properties=None, child_properties=None):
+        config = {"name": name}
+        if properties is not None:
+            config["properties"] = properties
+        super().__init__("pkg", config)
+        self.name = name
+        self.hash.add_string("identical-geometry")
+        self._child_properties = child_properties
+
+    def instantiate(self, _assembly):
+        child = _Part("leaf", self._child_properties)
+        child.cacheable = False
+        self.add(child, name="leaf")
+
+
+# The configuration says it, and the schema agrees
+# ------------------------------------------------
+
+
+def _validate(config):
+    jsonschema.validate(instance=config, schema=get_partcad_schema())
+
+
+def test_the_schema_takes_the_properties_section_on_a_part_and_on_an_assembly():
+    _validate(
+        {
+            "parts": {"bolt": {"type": "step", "properties": dict(STEEL, physics={"mass": 0.01})}},
+            "assemblies": {"rig": {"type": "assy", "properties": {"material": "steel"}}},
+        }
+    )
+
+
+def test_the_schema_refuses_the_flat_form_and_an_unknown_property():
+    """Where these used to sit, and what keeps the set of them closed."""
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        _validate({"parts": {"bolt": {"type": "step", "material": "steel"}}})
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        _validate({"parts": {"bolt": {"type": "step", "properties": {"smell": "burnt"}}}})
+
+
+def test_declaring_properties_does_not_move_the_cache_key():
+    """They say nothing about the geometry, so they must not rehash it.
+
+    A part that gains a material has not become a different shape, and a stale
+    entry is not the failure to prefer over a redundant one here: what is cached
+    is geometry, and nothing about the geometry changed.
+    """
+    assert _Part("bolt").hash.get() == _Part("bolt", STEEL).hash.get()
+
+
+# Onto the envelope
+# -----------------
+
+
+def test_the_metadata_a_shape_is_stamped_with_carries_its_properties():
+    assert _Part("bolt", STEEL).get_cache_metadata() == {
+        "name": "pkg:bolt",
+        "label": "bolt",
+        "properties": STEEL,
+    }
+    # One namespaced key or none: a shape that reports nothing adds nothing.
+    assert set(_Part("bolt").get_cache_metadata()) == {"name", "label"}
+    assert set(_Part("bolt", {}).get_cache_metadata()) == {"name", "label"}
+
+
+def test_an_assembly_is_stamped_the_same_way():
+    assert _Assembly("rig", BRASS).get_cache_metadata() == {
+        "name": "pkg:rig",
+        "label": "rig",
+        "properties": BRASS,
+    }
+
+
+def test_properties_survive_the_envelope_codec_at_every_level():
+    """The wire form is JSON, and a nested dict of them comes back identical."""
+    tree = {
+        "name": "pkg:rig",
+        "label": "rig",
+        "properties": BRASS,
+        "assembly": [{"name": "pkg:leaf", "label": "leaf", "properties": STEEL, "brep": BREP}],
+    }
+
+    text = shape_envelope.dumps(tree)
+    # Really JSON, and the properties are in it as they were written.
+    assert json.loads(text)["assembly"][0]["properties"] == STEEL
+
+    assert shape_envelope.loads(text) == tree
+
+
+# Through the cache
+# -----------------
+
+
+def test_the_cache_stores_no_properties_of_its_own_but_keeps_a_child_s(tmp_path):
+    """The outer layer is stripped; everything nested inside the payload is not.
+
+    A child's properties describe the tree, which is what the entry is about. The
+    assembly's own describe the assembly, which is what the reader supplies.
+    """
+    cache = _cache(tmp_path)
+    cache_hash = _hash()
+    child = {"name": "pkg:leaf", "label": "leaf", "properties": STEEL, "brep": BREP}
+    tree = {"name": "pkg:first", "label": "first", "properties": BRASS, "assembly": [child]}
+    asyncio.run(cache.write_async(cache_hash, {"assembly": tree}))
+
+    stored = json.loads((tmp_path / "cache" / "shapes" / ("%s.assembly" % cache_hash.get())).read_bytes())
+    assert stored == {"assembly": [shape_envelope.encode(child)]}
+    assert "brass" not in json.dumps(stored)
+
+    metadata = {"name": "pkg:second", "label": "second", "properties": STEEL}
+    read, _ = asyncio.run(cache.read_async(cache_hash, ["assembly"], metadata))
+
+    # The root wears the reader's own properties; the child kept its own.
+    assert read["assembly"] == dict(metadata, assembly=[child])
+
+
+def test_shapes_that_share_an_entry_each_get_their_own_properties(tmp_path):
+    """The regression the geometry-keyed cache used to cause, for properties.
+
+    Two parts built from the same file share one cache entry. The properties are
+    not in the entry - they are stamped on from the configuration of whichever
+    part is asking - so the second part cannot inherit the first one's material.
+    """
+    ctx = _Ctx(tmp_path)
+    first = asyncio.run(_Part("first", STEEL).get_wrapped(ctx))
+    second = asyncio.run(_Part("second", BRASS).get_wrapped(ctx))
+    plain = asyncio.run(_Part("plain").get_wrapped(ctx))
+
+    assert first["properties"] == STEEL
+    assert second["properties"] == BRASS
+    assert "properties" not in plain
+
+
+def test_an_assembly_read_back_keeps_its_own_properties_and_its_children_s(tmp_path):
+    ctx = _Ctx(tmp_path)
+    asyncio.run(_Assembly("first", BRASS, child_properties=STEEL).get_wrapped(ctx))
+    second = asyncio.run(_Assembly("second", STEEL, child_properties=STEEL).get_wrapped(ctx))
+
+    assert second["properties"] == STEEL
+    # The children came from the cache, and they are what the entry is about.
+    assert [child["properties"] for child in second["assembly"]] == [STEEL]
+
+
+def test_composition_carries_a_child_s_properties_into_the_parent(tmp_path):
+    """'Assembly._place()' copies the child's envelope, so they propagate."""
+    ctx = _Ctx(tmp_path)
+    tree = asyncio.run(_Assembly("rig", child_properties=BRASS).get_wrapped(ctx))
+
+    assert "properties" not in tree
+    assert tree["assembly"][0]["properties"] == BRASS
+
+
+# And into the exporter
+# ---------------------
+
+
+def test_the_index_is_built_from_the_raw_request_by_name():
+    """What an implementation that declared 'properties: true' is handed.
+
+    Keyed by the very name each envelope carries, because it is read off that
+    envelope - the two cannot disagree the way a separately collected index and
+    a separately stamped name could.
+    """
+    request = {
+        "wrapped": {
+            "name": "pkg:rig",
+            "label": "rig",
+            "properties": BRASS,
+            "assembly": [
+                {"name": "pkg:leaf", "label": "leaf", "properties": STEEL, "brep": "AAAA"},
+                # Nested one level deeper, and reporting nothing of its own.
+                {
+                    "name": "pkg:sub",
+                    "label": "sub",
+                    "assembly": [{"name": "pkg:deep", "label": "deep", "properties": STEEL, "brep": "AAAA"}],
+                },
+            ],
+        },
+        "shape_name": "rig",
+        "properties": True,
+    }
+
+    assert wrapper_export.properties_index(request) == {
+        "pkg:rig": BRASS,
+        "pkg:leaf": STEEL,
+        "pkg:deep": STEEL,
+    }
+
+
+def test_the_index_is_empty_when_nothing_reports_anything():
+    request = {"wrapped": {"name": "pkg:bolt", "label": "bolt", "brep": "AAAA"}, "properties": True}
+
+    assert wrapper_export.properties_index(request) == {}
+
+
+def test_a_shape_with_no_name_cannot_be_indexed_but_does_not_stop_the_walk():
+    request = {
+        "wrapped": {
+            "name": None,
+            "properties": STEEL,
+            "assembly": [{"name": "pkg:leaf", "properties": BRASS, "brep": "AAAA"}],
+        }
+    }
+
+    assert wrapper_export.properties_index(request) == {"pkg:leaf": BRASS}


### PR DESCRIPTION
## The distinction

PartCAD had two things that looked like duplicates. `parameters.material` (the MCFTT parameters, read by `ShapeConfig.get_mcftt()` for the manufacturing/quoting path) and the shape-level `material:` that #518 added for the exporters. This makes the difference structural rather than a matter of which one you happened to read about first:

- **`parameters:` are inputs.** A *request* made of the object type that produces the shape — the `width` a CadQuery script extrudes to, the material a provider should make the part out of. They only mean anything if that type accepts them, and they are part of what the shape cache is keyed on. Two parts that differ in a parameter are different shapes.
- **`properties:` are outputs.** What *instantiation produced* — what the resulting shape reports about itself. Declared where the shape cannot report it on its own: a mesh carries no material and no mass, so saying so is the only way an STL part has either. They say nothing about the geometry, so they are not hashed, and an exporter that has a way to state one writes it out rather than recomputing or losing it.

`parameters.material` asks for a part to be made of something. `properties.material` states what the part that came out is made of. Both sections of `docs/source/configuration.rst` now say so and cross-reference each other.

## The mechanics

**Schema.** `material`, `color` and `physics` move from three top-level shape keys into one `properties:` grouping (`#/definitions/shape-properties`), on parts and on assemblies. #518's flat syntax is unreleased — nothing in `examples/`, `partcad/tests/` or the docs used it except the URDF import path and one test fixture, all migrated here. The part branch's old `properties: {length: number}` — dead schema left behind by the generative-AI retirement (#486), referenced by nothing — is what the new definition replaces.

**Carriage.** The properties ride on the shape envelope, beside `name` and `label`, under a single namespaced key (`shape_envelope.KEY_PROPERTIES`) so the envelope's key space stays small. `Shape.get_cache_metadata()` and `Assembly.get_cache_metadata()` stamp them on from the object's own configuration — the same outer layer the shape cache strips on write and the reader supplies on read. So two parts sharing a geometry-keyed cache entry each get their own properties back, which is the failure that had `test_export_reports_properties_urdf_cannot_state` xfail'd. The marker is gone.

**The index.** The by-name index an export implementation is handed is now built in `wrapper_export.properties_index()`, by walking the **raw** request before `ocp_serialize.decode()` runs. That is what makes this strictly better than the side channel: a `decode: true` implementation gets the properties too, which it could not before, because decoding discards everything but the geometry. A future colour-aware 3MF or glTF exporter needs no core change — only `properties: true` on its own declaration. `export_urdf.py` is unchanged: it still reads `request["properties"]`, keyed the same way.

**Cache safety.** Nothing about the on-disk format, the cache key version (`cache_hash.VERSION` stays 2) or the JSON-RPC wire format changes. The hash covers `parameters`, `offset` and `scale` only, so declaring a property does not move a key; the envelope gains one optional key that every layer already carries opaquely. `Assembly._place()` copies the child envelope wholesale, so the key propagates through composition unchanged.

One behavioural consequence worth stating out loud, and documented: an object's *own* properties are re-stamped from live configuration on every cache read, but the properties of the parts *inside* a cached assembly tree are part of that tree, exactly as their names, labels and placements already are — so editing them does not invalidate the assembly entry any more than renaming a part does. Under the old side index they were re-derived from live configuration each time. This is the same staleness the tree structure already had, not a new class of it.

## What it deletes

- `Shape._property_index()` and `Shape.EXPORTED_PROPERTIES`. The index no longer needs building in the core, and no longer needs the `do_instantiate()` that came with it — which is why it had to be opt-in: asking for properties defeated the shape cache for the whole subtree.
- The swap in `Shape._output_request()`, and `output.PROPERTIES_KEY` with it — the core no longer touches that key at all.
- The `xfail` on `test_export_reports_properties_urdf_cannot_state`, whose stated reason is now structurally impossible.

`properties: true` **stays**, as a zero-cost opt-in rather than disappearing. It costs a flag test when off and a walk of a tree already in hand when on, so the reason it existed is gone — but the reason to keep it is not cost. It is a plain export parameter in a namespace where anything unreserved is handed to the implementation, so a package's own exporter may legitimately have a parameter called `properties`; making the index unconditional would silently replace it. And the declaration reads as what it is: this format has a way to state what the parts report about themselves.

## Not done here: object-type parameters

The idea that a type could declare which parameters it accepts (an STL may accept `material`, a STEP may not) does not fall out of this work, and there is nowhere in the codebase to put it today — `partTypes:` declares `kind`/`path`/`pythonRequirements` and no parameters; `output.Implementation.parameters` is the complement of a reserved-key set rather than a declaration; the schema's parts branch is one flat union across every built-in type with no per-type discrimination. Implementing it means introducing the concept, and that is a change of its own. Left as a proposal in the task report rather than expanded into this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJUdN3k39YTAL1rrofSzs)_