### PR TITLE
restore: re-land #533 and #529, dropped by a version-bump force-push

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1858,6 +1858,42 @@ the object's value wins:
         step:
           comment: Revision C.
 
+Two names are not entirely the package's own.
+
+``decode`` is not a parameter at all. It is one of the fields PartCAD reads
+itself -- it says whether the sandbox rebuilds the shape and assembly envelopes
+into live geometry before the implementation sees them (see ``urdf`` under
+`Built-in implementations`_) -- so no package can declare an export parameter
+named ``decode``: a ``decode:`` in a file type's configuration is always that
+flag.
+
+``properties`` is the other way round, and it is a parameter -- with a caveat. A
+file type that declares ``properties: true`` is handed, in place of the flag, an
+index of what the shapes being written declare about themselves: their
+``physics``, ``material`` and ``color``, keyed by the full ``<package>:<name>``
+of each shape, so an implementation given a whole assembly tree can look up the
+properties belonging to each node of it. Only shapes that declare at least one
+appear.
+
+.. code-block:: yaml
+
+  export:
+    urdf:
+      properties: true
+
+It is opt-in because building the index instantiates the whole assembly tree,
+which defeats the shape cache for that subtree: an assembly whose geometry could
+have been served from the cache has to be built anyway, so that its children
+exist to be walked. An implementation with no use for the properties should not
+pay for that. ``urdf`` is the one built-in file type that asks.
+
+The caveat is that ``properties``, unlike ``decode``, is *not* a reserved field
+name, and PartCAD intercepts it by value rather than by declaration: a package
+that declares an ordinary export parameter of its own named ``properties`` and
+gives it the value ``true`` will find that value replaced by the index before
+its implementation sees it. Any other value is passed through untouched, but the
+name is best avoided for anything else.
+
 Custom implementations
 ----------------------
 
@@ -1939,6 +1975,8 @@ declares and the images the other file types leave behind (see ``pc render`` in
 ``urdf`` is the one built-in file type that is not a single file: it writes a
 ``.urdf`` plus the directory of mesh files it references, which is why
 ``Shape.convert()`` refuses it (there is no single payload to hand back) and why
-it declares ``decode: false`` - it is handed the assembly *tree*, one URDF link
-per node, rather than the single compound the tree decodes to. See
-:doc:`simulation`.
+it declares ``decode: false`` - it is handed the assembly *tree* itself, one
+URDF link per node, rather than the geometry the tree decodes to. Decoding keeps
+the shape of the tree but nothing else about it: every node's ``name`` and
+``label`` is dropped, and its placement is baked into the geometry instead of
+staying readable as the joint origin. See :doc:`simulation`.

--- a/partcad/src/partcad/builtin/export/export_urdf.py
+++ b/partcad/src/partcad/builtin/export/export_urdf.py
@@ -7,14 +7,16 @@
 
 Writes a PartCAD shape or assembly as a URDF file plus its mesh files.
 
-Unlike the other exporters, this one is handed the assembly *tree* rather than
-the compound it decodes to - which is what 'decode: false' on this format's
-declaration asks for, see wrapper_export.DECODE_KEY: URDF is a tree of links
-joined by joints, and one link per node is exactly what makes the export
-reversible. Each node becomes a link, each parent/child edge a
-fixed joint carrying that child's placement, and each node that has geometry
-gets a mesh written next to the URDF and referenced from its ``<visual>`` and
-``<collision>``.
+Unlike the other exporters, this one is handed the assembly *tree* itself
+rather than the geometry it decodes to - which is what 'decode: false' on this
+format's declaration asks for, see wrapper_export.DECODE_KEY. Decoding would
+keep the tree's shape, and nothing else about it: every node's 'name' and
+'label' is dropped and its placement is baked into the geometry rather than
+staying readable as data. This exporter needs all three - the link names, the
+mesh names, the properties lookup and every joint origin come from them. Each
+node becomes a link, each parent/child edge a fixed joint carrying that child's
+placement, and each node that has geometry gets a mesh written next to the URDF
+and referenced from its ``<visual>`` and ``<collision>``.
 
 The URDF is built with ROS's own 'urdf_parser_py' and serialized by it, so what
 lands on disk is what the ROS toolchain itself would write and reads back

--- a/partcad/src/partcad/builtin/export/partcad.yaml
+++ b/partcad/src/partcad/builtin/export/partcad.yaml
@@ -114,13 +114,15 @@ export:
     desc: |
       Unified Robot Description Format: a URDF file plus the mesh files it
       references. Unlike every other format here it is handed the assembly
-      *tree* rather than the compound it decodes to (`decode: false`), because
-      one URDF link per assembly node is what makes the export reversible.
+      *tree* itself rather than the geometry it decodes to (`decode: false`),
+      because one URDF link per assembly node - named, placed and looked up by
+      what the tree says - is what makes the export reversible.
     path: export_urdf.py
     extension: urdf
     # 'decode: false' -- see wrappers/wrapper_export.py. The exporter walks the
-    # assembly envelopes itself; decoding them into live geometry would collapse
-    # the tree into a single compound and there would be no links left to write.
+    # assembly envelopes itself; decoding them into live geometry would keep the
+    # tree's shape but drop every node's name and label and bake its placement
+    # in, leaving nothing to name, group or joint the links by.
     decode: false
     pythonRequirements:
       - cadquery-ocp==7.9.3.1.1

--- a/partcad/src/partcad/factory.py
+++ b/partcad/src/partcad/factory.py
@@ -8,23 +8,80 @@
 #
 
 
+# The object types this PartCAD used to support and deliberately removed, each
+# mapped to the release that removed it.
+#
+# These are 'part' types, and only 'part' types. All four are the built-in
+# generative-AI part types retired by #486 ("retire the built-in generative-AI
+# functionality"), which deleted the 'part_factory_ai_*' modules together with
+# their 'register()' calls - every one of which was a
+# 'factory.register("part", ...)'. The public index is a separate repository and
+# still declares them, as does every package published while they existed - so
+# this is not something the user of such a package can correct. That is why
+# naming one of these is a warning and the object is skipped, while any other
+# unknown type stays an error (see 'Project.record_broken_object').
+#
+# Because the scope is 'part', 'instantiate' consults this only for that kind.
+# The same name on a sketch, an assembly, a provider or a repository was never a
+# type PartCAD had, so it is not a retirement and must not be forgiven as one -
+# and calling it retired would name a release that never supported it. Should a
+# non-part type ever be retired, this map has to grow a kind before that entry
+# can be added to it.
+#
+# Nothing else belongs in here. A type that never existed, or a typo in the
+# user's own package, must keep failing loudly.
+RETIRED_TYPES = {
+    "ai-build123d": "0.7.153",
+    "ai-cadquery": "0.7.153",
+    "ai-openscad": "0.7.153",
+    "ai-sdf": "0.7.153",
+}
+
+
 class UnknownTypeException(Exception):
     """A declared object names a type this PartCAD has no factory for.
 
-    Most often a package written against an older PartCAD that used a feature
-    since retired - the 'ai-cadquery'/'ai-build123d' part types, for instance.
     Nothing can be done with such an object, but the package it lives in is
     otherwise fine, so this is per object and never fails a whole package.
+
+    A type PartCAD used to have and dropped raises the 'RetiredTypeException'
+    subclass below instead, which is reported more gently.
     """
 
-    def __init__(self, kind: str, t: str, name=None):
+    def __init__(self, kind: str, t: str, name=None, message: str = None):
         self.kind = kind
         self.type = t
         self.name = name
-        known = ", ".join(sorted(all[kind])) if kind in all else ""
+        if message is None:
+            known = ", ".join(sorted(all[kind])) if kind in all else ""
+            message = "unknown %s type '%s'%s. This PartCAD supports: %s" % (
+                kind,
+                t,
+                "" if name is None else " for '%s'" % name,
+                known,
+            )
+        super().__init__(message)
+
+
+class RetiredTypeException(UnknownTypeException):
+    """A declared object names a type this PartCAD removed on purpose.
+
+    What separates it from a plain unknown type is whose problem it is. An
+    unknown type is a broken declaration - a typo, or a package to fix. A
+    retired type is a declaration that was correct when it was written, in a
+    package the user most often only depends on and cannot edit; PartCAD is the
+    side that changed. Reporting it as an error would make every command that
+    merely walks such a package exit non-zero, with nothing to act on.
+    """
+
+    def __init__(self, kind: str, t: str, name=None):
+        self.release = RETIRED_TYPES[t]
         super().__init__(
-            "unknown %s type '%s'%s. This PartCAD supports: %s"
-            % (kind, t, "" if name is None else " for '%s'" % name, known)
+            kind,
+            t,
+            name,
+            message="the %s type '%s'%s was retired in PartCAD %s; the object is skipped"
+            % (kind, t, "" if name is None else " of '%s'" % name, self.release),
         )
 
 
@@ -71,4 +128,12 @@ def instantiate(kind: str, t: str, ctx, source_project, target_project, config):
     # It used to be logged here instead, which dropped the object silently and
     # printed the whole configuration - including the multi-page descriptions
     # the retired 'ai-*' types carry - into the log for every occurrence.
+    #
+    # Checked after the lookups above, not before them, so that a type which is
+    # somehow registered again is served rather than reported as retired. Gated
+    # on 'part' because that is what every retired type was: naming one of them
+    # on any other kind is a broken declaration, not a retirement (see
+    # 'RETIRED_TYPES').
+    if kind == "part" and isinstance(t, str) and t in RETIRED_TYPES:
+        raise RetiredTypeException(kind, t, config.get("name"))
     raise UnknownTypeException(kind, t, config.get("name"))

--- a/partcad/src/partcad/output.py
+++ b/partcad/src/partcad/output.py
@@ -105,7 +105,11 @@ SCRIPT_KEY = "__script__"
 # The request key that says whether the sandbox rebuilds the shape and assembly
 # envelopes into live OCCT geometry before the implementation sees them. It
 # travels beside the script path for the same reason: the wrapper has to know
-# before it deserializes anything. Declared on a file type as 'decode: false'.
+# before it deserializes anything. Declared on a file type as 'decode: false',
+# which is what an implementation asks for when it needs what an envelope says
+# *about* a node: decoding mirrors the assembly tree in nested compounds, but
+# geometry is all it keeps - every node's 'name' and 'label' is dropped, and its
+# placement is baked into the shape instead of staying readable as data.
 DECODE_KEY = "__decode__"
 
 # A parameter, not a reserved key: a file type declares 'properties: true' to be

--- a/partcad/src/partcad/project.py
+++ b/partcad/src/partcad/project.py
@@ -650,9 +650,19 @@ class Project(project_config.Configuration):
         *package* requires a newer PartCAD, which is not a per-object condition
         and which the caller turns into its own "update PartCAD" prompt. Filing
         it against one object would swallow that prompt.
+
+        A type PartCAD itself retired ('factory.RetiredTypeException') is
+        reported at WARNING instead of ERROR. The object is still recorded as
+        broken and still skipped, but nothing the user of that package can do
+        would make it work - PartCAD dropped the feature - so it must not fail
+        the command. The public index, a separate repository, still declares the
+        generative-AI part types retired in 0.7.153. Every other reason stays an
+        error: an unknown type is a mistake somebody can fix.
         """
         if isinstance(reason, NeedsUpdateException):
             raise reason
+
+        retired = isinstance(reason, factory.RetiredTypeException)
 
         reason = str(reason) or type(reason).__name__
         # One line, and short: some of these configurations embed multi-page
@@ -662,7 +672,10 @@ class Project(project_config.Configuration):
             reason = reason[:197] + "..."
 
         self.broken_objects.setdefault(kind, {})[name] = reason
-        pc_logging.error("Failed to create the %s '%s:%s': %s" % (kind, self.name, name, reason))
+        if retired:
+            pc_logging.warning("Skipping the %s '%s:%s': %s" % (kind, self.name, name, reason))
+        else:
+            pc_logging.error("Failed to create the %s '%s:%s': %s" % (kind, self.name, name, reason))
 
     def get_broken_object_reason(self, kind: str, name: str):
         """Why an object could not be created, or None if it was not one of them."""

--- a/partcad/src/partcad/shape.py
+++ b/partcad/src/partcad/shape.py
@@ -915,9 +915,10 @@ class Shape(ShapeConfiguration):
         request = await self._output_request(obj, impl, kwargs)
         request[output.SCRIPT_KEY] = os.path.abspath(script)
         # Whether the sandbox rebuilds the envelopes into live geometry before
-        # the implementation sees them. Off for an implementation that walks the
-        # assembly *tree* (the URDF exporter turns each node into a link of its
-        # own), which decoding would have collapsed into one compound.
+        # the implementation sees them. Off for an implementation that needs what
+        # the envelopes say about each node (the URDF exporter names every link
+        # and places every joint from that), none of which decoding carries over
+        # into the geometry it builds.
         request[output.DECODE_KEY] = impl.decode
         request_serialized = shape_envelope.serialize(request)
 

--- a/partcad/src/partcad/wrappers/ocp_serialize.py
+++ b/partcad/src/partcad/wrappers/ocp_serialize.py
@@ -495,7 +495,9 @@ def deserialize_raw(data) -> object:
 
     The counterpart of the core-side 'shape_envelope.deserialize()', for the
     wrappers that need the *structure* of an assembly envelope rather than the
-    compound it decodes to: the URDF exporter turns each node of the tree into a
-    link of its own, which the flattening in 'decode()' would have thrown away.
+    geometry it decodes to: the URDF exporter names each link and places each
+    joint from what the envelope says about a node, and 'decode()' keeps none of
+    that - the compound it builds mirrors the tree, but the names and labels are
+    gone and the placements are baked into the geometry.
     """
     return json.loads(_payload_line(data))

--- a/partcad/src/partcad/wrappers/wrapper_common.py
+++ b/partcad/src/partcad/wrappers/wrapper_common.py
@@ -27,8 +27,11 @@ def handle_input(decode=True):
 
     'decode' off keeps the request exactly as it travelled, with shape and
     assembly envelopes left as their dicts instead of being rebuilt into live
-    OCCT geometry. A wrapper that walks an assembly *tree* needs that, because
-    decoding collapses the tree into one compound (see ocp_serialize.decode).
+    OCCT geometry. A wrapper that needs a node's 'name' or 'label', or its
+    location as separate data, needs that: decoding mirrors the tree in nested
+    compounds but keeps geometry alone, dropping the names and baking the
+    placements in (see ocp_serialize.decode, which hands each envelope it finds
+    to decode_shape - the per-node walk that does this).
     """
     if len(sys.argv) < 2:
         sys.stderr.write("Usage: %s <path>\n" % sys.argv[0])

--- a/partcad/src/partcad/wrappers/wrapper_export.py
+++ b/partcad/src/partcad/wrappers/wrapper_export.py
@@ -52,9 +52,11 @@ SCRIPT_KEY = "__script__"
 # The key that says whether the envelopes are rebuilt into live OCCT geometry
 # before the implementation sees them. It has to travel in the request and be
 # read before anything is decoded, which is why the request is always read raw
-# here and decoded afterwards. An implementation that walks an assembly *tree*
-# (the URDF exporter turns each node into a link of its own) declares
-# 'decode: false', because decoding collapses the tree into one compound.
+# here and decoded afterwards. An implementation that needs what an envelope
+# says *about* a node (the URDF exporter names each link after the node and
+# reads its location as a joint origin) declares 'decode: false', because
+# decoding keeps the tree's shape but only its geometry: names and labels are
+# gone and placements are baked in rather than left as data.
 DECODE_KEY = "__decode__"
 
 

--- a/partcad/tests/unit/test_output.py
+++ b/partcad/tests/unit/test_output.py
@@ -456,10 +456,11 @@ def test_parameters_exclude_the_reserved_fields():
 def test_a_format_decodes_its_envelopes_unless_it_declares_otherwise(ctx):
     """'decode' is off for URDF alone, and nothing else may lose it silently.
 
-    The URDF exporter is handed the assembly tree, one link per node; decoding
-    would collapse it into a single compound and the export would quietly write
-    a one-link robot. It is the only built-in format that asks for that, so this
-    also guards the other direction.
+    The URDF exporter is handed the assembly tree, one link per node; decoded
+    geometry carries no node names, labels or separate placements to build those
+    links from, so 'export_urdf.process()' rejects it outright and the export
+    fails with "needs a shape or an assembly to export". It is the only built-in
+    format that asks for that, so this also guards the other direction.
     """
     off = set()
     for section in output.SECTIONS:

--- a/partcad/tests/unit/test_project_resilience.py
+++ b/partcad/tests/unit/test_project_resilience.py
@@ -82,17 +82,27 @@ def test_getting_an_object_that_was_never_declared_still_returns_none(package):
 
 
 def test_unknown_type_exception_lists_what_is_supported():
+    # Deliberately a type nobody ever had rather than a retired one.
+    # 'RetiredTypeException' subclasses this and hands its own message to
+    # super(), so the supported-type list is never built for a retired type -
+    # asking 'ai-cadquery' here asserted nothing, and 'cadquery' matched only
+    # the substring inside the bad type's own name. The retired path has its
+    # own tests further down.
     with pytest.raises(factory.UnknownTypeException) as excinfo:
-        factory.instantiate("part", "ai-cadquery", None, None, None, {"name": "some_part"})
+        factory.instantiate("part", "nonsense", None, None, None, {"name": "some_part"})
+
+    assert not isinstance(excinfo.value, factory.RetiredTypeException)
 
     message = str(excinfo.value)
-    assert "ai-cadquery" in message
+    assert "nonsense" in message
     assert "some_part" in message
     # The supported types are listed, because "unknown type" on its own leaves
-    # the user with nothing to do about it.
+    # the user with nothing to do about it. Asserted on the sentence that
+    # introduces the list, and on a type name the bad type cannot supply itself.
+    assert "supports" in message
     assert "cadquery" in message
     assert excinfo.value.kind == "part"
-    assert excinfo.value.type == "ai-cadquery"
+    assert excinfo.value.type == "nonsense"
 
 
 def test_a_parametrized_instance_of_an_unusable_declaration_returns_none(tmp_path):
@@ -198,3 +208,179 @@ def test_a_factory_that_produces_nothing_is_recorded_rather_than_indexed(tmp_pat
             del factory.all["part"]["test-silent"]
         else:
             factory.register("part", "test-silent", saved)
+
+
+# A type PartCAD itself retired is not the same as a type nobody ever had.
+#
+# The public index is a separate repository, and it still declares the
+# generative-AI part types removed in 0.7.153. Reporting those as errors makes
+# every command that so much as walks the index exit non-zero, over declarations
+# the user cannot edit and cannot fix. Reporting a genuine typo as anything less
+# than an error would be worse, so the two have to stay apart.
+
+
+def _record_warnings(monkeypatch):
+    """Collect pc_logging.warning() calls.
+
+    The 'partcad' logger sets propagate=False, so the caplog fixture (which
+    attaches to the root logger) sees nothing on the pytest version used in CI.
+    """
+    recorded = []
+    monkeypatch.setattr(pc.logging, "warning", lambda *args, **kwargs: recorded.append(" ".join(str(a) for a in args)))
+    return recorded
+
+
+@pytest.fixture
+def unknown_type_package(tmp_path):
+    """The same package, but the unusable type is a typo rather than a retirement."""
+    config = {
+        "name": "//test",
+        "parts": {
+            "good_before": {"type": "cadquery", "path": "cube.py"},
+            "typo": {"type": "nonsense"},
+            "good_after": {"type": "cadquery", "path": "cube.py"},
+        },
+    }
+    (tmp_path / "partcad.yaml").write_text(yaml.safe_dump(config))
+    (tmp_path / "cube.py").write_text("import cadquery as cq\nshow_object(cq.Workplane('front').box(1, 1, 1))\n")
+    return tmp_path
+
+
+def test_the_retired_types_are_the_ones_that_were_removed():
+    """The set is closed, and comes from what #486 actually deleted.
+
+    Those four are the 'part_factory_ai_*' modules that PR removed along with
+    their 'factory.register()' calls. Anything else added here would quietly
+    downgrade a real error.
+    """
+    assert set(factory.RETIRED_TYPES) == {"ai-build123d", "ai-cadquery", "ai-openscad", "ai-sdf"}
+    assert set(factory.RETIRED_TYPES.values()) == {"0.7.153"}
+    # And none of them is registered, which is what makes them retired.
+    for kind in factory.all:
+        assert not set(factory.RETIRED_TYPES) & set(factory.all[kind])
+
+
+def test_a_retired_type_does_not_make_the_command_fail(package):
+    """pc_logging.error() sets the flag the CLI turns into a non-zero exit code.
+
+    This is the whole point: 'pc list -r //pub/examples' walked the index, hit
+    the retired declarations it carries, and aborted on them.
+    """
+    pc.logging.reset_errors()
+
+    ctx = pc.Context(str(package))
+    project = ctx.get_project("//")
+
+    assert pc.logging.had_errors is False
+    # Still skipped, and still recorded as broken - only the severity changed.
+    assert sorted(project.parts.keys()) == ["good_after", "good_before"]
+    assert list(project.broken_objects["part"]) == ["obsolete"]
+
+
+def test_a_retired_type_says_it_was_retired_and_when(package, monkeypatch):
+    recorded = _record_warnings(monkeypatch)
+
+    project = pc.Context(str(package)).get_project("//")
+
+    reason = project.get_broken_object_reason("part", "obsolete")
+    assert "retired in PartCAD 0.7.153" in reason
+    assert "ai-cadquery" in reason
+    assert any("ai-cadquery" in message and "retired" in message for message in recorded), recorded
+
+
+def test_a_retired_type_raises_a_retired_type_exception():
+    with pytest.raises(factory.RetiredTypeException) as excinfo:
+        factory.instantiate("part", "ai-openscad", None, None, None, {"name": "some_part"})
+
+    # Still an unknown type, so every caller that handles those keeps working.
+    assert isinstance(excinfo.value, factory.UnknownTypeException)
+    assert excinfo.value.release == "0.7.153"
+    assert "retired" in str(excinfo.value)
+    assert "some_part" in str(excinfo.value)
+
+
+def test_an_unknown_type_is_still_an_error(unknown_type_package):
+    """The property that must not regress along with the above.
+
+    A type nobody retired is a mistake in the package being loaded, and it has
+    to keep failing the command that found it.
+    """
+    pc.logging.reset_errors()
+
+    project = pc.Context(str(unknown_type_package)).get_project("//")
+
+    assert pc.logging.had_errors is True
+    reason = project.get_broken_object_reason("part", "typo")
+    assert "unknown part type 'nonsense'" in reason
+    assert "retired" not in reason
+    # ...and it costs the caller that one object, exactly as before.
+    assert sorted(project.parts.keys()) == ["good_after", "good_before"]
+
+
+def test_an_unknown_type_is_reported_at_error_level(unknown_type_package, monkeypatch):
+    recorded = _record_warnings(monkeypatch)
+
+    pc.Context(str(unknown_type_package)).get_project("//")
+
+    assert not any("nonsense" in message for message in recorded), recorded
+
+
+# ...and the retirement is scoped to the kind that was actually retired.
+#
+# Every 'ai-*' registration #486 removed was a 'factory.register("part", ...)';
+# there never was an 'ai-cadquery' sketch, assembly, provider or repository. So
+# the name only means "retired" on a part. Anywhere else it is a typo in a
+# package somebody can fix, and forgiving it would both hide that and claim a
+# release had a type it never had.
+
+
+@pytest.fixture
+def retired_part_type_on_a_sketch_package(tmp_path):
+    """A sketch declared with a type only ever registered for parts."""
+    config = {
+        "name": "//test",
+        "sketches": {"not_a_sketch_type": {"type": "ai-cadquery"}},
+    }
+    (tmp_path / "partcad.yaml").write_text(yaml.safe_dump(config))
+    return tmp_path
+
+
+def test_a_retired_part_type_on_a_sketch_is_unknown_rather_than_retired(
+    retired_part_type_on_a_sketch_package,
+):
+    """It has to fail the command, exactly as any other unknown sketch type does."""
+    pc.logging.reset_errors()
+
+    project = pc.Context(str(retired_part_type_on_a_sketch_package)).get_project("//")
+
+    assert pc.logging.had_errors is True
+    reason = project.get_broken_object_reason("sketch", "not_a_sketch_type")
+    assert "unknown sketch type 'ai-cadquery'" in reason
+    # And it must not claim a release that never had such a sketch type.
+    assert "retired" not in reason
+    assert "0.7.153" not in reason
+
+
+def test_a_retired_part_type_on_a_sketch_is_not_reported_as_a_warning(
+    retired_part_type_on_a_sketch_package, monkeypatch
+):
+    recorded = _record_warnings(monkeypatch)
+
+    pc.Context(str(retired_part_type_on_a_sketch_package)).get_project("//")
+
+    assert not any("ai-cadquery" in message for message in recorded), recorded
+
+
+@pytest.mark.parametrize("kind", ["sketch", "assembly", "provider", "repository"])
+def test_a_retired_part_type_raises_a_plain_unknown_type_for_other_kinds(kind):
+    with pytest.raises(factory.UnknownTypeException) as excinfo:
+        factory.instantiate(kind, "ai-cadquery", None, None, None, {"name": "some_object"})
+
+    assert not isinstance(excinfo.value, factory.RetiredTypeException)
+    assert "unknown %s type 'ai-cadquery'" % kind in str(excinfo.value)
+
+
+def test_a_retired_part_type_is_still_retired_on_a_part():
+    """The guard above must not have cost the case the retirement is for."""
+    with pytest.raises(factory.RetiredTypeException):
+        factory.instantiate("part", "ai-cadquery", None, None, None, {"name": "some_part"})


### PR DESCRIPTION
#533 and #529 were merged to `devel` and are gone from it.

Both merges succeeded (`7bc5dd70` and `1fd9ca8b`). The version-bump job then force-pushed `devel` from a base it had read before those merges landed: `a24defe9` ("Version updated from 0.7.177 to 0.7.178") has `1abad6ba` (#528) as its parent, not `1fd9ca8b`, so the two merge commits between them were discarded. `git merge-base --is-ancestor` confirms neither is reachable from `devel`; #527, #528 and #530 are.

This re-lands them by cherry-picking the two squashed commits onto the current `devel`. Both applied without conflict; `docs/source/configuration.rst` auto-merged against #530, which landed in between.

The recovered content is unchanged from what was reviewed and approved on the original PRs:

- **#533** — scope the retired `ai-*` type tolerance to part declarations, so `ai-cadquery` on a sketch, assembly, provider or repository is an unknown type (error) rather than a retired one (warning). Plus the repair of `test_unknown_type_exception_lists_what_is_supported`, which had gone vacuous.
- **#529** — correct the rationale for why the URDF format declares `decode: false`.

Nothing else is in this branch.

Worth noting for the future: the bump job force-pushes `devel` without re-reading the ref, so any merge landing inside its read-modify-write window is silently lost. Nothing in the merge result reports it — both merges returned success.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJUdN3k39YTAL1rrofSzs)_