### PR TITLE
fix(ci): stop the IDE workflow cancelling Standalone, and stop building the bundles twice

### DIFF
--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -7,14 +7,16 @@ on:
   # Called by "deploy.yml", which uploads the archives to the GitHub release.
   workflow_call:
     inputs:
-      build_tools:
+      tools_in_this_run:
         description: >-
-          Build the standalone command line bundles as part of this workflow.
-          Set it to false when the caller has already built them in this run:
-          a called workflow shares the run's artifacts, so building them twice
-          only costs an hour per platform.
+          Set it to true when the caller has already built the standalone
+          command line bundles in this run: a called workflow shares the run's
+          artifacts, so the IDE build downloads them from here. Left false, it
+          instead finds the sibling "Standalone" workflow run for this commit
+          and downloads them from there -- see the "bundles" job below. Only
+          "deploy.yml" builds the bundles itself, and it is the only caller.
         type: boolean
-        default: true
+        default: false
   merge_group:
   # Not on every change: this builds the standalone command line bundles first,
   # to put them inside the IDE, and those pull ~500MB of OpenCASCADE per runner.
@@ -37,8 +39,13 @@ on:
       - "install.sh"
       - ".github/workflows/build-ide-standalone.yml"
 
+# `actions: read` is what lets the "build" job list and download the artifacts
+# of *another* workflow run -- the sibling "Standalone" run that froze the
+# command line bundles. `contents: read` alone reaches only the current run's
+# artifacts. Nothing here writes anything, so this is the whole of it.
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -65,43 +72,283 @@ jobs:
       - name: Run the tests
         run: python -m pytest partcad-ide-standalone/tests -o addopts= -v
 
-  # The command line tools that go inside the IDE. The same bundles that are
-  # published on their own, built by the same workflow, so the IDE cannot ship
-  # tools that differ from the ones `install.sh` installs.
+  # Where the command line bundles that go inside the IDE come from.
+  #
+  # They are the same bundles `install.sh` installs, frozen by the "Standalone"
+  # workflow, and this workflow no longer calls it. It used to: this job was
+  # `uses: ./.github/workflows/build-standalone.yml`. That was wrong twice over.
+  #
+  # "Standalone" runs on its own `push`/`pull_request` triggers, and its path
+  # filters overlap this workflow's -- every version bump touches
+  # "partcad-ide-vscode/package.json" (ours) and "partcad-cli/src/**" (theirs).
+  # So one commit started the seven-platform, ~35-minute freeze twice: once as
+  # its own run and once inside this one, and half of it was thrown away.
+  #
+  # Worse, the two cancelled each other. A called workflow evaluates
+  # `github.workflow` as the *caller's* name, so the called instance computed
+  # the same concurrency group this run was already holding and
+  # `cancel-in-progress` killed it -- in 13 seconds, with no failed job to point
+  # at. See the note on `concurrency` in "build-standalone.yml", which is where
+  # that is fixed.
+  #
+  # The arrangement now is the one "deploy.yml" already used on the release
+  # path, generalised: exactly one run owns the freeze and everyone else
+  # downloads what it produced. On the release path that run is the
+  # `build-standalone` job of the "Deployment" run itself, and the matrix below
+  # downloads from its own run (`tools_in_this_run`). On every other trigger it
+  # is the sibling "Standalone" run for this same commit, which this job finds,
+  # waits for, and hands down as `run-id`.
+  #
+  # Rejected: keeping the call and only giving it a distinct concurrency group.
+  # That fixes the cancellation and leaves the duplication -- fourteen frozen
+  # bundles per version bump instead of seven.
+  #
+  # Rejected: building the IDE without the command line tools on push and pull
+  # request. The archive would then not be the artifact that gets released, and
+  # the "Install" jobs below -- which are the point of building it at all --
+  # could not check that `pc` runs out of the installed IDE.
+  #
+  # This is one ubuntu-latest job rather than a step inside the matrix because
+  # the answer is the same for all three platforms and the matrix runners are
+  # macOS and Windows, billed at 10x and 2x. It is also unconditional rather
+  # than skipped on the release path: a skipped dependency would drag "build"
+  # into the `!cancelled() && ... == 'skipped'` contortion this file used to
+  # need, and the step inside it costs seconds when there is nothing to look up.
   bundles:
     name: "Command line tools"
-    # Build them unless a "workflow_call" caller says it already has: only
-    # "deploy.yml" does, and it passes its own build down through the run's
-    # artifacts. Every other trigger -- push, pull request, merge group, manual
-    # dispatch -- has to build them here, or the jobs below have nothing to
-    # download.
-    #
-    # `toJSON` rather than the `inputs.build_tools != false` this used to say.
-    # Outside "workflow_call"/"workflow_dispatch" there is no `inputs` context,
-    # so `inputs.build_tools` is null, and GitHub compares mismatched types by
-    # coercing both to numbers: null becomes 0, false becomes 0, and
-    # `null != false` is therefore false. That skipped this job on every push
-    # and pull request while still letting "build" run -- it tolerates a skipped
-    # "bundles" for deploy.yml's sake -- so the IDE build failed at "Download the
-    # command line tools" for a day. `toJSON` compares the value as text
-    # ("null", "true", "false"), which is what tells an absent input apart from
-    # one that was deliberately set to false.
-    #
-    # Not `github.event_name == 'workflow_call'`: in a called workflow the
-    # `github` context is the caller's, so that reads "push" on the release
-    # path, never "workflow_call".
-    if: ${{ toJSON(inputs.build_tools) != 'false' }}
-    uses: ./.github/workflows/build-standalone.yml
+    runs-on: ubuntu-latest
+    # Long enough to sit out a whole "Standalone" run. The freeze itself is
+    # ~35 minutes; the install, snap and examples jobs after it have taken the
+    # run past an hour. The step below gives up before this does, so the
+    # failure says what it was waiting for instead of "timed out".
+    timeout-minutes: 90
+    outputs:
+      # The run whose "partcad-standalone-*" artifacts the matrix downloads.
+      # Empty when the caller froze them in this run, where there is nothing to
+      # look up and nothing reads this.
+      run-id: ${{ steps.resolve.outputs.run-id }}
+    steps:
+      - name: Find the "Standalone" run that built the bundles
+        id: resolve
+        # `toJSON` rather than `inputs.tools_in_this_run == true`. Outside
+        # "workflow_call"/"workflow_dispatch" there is no `inputs` context, so
+        # the value is null, and GitHub compares mismatched types by coercing
+        # both to numbers -- null and false both become 0, and the comparison
+        # then cannot tell "not passed" from "passed as false". `toJSON`
+        # compares the value as text ("null", "true", "false"), which can.
+        # This file learned that the hard way once already; see git history for
+        # the day the IDE build downloaded artifacts that were never built.
+        #
+        # Not `github.event_name == 'workflow_call'`: in a called workflow the
+        # `github` context is the caller's, so that reads "push" on the release
+        # path, never "workflow_call".
+        if: ${{ toJSON(inputs.tools_in_this_run) != 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          # The commit both workflows saw. On a pull request `github.sha` is the
+          # merge commit, which no workflow ever ran on -- the head of the
+          # branch is what "Standalone" recorded as its `head_sha`.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Where to look when this commit has no "Standalone" run of its own.
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name }}
+          # Long enough for the freeze plus everything after it, and short
+          # enough that this job's own timeout above never gets there first.
+          WAIT_SECONDS: "4500"
+          # The sibling run is created in the same second as this one but its
+          # first job takes a moment to appear, so "no run for this commit" is
+          # not a conclusion that can be drawn immediately. Anything less than
+          # this and a race decides whether the IDE embeds this commit's
+          # bundles or an older commit's.
+          GRACE_SECONDS: "300"
+          POLL_SECONDS: "30"
+        run: |
+          set -euo pipefail
+
+          workflow="build-standalone.yml"
+          base="${BASE_BRANCH#refs/heads/}"
+
+          say() { printf '%s  %s\n' "$(date -u '+%H:%M:%S')" "$*"; }
+          run_url() { printf '%s/%s/actions/runs/%s' "${SERVER_URL}" "${REPO}" "$1"; }
+
+          # Every unexpired "partcad-standalone-*" artifact a run still holds.
+          #
+          # This, and not the run's conclusion, is the test. "Standalone"
+          # uploads the bundles in its "Build" jobs and then spends another
+          # half hour running examples through them, and those fail on their
+          # own schedule: at the time of writing not one of the last thirty
+          # "Standalone" runs on devel concluded `success`, while their bundles
+          # were built, uploaded and perfectly good. Requiring `success` here
+          # would mean the IDE never builds again. A run that produced no
+          # bundle at all is the real failure, and it is caught below.
+          bundles_of() {
+            gh api "repos/${REPO}/actions/runs/$1/artifacts?per_page=100" \
+              --jq '[.artifacts[] | select(.expired == false)
+                     | select(.name | startswith("partcad-standalone-")) | .name]
+                    | sort | join(" ")'
+          }
+
+          # id, status and conclusion of every "Standalone" run for a commit,
+          # newest first. Called workflows do not get a run of their own -- they
+          # are jobs of the caller's run -- so this only ever lists the
+          # independent ones, which is exactly what is wanted.
+          runs_for_sha() {
+            gh api "repos/${REPO}/actions/workflows/${workflow}/runs?head_sha=$1&per_page=100" \
+              --jq '.workflow_runs | sort_by(.created_at) | reverse
+                    | .[] | [.id, .status, .conclusion] | @tsv'
+          }
+
+          # The same, for the most recent finished runs on a branch.
+          runs_on_branch() {
+            gh api "repos/${REPO}/actions/workflows/${workflow}/runs?branch=$1&status=completed&per_page=30" \
+              --jq '.workflow_runs | sort_by(.created_at) | reverse
+                    | .[] | [.id, .head_sha, .conclusion] | @tsv'
+          }
+
+          started=$(date +%s)
+          use_run=""
+          use_conclusion=""
+          use_sha="${HEAD_SHA}"
+
+          say "Looking for a \"Standalone\" run for ${HEAD_SHA}."
+
+          # (1) The run for this very commit, waited out if it is still going.
+          while :; do
+            elapsed=$(( $(date +%s) - started ))
+            pending=""
+            pending_first=""
+            barren=""
+            barren_first=""
+
+            listing=$(runs_for_sha "${HEAD_SHA}")
+            while IFS=$'\t' read -r id status conclusion; do
+              [ -n "${id}" ] || continue
+              if [ "${status}" != "completed" ]; then
+                pending="${pending} ${id}"
+                [ -n "${pending_first}" ] || pending_first="${id}"
+                continue
+              fi
+              names=$(bundles_of "${id}")
+              if [ -n "${names}" ]; then
+                use_run="${id}"
+                use_conclusion="${conclusion}"
+                say "Run ${id} (${conclusion}) has: ${names}"
+                break
+              fi
+              barren="${barren} ${id} (${conclusion})"
+              [ -n "${barren_first}" ] || barren_first="${id}"
+            done <<<"${listing}"
+
+            [ -z "${use_run}" ] || break
+
+            if [ -n "${pending}" ]; then
+              if [ "${elapsed}" -ge "${WAIT_SECONDS}" ]; then
+                echo "::error::Gave up after $(( elapsed / 60 )) minutes waiting" \
+                  "for the \"Standalone\" workflow run(s)${pending} to finish" \
+                  "freezing the command line bundles for ${HEAD_SHA}. The IDE" \
+                  "embeds those bundles, so there is nothing to build until" \
+                  "they exist. Re-run this workflow once $(run_url "${pending_first}")" \
+                  "has finished."
+                exit 1
+              fi
+              say "Run(s)${pending} still going (${elapsed}s in, giving up at ${WAIT_SECONDS}s)."
+              sleep "${POLL_SECONDS}"
+              continue
+            fi
+
+            if [ -n "${barren}" ]; then
+              echo "::error::The \"Standalone\" workflow run(s) for ${HEAD_SHA}" \
+                "--${barren} -- finished without leaving a single" \
+                "partcad-standalone-* artifact, so there is no command line" \
+                "bundle to put inside the IDE. Fix or re-run that workflow for" \
+                "this commit, then re-run this one: $(run_url "${barren_first}")."
+              exit 1
+            fi
+
+            # No run at all for this commit -- yet, or ever.
+            if [ "${elapsed}" -lt "${GRACE_SECONDS}" ]; then
+              say "No run for ${HEAD_SHA} yet (${elapsed}s in, deciding at ${GRACE_SECONDS}s)."
+              sleep "${POLL_SECONDS}"
+              continue
+            fi
+            break
+          done
+
+          # (2) No run for this commit. That is legitimate: the two workflows
+          # have different path filters, and a change confined to
+          # "partcad-ide-standalone/**" fires this one and not that one. The
+          # IDE build only needs a working bundle to embed and smoke-test, so
+          # the newest one on the base branch keeps that coverage -- as long as
+          # nobody reading the log can mistake it for this commit's.
+          if [ -z "${use_run}" ]; then
+            say "No \"Standalone\" run exists for ${HEAD_SHA}; falling back to ${base}."
+            listing=$(runs_on_branch "${base}")
+            while IFS=$'\t' read -r id sha conclusion; do
+              [ -n "${id}" ] || continue
+              names=$(bundles_of "${id}")
+              [ -n "${names}" ] || continue
+              use_run="${id}"
+              use_conclusion="${conclusion}"
+              use_sha="${sha}"
+              say "Run ${id} (${conclusion}, ${sha}) has: ${names}"
+              break
+            done <<<"${listing}"
+
+            if [ -z "${use_run}" ]; then
+              echo "::error::No \"Standalone\" workflow run has command line" \
+                "bundles to offer: none ran for ${HEAD_SHA}, and none of the" \
+                "last 30 finished runs on ${base} still has an unexpired" \
+                "partcad-standalone-* artifact (they are kept for 14 days)." \
+                "The IDE cannot be built without them. Run the \"Standalone\"" \
+                "workflow on ${base} -- manually, or by pushing a change under" \
+                "one of its paths -- and then re-run this one."
+              exit 1
+            fi
+
+            echo "::warning::The command line bundles inside this IDE build are" \
+              "NOT from ${HEAD_SHA}. They come from \"Standalone\" run ${use_run}," \
+              "which built ${use_sha} on ${base}: $(run_url "${use_run}")." \
+              "\"Standalone\" never ran for this commit -- its path filters did" \
+              "not match it -- so an older bundle is the only one there is, and" \
+              "embedding it still exercises the IDE build end to end. Do not" \
+              "read a green result as having tested this commit's command line" \
+              "tools, though, because it has not."
+          fi
+
+          if [ "${use_conclusion}" != "success" ]; then
+            echo "::warning::Taking the command line bundles from \"Standalone\"" \
+              "run ${use_run}, which concluded \"${use_conclusion}\". The bundles" \
+              "were uploaded before it did and they are what the IDE embeds;" \
+              "whatever went wrong afterwards is reported in that run:" \
+              "$(run_url "${use_run}")."
+          fi
+
+          say "Using \"Standalone\" run ${use_run} ($(run_url "${use_run}"))."
+          echo "run-id=${use_run}" >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "### Command line tools"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Run | [${use_run}]($(run_url "${use_run}")) |"
+            echo "| Conclusion | \`${use_conclusion}\` |"
+            echo "| Commit | \`${use_sha}\` |"
+            if [ "${use_sha}" != "${HEAD_SHA}" ]; then
+              echo "| | **not this commit (\`${HEAD_SHA}\`)** |"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   build:
     name: "Build (${{ matrix.platform }})"
+    # Both dependencies always run -- "bundles" resolves where the command line
+    # tools come from rather than building them -- so a plain `needs` says all
+    # there is to say. The `!cancelled() && ... == 'skipped'` guard that used to
+    # be here existed only to tolerate a "bundles" job that the release path
+    # skipped, and there is no longer such a path.
     needs: [tools, bundles]
-    # "bundles" is skipped when the caller built the tools itself, and a skipped
-    # dependency would otherwise skip this job with it.
-    if: >-
-      ${{ !cancelled()
-      && needs.tools.result == 'success'
-      && (needs.bundles.result == 'success' || needs.bundles.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:
@@ -173,11 +420,30 @@ jobs:
             choco install innosetup --no-progress --yes
           fi
 
-      - name: Download the command line tools
+      # Two steps for one download, because the bundles live in one of two
+      # places and neither is a fallback for the other. On the release path
+      # "deploy.yml" froze them in this very run and a called workflow shares
+      # the run's artifacts, so the plain download finds them. Everywhere else
+      # they belong to the sibling "Standalone" run the "bundles" job above
+      # resolved, which takes `run-id` and a token to reach.
+      - name: Download the command line tools (built in this run)
+        if: ${{ toJSON(inputs.tools_in_this_run) == 'true' }}
         uses: actions/download-artifact@v8
         with:
           name: partcad-standalone-${{ matrix.bundle }}
           path: bundles
+
+      - name: Download the command line tools (from the "Standalone" run)
+        if: ${{ toJSON(inputs.tools_in_this_run) != 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: partcad-standalone-${{ matrix.bundle }}
+          path: bundles
+          # Another run, of another workflow. `actions: read` in `permissions`
+          # is what makes the token able to see it; without that this fails
+          # with a bare 403 rather than anything that names the cause.
+          run-id: ${{ needs.bundles.outputs.run-id }}
+          github-token: ${{ github.token }}
 
       - name: Unpack the command line tools
         shell: bash

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -5,6 +5,26 @@ on:
   workflow_dispatch:
   # Called by "deploy.yml", which uploads the bundles to the GitHub release.
   workflow_call:
+    inputs:
+      # Not a knob, and nothing passes it. It exists so that the `concurrency`
+      # group below can tell a called instance of this workflow from an
+      # independent one -- which nothing else in the expression context can.
+      #
+      # `github.workflow` looks like the discriminator and is the wrong one:
+      # inside a called workflow the whole `github` context is the *caller's*,
+      # so it reads "IDE" or "Deployment" here, never "Standalone". (Same trap
+      # as `github.event_name`, which reads "push" on the release path rather
+      # than "workflow_call" -- "build-ide-standalone.yml" says so too.) The
+      # `inputs` context, by contrast, exists only under `workflow_call` and
+      # `workflow_dispatch`, and this workflow declares no `workflow_dispatch`
+      # inputs -- so `inputs.called` is null on every trigger except a call,
+      # and non-null on a call whether or not the caller passed anything.
+      called:
+        description: >-
+          Reserved. Do not pass it: its presence, not its value, is what marks
+          an instance of this workflow that another workflow called.
+        type: boolean
+        default: true
   merge_group:
   # Freezing pulls ~500MB of OpenCASCADE per runner, so this does not run on
   # every change: only on the ones that can change what is frozen. The two
@@ -39,8 +59,27 @@ on:
 permissions:
   contents: read
 
+# One build per branch, or per pull request, and a new push supersedes the one
+# in flight. That is the plain half of the group. The suffix is the other half,
+# and it is not cosmetic.
+#
+# Being called used to be fatal here. `github.workflow` is the *caller's*
+# workflow name inside a called workflow, so an instance called by the "IDE"
+# workflow computed the group "IDE-refs/heads/devel" -- byte for byte the group
+# the IDE run that called it was already holding. `cancel-in-progress` then did
+# exactly what it was told. Every "IDE" run died that way, on devel and on
+# every pull request, in well under a minute and with no failed job to point
+# at: the called workflow was cancelled before it started a single one.
+#
+# Appending the run id when, and only when, an `inputs` context exists closes
+# both halves of that. A called instance can no longer share a group with the
+# run that called it, because the caller's own group carries no such suffix;
+# and it can no longer share one with any other instance, called or
+# independent, because no two runs share a run id. Independent runs keep the
+# plain group unchanged, so a second push to a branch still cancels the build
+# in flight -- which is why the suffix is conditional rather than always there.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ toJSON(inputs.called) == 'null' && '' || format('-called-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 # One bundle per supported OS version, not one per operating system. A frozen

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -78,8 +78,17 @@ permissions:
 # independent, because no two runs share a run id. Independent runs keep the
 # plain group unchanged, so a second push to a branch still cancels the build
 # in flight -- which is why the suffix is conditional rather than always there.
+#
+# Note which way round the two branches go. `a && b || c` is the only
+# conditional an expression has, and it is not a ternary: `&&` yields the first
+# falsy operand and `||` the first truthy one, so a *falsy* `b` falls through to
+# `c` and the condition stops meaning anything at all. An empty string is falsy.
+# Written the other way -- `== 'null' && '' || format(...)` -- this would append
+# the suffix to every run, independent ones included, and no push would ever
+# supersede the build in flight again. The non-empty half has to be the half the
+# condition selects.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ toJSON(inputs.called) == 'null' && '' || format('-called-{0}', github.run_id) }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ toJSON(inputs.called) != 'null' && format('-called-{0}', github.run_id) || '' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 # One bundle per supported OS version, not one per operating system. A frozen

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,15 @@ jobs:
 
   # The PartCAD IDE: the editor with the PartCAD extension and the command line
   # bundles above inside it, attached to the same release. It waits for the
-  # bundles and is told not to build them again -- a called workflow shares this
-  # run's artifacts, so it downloads what the job above produced.
+  # bundles and is told they are already here -- a called workflow shares this
+  # run's artifacts, so it downloads what the job above produced. This is the
+  # only place that says so: on every other trigger the IDE workflow finds the
+  # sibling "Standalone" run for the commit instead of building anything.
   build-ide:
     needs: build-standalone
     uses: ./.github/workflows/build-ide-standalone.yml
     with:
-      build_tools: false
+      tools_in_this_run: true
 
   # Keep the "build" job identical to "python-build.yml".
   # TODO(clairbee): include "python-build.yml" instead

--- a/partcad-ide-standalone/README.md
+++ b/partcad-ide-standalone/README.md
@@ -223,3 +223,11 @@ without building.
 `install.sh --ide` on a runner that has never seen PartCAD. `deploy.yml` calls it on a push to `main` and
 uploads the archives to the same GitHub release as the wheels and the command line bundles, which is where
 `install.sh --ide` downloads from.
+
+It does not build the command line bundles it embeds. `deploy.yml` builds them once, in the same run, and the
+IDE build downloads them from there; on every other trigger the IDE build finds the sibling `Standalone`
+workflow run for the same commit and downloads them from that run instead. Building them here as well would
+mean freezing every platform twice for one commit -- and the `bundles` job in that workflow explains what else
+it meant. When no `Standalone` run exists for the commit (a change confined to `partcad-ide-standalone/**`
+fires the IDE workflow and not that one) the build falls back to the newest bundles on the base branch and says
+so, loudly, in the log and the run summary.


### PR DESCRIPTION
Two fixes to the `IDE` workflow, which has not had a successful run in days.

## The concurrency collision

`github.workflow` inside a called workflow is the **caller's** name, so the instance of `Standalone` called by `IDE` computed the group `IDE-refs/heads/devel` — byte for byte the group the `IDE` run calling it already held. `cancel-in-progress` then did what it was told.

Evidence on `ac9ae8d0`: the `IDE` run lasted **13 seconds**, concluded `failure` with **zero failed jobs**, had no `Command line tools` job in its listing at all, and skipped `build` — which its guard only permits when `needs.bundles.result` is neither `success` nor `skipped`. The independent `Standalone` run for the same commit started 19 s later and ran 21 jobs over ~35 minutes.

`build-standalone.yml` now appends the run id to its concurrency group when, and only when, an `inputs` context exists — a called instance can share a group with neither its caller nor any other instance, while independent runs keep the plain group so a new push still supersedes the build in flight. The discriminator is a reserved `workflow_call` input that nothing passes; its *presence*, not its value, is what marks a call. `github.workflow` cannot serve, for the reason above.

## The duplicate build

Every version bump touches both workflows' path filters — `ac9ae8d0` hits `partcad-ide-vscode/package.json` and `partcad-cli/src/**` — so `Standalone` was being built twice for the same commit, ~35 minutes across the platform matrix each time.

`IDE` no longer calls `Standalone` at all. On push, pull request, merge group and dispatch it locates the sibling `Standalone` run for the same commit, waits for it, and downloads its artifacts cross-run. The release path is unchanged: `deploy.yml` builds the bundles once and tells `IDE` they are already in the run, and that download step is byte-for-byte the one it always used.

Resolution order, each case exercised against a stubbed `gh`:

1. A run for this commit — polled until it completes; an older run for the same commit that already holds bundles is used immediately.
2. No run for this commit — legitimate, since the two path filters differ. After a grace period (the sibling run is created in the same second, and racing it would silently select an older commit) it falls back to the newest run on the base branch that still holds bundles, warns naming the run *and* the commit, and flags it in the run summary.
3. Neither — fails, naming both lookups and the 14-day artifact retention.
4. A run with no bundles — fails, naming the run and its conclusion.

Runs are selected on **artifacts, not conclusion**. Zero of the last 30 `Standalone` runs on `devel` concluded `success`, yet run `32658478011` holds all seven `partcad-standalone-*` artifacts and both snaps, unexpired — its `Build` jobs succeeded and uploaded, and the `Examples` jobs failed twenty minutes later. A conclusion gate would mean the IDE never builds again. A red run whose bundles are present is used, with a warning naming it.

`build_tools` is renamed `tools_in_this_run` with inverted polarity: nothing here builds tools any more, so the old name asserted something false.

## Note on the second commit

The first commit wrote the concurrency suffix as `== 'null' && '' || format(...)`. `a && b || c` is not a ternary — `&&` yields the first falsy operand and `||` the first truthy one — so a falsy `b` falls through to `c`. An empty string is falsy, and both branches therefore produced the suffix: every run would have got a group of its own and no push would ever have superseded another. The second commit inverts it so the condition selects the non-empty half, and records why the order is load-bearing.

## Validation

Workflow logic cannot be executed outside GitHub Actions, and none of this has been run there. What was checked: YAML parse of all changed files; `actionlint` clean on the three workflows, with the checks shown to be live rather than vacuous (a typo'd input name is reported against the declared schema); `shellcheck` on the resolver script extracted from the YAML; the applicable `pre-commit` hooks; the tree parsed back out to assert that the release path still reaches the same-run download and that the two download steps are mutually exclusive across all input states; and the resolver's control flow executed for all four cases plus the red-run and grace-race variants.

Not proved, and only CI can prove it: that GitHub evaluates the concurrency expression as reasoned, that `actions/download-artifact@v8` succeeds cross-run with `actions: read`, and the end-to-end release path.

Host tooling throughout, not the pinned container toolchain — Docker is unavailable in the authoring environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJUdN3k39YTAL1rrofSzs)_