### PR TITLE
feat(devcontainer): hand the host's Docker daemon to the dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,8 +48,8 @@ RUN apt-get update -y \
   openscad \
   pypy3 \
   pypy3-dev \
-  # Docker troubleshooting tools
-  docker.io inetutils-telnet inetutils-ping \
+  # Docker socket forwarding (docker-socket-start.sh) and troubleshooting tools
+  socat inetutils-telnet inetutils-ping \
   # Development tools
   file xxd \
   bash-completion \
@@ -104,15 +104,33 @@ RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/download/26.3.
 #   curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 #   && apt-get install -y nodejs
 
-ENV DOCKERVERSION=18.03.1-ce
-RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
-  && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
-  -C /usr/local/bin docker/docker \
-  && rm docker-${DOCKERVERSION}.tgz
+# The Docker CLI, for driving the host's daemon from inside this container --
+# see .devcontainer/docker-socket-start.sh, which is what puts the daemon
+# within reach. It comes from Docker's own repository rather than Debian's:
+# `docker.io` on bookworm is 20.10, and its API version 1.41 is below the 1.44
+# that Docker Engine 29 accepts, so it can talk to a current daemon at all.
+# Buildx comes along because `docker build` is the modern CLI's front end to it
+# (tools/containers/kicad/README.md builds the KiCad sandbox image that way).
+ARG DOCKER_CLI_VERSION=5:29.7.2-1~debian.12~bookworm
+ARG DOCKER_BUILDX_VERSION=0.36.1-1~debian.12~bookworm
+RUN install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+  && chmod a+r /etc/apt/keyrings/docker.asc \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+  >/etc/apt/sources.list.d/docker.list \
+  && apt-get update -y \
+  && apt-get install --no-install-recommends -y \
+  "docker-ce-cli=${DOCKER_CLI_VERSION}" \
+  "docker-buildx-plugin=${DOCKER_BUILDX_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
 
 # TODO(clairbee): fix the scripts that led to the wrong permissions instead of chmod
+# COPY rather than `RUN --mount=type=bind`: the latter is the only instruction
+# in this file that BuildKit is required for, and requiring it means the image
+# cannot be built by a plain `docker build` on a machine without the buildx
+# plugin. The two scripts are ~4 KB and the RUN below deletes them again.
 # hadolint ignore=DL3004
-RUN --mount=type=bind,source=./docker-build-bootstrap.sh,target=/tmp/docker-build-bootstrap.sh \
-  --mount=type=bind,source=./docker-build-dbus.sh,target=/tmp/docker-build-dbus.sh \
-  /tmp/docker-build-bootstrap.sh \
-  && /tmp/docker-build-dbus.sh
+COPY ./docker-build-bootstrap.sh ./docker-build-dbus.sh /tmp/
+RUN /tmp/docker-build-bootstrap.sh \
+  && /tmp/docker-build-dbus.sh \
+  && rm -f /tmp/docker-build-bootstrap.sh /tmp/docker-build-dbus.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,17 +8,43 @@
     // TODO: poetry-* hooks are source of unnecessary conflicts in PRs and should be handled by dependabot.
     "SKIP": "behave,prepare-commit-msg,poetry-install,poetry-lock,poetry-export"
   },
+  // Runs on the host, before the container exists: resolves the Docker socket
+  // of a host that does not keep one at the standard path. See the second
+  // "-v" under runArgs below. Named ".cmd" rather than ".sh" because this
+  // runs in the host's own shell and a failure here aborts `devcontainer up`:
+  // the file is a polyglot that cmd.exe reads as a batch script doing nothing
+  // and /bin/sh reads as a wrapper around docker-socket-init.sh. Quoted, so a
+  // workspace path with a space in it still resolves.
+  "initializeCommand": {
+    "docker-socket": "\"${localWorkspaceFolder}/.devcontainer/docker-socket-init.cmd\""
+  },
   "postCreateCommand": {
     "Start D-Bus": "sudo service dbus start && (until systemctl is-active --quiet dbus; do sleep 1; done)"
   },
   "postStartCommand": {
     "pre-commit": "pre-commit install --config dev-tools/pre-commit-config.yaml",
-    "docker-permission": "sudo chown $(whoami):$(whoami) /var/run/docker.sock"
+    "docker-socket": ".devcontainer/docker-socket-start.sh"
   },
-  "runArgs": ["--privileged"],
+  "runArgs": [
+    "--privileged",
+    // The host's Docker daemon, so that this container can start containers of
+    // its own -- PartCAD's KiCad sandbox, for one. Two candidates, which
+    // .devcontainer/docker-socket-start.sh tries in this order.
+    //
+    // The standard path first: on macOS and Windows the daemon is not there at
+    // all (on Windows it is a named pipe), and this exact name is what Docker
+    // Desktop translates, so no other spelling works on those hosts.
+    "-v", "/var/run/docker.sock:/var/run/docker-host.sock",
+    // Then whatever .devcontainer/docker-socket-init.sh resolved, for a Linux
+    // host that keeps its daemon somewhere else: rootless, a unix:// value in
+    // DOCKER_HOST, Colima.
+    "-v", "/tmp/partcad-devcontainer-${localEnv:USER}/docker.sock:/var/run/docker-host-alt.sock"
+    // Both are "-v" rather than "mounts" entries deliberately: "mounts" turns
+    // into "--mount", which aborts `devcontainer up` when the source does not
+    // exist, whereas "-v" leaves an empty directory in its place, which the
+    // container side reads as "no daemon here" and passes over in silence.
+  ],
   "mounts": [
-    // Docker socket inside the container to run docker runtimes
-    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
     // TODO: For some reason this leads to tests hanging in the CI.
     // "source=partcad-partcad,target=/home/vscode/.partcad,type=volume",
     "source=partcad-cache,target=/home/vscode/.cache,type=volume",

--- a/.devcontainer/docker-socket-init.cmd
+++ b/.devcontainer/docker-socket-init.cmd
@@ -1,0 +1,27 @@
+:<<"::CMDLITERAL"
+@echo off
+rem
+rem  The Windows half. There is nothing to resolve here: Docker Desktop is what
+rem  gives a Windows host the name "/var/run/docker.sock" -- the daemon behind
+rem  it is a named pipe -- and devcontainer.json binds that name directly, so
+rem  the socket the POSIX half below goes looking for is already in the
+rem  container's hands. Succeed and say nothing.
+rem
+rem  This file is a polyglot on purpose. "initializeCommand" runs in the host's
+rem  own shell, and a failing one aborts "devcontainer up", so naming a ".sh"
+rem  there would make this workspace unopenable on a Windows host, where
+rem  cmd.exe cannot run one. cmd.exe reads the batch script above, because of
+rem  the ".cmd" extension; /bin/sh reads the shell script below, because the
+rem  line that opens this comment is a here-document to sh and a label to
+rem  cmd. Both halves are terminated before the other's begins.
+rem
+rem  Keep this file LF-only (.gitattributes pins it): the shell half breaks on
+rem  a trailing CR, and the batch half has no label the parser has to seek back
+rem  to, which is where cmd.exe minds LF endings.
+rem
+exit /b 0
+::CMDLITERAL
+
+# The POSIX half. The work lives in a separate ".sh" so that it stays under
+# shellcheck, which does not recognize a ".cmd" as a shell script.
+exec "$(dirname "$0")/docker-socket-init.sh" "$@"

--- a/.devcontainer/docker-socket-init.sh
+++ b/.devcontainer/docker-socket-init.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Runs on the HOST, before the dev container is created or started.
+#
+# Covers the hosts whose Docker daemon is not at /var/run/docker.sock: rootless
+# Docker, a unix:// DOCKER_HOST, Colima. devcontainer.json binds that standard
+# path directly -- it is the only one Docker Desktop understands on macOS and
+# Windows -- and binds the link this script writes as a second candidate, which
+# the container side falls back to. Docker resolves the link host-side, so the
+# container receives the socket itself.
+#
+# Nothing here may fail: a failing initializeCommand aborts `devcontainer up`,
+# and a host with no daemon at all is a supported way to open this workspace.
+# So every step that can fail gives up quietly instead, leaving no link behind
+# and the container with nothing to fall back to.
+
+# Shell options for maximum safety:
+# -e: Exit on error
+# -u: Error on undefined variables
+# -o pipefail: Exit on pipe failures
+set -euo pipefail
+
+# Kept in step with the "-v" source in devcontainer.json, which spells the same
+# path with ${localEnv:USER}. Per user, because /tmp is shared: a fixed name is
+# a link somebody else on this host could have planted first, and it would be
+# bind-mounted into a privileged container as if it were the Docker socket.
+link_dir="/tmp/partcad-devcontainer-${USER:-}"
+link="${link_dir}/docker.sock"
+
+mkdir -p "${link_dir}" 2>/dev/null || exit 0
+# Somebody else's directory of the same name: leave it alone, and leave the
+# container to the standard path.
+[[ -O "${link_dir}" ]] || exit 0
+chmod 700 "${link_dir}" 2>/dev/null || exit 0
+rm -f "${link}" 2>/dev/null || exit 0
+
+candidates=()
+# An explicit DOCKER_HOST wins, but only a local socket can be bind-mounted:
+# a tcp:// or ssh:// daemon is somebody else's machine.
+if [[ "${DOCKER_HOST:-}" == unix://* ]]; then
+  candidates+=("${DOCKER_HOST#unix://}")
+fi
+# Rootless Docker.
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+  candidates+=("${XDG_RUNTIME_DIR}/docker.sock")
+fi
+if [[ -n "${HOME:-}" ]]; then
+  # Docker Desktop with the default socket turned off, and Colima.
+  candidates+=("${HOME}/.docker/run/docker.sock")
+  candidates+=("${HOME}/.colima/default/docker.sock")
+fi
+# Last, the standard path -- already bound directly, so reaching it here only
+# means the fallback duplicates the primary, which costs nothing.
+candidates+=("/var/run/docker.sock")
+
+for socket in "${candidates[@]}"; do
+  if [[ -S "${socket}" ]]; then
+    ln -s "${socket}" "${link}" 2>/dev/null || true
+    exit 0
+  fi
+done
+
+# No daemon on this machine, so no link. devcontainer.json binds this path with
+# "-v", which creates an empty directory rather than failing the way a "mounts"
+# entry would, and the container side reads that as "no Docker".
+exit 0

--- a/.devcontainer/docker-socket-start.sh
+++ b/.devcontainer/docker-socket-start.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Runs INSIDE the dev container, on every start.
+#
+# The host's Docker daemon arrives as one of two bind mounts: the standard
+# /var/run/docker.sock, which is the only path Docker Desktop understands on
+# macOS and Windows, and whatever docker-socket-init.sh resolved for a Linux
+# host that keeps its daemon elsewhere. Either may be an empty directory rather
+# than a socket -- that is what Docker leaves when the source does not exist.
+# This picks whichever is real, puts it where every Docker client looks for it,
+# /var/run/docker.sock, and makes it reachable by the container user, so that
+# `docker` and PartCAD's Docker sandboxes (the KiCad one, for one) can start
+# containers on the host.
+#
+# What it does not do is chown the mounted socket. That inode belongs to the
+# host: changing its owner here changes it there too, taking Docker away from
+# everyone else on the host who reaches it through the `docker` group, until
+# the daemon restarts and puts it back.
+
+# Shell options for maximum safety:
+# -e: Exit on error
+# -u: Error on undefined variables
+# -o pipefail: Exit on pipe failures
+set -euo pipefail
+
+socket=/var/run/docker.sock
+
+host_socket=""
+for candidate in /var/run/docker-host.sock /var/run/docker-host-alt.sock; do
+  if [[ -S "${candidate}" ]]; then
+    host_socket="${candidate}"
+    break
+  fi
+done
+
+# Neither is a socket: this machine has no Docker daemon to expose. Nothing to
+# do, and nothing worth complaining about -- Docker clients in here will report
+# that they cannot connect, if anything ever asks.
+[[ -n "${host_socket}" ]] || exit 0
+
+if [[ -w "${host_socket}" ]]; then
+  # Already ours to use. The well-known path only has to point at it.
+  sudo ln -sfn "${host_socket}" "${socket}"
+  exit 0
+fi
+
+if command -v socat >/dev/null 2>&1; then
+  # Proxy it instead of touching its permissions: the listening socket is ours
+  # to own, and the host's stays exactly as the host left it.
+  sudo pkill -f "UNIX-LISTEN:${socket}" || true
+  sudo rm -f "${socket}"
+  sudo nohup socat \
+    "UNIX-LISTEN:${socket},fork,mode=660,user=$(id -u),group=$(id -g)" \
+    "UNIX-CONNECT:${host_socket}" </dev/null >/dev/null 2>&1 &
+  disown
+
+  # socat needs a moment to bind before anything can connect.
+  for _ in $(seq 1 50); do
+    if [[ -S "${socket}" ]]; then
+      exit 0
+    fi
+    sleep 0.1
+  done
+  echo "docker-socket-start.sh: socat did not create ${socket}" >&2
+  exit 0
+fi
+
+# No socat in this image: fall back to handing the container user the socket's
+# group. Supplementary groups are resolved when a session starts, so the shells
+# opened after this point are the ones that get it.
+group_id="$(stat -c %g "${host_socket}")"
+if [[ "${group_id}" != "0" ]]; then
+  group_name="$(getent group "${group_id}" | cut -d: -f1)"
+  if [[ -z "${group_name}" ]]; then
+    group_name=docker-host
+    sudo groupadd -g "${group_id}" "${group_name}"
+  fi
+  sudo usermod -aG "${group_name}" "$(id -un)"
+fi
+sudo ln -sfn "${host_socket}" "${socket}"

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 *.stl binary
 **/*.jpg filter=lfs diff=lfs merge=lfs -text
 **/*.png filter=lfs diff=lfs merge=lfs -text
+
+# The dev container's polyglot initializeCommand shim: cmd.exe reads the top of it
+# and /bin/sh the bottom, and the shell half breaks on a trailing CR -- so pin it to
+# LF whatever the checkout's core.eol says.
+/.devcontainer/docker-socket-init.cmd text eol=lf

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -13,7 +13,15 @@ on:
     branches: ["devel"]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # A push whose head commit is a version bump is the only run that publishes
+  # the dev container image tagged with that version: the job that builds it is
+  # skipped on every other push to devel, and the tag is never built again. So
+  # cancelling such a run loses that image for good -- 0.7.180 has no dev
+  # container image on ghcr for exactly this reason, its run having been
+  # cancelled by the next push. Give version bumps a concurrency group of their
+  # own, keyed by commit, so nothing can supersede them. Every other run keeps
+  # cancelling its predecessor as before.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ startsWith(github.event.head_commit.message, 'Version updated') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Version bumps get a concurrency group of their own, keyed by commit: theirs
+  # is the run that publishes the version-tagged KiCad sandbox image and the
+  # only one that runs the full matrix on devel, and neither is ever done again
+  # for that version. Cancelling it is what left 0.7.180 without a KiCad image
+  # on ghcr. See the same block in "test-dev.yml" for the dev container image.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ startsWith(github.event.head_commit.message, 'Version updated') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## What

PartCAD runs its KiCad sandbox as a sibling container, so the dev container needs a Docker daemon it can reach. It had one bound in, could not use it, and what made it usable reached back out onto the host.

**The Docker CLI could not talk to the daemon.** Both CLIs in the image were too old: the static `18.03.1-ce` in `/usr/local/bin` shadowed Debian's `docker.io` 20.10, and API version 1.41 is below the 1.44 that Docker Engine 29 accepts — `docker version` inside the container answered `client version 1.41 is too old`. Both are gone, replaced by `docker-ce-cli` 29.7.2 and buildx 0.36.1 from Docker's own repository, plus `socat`. Buildx because `docker build` is the modern CLI's front end to it, and `tools/containers/kicad/README.md` builds the sandbox image that way.

**The `postStartCommand` chowned the host's socket.** `sudo chown $(whoami):$(whoami) /var/run/docker.sock` writes to the host's inode: it takes Docker away from everyone else on that host who reaches it through the `docker` group, until the daemon restarts and puts it back. `docker-socket-start.sh` replaces it — symlink when the socket is already usable, a socat proxy when it is not, and sharing the socket's group as a fallback on an image without socat, which is every image published before this commit for as long as `devcontainer.json` pins one. It never writes to the mounted socket.

**A host with no daemon at the standard path aborted `devcontainer up`.** The socket moved from `mounts` to two `-v` arguments: `mounts` becomes `--mount`, which fails outright on a missing source, whereas `-v` leaves an empty directory the container reads as "no Docker" and passes over in silence.

- The first `-v` is the literal `/var/run/docker.sock`. On macOS and Windows the daemon is not there at all — on Windows it is a named pipe — and that exact name is what Docker Desktop translates, so no other spelling works on those hosts.
- The second is whatever `docker-socket-init.sh` resolved for a Linux host that keeps its daemon elsewhere: rootless, a `unix://` `DOCKER_HOST`, Colima.

That resolver runs on the host, where a failing `initializeCommand` aborts the `up`, so it gives up quietly at every step it could fail at. It is reached through `docker-socket-init.cmd`, a polyglot: cmd.exe reads a batch script that does nothing and succeeds, `/bin/sh` reads a wrapper around the `.sh`. Without it a Windows host could not open this workspace at all, since cmd.exe cannot run a shell script.

## Two repairs that came out of testing this

**BuildKit is no longer required to build the image.** `RUN --mount=type=bind` was the only instruction in the Dockerfile that needed it, so the image could not be built by a plain `docker build` on a machine without the buildx plugin. CI has buildx, which is why nobody hit it. `COPY` plus a `RUN` that deletes the scripts again costs 4 KB and no dependency.

**Version-tagged images stop getting cancelled.** They are published by exactly one run — the push whose head commit is the version bump — and `cancel-in-progress` let the next push to devel cancel it. That is why ghcr has no image for 0.7.180 and several of its neighbours, for either `partcad-devcontainer` or `partcad-container-kicad`. Since the property is read off the *incoming* run, sparing version bumps from cancellation does not help; they need a concurrency group of their own, keyed by commit, which is what they now get in `test-dev.yml` and `test.yml`.

## Testing

In a dev container on Linux (Docker Engine 29.1.3), against an image built from this branch's Dockerfile:

- `test_part_example_kicad` passes — 74s, a 61 KB `Arduino_Nano.step` produced by `kicad-cli` in a sibling container.
- `docker version` reports client 29.7.2 / server 29.1.3; `docker run` starts a sibling container; the Python SDK calls `runtime.use_docker` makes (`containers.run`, bridge-IP lookup) work.
- Socket handling, all four paths: primary present → used; primary missing and fallback present → fallback used and the daemon answers through it; both missing → `up` succeeds, the script exits 0 silently, no `/var/run/docker.sock`; socket present but not writable → socat proxy, with the source socket's ownership verifiably unchanged. The no-socat group fallback was exercised by hiding socat.
- Docker still reachable after a container stop/start cycle.
- The Dockerfile builds end to end on the legacy builder on a host with no buildx.
- `pre-commit` passes (shellcheck, hadolint, workflow schema); `actionlint` is clean on both workflows.

## Not verified

No macOS or Windows host was available. The literal `/var/run/docker.sock` bind is the form Docker Desktop is documented to translate, but two things want a few minutes on a real Desktop host before this is called done:

- whether Docker Desktop for Windows accepts `/tmp/...` as a `-v` source at all — it has a history of mangling Unix-style paths. If it does not, the right move is dropping the fallback `-v` rather than working around it.
- the batch half of the polyglot, which cannot be executed on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
