### PR TITLE
fix(sandbox): pin every conda command to the GIL interpreter, not just the create

### DIFF
--- a/partcad/src/partcad/runtime_python_conda.py
+++ b/partcad/src/partcad/runtime_python_conda.py
@@ -80,6 +80,56 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
             pc_logging.error(f"Error locating conda executable: {e}")
             return None
 
+    def python_abi_specs(self):
+        """The specs holding every solve in this prefix to the GIL interpreter.
+
+        Every conda command that touches the prefix has to carry these, not just
+        the "create". A solve is free to replace what a previous one installed,
+        and an unconstrained one does: creating with the ABI pinned and then
+        running a plain "conda install pip pycairo" swapped the interpreter out
+        from under the sandbox for the free-threaded build of the same version --
+
+            UNLINK python 3.14.0 h32b2ec7_103_cp314
+            LINK   python 3.14.6 hf9ea5aa_1_cp314t
+
+        which is how a sandbox created with the pin still ended up free-threaded.
+        The two builds are the same version with the same build number, so
+        nothing but this spec decides which one a tie goes to.
+
+        Empty below 3.13, where CPython has no free-threaded build to
+        disambiguate. See sandbox_versions.python_abi_requirement().
+        """
+        python_abi = sandbox_versions.python_abi_requirement(self.version, exact=self.is_mamba)
+        return [] if python_abi is None else [python_abi]
+
+    def discard_prefix(self):
+        """Remove the sandbox prefix and forget everything that described it.
+
+        The install guards are marker files inside the prefix, so they go with
+        it. What does not is what this object remembers: 'initialized' was read
+        off the prefix existing (see runtime.Runtime), and 'constraints_path' is
+        memoized on first use. Left alone, the rebuilt prefix would be handed a
+        constraints file that no longer exists -- "Could not open constraint
+        file" on every install into it -- and would never be given the CAD stack,
+        because once() skips that whole block when 'initialized' is set.
+        """
+        shutil.rmtree(self.path, ignore_errors=True)
+        self.initialized = False
+        self.conda_initialized = False
+        self.constraints_path = None
+
+    def discard_if_free_threaded(self):
+        """Throw the prefix away if it holds a free-threaded interpreter.
+
+        Only ever true for a sandbox whose interpreter has no CAD wheels at all
+        (see verify_conda). Every other verify failure leaves the prefix where it
+        is, as before, for the next attempt to install into.
+        """
+        if not self.conda_free_threaded:
+            return
+        self.discard_prefix()
+        self.conda_free_threaded = False
+
     def verify_conda(self):
         # Make a best effort attempt to determine if it's valid
         python_path = self.get_venv_python_path()
@@ -170,23 +220,27 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
             # See if it just got created
             if os.path.exists(self.path):
                 self.verify_conda()
+                self.discard_if_free_threaded()
 
-                if self.conda_free_threaded:
-                    # Only ever true for a sandbox whose interpreter has no CAD
-                    # wheels at all (see verify_conda), and only reachable here
-                    # under the install lock. Every other verify failure leaves
-                    # the prefix where it is, as before.
-                    shutil.rmtree(self.path, ignore_errors=True)
-                    self.conda_free_threaded = False
+            # TODO(clairbee): Does it make sense to retry more than once?
+            attempts = 0
+            while not self.conda_initialized and attempts < 2:
+                # Sometimes it fails to create from the first attempt
+                attempts += 1
+                self.once_conda_locked_attempt()
+                if self.conda_initialized:
+                    # An attempt reports success from the exit code of the last
+                    # command it ran, which says nothing about *which*
+                    # interpreter ended up in the prefix. Ask the prefix itself,
+                    # so a create that quietly produced the wrong one is caught
+                    # here rather than by the next process to open this sandbox
+                    # -- which is what turned this into a rebuild every sandbox
+                    # of every run repeated and none of them fixed.
+                    self.verify_conda()
+                    self.discard_if_free_threaded()
 
             if not self.conda_initialized:
-                self.once_conda_locked_attempt()
-                if not self.conda_initialized:
-                    # Sometime it fails to create from the first attempt
-                    self.once_conda_locked_attempt()
-                # TODO(clairbee): Does it make sense to retry more than once?
-                if not self.conda_initialized:
-                    raise Exception("ERROR: Conda environment initialization failed")
+                raise Exception("ERROR: Conda environment initialization failed")
 
     # TODO(clairbee): Make an async version of this function
     def once_conda_locked_attempt(self):
@@ -209,16 +263,21 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                             "-p",
                             self.path,
                             *self.variant_packages,
-                            "python==%s" % self.version if self.is_mamba else "python=%s" % self.version,
+                            # "=" rather than "=="; the two do not mean the same
+                            # thing here. libmamba reads "python==3.14" as the
+                            # 3.14 release exactly, which is 3.14.0 -- so the
+                            # mamba branch this used to have pinned every sandbox
+                            # to the oldest patch of its line, and left the next
+                            # solve wanting to upgrade it. "=3.14" is the fuzzy
+                            # "3.14.*" both conda and mamba mean by it.
+                            "python=%s" % self.version,
+                            # The python spec above names a version and nothing
+                            # else, which from 3.13 on leaves the solver free to
+                            # pick the free-threaded (no-GIL) build of it -- and
+                            # it does. No CAD wheel exists for that ABI, so pin
+                            # the GIL one.
+                            *self.python_abi_specs(),
                         ]
-                        # The python spec above names a version and nothing else,
-                        # which from 3.13 on leaves the solver free to pick the
-                        # free-threaded (no-GIL) build of it -- and it does. No
-                        # CAD wheel exists for that ABI, so pin the GIL one.
-                        # See sandbox_versions.python_abi_requirement().
-                        python_abi = sandbox_versions.python_abi_requirement(self.version, exact=self.is_mamba)
-                        if python_abi is not None:
-                            args.append(python_abi)
                         # Strip user home directory from the path, if any
                         sanitized_args = copy.copy(args)
                         sanitized_args[0] = os.path.join("...", os.path.basename(sanitized_args[0]))
@@ -233,7 +292,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                             shell=False,
                             encoding="utf-8",
                         )
-                        _, stderr = p.communicate()
+                        stdout, stderr = p.communicate()
 
                     if not stderr is None and stderr.strip() != "":
                         # Handle most common sporadic conda/mamba failures
@@ -250,6 +309,16 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                             attempts += 1
                             continue
                         pc_logging.error("conda env install error: %s" % stderr)
+                    elif p.returncode != 0:
+                        # A failed solve under "--json" is reported *on stdout*,
+                        # as {"success": false, "error": ...}, and leaves stderr
+                        # empty -- so the check above sees a clean run and this
+                        # one is the only thing between a failed create and the
+                        # "conda install" below being asked to populate a prefix
+                        # that was never made.
+                        pc_logging.error(
+                            "conda env create failed (exit %s): %s" % (p.returncode, (stdout or "").strip())
+                        )
                     break
 
                 with telemetry.start_as_current_span(
@@ -274,6 +343,10 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                         # PNG output work without any system dependency; pip then
                         # sees it already satisfied and does not rebuild it.
                         "pycairo",
+                        # Not redundant with the "create" above: this solve is
+                        # free to replace the interpreter that one installed, and
+                        # without this it does. See python_abi_specs().
+                        *self.python_abi_specs(),
                     ]
                     if sys.platform.startswith("linux"):
                         # conda-forge's ICU 78 (pulled in through build123d ->
@@ -308,5 +381,5 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                 else:
                     self.conda_initialized = True
             except Exception as e:
-                shutil.rmtree(self.path)
+                self.discard_prefix()
                 raise e

--- a/partcad/src/partcad/sandbox_versions.py
+++ b/partcad/src/partcad/sandbox_versions.py
@@ -278,9 +278,13 @@ def python_abi_requirement(python_version: str, exact: bool = True) -> str | Non
     and conda-forge's build strings end in "_cpython" rather than "_cp312", so a
     "*_cp312" pin would match no package at all and fail the solve outright.
 
-    'exact' picks the spelling of the equality, mirroring the python spec the
-    caller builds: mamba is given "==", conda "=". Both select the same package
-    here, since python_abi's version is the bare "<major>.<minor>".
+    'exact' picks the spelling of the equality: mamba is given "==", conda "=".
+    Both select the same package here, since python_abi's version is the bare
+    "<major>.<minor>" and there is no patch component for the two to disagree
+    about. That is a property of this package alone, and does not carry over to
+    the 'python' spec beside it: libmamba reads "python==3.14" as the 3.14
+    release exactly, i.e. 3.14.0, so that one is always spelled with a single
+    "=" (see CondaPythonRuntime.once_conda_locked_attempt).
 
     That is also why both halves of the spec are derived from _major_minor()
     rather than from the caller's string: a "3.13.1" would otherwise ask for a

--- a/partcad/tests/unit/test_runtime_python_conda.py
+++ b/partcad/tests/unit/test_runtime_python_conda.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""What a conda sandbox actually asks conda for.
+
+A sandbox is made by two conda commands, and whether it comes out usable is a
+property of the two together - which is exactly what nothing here used to see. A
+prefix created with the interpreter's ABI pinned and then populated by an
+unconstrained second command had its interpreter swapped for the free-threaded
+build of the same version, which no CAD wheel is built for.
+
+Nothing is run: the commands are recorded and read. What went wrong was in the
+arguments, and reproducing it for real means a conda solve per case.
+"""
+
+import os
+import pathlib
+
+import pytest
+
+from partcad import runtime_python_conda
+from partcad.runtime_python_conda import CondaPythonRuntime
+
+
+class _FakeProcess:
+    """A process that ran nothing, said nothing and succeeded."""
+
+    returncode = 0
+
+    def communicate(self):
+        return "{}", ""
+
+
+@pytest.fixture
+def recorded_commands(monkeypatch):
+    """Every command 'subprocess.Popen' is handed, in order."""
+    commands = []
+
+    def popen(args, **kwargs):
+        commands.append(list(args))
+        return _FakeProcess()
+
+    monkeypatch.setattr(runtime_python_conda.subprocess, "Popen", popen)
+    return commands
+
+
+def _bare_runtime(path, version, is_mamba=True):
+    """A CondaPythonRuntime with just what once_conda_locked_attempt() reads.
+
+    __init__ wants a full context, a lock file and a conda on PATH, none of which
+    have anything to say about the command that gets built.
+    """
+    runtime = CondaPythonRuntime.__new__(CondaPythonRuntime)
+    runtime.conda_path = "mamba" if is_mamba else "conda"
+    runtime.is_mamba = is_mamba
+    runtime.version = version
+    runtime.path = str(path / ("pc-py-conda-" + version))
+    runtime.variant_packages = []
+    runtime.conda_initialized = False
+    runtime.constraints_path = None
+    runtime.initialized = True
+    return runtime
+
+
+@pytest.mark.parametrize("version", ["3.13", "3.14"])
+def test_every_conda_command_pins_the_gil_abi(tmp_path, recorded_commands, version):
+    """Both commands, not just the "create".
+
+    The second one installs pip and pycairo and names no interpreter, so the
+    solver was free to replace the one the first had just pinned - and it did,
+    with the free-threaded build, because the two are the same version with the
+    same build number and nothing else was there to break the tie.
+    """
+    _bare_runtime(tmp_path, version).once_conda_locked_attempt()
+
+    assert len(recorded_commands) == 2, recorded_commands
+    pin = "python_abi==%s=*_cp%s" % (version, version.replace(".", ""))
+    for command in recorded_commands:
+        assert pin in command, command
+
+
+def test_nothing_is_pinned_below_the_free_threaded_builds(tmp_path, recorded_commands):
+    """There are no two builds to tell apart before 3.13, and no pin that would.
+
+    conda-forge's build strings there end in "_cpython" rather than "_cp312", so
+    a "*_cp312" pin matches no package at all and fails the solve outright.
+    """
+    _bare_runtime(tmp_path, "3.12").once_conda_locked_attempt()
+
+    assert not [spec for command in recorded_commands for spec in command if spec.startswith("python_abi")]
+
+
+@pytest.mark.parametrize("is_mamba", [True, False])
+def test_the_python_spec_is_the_fuzzy_one(tmp_path, recorded_commands, is_mamba):
+    """"python==3.14" does not mean what it looks like it means.
+
+    libmamba reads it as the 3.14 release exactly, which is 3.14.0 - the oldest
+    patch of the line rather than the newest - and then the next solve wants to
+    upgrade what it pinned. "=3.14" is the "3.14.*" both conda and mamba mean.
+    """
+    _bare_runtime(tmp_path, "3.14", is_mamba=is_mamba).once_conda_locked_attempt()
+
+    create = recorded_commands[0]
+    assert "python=3.14" in create, create
+    assert "python==3.14" not in create, create
+
+
+def test_discarding_the_prefix_forgets_what_described_it(tmp_path):
+    """A rebuild has to leave nothing of the prefix behind, in memory either.
+
+    Both of these were read off a prefix that no longer exists. A stale
+    'constraints_path' fails every later install with "Could not open constraint
+    file", and a stale 'initialized' has once() skip installing the CAD stack
+    into the sandbox that was just rebuilt to receive it.
+    """
+    runtime = _bare_runtime(tmp_path, "3.14")
+    os.makedirs(runtime.path)
+    runtime.constraints_path = os.path.join(runtime.path, "partcad-constraints.txt")
+    pathlib.Path(runtime.constraints_path).touch()
+
+    runtime.discard_prefix()
+
+    assert not os.path.exists(runtime.path)
+    assert runtime.constraints_path is None
+    assert runtime.initialized is False
+
+
+def test_a_free_threaded_prefix_is_the_only_one_thrown_away(tmp_path):
+    """Every other verify failure leaves the prefix for the next attempt.
+
+    A prefix that failed to answer, or answered with the wrong version, may
+    still be one an install can repair. A free-threaded one cannot be: no CAD
+    wheel is built for that ABI, so there is nothing to install into it.
+    """
+    runtime = _bare_runtime(tmp_path, "3.14")
+    os.makedirs(runtime.path)
+
+    runtime.conda_free_threaded = False
+    runtime.discard_if_free_threaded()
+    assert os.path.exists(runtime.path)
+
+    runtime.conda_free_threaded = True
+    runtime.discard_if_free_threaded()
+    assert not os.path.exists(runtime.path)
+    assert runtime.conda_free_threaded is False


### PR DESCRIPTION
`test_convert_cad_file[cadquery-stl]` fails on every Python 3.14 job on Linux and Windows. The reported error
names something that has nothing to do with it:

```
wrapper_cadquery.py:20  import py_stubs.ocp_vscode
py_stubs/ocp_vscode.py:11  from ocp_tessellate.ocp_utils import (...)
ModuleNotFoundError: No module named 'ocp_tessellate'
```

### Why

The sandbox interpreter is the free-threaded build, which no CAD wheel is built for, so `nlopt`, `cadquery`,
`build123d` and `cadquery-ocp` all fail to install and the wrapper then runs against an empty environment.

#532 pinned `python_abi` to the GIL build to prevent exactly this. The pin is correct and libmamba honours it —
it just is not on every command that touches the prefix. A sandbox is built by **two** conda commands, and the
second one names no interpreter at all:

```
conda create  -p <prefix> python=3.14 python_abi=3.14=*_cp314
conda install -p <prefix> pip pycairo libstdcxx-ng          # <- unconstrained
```

A solve is free to replace what a previous one installed, and this one does. Reproduced against conda-forge
with micromamba 2.9.0 (the libmamba generation CI's miniforge ships):

```
$ micromamba install --dry-run -p ./probe pip pycairo libstdcxx-ng
UNLINK python      3.14.0 h32b2ec7_103_cp314
UNLINK python_abi  3.14   8_cp314
LINK   python      3.14.6 hf9ea5aa_1_cp314t
LINK   python_abi  3.14   8_cp314t
```

`3.14.6` free-threaded — the exact version and ABI the CI logs report. The two builds are the same version with
the same build number, so nothing but this spec decides which one a tie goes to. Repeating the pin on that
command leaves the interpreter untouched.

Worth saying plainly, since it was the first guess: **updating conda or mamba does not help.** CI already runs
the newest miniforge, the pin parses and is honoured on both mamba 1.5.9 and libmamba 2.9.0, and the swap above
is a legitimate solve for the constraints it was given.

### What else was wrong

Four things that turned one missing constraint into a failure that named nothing useful:

1. `"python==3.14"` means the 3.14 release *exactly* to libmamba, which is **3.14.0** — the oldest patch of the
   line rather than the newest (`"python=3.14"` gives 3.14.7). Sandboxes were pinned to it, and the next solve
   then wanted to upgrade what had just been pinned.
2. A create that reports success says nothing about *which* interpreter landed in the prefix, and nothing
   asked. #532's guard therefore only fired on the next process to open the sandbox — which rebuilt it just as
   wrongly. In the Behave log that is a rebuild at 18:38, 18:39, 18:40, 18:41, none of them fixing anything.
3. Under `--json` a failed solve is reported on **stdout** and leaves stderr empty, and only stderr was
   inspected — so a create that never made the prefix looked like a clean run.
4. Discarding a prefix left the runtime object still describing it. `constraints_path` memoized a file that had
   just been deleted (`Could not open constraint file` on every install afterwards) and `initialized`, read
   from the prefix existing, still said the CAD stack was there — so `once()` skipped installing it into the
   sandbox that had just been rebuilt to receive it. This is why the guard could not heal a sandbox even in
   principle.

### The change

`python_abi_specs()` is now carried by both commands; the python spec is the fuzzy `=`; an attempt verifies
what it made and fails loudly instead of looping; a non-zero create is reported with the stdout that explains
it; and `discard_prefix()` forgets `constraints_path`/`initialized` along with the directory.

### Verification

`test_runtime_python_conda.py` records the commands rather than running them — what went wrong was in the
arguments, and reproducing it for real costs a conda solve per case. It asserts the pin is on **both**
commands, that nothing is pinned below 3.13 (where a `*_cp312` pin would match no package and fail the solve),
that the python spec is never the exact one, and that a discarded prefix is forgotten.

End to end, against real conda-forge repodata, the new sequence:

```
$ micromamba create -p ./probe python=3.14 python_abi=3.14=*_cp314
$ ./probe/bin/python -c "import sys; print(sys.version)"
3.14.7 | packaged by conda-forge | (main, Aug 19 2026, 15:32:49) [GCC 15.3.0]
$ micromamba install --dry-run -p ./probe pip pycairo python_abi=3.14=*_cp314 libstdcxx-ng
   interpreter untouched
```

Full `pre-commit --config dev-tools/pre-commit-config.yaml` clean in the dev container (pytest over
`partcad/tests`, 1177 passed).

Not addressed here: `pythonVersion` still defaults to the *host* interpreter's version
(`project_config.py:126`), which is why CI on a 3.14 runner provisions a 3.14 CAD sandbox at all, and
`at_least()` has no ceiling to stop it reaching a Python the pinned stack does not support. That wants its own
change; the stack does support 3.14 once it is the GIL build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
