### PR TITLE
[FEATURE] object-type parameters — material, color and tolerance only where a part is one of each

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1067,32 +1067,52 @@ likes, and nothing outside that script knows what it means, so PartCAD lets a
 part declare any name it wants. A few are **object-type parameters** instead:
 contributed by the part *type* rather than declared out of nothing, with a
 meaning PartCAD itself acts on. They are therefore only available on the types
-that can honour them. ``material`` is the first, and today the only, one.
+that can honour them. Today there are three - ``material``, ``color`` and
+``tolerance``.
 
-What decides which types accept ``material`` is whether the part is a single
+What decides which types accept them is whether the part is a single
 homogeneous body - one solid, made of one thing - because that is what has to
-be true for one ``material:`` value to be true of the whole part. A mesh is one
-body: an STL file is a surface with nothing inside it to vary, and the only way
-it has a material at all is for somebody to say so. So is a solid built by a
-script, and so is one extruded from a single sketch. ``stl``, ``cadquery``,
-``build123d``, ``sdf`` and ``extrude`` accept ``material``.
+be true for one ``material:``, one ``color:`` or one ``tolerance:`` to be true
+of the whole part. A mesh is one body: an STL file is a surface with nothing
+inside it to vary, and the only way it has a material at all is for somebody to
+say so. So is a solid built by a script, and so is one extruded from a single
+sketch. ``stl``, ``cadquery``, ``build123d``, ``sdf`` and ``extrude`` accept
+all three.
 
 A STEP file is not one body. It can carry many solids, each already stating a
-material of its own, and naming one material for the file would be a claim
-about a part the file itself describes better. ``step`` rejects ``material``,
-and so does ``kicad``, which is a STEP file behind a footprint. What such a
-part is made of belongs under :ref:`properties`, where a shape says what it
-turned out to be rather than what was asked of it.
+material and a colour of its own, and naming one for the file would be a claim
+about a part the file itself describes better. ``step`` rejects them, and so
+does ``kicad``, which is a STEP file behind a footprint. What such a part is
+made of belongs under :ref:`properties`, where a shape says what it turned out
+to be rather than what was asked of it.
 
-Every other part type rejects ``material`` too, but for a different reason:
-whether it should accept it has not been decided yet, and answering "no" until
-somebody decides leaves the question open rather than settling it by accident.
+Every other part type rejects them too, but for a different reason: whether it
+should accept them has not been decided yet, and answering "no" until somebody
+decides leaves the question open rather than settling it by accident.
 
-Declaring ``material`` under ``parameters:`` of a type that does not accept it
+Declaring one of these under ``parameters:`` of a type that does not accept it
 is an error, not a warning. It costs the package that one part - the rest of
 the package loads and builds as usual - and the command that found it reports a
 failure. No other parameter name is restricted anywhere: what is policed is the
-one name PartCAD gives a meaning to, not the right to declare parameters.
+handful of names PartCAD gives a meaning to, not the right to declare
+parameters. It is the parameter's *name* that is policed, too, and not the
+shape of its declaration - any parameter may carry ``color:`` and ``material:``
+fields of its own describing what one of its values looks like, whatever the
+part type.
+
+``tolerance`` is the one of the three that has a default, ``0.0``: it reads
+back as that on any type that accepts it, whether or not a part declares one.
+The default is applied when the value is read and is never written into the
+part's ``parameters:`` section, because that section is part of what the shape
+cache is keyed on - writing a default in would move the cache key of every part
+that never mentioned a tolerance, for a value nobody set. A tolerance somebody
+did declare keys the cache like any other input, because it is one.
+
+A tolerance of ``0.0`` means nobody said. It reads as a demand for perfect
+precision, which is not something a manufacturer can be asked for, so
+:doc:`pc test <cli>` fails a part that is going to be *made* and has no
+tolerance - including a part reached through an assembly in the package. A part
+that is bought rather than made is not asked: it comes as it comes.
 
 Each part may have a list of parameters that are passed into the scripts to
 modify the part.
@@ -1131,6 +1151,8 @@ visualization, simulation calculations and, if applicable, manufacturing
 
 - ``color``
 
+  This one is an object-type parameter too, with the same restriction.
+
   **Not implemented yet. Use color names for now.**
 
 - ``finish``
@@ -1147,9 +1169,10 @@ visualization, simulation calculations and, if applicable, manufacturing
 
 - ``tolerance``
 
-  Optional. Can be omitted for a claim to perfect precision during manufacturing.
-
-  **Not implemented yet.**
+  An object-type parameter as well, and the one with a default: omitting it is
+  the same as writing ``0.0``, which is a claim to perfect precision and is
+  what ``pc test`` rejects on a part that is to be manufactured. Give it a real
+  value on anything you intend to have made.
 
 If the part has variable MCFTT parameters depending on the surface,
 then either this part must be broken down into multiple parts,

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1114,6 +1114,17 @@ precision, which is not something a manufacturer can be asked for, so
 tolerance - including a part reached through an assembly in the package. A part
 that is bought rather than made is not asked: it comes as it comes.
 
+A CadQuery or build123d script is handed every parameter the part declares, each
+as a variable of the same name, and the script has to assign that name at its
+own top level for the value to land anywhere - a parameter the script never
+mentions is a parameter nobody will read, so naming one is an error and usually
+a typo. Object-type parameters are the one exception, because the part may be
+required to declare one the script has no use for: a script that assigns
+``material`` still receives the declared material, and a script that does not
+mention it is left alone rather than refused. Nothing else is forgiven. An SDF
+script takes its parameters differently - they are prepended to it as
+assignments - so this never arose there.
+
 Each part may have a list of parameters that are passed into the scripts to
 modify the part.
 The parameters can be of types ``string``, ``float``, ``int`` and ``bool``.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1062,6 +1062,38 @@ even where they share a name: ``parameters.material`` asks for a part to be made
 of something, and ``properties.material`` states what the part that came out is
 made of.
 
+Most parameters are the part's own invention. A script may call one whatever it
+likes, and nothing outside that script knows what it means, so PartCAD lets a
+part declare any name it wants. A few are **object-type parameters** instead:
+contributed by the part *type* rather than declared out of nothing, with a
+meaning PartCAD itself acts on. They are therefore only available on the types
+that can honour them. ``material`` is the first, and today the only, one.
+
+What decides which types accept ``material`` is whether the part is a single
+homogeneous body - one solid, made of one thing - because that is what has to
+be true for one ``material:`` value to be true of the whole part. A mesh is one
+body: an STL file is a surface with nothing inside it to vary, and the only way
+it has a material at all is for somebody to say so. So is a solid built by a
+script, and so is one extruded from a single sketch. ``stl``, ``cadquery``,
+``build123d``, ``sdf`` and ``extrude`` accept ``material``.
+
+A STEP file is not one body. It can carry many solids, each already stating a
+material of its own, and naming one material for the file would be a claim
+about a part the file itself describes better. ``step`` rejects ``material``,
+and so does ``kicad``, which is a STEP file behind a footprint. What such a
+part is made of belongs under :ref:`properties`, where a shape says what it
+turned out to be rather than what was asked of it.
+
+Every other part type rejects ``material`` too, but for a different reason:
+whether it should accept it has not been decided yet, and answering "no" until
+somebody decides leaves the question open rather than settling it by accident.
+
+Declaring ``material`` under ``parameters:`` of a type that does not accept it
+is an error, not a warning. It costs the package that one part - the rest of
+the package loads and builds as usual - and the command that found it reports a
+failure. No other parameter name is restricted anywhere: what is policed is the
+one name PartCAD gives a meaning to, not the right to declare parameters.
+
 Each part may have a list of parameters that are passed into the scripts to
 modify the part.
 The parameters can be of types ``string``, ``float``, ``int`` and ``bool``.
@@ -1088,6 +1120,8 @@ visualization, simulation calculations and, if applicable, manufacturing
 
   Must point at an object of type ``material``.
   Some of them are defined in ``//pub/std/manufacturing/material``.
+  This one is an object-type parameter, so it may only be declared on the part
+  types listed above.
   When a request is made to a manufacturing API,
   a close enough material is selected from the materials provided by the
   manufacturer. The responsibility to select the right material is on the

--- a/examples/provider_manufacturer/partcad.yaml
+++ b/examples/provider_manufacturer/partcad.yaml
@@ -81,6 +81,11 @@ parts:
       material:
         type: string
         default: //pub/std/manufacturing/material/plastic:pla
+      # How precisely it has to be made. Without this the part is asking for
+      # perfect precision, which "pc test" reports as no tolerance at all.
+      tolerance:
+        type: float
+        default: 0.1
     manufacturing:
       method: additive
 

--- a/partcad/src/partcad/factory.py
+++ b/partcad/src/partcad/factory.py
@@ -85,6 +85,38 @@ class RetiredTypeException(UnknownTypeException):
         )
 
 
+class ObjectTypeParameterException(Exception):
+    """A declared object asks for an object-type parameter its type does not accept.
+
+    An *object-type parameter* is one an object type contributes to the
+    parameter list, rather than the author of the object declaring it from
+    nothing: it has a meaning PartCAD itself acts on, so it only means anything
+    on a type that can honour it. 'material' is the first, and today the only,
+    one of them.
+
+    Which types accept which is decided by the factory classes (see
+    'PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS'), not by the schema: the
+    schema takes any parameter name at all, and has no per-type branching to
+    hang this on. Every name outside the policed registry stays free, because
+    parameters are otherwise the object's own invention.
+
+    Raised while the object is being created, like 'UnknownTypeException' above,
+    so that 'Project.record_broken_object()' files it against that one object
+    and the rest of the package goes on loading. It stays an error rather than
+    being softened the way 'RetiredTypeException' is: this is a declaration
+    whose author can correct it, not a feature PartCAD took away.
+    """
+
+    def __init__(self, kind: str, t, name, parameter: str):
+        self.kind = kind
+        self.type = t
+        self.name = name
+        self.parameter = parameter
+        super().__init__(
+            "the %s type '%s' does not accept the '%s' parameter declared by '%s'" % (kind, t, parameter, name)
+        )
+
+
 class Factory:
     def __init__(self) -> None:
         pass

--- a/partcad/src/partcad/factory.py
+++ b/partcad/src/partcad/factory.py
@@ -91,8 +91,8 @@ class ObjectTypeParameterException(Exception):
     An *object-type parameter* is one an object type contributes to the
     parameter list, rather than the author of the object declaring it from
     nothing: it has a meaning PartCAD itself acts on, so it only means anything
-    on a type that can honour it. 'material' is the first, and today the only,
-    one of them.
+    on a type that can honour it. 'material', 'color' and 'tolerance' are the
+    ones that exist today.
 
     Which types accept which is decided by the factory classes (see
     'PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS'), not by the schema: the

--- a/partcad/src/partcad/part_factory.py
+++ b/partcad/src/partcad/part_factory.py
@@ -33,21 +33,35 @@ class PartFactory(ShapeFactory):
     # Two class-level sets, so the mechanism is not welded to the one parameter
     # that exists today.
     #
-    # POLICED_OBJECT_TYPE_PARAMETERS is the registry of names policed at all.
-    # Only a name in here may ever be rejected. Parameters are otherwise
-    # arbitrary - a script may call its own whatever it likes - so a name that
-    # is not in this registry must stay free on every type, forever.
-    POLICED_OBJECT_TYPE_PARAMETERS: typing.FrozenSet[str] = frozenset({"material"})
+    # POLICED_OBJECT_TYPE_PARAMETERS is the registry of names policed at all,
+    # and stays a plain set of names: whether a name is policed is a property
+    # of the name, the same everywhere. Only a name in here may ever be
+    # rejected. Parameters are otherwise arbitrary - a script may call its own
+    # whatever it likes - so a name that is not in this registry must stay free
+    # on every type, forever.
+    #
+    # A name, not a shape of declaration: a parameter *named* 'color' is
+    # policed, while the 'color:' and 'material:' fields a parameter of any
+    # name may carry inside its own definition (see 'shape-parameter' in the
+    # schema, and 'features/lint.feature') are a different thing entirely and
+    # are never looked at here.
+    POLICED_OBJECT_TYPE_PARAMETERS: typing.FrozenSet[str] = frozenset({"material", "color", "tolerance"})
 
     # ACCEPTED_OBJECT_TYPE_PARAMETERS is what *this* factory accepts of the
-    # policed names. Empty here, which makes "does not accept" the default: a
-    # type opts in by mixing in a class that widens the set (see
-    # 'PartFactoryHomogen'). The types that have not opted in are deliberate,
-    # not an oversight - whether each of them should accept 'material' has not
-    # been decided, and will be settled case by case. Defaulting to "no" is
-    # what leaves that decision open; defaulting to "yes" would silently make
-    # it.
-    ACCEPTED_OBJECT_TYPE_PARAMETERS: typing.FrozenSet[str] = frozenset()
+    # policed names, mapped to the default each reads back as when nothing
+    # declares it. 'NO_DEFAULT' means absent stays absent. Empty here, which
+    # makes "does not accept" the default: a type opts in by mixing in a class
+    # that widens the mapping (see 'PartFactoryHomogen'). The types that have
+    # not opted in are deliberate, not an oversight - whether each of them
+    # should accept these has not been decided, and will be settled case by
+    # case. Defaulting to "no" is what leaves that decision open; defaulting to
+    # "yes" would silently make it.
+    #
+    # Only what is *accepted* carries defaults, which is why this is a mapping
+    # and the registry above is not. A default is what a type promises about a
+    # parameter it honours, and a type that rejects a parameter promises
+    # nothing about it.
+    ACCEPTED_OBJECT_TYPE_PARAMETERS: typing.Dict[str, typing.Any] = {}
 
     def __init__(
         self,
@@ -97,6 +111,11 @@ class PartFactory(ShapeFactory):
 
     def _create_part(self, config: object) -> Part:
         part = Part(self.target_project.name, config)
+        # What this part's type contributes, so that reading an object-type
+        # parameter off the part applies the type's default without the reader
+        # having to know which factory made it (see
+        # 'ShapeConfiguration.get_object_type_parameter').
+        part.object_type_parameters = self.ACCEPTED_OBJECT_TYPE_PARAMETERS
         part.instantiate = lambda part_self: self.instantiate(part_self)
         part._prepare = lambda shape_self: self.prepare_async(shape_self)
         part.info = lambda: self.info(part)

--- a/partcad/src/partcad/part_factory.py
+++ b/partcad/src/partcad/part_factory.py
@@ -9,6 +9,7 @@
 
 import typing
 
+from . import factory
 from .part import Part
 from .shape_factory import ShapeFactory
 from . import telemetry
@@ -22,6 +23,32 @@ class PartFactory(ShapeFactory):
     name: str
     orig_name: str
 
+    # Object-type parameters: the parameters an object *type* contributes to
+    # the parameter list, rather than the author of the part declaring them
+    # from nothing. They are told apart from the rest here, in the factory
+    # layer, because that is the only layer that knows what type produced the
+    # part: the schema accepts any parameter name matching its pattern and has
+    # no per-part-type branching at all.
+    #
+    # Two class-level sets, so the mechanism is not welded to the one parameter
+    # that exists today.
+    #
+    # POLICED_OBJECT_TYPE_PARAMETERS is the registry of names policed at all.
+    # Only a name in here may ever be rejected. Parameters are otherwise
+    # arbitrary - a script may call its own whatever it likes - so a name that
+    # is not in this registry must stay free on every type, forever.
+    POLICED_OBJECT_TYPE_PARAMETERS: typing.FrozenSet[str] = frozenset({"material"})
+
+    # ACCEPTED_OBJECT_TYPE_PARAMETERS is what *this* factory accepts of the
+    # policed names. Empty here, which makes "does not accept" the default: a
+    # type opts in by mixing in a class that widens the set (see
+    # 'PartFactoryHomogen'). The types that have not opted in are deliberate,
+    # not an oversight - whether each of them should accept 'material' has not
+    # been decided, and will be settled case by case. Defaulting to "no" is
+    # what leaves that decision open; defaulting to "yes" would silently make
+    # it.
+    ACCEPTED_OBJECT_TYPE_PARAMETERS: typing.FrozenSet[str] = frozenset()
+
     def __init__(
         self,
         ctx,
@@ -33,6 +60,40 @@ class PartFactory(ShapeFactory):
         self.target_project = target_project
         self.name = config["name"]
         self.orig_name = config["orig_name"]
+
+        self._validate_object_type_parameters(config)
+
+    def _validate_object_type_parameters(self, config: object) -> None:
+        """Reject an object-type parameter this part type does not accept.
+
+        Runs from the constructor rather than from 'post_create()', the base
+        class catch-all that would otherwise be the natural hook, because
+        '_create()' registers the part in 'target_project.parts' *before* it
+        calls 'post_create()'. Raising from there would have the package record
+        the object as broken and go on holding a fully registered, buildable
+        part under the same name: the rejection would be reported and not
+        enforced. Nothing is registered yet at this point, so the failure is
+        the same per-object failure an unknown type produces - caught by
+        'Project.init_objects()' / 'Project.get_object()' and filed against
+        this one object by 'Project.record_broken_object()', which logs it as
+        an error and so sets the CLI's error state, while the rest of the
+        package loads and builds.
+        """
+        parameters = config.get("parameters") or {}
+        if not isinstance(parameters, dict):
+            # Malformed; the schema has its own say about that.
+            return
+        for name in sorted(parameters):
+            if name not in self.POLICED_OBJECT_TYPE_PARAMETERS:
+                continue
+            if name in self.ACCEPTED_OBJECT_TYPE_PARAMETERS:
+                continue
+            raise factory.ObjectTypeParameterException(
+                "part",
+                config.get("type"),
+                config.get("name"),
+                name,
+            )
 
     def _create_part(self, config: object) -> Part:
         part = Part(self.target_project.name, config)

--- a/partcad/src/partcad/part_factory.py
+++ b/partcad/src/partcad/part_factory.py
@@ -109,6 +109,24 @@ class PartFactory(ShapeFactory):
                 name,
             )
 
+    def object_type_parameter_names(self) -> list:
+        """The object-type parameter names this part's type contributes.
+
+        Put into the request a script-running wrapper is handed, so the wrapper
+        learns them from the type instead of carrying a copy of the list. A
+        wrapper that runs a CadQuery/build123d script is otherwise strict about
+        build parameters the script does not declare - rightly, since such a
+        name is usually a typo - but a part may be obliged to declare an
+        object-type parameter its script has no use for ('pc test' requires a
+        manufactured part to state a tolerance). Those names, and only those,
+        are dropped there when the script does not want them; see
+        'wrappers/custom_cqgi.filter_optional_params'.
+
+        Sorted, so the request is stable and two identical parts serialize
+        identically.
+        """
+        return sorted(self.ACCEPTED_OBJECT_TYPE_PARAMETERS)
+
     def _create_part(self, config: object) -> Part:
         part = Part(self.target_project.name, config)
         # What this part's type contributes, so that reading an object-type

--- a/partcad/src/partcad/part_factory_build123d.py
+++ b/partcad/src/partcad/part_factory_build123d.py
@@ -58,6 +58,10 @@ class PartFactoryBuild123d(PartFactoryPython):
             if "parameters" in self.config:
                 for param_name, param in self.config["parameters"].items():
                     request["build_parameters"][param_name] = param["default"]
+            # Which of the above the part's *type* contributed. The wrapper needs
+            # it to tell a parameter the script forgot to declare (an error) from
+            # one the script was never asked to want (not an error).
+            request["object_type_parameters"] = self.object_type_parameter_names()
             patch = {}
             if "show" in self.config:
                 patch["\\Z"] = "\nshow(%s)\n" % self.config["show"]

--- a/partcad/src/partcad/part_factory_cadquery.py
+++ b/partcad/src/partcad/part_factory_cadquery.py
@@ -61,6 +61,10 @@ class PartFactoryCadquery(PartFactoryPython):
             if "parameters" in self.config:
                 for param_name, param in self.config["parameters"].items():
                     request["build_parameters"][param_name] = param["default"]
+            # Which of the above the part's *type* contributed. The wrapper needs
+            # it to tell a parameter the script forgot to declare (an error) from
+            # one the script was never asked to want (not an error).
+            request["object_type_parameters"] = self.object_type_parameter_names()
             patch = {}
             if "show" in self.config:
                 patch["\\Z"] = "\nshow(%s)\n" % self.config["show"]

--- a/partcad/src/partcad/part_factory_extrude.py
+++ b/partcad/src/partcad/part_factory_extrude.py
@@ -7,7 +7,7 @@
 # Licensed under Apache License, Version 2.0.
 #
 
-from .part_factory import PartFactory
+from .part_factory_homogen import PartFactoryHomogen
 from .sketch import Sketch
 from . import logging as pc_logging
 from . import wrapper
@@ -16,8 +16,14 @@ from . import sandbox_versions
 from . import telemetry
 
 
+# Homogeneous: an extrusion is one sketch swept into one solid, so a single
+# 'material:' is true of the whole of it - the same argument that lets a
+# script-built solid have one. It is also the only part type in this
+# repository that already ships a part declaring 'parameters: material:'
+# (examples/provider_manufacturer), which is the quoting path this parameter
+# exists for.
 @telemetry.instrument()
-class PartFactoryExtrude(PartFactory):
+class PartFactoryExtrude(PartFactoryHomogen):
     PYTHON_SANDBOX_VERSION = sandbox_versions.DEFAULT_PYTHON_VERSION
 
     depth: float

--- a/partcad/src/partcad/part_factory_homogen.py
+++ b/partcad/src/partcad/part_factory_homogen.py
@@ -5,37 +5,56 @@
 #
 
 from .part_factory import PartFactory
+from .shape_config import NO_DEFAULT
 
 
 class PartFactoryHomogen(PartFactory):
     """The part types that produce a single homogeneous body.
 
     Mixed into a part factory to say that the part it produces is one solid
-    made of one thing, and that the type therefore accepts 'material' as an
-    object-type parameter (see 'PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS').
+    made of one thing, and that the type therefore accepts the object-type
+    parameters below (see 'PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS').
 
-    Homogeneity is the axis because it is what decides whether a single
-    'material:' value can be true of the whole part. A mesh is one body: an STL
-    file is a surface with nothing inside it to vary, and the only way it has a
-    material at all is for somebody to say so. A solid a script builds is one
+    Homogeneity is the axis because it is what decides whether a single value
+    can be true of the whole part - one material, one colour, one manufacturing
+    tolerance. A mesh is one body: an STL file is a surface with nothing inside
+    it to vary, and the only way it has a material at all is for somebody to
+    say so. A solid a script builds is one
     body too - a CadQuery, build123d or SDF part is the result of one modelling
     session, and PartCAD hands the whole of it to a manufacturer as one thing.
     An extrusion of one sketch is the same case.
 
-    A STEP file is not. It can carry many solids, each with a material of its
-    own already stated in the file, so naming one material for the file would
-    be a claim about a part the file describes better than the declaration
-    does. 'step' - and 'kicad', which is a STEP file behind a footprint and
-    inherits this by inheriting 'PartFactoryStep' - therefore do not mix this
-    in. What such a part is made of belongs in 'properties:', which is where a
-    shape says what it turned out to be rather than what was asked of it.
+    A STEP file is not. It can carry many solids, each with a material and a
+    colour of its own already stated in the file, so naming one for the file
+    would be a claim about a part the file describes better than the
+    declaration does. 'step' - and 'kicad', which is a STEP file behind a
+    footprint and inherits this by inheriting 'PartFactoryStep' - therefore do
+    not mix this in. What such a part is made of belongs in 'properties:',
+    which is where a shape says what it turned out to be rather than what was
+    asked of it.
 
     Carries no '__init__' on purpose. It is mixed in ahead of a factory's real
     base ('PartFactoryStl(PartFactoryHomogen, PartFactoryFile)'), and a
     constructor here would sit in the middle of that diamond and have to
     forward every base's signature. With no constructor, attribute lookup walks
     straight past it to the real base, and all this class contributes is the
-    class-level set below.
+    class-level mapping below.
     """
 
-    ACCEPTED_OBJECT_TYPE_PARAMETERS = PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS | {"material"}
+    ACCEPTED_OBJECT_TYPE_PARAMETERS = {
+        **PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS,
+        # No default: a part either was declared to be made of something, or
+        # was not, and there is nothing sensible to invent for it.
+        "material": NO_DEFAULT,
+        "color": NO_DEFAULT,
+        # A default of 0.0, meaning "nobody said". It is a real value rather
+        # than a sentinel because the manufacturability tests need something to
+        # compare against, and because 0.0 - a demand for perfect precision -
+        # is exactly what an unspecified manufacturing tolerance amounts to.
+        # Being numeric is also what tells the reader to hand it back as a
+        # number (see 'ShapeConfiguration.get_object_type_parameter'). The
+        # default is applied on read and never written into
+        # 'config["parameters"]', so a part that declares no tolerance keeps
+        # the cache key it has always had.
+        "tolerance": 0.0,
+    }

--- a/partcad/src/partcad/part_factory_homogen.py
+++ b/partcad/src/partcad/part_factory_homogen.py
@@ -1,0 +1,41 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+from .part_factory import PartFactory
+
+
+class PartFactoryHomogen(PartFactory):
+    """The part types that produce a single homogeneous body.
+
+    Mixed into a part factory to say that the part it produces is one solid
+    made of one thing, and that the type therefore accepts 'material' as an
+    object-type parameter (see 'PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS').
+
+    Homogeneity is the axis because it is what decides whether a single
+    'material:' value can be true of the whole part. A mesh is one body: an STL
+    file is a surface with nothing inside it to vary, and the only way it has a
+    material at all is for somebody to say so. A solid a script builds is one
+    body too - a CadQuery, build123d or SDF part is the result of one modelling
+    session, and PartCAD hands the whole of it to a manufacturer as one thing.
+    An extrusion of one sketch is the same case.
+
+    A STEP file is not. It can carry many solids, each with a material of its
+    own already stated in the file, so naming one material for the file would
+    be a claim about a part the file describes better than the declaration
+    does. 'step' - and 'kicad', which is a STEP file behind a footprint and
+    inherits this by inheriting 'PartFactoryStep' - therefore do not mix this
+    in. What such a part is made of belongs in 'properties:', which is where a
+    shape says what it turned out to be rather than what was asked of it.
+
+    Carries no '__init__' on purpose. It is mixed in ahead of a factory's real
+    base ('PartFactoryStl(PartFactoryHomogen, PartFactoryFile)'), and a
+    constructor here would sit in the middle of that diamond and have to
+    forward every base's signature. With no constructor, attribute lookup walks
+    straight past it to the real base, and all this class contributes is the
+    class-level set below.
+    """
+
+    ACCEPTED_OBJECT_TYPE_PARAMETERS = PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS | {"material"}

--- a/partcad/src/partcad/part_factory_python.py
+++ b/partcad/src/partcad/part_factory_python.py
@@ -10,13 +10,14 @@
 import os
 
 from .part_factory_file import PartFactoryFile
+from .part_factory_homogen import PartFactoryHomogen
 from .runtime_python import PythonRuntime, environment_requirements
 from . import sandbox_versions
 from . import telemetry
 
 
 @telemetry.instrument()
-class PartFactoryPython(PartFactoryFile):
+class PartFactoryPython(PartFactoryHomogen, PartFactoryFile):
     runtime: PythonRuntime
     cwd: str
 

--- a/partcad/src/partcad/part_factory_stl.py
+++ b/partcad/src/partcad/part_factory_stl.py
@@ -10,6 +10,7 @@
 import os
 
 from .part_factory_file import PartFactoryFile
+from .part_factory_homogen import PartFactoryHomogen
 from . import logging as pc_logging
 from . import wrapper
 from . import telemetry
@@ -18,7 +19,7 @@ from . import shape_envelope
 
 
 @telemetry.instrument()
-class PartFactoryStl(PartFactoryFile):
+class PartFactoryStl(PartFactoryHomogen, PartFactoryFile):
     PYTHON_SANDBOX_VERSION = "3.11"
 
     def __init__(self, ctx, source_project, target_project, config):

--- a/partcad/src/partcad/shape_config.py
+++ b/partcad/src/partcad/shape_config.py
@@ -14,8 +14,31 @@ from partcad.shape_config_store import ShapeConfigStore
 from . import logging as pc_logging
 
 
+class _NoDefault:
+    """Sentinel: an object-type parameter that has no default.
+
+    For such a parameter, absent means absent - 'material' and 'color' either
+    were declared or were not, and there is nothing sensible to invent for
+    them. A parameter whose default is a real value (a 'tolerance' of 0.0)
+    reads back as that value when nothing declared it.
+    """
+
+    def __repr__(self) -> str:
+        return "NO_DEFAULT"
+
+
+NO_DEFAULT = _NoDefault()
+
+
 class ShapeConfiguration:
     is_manufacturable: bool = False
+
+    # The object-type parameters the type that produces this shape accepts,
+    # mapped to their defaults (see 'PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS',
+    # which is what a part factory stamps here as the part is created). Empty
+    # for every shape whose type contributes none - which today is every shape
+    # that is not a part.
+    object_type_parameters: dict = {}
 
     def __init__(self, config: dict) -> None:
         self.config = config
@@ -93,3 +116,54 @@ class ShapeConfiguration:
         ):
             return None
         return self.config["parameters"][property]["default"]
+
+    def get_object_type_parameter(self, name: str):
+        """The value of an object-type parameter, with the type's default applied.
+
+        The counterpart of 'get_mcftt()' for the parameters a type contributes
+        rather than the object invents. It reads the same place - the object's
+        own 'parameters:' - and differs in what happens when nothing is
+        declared: the default comes from the type that produces the shape, not
+        from here.
+
+        The default is applied *here*, on the way out, and is deliberately never
+        written into 'config["parameters"]'. 'Shape.__init__' hashes that
+        dictionary into the shape's cache key, so injecting a default would move
+        the key of every homogeneous part that never mentioned a tolerance - a
+        mass invalidation of existing cache entries for a value nobody set. Read
+        this way, an undeclared tolerance stays out of the hash entirely, while a
+        tolerance somebody did declare keys the cache like any other input,
+        because it is one.
+
+        The default doubles as the parameter's type witness: a numeric default
+        means the parameter is numeric, so a declared value is coerced to a
+        number. A value that will not coerce is reported and the default is used
+        instead, which is how 'PartConfigManufacturing' treats a manufacturing
+        method it does not recognize.
+
+        Reads 'self.config' rather than the resolved final configuration, the
+        same as 'get_mcftt()' does, so an alias reports what the alias itself
+        declares. That is a pre-existing property of both readers, not something
+        decided here.
+        """
+        accepted = self.object_type_parameters
+        if name not in accepted:
+            # Not a parameter this type contributes at all.
+            return None
+        default = accepted[name]
+        fallback = None if isinstance(default, _NoDefault) else default
+
+        parameters = self.config.get("parameters") or {}
+        declared = parameters.get(name) if isinstance(parameters, dict) else None
+        if not isinstance(declared, dict) or "default" not in declared:
+            return fallback
+
+        value = declared["default"]
+        if isinstance(default, float):
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                kind = getattr(self, "kind", "object").capitalize()
+                pc_logging.error(f"{kind} '{self.name}' has a non-numeric '{name}': {value!r}")
+                return fallback
+        return value

--- a/partcad/src/partcad/test/cam.py
+++ b/partcad/src/partcad/test/cam.py
@@ -59,6 +59,32 @@ class CamTest(Test):
 
         return f"No suppliers provide the {shape.kind}"
 
+    def tolerance_failure(self, part: Part) -> str | None:
+        """Why this part's manufacturing tolerance is unusable, or None if it is fine.
+
+        A part that is going to be made has to say how precisely. 'tolerance' is
+        an object-type parameter of the homogeneous part types, and it reads back
+        as 0.0 when nothing declared one - a demand for perfect precision, which
+        is what "nobody said" amounts to and is not something a manufacturer can
+        be asked for. Read through 'get_object_type_parameter()' rather than
+        'get_mcftt()' because the default lives on the part's type, and that is
+        the reader that knows it.
+
+        Checked here, in the part path of the CAM test, rather than in a sibling
+        test class: the siblings ('cam-additive', 'cam-subtractive',
+        'cam-forming') each check the geometry for one manufacturing method,
+        while this applies to a part however it is made, and it needs exactly the
+        purchased-or-manufactured determination this method has just made.
+        Assemblies reach it for free - 'test_assembly()' runs every test in
+        'tests_to_run' over its supply BoM, and this test is one of them.
+        """
+        tolerance = part.get_object_type_parameter("tolerance")
+        if tolerance is None:
+            return "No manufacturing tolerance: the part type '%s' does not accept one" % part.config.get("type")
+        if tolerance == 0.0:
+            return "No manufacturing tolerance is specified"
+        return None
+
     async def test_part(self, tests_to_run: list[Test], ctx, part: Part, test_ctx: dict = {}) -> bool:
         self.debug(part, "Testing for manufacturability")
 
@@ -81,6 +107,15 @@ class CamTest(Test):
 
         if not can_be_purchased and not can_be_manufactured:
             return self.failed(part, "Cannot be purchased or manufactured")
+
+        if not can_be_purchased:
+            # Only what is actually made needs a manufacturing tolerance. A part
+            # that is bought comes as it comes, which is the same reason the
+            # MCFTT parameters are documented as having no effect on a part with
+            # a vendor and an SKU.
+            failure = self.tolerance_failure(part)
+            if failure:
+                return self.failed(part, failure)
 
         failure = await self.supply_failure(ctx, part)
         if failure:

--- a/partcad/src/partcad/wrappers/custom_cqgi.py
+++ b/partcad/src/partcad/wrappers/custom_cqgi.py
@@ -30,6 +30,35 @@ def parse(script_source):
     return model
 
 
+# Added by PartCAD; not part of the CadQuery original above.
+def filter_optional_params(model, params, optional):
+    """Drop the object-type parameters this script did not ask for.
+
+    'set_param_values()' below is strict on purpose: a build parameter that is
+    not a top-level assignment in the script is a name nobody will ever read,
+    which is almost always a typo, and it has to keep failing loudly.
+
+    Object-type parameters are the exception, and only they. They are
+    contributed by the part *type* rather than written by the author of the
+    script - 'material', 'color' and 'tolerance' today - so a part may be
+    obliged to declare one ('pc test' requires a manufactured part to state a
+    tolerance) while the script that builds its geometry has no use for it. Such
+    a name is dropped here, before the strict setter ever sees it. A script that
+    *does* assign one still receives its value, which is the entire point of
+    passing them through.
+
+    'optional' arrives in the request, from the factory that knows which names
+    the part's type contributes; this function never carries a list of its own.
+    An empty or absent 'optional' therefore leaves the behaviour exactly as it
+    was - which is what a sketch, whose types contribute nothing, gets.
+    """
+    optional = set(optional or [])
+    if not optional:
+        return params
+    declared = model.metadata.parameters
+    return {name: value for name, value in params.items() if name not in optional or name in declared}
+
+
 class CQModel(object):
     """
     Represents a Cadquery Script.

--- a/partcad/src/partcad/wrappers/wrapper_build123d.py
+++ b/partcad/src/partcad/wrappers/wrapper_build123d.py
@@ -67,6 +67,12 @@ def process(path, request):
 
     # Execute the script
     script_object = custom_cqgi.parse(script)
+    # An object-type parameter the script has no use for is dropped rather than
+    # rejected: which names those are comes from the request, so the part type
+    # stays the one place that decides. Everything else is still strict.
+    build_parameters = custom_cqgi.filter_optional_params(
+        script_object, build_parameters, request.get("object_type_parameters")
+    )
     build_result = script_object.build(build_parameters=build_parameters)
 
     if not build_result.success:

--- a/partcad/src/partcad/wrappers/wrapper_cadquery.py
+++ b/partcad/src/partcad/wrappers/wrapper_cadquery.py
@@ -54,6 +54,12 @@ def process(path, request):
 
     # Execute the script
     script_object = custom_cqgi.parse(script)
+    # An object-type parameter the script has no use for is dropped rather than
+    # rejected: which names those are comes from the request, so the part type
+    # stays the one place that decides. Everything else is still strict.
+    build_parameters = custom_cqgi.filter_optional_params(
+        script_object, build_parameters, request.get("object_type_parameters")
+    )
     build_result = script_object.build(build_parameters=build_parameters)
 
     if not build_result.success:

--- a/partcad/tests/unit/test_cam_tolerance.py
+++ b/partcad/tests/unit/test_cam_tolerance.py
@@ -1,0 +1,177 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""A part that is going to be made has to say how precisely.
+
+'tolerance' is an object-type parameter of the homogeneous part types, and it
+reads back as 0.0 when nothing declared one. 0.0 is a demand for perfect
+precision, which is what "nobody said" amounts to and is not something a
+manufacturer can be asked for, so the CAM test rejects it - for a part in the
+package, and for a part an assembly in the package is procured from.
+
+Only what is actually made is asked: a part that is bought comes as it comes.
+"""
+
+import asyncio
+
+import yaml
+
+import partcad as pc
+from partcad.test.cam import CamTest
+
+
+def _record_errors(monkeypatch):
+    """Collect pc_logging.error() calls.
+
+    The 'partcad' logger sets propagate=False, so the caplog fixture (which
+    attaches to the root logger) sees nothing on the pytest version used in CI.
+    """
+    recorded = []
+    monkeypatch.setattr(pc.logging, "error", lambda *args, **kwargs: recorded.append(" ".join(str(a) for a in args)))
+    return recorded
+
+
+def _package(tmp_path, parts, assemblies=None):
+    config = {"name": "//test", "manufacturable": True, "parts": parts}
+    if assemblies:
+        config["assemblies"] = assemblies
+    (tmp_path / "partcad.yaml").write_text(yaml.safe_dump(config))
+    for name in parts:
+        (tmp_path / (name + ".stl")).write_text("")
+    return pc.Context(str(tmp_path))
+
+
+def _made_part(**parameters):
+    part = {"type": "stl", "manufacturing": {"method": "additive"}}
+    if parameters:
+        part["parameters"] = {k: {"type": "float", "default": v} for k, v in parameters.items()}
+    return part
+
+
+def test_a_part_with_no_tolerance_fails(tmp_path):
+    ctx = _package(tmp_path, {"body": _made_part()})
+    part = ctx.get_part("//:body")
+
+    failure = CamTest().tolerance_failure(part)
+
+    assert failure is not None
+    assert "tolerance" in failure
+
+
+def test_a_part_with_a_tolerance_of_zero_fails_the_same_way(tmp_path):
+    """Declaring the default explicitly is still nothing specified."""
+    ctx = _package(tmp_path, {"body": _made_part(tolerance=0.0)})
+    part = ctx.get_part("//:body")
+
+    assert CamTest().tolerance_failure(part) is not None
+
+
+def test_a_part_with_a_tolerance_passes(tmp_path):
+    ctx = _package(tmp_path, {"body": _made_part(tolerance=0.1)})
+    part = ctx.get_part("//:body")
+
+    assert CamTest().tolerance_failure(part) is None
+
+
+def test_a_type_that_cannot_carry_a_tolerance_says_so(tmp_path):
+    """A STEP part has no tolerance to declare, and the message says which."""
+    (tmp_path / "partcad.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "//test",
+                "manufacturable": True,
+                "parts": {"body": {"type": "step", "manufacturing": {"method": "additive"}}},
+            }
+        )
+    )
+    (tmp_path / "body.step").write_text("")
+    part = pc.Context(str(tmp_path)).get_part("//:body")
+
+    failure = CamTest().tolerance_failure(part)
+
+    assert failure is not None
+    assert "step" in failure
+
+
+def test_the_cam_test_reports_a_missing_tolerance_against_the_part(tmp_path, monkeypatch):
+    """Reported through Test.failed(), like every other CAM failure."""
+    recorded = _record_errors(monkeypatch)
+    ctx = _package(tmp_path, {"body": _made_part()})
+    part = ctx.get_part("//:body")
+
+    cam = CamTest()
+    assert asyncio.run(cam.test([cam], ctx, part)) == CamTest.TEST_FAILED
+    assert any("body" in message and "tolerance" in message for message in recorded), recorded
+
+
+def test_a_purchased_part_is_not_asked_for_a_tolerance(tmp_path, monkeypatch):
+    """It comes as it comes; the MCFTT parameters do not apply to it.
+
+    It still fails - nothing in this package supplies it - but on the supplier
+    question, which is what proves the tolerance check let it through.
+    """
+    recorded = _record_errors(monkeypatch)
+    (tmp_path / "partcad.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "//test",
+                "manufacturable": True,
+                "parts": {"body": {"type": "stl", "vendor": "acme", "sku": "X-1"}},
+            }
+        )
+    )
+    (tmp_path / "body.stl").write_text("")
+    ctx = pc.Context(str(tmp_path))
+    part = ctx.get_part("//:body")
+
+    cam = CamTest()
+    asyncio.run(cam.test([cam], ctx, part))
+
+    assert not any("tolerance" in message for message in recorded), recorded
+
+
+def _assembly_of(tmp_path, monkeypatch, part_config):
+    """An assembly procured from one part, ready to be tested.
+
+    'get_supply_bom()' is stubbed rather than computed: the real one calls
+    'do_instantiate()', which builds the assembly and so needs a CAD kernel,
+    while what is under test here is what 'test_assembly()' does with the bill
+    of materials it is handed. That the bill is computed correctly is the
+    subject of the assembly tests, not of this one.
+    """
+    (tmp_path / "top.assy").write_text("links:\n  - part: :body\n")
+    ctx = _package(tmp_path, {"body": part_config}, assemblies={"top": {"type": "assy"}})
+    assembly = ctx.get_assembly("//:top")
+
+    async def supply_bom():
+        return {f"{assembly.project_name}:body": 1}
+
+    monkeypatch.setattr(assembly, "get_supply_bom", supply_bom)
+    return ctx, assembly
+
+
+def test_an_assembly_whose_part_has_no_tolerance_fails(tmp_path, monkeypatch):
+    """The assembly path reaches the parts the assembly is procured from."""
+    recorded = _record_errors(monkeypatch)
+    ctx, assembly = _assembly_of(tmp_path, monkeypatch, _made_part())
+
+    cam = CamTest()
+    assert asyncio.run(cam.test([cam], ctx, assembly)) == CamTest.TEST_FAILED
+
+    # Once against the part that has no tolerance...
+    assert any("body" in message and "tolerance" in message for message in recorded), recorded
+    # ...and once against the assembly that is made of it.
+    assert any("top" in message and "body" in message for message in recorded), recorded
+
+
+def test_an_assembly_whose_part_has_a_tolerance_is_not_failed_for_it(tmp_path, monkeypatch):
+    recorded = _record_errors(monkeypatch)
+    ctx, assembly = _assembly_of(tmp_path, monkeypatch, _made_part(tolerance=0.1))
+
+    cam = CamTest()
+    asyncio.run(cam.test([cam], ctx, assembly))
+
+    assert not any("tolerance" in message for message in recorded), recorded

--- a/partcad/tests/unit/test_object_type_parameters.py
+++ b/partcad/tests/unit/test_object_type_parameters.py
@@ -4,14 +4,14 @@
 # Licensed under Apache License, Version 2.0.
 #
 
-"""'material' is contributed by the part type, not invented by the part.
+"""'material', 'color' and 'tolerance' are contributed by the part type.
 
 Parameters are otherwise the object's own business: the schema takes any name
 matching its pattern, and nothing but the script behind the part knows what one
-means. 'material' is different - PartCAD itself acts on it, in the
-manufacturing and quoting path - so it only means anything on a type that can
-honour it, and the types that can are the ones producing a single homogeneous
-body. Declaring it anywhere else is a per-object error: the package keeps
+means. These three are different - PartCAD itself acts on them, in the
+manufacturing and quoting path - so they only mean anything on a type that can
+honour them, and the types that can are the ones producing a single homogeneous
+body. Declaring one anywhere else is a per-object error: the package keeps
 loading, that one part does not.
 """
 
@@ -21,9 +21,11 @@ import pytest
 import yaml
 
 import partcad as pc
+from partcad.part_factory import PartFactory
 
 ACCEPTING_TYPES = ["stl", "cadquery", "build123d", "sdf", "extrude"]
 REJECTING_TYPES = ["step", "kicad"]
+POLICED = ["material", "color", "tolerance"]
 
 
 def _write_package(tmp_path, parts):
@@ -58,15 +60,28 @@ def _part(part_type, **extra):
     return config
 
 
-def _material(value="//pub/std/manufacturing/material/plastic:pla"):
-    return {"material": {"type": "string", "default": value}}
+def _declare(name, value=None):
+    """One policed parameter, declared the way a part author would declare it."""
+    if value is None:
+        value = 0.1 if name == "tolerance" else "//pub/std/manufacturing/material/plastic:pla"
+    kind = "float" if isinstance(value, float) else "string"
+    return {name: {"type": kind, "default": value}}
+
+
+def test_the_policed_registry_is_the_three_names():
+    """The registry is a set of names, not a mapping: policing is per name."""
+    assert PartFactory.POLICED_OBJECT_TYPE_PARAMETERS == frozenset(POLICED)
+    assert isinstance(PartFactory.POLICED_OBJECT_TYPE_PARAMETERS, frozenset)
+    # Nothing is accepted by default; only what a factory opts into is.
+    assert PartFactory.ACCEPTED_OBJECT_TYPE_PARAMETERS == {}
 
 
 @pytest.mark.parametrize("part_type", ACCEPTING_TYPES)
-def test_material_is_accepted_by_the_homogeneous_types(tmp_path, part_type):
-    """One body of one thing, so one 'material:' can be true of the whole part."""
+@pytest.mark.parametrize("name", POLICED)
+def test_accepted_by_the_homogeneous_types(tmp_path, part_type, name):
+    """One body of one thing, so one value can be true of the whole part."""
     pc.logging.reset_errors()
-    package = _write_package(tmp_path, {"body": _part(part_type, parameters=_material())})
+    package = _write_package(tmp_path, {"body": _part(part_type, parameters=_declare(name))})
 
     project = pc.Context(str(package)).get_project("//")
 
@@ -76,7 +91,8 @@ def test_material_is_accepted_by_the_homogeneous_types(tmp_path, part_type):
 
 
 @pytest.mark.parametrize("part_type", REJECTING_TYPES)
-def test_material_is_rejected_by_the_types_that_can_carry_many(tmp_path, part_type):
+@pytest.mark.parametrize("name", POLICED)
+def test_rejected_by_the_types_that_can_carry_many(tmp_path, part_type, name):
     """A STEP file may hold many solids, each already stating its own material.
 
     Per object, not per package: the sibling part is declared after the bad one
@@ -86,7 +102,7 @@ def test_material_is_rejected_by_the_types_that_can_carry_many(tmp_path, part_ty
     package = _write_package(
         tmp_path,
         {
-            "body": _part(part_type, parameters=_material()),
+            "body": _part(part_type, parameters=_declare(name)),
             "sibling": _part("stl"),
         },
     )
@@ -101,14 +117,14 @@ def test_material_is_rejected_by_the_types_that_can_carry_many(tmp_path, part_ty
     # The object, the parameter and the type, and what is wrong with the three
     # of them together.
     assert "body" in reason
-    assert "material" in reason
+    assert name in reason
     assert part_type in reason
     assert "does not accept" in reason
 
 
 @pytest.mark.parametrize("part_type", REJECTING_TYPES)
 def test_asking_for_a_rejected_part_by_name_returns_none(tmp_path, part_type):
-    package = _write_package(tmp_path, {"body": _part(part_type, parameters=_material())})
+    package = _write_package(tmp_path, {"body": _part(part_type, parameters=_declare("material"))})
     ctx = pc.Context(str(package))
 
     assert ctx.get_part("//:body") is None
@@ -118,8 +134,8 @@ def test_asking_for_a_rejected_part_by_name_returns_none(tmp_path, part_type):
 def test_any_other_parameter_name_is_left_alone(tmp_path, part_type):
     """Only the policed names may ever be rejected; the rest stay arbitrary.
 
-    Including on the types that reject 'material' - what is restricted is the
-    one name PartCAD gives a meaning to, not the right to declare parameters.
+    Including on the types that reject them - what is restricted is the handful
+    of names PartCAD gives a meaning to, not the right to declare parameters.
     """
     pc.logging.reset_errors()
     package = _write_package(
@@ -134,36 +150,159 @@ def test_any_other_parameter_name_is_left_alone(tmp_path, part_type):
     assert pc.logging.had_errors is False
 
 
-def test_get_mcftt_still_reads_the_declared_material(tmp_path):
-    """The consumer of 'parameters.material' is unchanged by any of the above."""
-    package = _write_package(tmp_path, {"body": _part("stl", parameters=_material("//pub:brass"))})
+@pytest.mark.parametrize("part_type", ACCEPTING_TYPES + REJECTING_TYPES)
+def test_a_parameter_carrying_a_color_field_is_not_a_parameter_named_color(tmp_path, part_type):
+    """The schema lets any parameter carry 'color:' and 'material:' of its own.
 
-    part = pc.Context(str(package)).get_part("//:body")
-
-    assert asyncio.run(part.get_mcftt("material")) == "//pub:brass"
-
-
-def test_the_material_is_part_of_the_cache_key(tmp_path):
-    """Two parts alike but for their material are two shapes, not one.
-
-    'parameters' is what 'Shape.__init__' folds into the hash, and 'material'
-    only stays honest as a parameter for as long as that keeps being true: a
-    part made of brass must not be served out of the cache entry a part made of
-    steel wrote. Nothing else asserted this.
+    See 'shape-parameter' in partcad.json, and features/lint.feature, which
+    declares exactly this on a parameter called 'kind'. Those fields describe
+    what one *value* of that parameter looks like; what is policed is the
+    parameter's *name*. A type that rejects a parameter named 'color' must
+    still take a parameter of any other name that carries a 'color:' field.
     """
+    pc.logging.reset_errors()
     package = _write_package(
         tmp_path,
         {
-            "brass": _part("stl", path="body.stl", parameters=_material("//pub:brass")),
-            "steel": _part("stl", path="body.stl", parameters=_material("//pub:steel")),
-            "brass_again": _part("stl", path="body.stl", parameters=_material("//pub:brass")),
+            "body": _part(
+                part_type,
+                parameters={
+                    "kind": {
+                        "type": "string",
+                        "enum": ["X", "Y"],
+                        "default": "Y",
+                        "color": "#FF0000",
+                        "material": "steel",
+                    }
+                },
+            )
         },
     )
 
     project = pc.Context(str(package)).get_project("//")
-    keys = {name: project.parts[name].hash.get() for name in ["brass", "steel", "brass_again"]}
+
+    assert "body" in project.parts
+    assert project.get_broken_object_reason("part", "body") is None
+    assert pc.logging.had_errors is False
+
+
+@pytest.mark.parametrize("name", ["material", "color"])
+def test_get_mcftt_still_reads_the_declared_value(tmp_path, name):
+    """The consumer of these parameters is unchanged by any of the above."""
+    package = _write_package(tmp_path, {"body": _part("stl", parameters=_declare(name, "//pub:brass"))})
+
+    part = pc.Context(str(package)).get_part("//:body")
+
+    assert asyncio.run(part.get_mcftt(name)) == "//pub:brass"
+
+
+def test_a_declared_tolerance_reads_back_as_a_number(tmp_path):
+    package = _write_package(tmp_path, {"body": _part("stl", parameters=_declare("tolerance", 0.25))})
+
+    part = pc.Context(str(package)).get_part("//:body")
+
+    value = part.get_object_type_parameter("tolerance")
+    assert isinstance(value, float)
+    assert value == 0.25
+    # ...and get_mcftt, which reads the declaration as it stands, agrees.
+    assert asyncio.run(part.get_mcftt("tolerance")) == 0.25
+
+
+def test_an_undeclared_tolerance_reads_back_as_the_type_default(tmp_path):
+    package = _write_package(tmp_path, {"body": _part("stl")})
+
+    part = pc.Context(str(package)).get_part("//:body")
+
+    assert part.get_object_type_parameter("tolerance") == 0.0
+    # The names with no default stay absent instead of being invented.
+    assert part.get_object_type_parameter("material") is None
+    assert part.get_object_type_parameter("color") is None
+
+
+def test_a_type_that_accepts_no_tolerance_reports_none(tmp_path):
+    """Not 0.0: 'this type has no such parameter' and 'nobody set it' differ."""
+    package = _write_package(tmp_path, {"body": _part("step")})
+
+    part = pc.Context(str(package)).get_part("//:body")
+
+    assert part.get_object_type_parameter("tolerance") is None
+
+
+def test_a_non_numeric_tolerance_is_reported_and_falls_back(tmp_path):
+    """Reported and defaulted, the way an unknown manufacturing method is."""
+    pc.logging.reset_errors()
+    package = _write_package(tmp_path, {"body": _part("stl", parameters=_declare("tolerance", "quite tight"))})
+
+    part = pc.Context(str(package)).get_part("//:body")
+
+    assert part.get_object_type_parameter("tolerance") == 0.0
+    assert pc.logging.had_errors is True
+
+
+def test_reading_a_defaulted_tolerance_does_not_write_it_into_the_configuration(tmp_path):
+    """The default is applied on the way out, and only there.
+
+    'Shape.__init__' hashes config["parameters"] into the cache key, so writing
+    a default in would move the key of every homogeneous part that never
+    mentioned a tolerance - a mass invalidation for a value nobody set.
+    """
+    package = _write_package(tmp_path, {"body": _part("stl", parameters=_declare("material"))})
+
+    project = pc.Context(str(package)).get_project("//")
+    part = project.parts["body"]
+    before = part.hash.get()
+
+    assert part.get_object_type_parameter("tolerance") == 0.0
+
+    assert "tolerance" not in part.config["parameters"]
+    assert part.hash.get() == before
+
+
+def test_declaring_the_default_tolerance_is_not_the_same_as_not_declaring_it(tmp_path):
+    """Which is the other half of the proof that nothing is injected.
+
+    An explicit 'tolerance: 0.0' is an input like any other and keys the cache;
+    an absent one is absent. If the default were written into the configuration
+    the two would collapse into one key.
+    """
+    package = _write_package(
+        tmp_path,
+        {
+            "silent": _part("stl", path="body.stl"),
+            "explicit": _part("stl", path="body.stl", parameters=_declare("tolerance", 0.0)),
+        },
+    )
+
+    project = pc.Context(str(package)).get_project("//")
+    keys = {name: project.parts[name].hash.get() for name in ["silent", "explicit"]}
 
     assert None not in keys.values()
-    assert keys["brass"] != keys["steel"]
+    assert keys["silent"] != keys["explicit"]
+
+
+@pytest.mark.parametrize("name", POLICED)
+def test_a_policed_parameter_is_part_of_the_cache_key(tmp_path, name):
+    """Two parts alike but for one of these are two shapes, not one.
+
+    'parameters' is what 'Shape.__init__' folds into the hash, and these only
+    stay honest as parameters for as long as that keeps being true: a part made
+    of brass must not be served out of the cache entry a part made of steel
+    wrote. Nothing else asserted this.
+    """
+    one, other = (0.1, 0.2) if name == "tolerance" else ("brass", "steel")
+    package = _write_package(
+        tmp_path,
+        {
+            "first": _part("stl", path="body.stl", parameters=_declare(name, one)),
+            "second": _part("stl", path="body.stl", parameters=_declare(name, other)),
+            "first_again": _part("stl", path="body.stl", parameters=_declare(name, one)),
+        },
+    )
+
+    project = pc.Context(str(package)).get_project("//")
+    keys = {n: project.parts[n].hash.get() for n in ["first", "second", "first_again"]}
+
+    assert None not in keys.values()
+    assert keys["first"] != keys["second"]
     # ...and the name is not what made them differ.
-    assert keys["brass"] == keys["brass_again"]
+    assert keys["first"] == keys["first_again"]

--- a/partcad/tests/unit/test_object_type_parameters.py
+++ b/partcad/tests/unit/test_object_type_parameters.py
@@ -1,0 +1,169 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""'material' is contributed by the part type, not invented by the part.
+
+Parameters are otherwise the object's own business: the schema takes any name
+matching its pattern, and nothing but the script behind the part knows what one
+means. 'material' is different - PartCAD itself acts on it, in the
+manufacturing and quoting path - so it only means anything on a type that can
+honour it, and the types that can are the ones producing a single homogeneous
+body. Declaring it anywhere else is a per-object error: the package keeps
+loading, that one part does not.
+"""
+
+import asyncio
+
+import pytest
+import yaml
+
+import partcad as pc
+
+ACCEPTING_TYPES = ["stl", "cadquery", "build123d", "sdf", "extrude"]
+REJECTING_TYPES = ["step", "kicad"]
+
+
+def _write_package(tmp_path, parts):
+    """A package of the given parts, with every source file they need on disk.
+
+    The files are never opened here - none of these tests instantiates a shape -
+    but the file-backed factories check that the path exists before they will
+    create the part at all, so an empty file is enough and is what keeps these
+    tests free of a CAD kernel.
+    """
+    config = {
+        "name": "//test",
+        "sketches": {"circle": {"type": "basic", "circle": 10.0}},
+        "parts": parts,
+    }
+    (tmp_path / "partcad.yaml").write_text(yaml.safe_dump(config))
+    for extension in [".stl", ".py", ".step"]:
+        for name in parts:
+            (tmp_path / (name + extension)).write_text("")
+            path = parts[name].get("path")
+            if path:
+                (tmp_path / path).write_text("")
+    return tmp_path
+
+
+def _part(part_type, **extra):
+    config = {"type": part_type}
+    if part_type == "extrude":
+        config["sketch"] = "circle"
+        config["depth"] = 10.0
+    config.update(extra)
+    return config
+
+
+def _material(value="//pub/std/manufacturing/material/plastic:pla"):
+    return {"material": {"type": "string", "default": value}}
+
+
+@pytest.mark.parametrize("part_type", ACCEPTING_TYPES)
+def test_material_is_accepted_by_the_homogeneous_types(tmp_path, part_type):
+    """One body of one thing, so one 'material:' can be true of the whole part."""
+    pc.logging.reset_errors()
+    package = _write_package(tmp_path, {"body": _part(part_type, parameters=_material())})
+
+    project = pc.Context(str(package)).get_project("//")
+
+    assert "body" in project.parts
+    assert project.get_broken_object_reason("part", "body") is None
+    assert pc.logging.had_errors is False
+
+
+@pytest.mark.parametrize("part_type", REJECTING_TYPES)
+def test_material_is_rejected_by_the_types_that_can_carry_many(tmp_path, part_type):
+    """A STEP file may hold many solids, each already stating its own material.
+
+    Per object, not per package: the sibling part is declared after the bad one
+    and still has to load, and the command still has to report a failure.
+    """
+    pc.logging.reset_errors()
+    package = _write_package(
+        tmp_path,
+        {
+            "body": _part(part_type, parameters=_material()),
+            "sibling": _part("stl"),
+        },
+    )
+
+    project = pc.Context(str(package)).get_project("//")
+
+    assert "body" not in project.parts
+    assert "sibling" in project.parts
+    assert pc.logging.had_errors is True
+
+    reason = project.get_broken_object_reason("part", "body")
+    # The object, the parameter and the type, and what is wrong with the three
+    # of them together.
+    assert "body" in reason
+    assert "material" in reason
+    assert part_type in reason
+    assert "does not accept" in reason
+
+
+@pytest.mark.parametrize("part_type", REJECTING_TYPES)
+def test_asking_for_a_rejected_part_by_name_returns_none(tmp_path, part_type):
+    package = _write_package(tmp_path, {"body": _part(part_type, parameters=_material())})
+    ctx = pc.Context(str(package))
+
+    assert ctx.get_part("//:body") is None
+
+
+@pytest.mark.parametrize("part_type", ACCEPTING_TYPES + REJECTING_TYPES)
+def test_any_other_parameter_name_is_left_alone(tmp_path, part_type):
+    """Only the policed names may ever be rejected; the rest stay arbitrary.
+
+    Including on the types that reject 'material' - what is restricted is the
+    one name PartCAD gives a meaning to, not the right to declare parameters.
+    """
+    pc.logging.reset_errors()
+    package = _write_package(
+        tmp_path,
+        {"body": _part(part_type, parameters={"width": {"type": "float", "default": 1.0}})},
+    )
+
+    project = pc.Context(str(package)).get_project("//")
+
+    assert "body" in project.parts
+    assert project.get_broken_object_reason("part", "body") is None
+    assert pc.logging.had_errors is False
+
+
+def test_get_mcftt_still_reads_the_declared_material(tmp_path):
+    """The consumer of 'parameters.material' is unchanged by any of the above."""
+    package = _write_package(tmp_path, {"body": _part("stl", parameters=_material("//pub:brass"))})
+
+    part = pc.Context(str(package)).get_part("//:body")
+
+    assert asyncio.run(part.get_mcftt("material")) == "//pub:brass"
+
+
+def test_the_material_is_part_of_the_cache_key(tmp_path):
+    """Two parts alike but for their material are two shapes, not one.
+
+    'parameters' is what 'Shape.__init__' folds into the hash, and 'material'
+    only stays honest as a parameter for as long as that keeps being true: a
+    part made of brass must not be served out of the cache entry a part made of
+    steel wrote. Nothing else asserted this.
+    """
+    package = _write_package(
+        tmp_path,
+        {
+            "brass": _part("stl", path="body.stl", parameters=_material("//pub:brass")),
+            "steel": _part("stl", path="body.stl", parameters=_material("//pub:steel")),
+            "brass_again": _part("stl", path="body.stl", parameters=_material("//pub:brass")),
+        },
+    )
+
+    project = pc.Context(str(package)).get_project("//")
+    keys = {name: project.parts[name].hash.get() for name in ["brass", "steel", "brass_again"]}
+
+    assert None not in keys.values()
+    assert keys["brass"] != keys["steel"]
+    # ...and the name is not what made them differ.
+    assert keys["brass"] == keys["brass_again"]

--- a/partcad/tests/unit/test_wrapper_object_type_parameters.py
+++ b/partcad/tests/unit/test_wrapper_object_type_parameters.py
@@ -1,0 +1,195 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""An object-type parameter the script has no use for must not break the build.
+
+CQGI is strict about build parameters: a name the script does not assign at top
+level is a name nobody will ever read, which is almost always a typo, so it
+raises. That is right for a parameter the author of the part invented, and wrong
+for one the part's *type* contributed - a part can be obliged to declare a
+tolerance ('pc test' requires one of anything manufactured) while the script
+that builds its geometry has no interest in it.
+
+So the factory tells the wrapper which names came from the type, and the wrapper
+drops those - and only those - when the script does not declare them. A name the
+script does declare is still passed through, and everything else stays strict.
+
+What runs here: the factory's side of the request, and the filtering at the CQGI
+boundary, including that the strict setter accepts what the filter produced.
+Actually executing a script needs CadQuery and a CAD kernel, which this
+environment does not have; that half is covered by the existing script-building
+tests in CI.
+"""
+
+import asyncio
+import importlib.util
+import os
+
+import pytest
+import yaml
+
+import partcad as pc
+import partcad.wrapper
+from partcad import shape_envelope
+from partcad.part_factory_build123d import PartFactoryBuild123d
+from partcad.part_factory_cadquery import PartFactoryCadquery
+from partcad.part_factory_python import PartFactoryPython
+from partcad.part_factory_step import PartFactoryStep
+
+OBJECT_TYPE_PARAMETERS = ["color", "material", "tolerance"]
+
+
+def _load_wrapper_module(name):
+    """Import a wrapper-side module the way the sandbox does: by path.
+
+    'wrappers/' is not a package - the sandbox puts the directory on sys.path
+    and imports the scripts by name - so there is nothing to import normally.
+    'custom_cqgi' is pure AST work and pulls in no CAD library, which is what
+    makes the filtering testable outside a sandbox at all.
+    """
+    directory = os.path.dirname(partcad.wrapper.get("cadquery.py"))
+    spec = importlib.util.spec_from_file_location(name, os.path.join(directory, name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+custom_cqgi = _load_wrapper_module("custom_cqgi")
+
+
+# ---------------------------------------------------------------- factory side
+
+
+class _Stop(Exception):
+    """Raised from the serializer to stop 'instantiate()' once the request exists."""
+
+
+def _captured_request(monkeypatch, tmp_path, part_type):
+    """The request the factory would send, without provisioning a sandbox.
+
+    'prepare_python()' is stubbed because it installs into a sandbox, and the
+    serializer is stubbed to capture the request and stop right there - which is
+    as far as this test needs the real code path to run, and no further.
+    """
+    (tmp_path / "body.py").write_text("width = 1.0\nshow_object(None)\n")
+    (tmp_path / "partcad.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "//test",
+                "parts": {
+                    "body": {
+                        "type": part_type,
+                        "path": "body.py",
+                        "parameters": {
+                            "width": {"type": "float", "default": 2.0},
+                            "tolerance": {"type": "float", "default": 0.1},
+                        },
+                    }
+                },
+            }
+        )
+    )
+
+    captured = {}
+
+    async def no_sandbox(self):
+        return None
+
+    def capture(obj, *args, **kwargs):
+        captured["request"] = obj
+        raise _Stop()
+
+    monkeypatch.setattr(PartFactoryPython, "prepare_python", no_sandbox)
+    monkeypatch.setattr(shape_envelope, "serialize", capture)
+
+    part = pc.Context(str(tmp_path)).get_part("//:body")
+    with pytest.raises(_Stop):
+        asyncio.run(part.instantiate(part))
+    return captured["request"]
+
+
+@pytest.mark.parametrize("part_type", ["cadquery", "build123d"])
+def test_the_request_names_what_the_type_contributed(monkeypatch, tmp_path, part_type):
+    """Which is what lets the wrapper tell those names from the part's own."""
+    request = _captured_request(monkeypatch, tmp_path, part_type)
+
+    # Every declared parameter is still passed to the script, as before.
+    assert request["build_parameters"] == {"width": 2.0, "tolerance": 0.1}
+    # ...and the type's own names travel beside them.
+    assert request["object_type_parameters"] == OBJECT_TYPE_PARAMETERS
+
+
+@pytest.mark.parametrize(
+    "factory, expected",
+    [
+        (PartFactoryCadquery, OBJECT_TYPE_PARAMETERS),
+        (PartFactoryBuild123d, OBJECT_TYPE_PARAMETERS),
+        # A type that contributes nothing offers nothing, which leaves a wrapper
+        # exactly as strict as it was.
+        (PartFactoryStep, []),
+    ],
+)
+def test_the_names_come_from_the_part_type(factory, expected):
+    """Read off the class, so there is no second list to drift from it."""
+    assert factory.object_type_parameter_names(factory) == expected
+
+
+# ------------------------------------------------------------ wrapper/CQGI side
+
+
+def _filter(script, params, optional=OBJECT_TYPE_PARAMETERS):
+    model = custom_cqgi.parse(script)
+    return model, custom_cqgi.filter_optional_params(model, params, optional)
+
+
+def test_an_object_type_parameter_the_script_ignores_is_dropped():
+    """The failure this whole change is about: the script never wanted it."""
+    model, filtered = _filter("width = 1.0\n", {"width": 2.0, "tolerance": 0.1})
+
+    assert filtered == {"width": 2.0}
+    # And the strict setter, which used to raise here, is now content.
+    model.set_param_values(filtered)
+
+
+def test_an_object_type_parameter_the_script_declares_is_still_passed():
+    """The pass-through is the point; the fix must not have removed it."""
+    model, filtered = _filter(
+        "width = 1.0\nmaterial = 'steel'\n",
+        {"width": 2.0, "material": "brass", "tolerance": 0.1},
+    )
+
+    assert filtered == {"width": 2.0, "material": "brass"}
+    model.set_param_values(filtered)
+
+
+def test_a_typo_in_an_ordinary_parameter_still_raises():
+    """The guard that the fix did not simply disable the check."""
+    model, filtered = _filter("width = 1.0\n", {"widht": 2.0})
+
+    assert filtered == {"widht": 2.0}
+    with pytest.raises(custom_cqgi.InvalidParameterError):
+        model.set_param_values(filtered)
+
+
+def test_a_typo_in_an_object_type_parameter_name_is_not_privileged():
+    """Only the exact names the type contributed are forgiven."""
+    model, filtered = _filter("width = 1.0\n", {"matrial": "brass"})
+
+    assert filtered == {"matrial": "brass"}
+    with pytest.raises(custom_cqgi.InvalidParameterError):
+        model.set_param_values(filtered)
+
+
+def test_a_request_that_names_nothing_leaves_everything_strict():
+    """What a sketch gets: its types contribute no object-type parameters.
+
+    The key is absent from the request altogether, so the wrapper passes None.
+    """
+    model, filtered = _filter("width = 1.0\n", {"tolerance": 0.1}, optional=None)
+
+    assert filtered == {"tolerance": 0.1}
+    with pytest.raises(custom_cqgi.InvalidParameterError):
+        model.set_param_values(filtered)


### PR DESCRIPTION
`material` and `color` have been declarable as parameters on every part type, including the types where they cannot mean anything. This introduces **object-type parameters** — the parameters an object *type* contributes, rather than the part's author declaring them from nothing — covering `material`, `color` and a new numeric `tolerance`.

Nothing about how these are read changes. `ShapeConfiguration.get_mcftt()` still reads `config["parameters"][name]["default"]`, and the manufacturing/quoting path still consumes it through `plugin_provider_data_cart.set_spec()`. `properties.material` from #534 is untouched and still means the other thing: what the instantiated shape reports, as opposed to what was asked of the type. What is new is who may declare these, that one of them has a default, that a manufactured part must now state a tolerance, and that a script is no longer obliged to use one it is handed.

## Which types, and why

The axis is whether the part is a single homogeneous body, since that is what decides whether one value can be true of the whole part — one material, one colour, one manufacturing tolerance. A mesh is one body with nothing inside it to vary. A solid a script builds is one modelling session's result. An extrusion of one sketch is the same case. A STEP file is not: it can carry many solids, each already stating its own material, so naming one for the file would be a worse claim than the file itself makes.

`PartFactoryHomogen` is mixed into `PartFactoryStl` and `PartFactoryPython` (giving cadquery, build123d and sdf through their base), and into `PartFactoryExtrude`. `step` — and `kicad`, which inherits `PartFactoryStep` — do not mix it in and now reject all three. Every other type defaults to not accepting, which is deliberate: whether each should is undecided, and defaulting to "no" leaves that decision open where defaulting to "yes" would silently make it.

`extrude` is beyond the originally discussed list because `examples/provider_manufacturer/partcad.yaml` ships a `type: extrude` part declaring both `material` and `color` — it is the example the quoting path exists for. Excluding it would have made PartCAD reject its own shipped example, and by the design's own discriminator one sketch swept into one solid is homogeneous.

## Shape of the change

Two class-level members on `PartFactory`, so the mechanism is not welded to the parameters that exist today:

- `POLICED_OBJECT_TYPE_PARAMETERS` — a set of the names that may ever be rejected: `material`, `color`, `tolerance`. Parameters are otherwise arbitrary, so any name outside this registry stays free on every type.
- `ACCEPTED_OBJECT_TYPE_PARAMETERS` — a **name→default mapping** of what this factory accepts. Empty on the base. `PartFactoryHomogen` sets `material` and `color` to a `NO_DEFAULT` sentinel (a part either was declared to be made of something or was not) and `tolerance` to `0.0`.

A parameter **named** `color` and a parameter **carrying** a `color:` field are different things — `shape-parameter` lets any parameter carry its own `color:` and `material:` keys, and `features/lint.feature:100-111` does exactly that. The check iterates parameter names only and never looks inside a definition; a test pins this across all seven types, including the rejecting ones.

`PartFactoryHomogen` carries no `__init__` on purpose. It is mixed in ahead of a factory's real base, and a constructor there would sit in the middle of the diamond and have to forward every base's signature; with none, attribute lookup walks straight past it.

The check runs from `PartFactory.__init__`, **not** from `post_create()`. `_create()` registers the part in `target_project.parts` before calling `post_create()`, so raising from there would file the object as broken while still holding a fully registered, buildable part under the same name — reported but not enforced.

Violations raise `factory.ObjectTypeParameterException`, alongside the existing `UnknownTypeException`/`RetiredTypeException`, and are caught by the same handlers in `Project.init_objects()` / `Project.get_object()` and filed by `record_broken_object()`. It logs as an error, so the CLI exits non-zero, while the package and its sibling parts keep loading.

## The tolerance default is applied at read time, never injected

New `ShapeConfiguration.get_object_type_parameter()` applies the type's default when the parameter is absent. Nothing is written into `config["parameters"]`.

That is deliberate and load-bearing. `Shape.__init__` hashes `config["parameters"]`, so injecting a default would change the cache key of every homogeneous part that declares no tolerance — a mass invalidation of existing entries for a value nobody set. Measured directly on the same STL part, once with `partcad/src` stashed and once restored: cache key `e323f06f12075d914129d5c250c58bef` both times. Two tests pin it, including one asserting that an explicit `tolerance: 0.0` gets a *different* key from silence — if the default were injected, those two would collapse into one.

A numeric default makes the parameter numeric. A non-coercible declaration is logged at error level (so the CLI exits non-zero) and the default is used, mirroring how `PartConfigManufacturing` handles an unrecognized method.

## `pc test` now requires a tolerance on manufactured parts

`CamTest.tolerance_failure()` sits beside `supply_failure()` in `partcad/src/partcad/test/cam.py` — the other "why can this not be manufactured" question that test already asks. It is not a sibling test class because the siblings each gate on one `manufacturing.method` and check geometry, while a tolerance applies however a part is made, and the check needs the purchased-vs-manufactured determination `test_part` has just computed.

Both `tolerance == 0.0` and `tolerance is None` (a type that cannot carry one) fail, with different messages. Purchased parts are exempt — a bought part comes as it comes. Parts reached through an assembly are covered with no new code: `test_assembly` already walks `get_supply_bom()` and runs every test over each entry, and a test proves an assembly whose part has no tolerance fails.

**This is a behaviour change for existing packages.** Any package with manufactured parts that never declared a tolerance will start failing `pc test`. `examples/provider_manufacturer` gains `tolerance: 0.1` on its cylinder for exactly that reason — it is the only shipped part that is actually manufactured, and without it the example PartCAD ships would fail the check PartCAD ships.

## A script is not obliged to use what its type contributes

CQGI is strict by design: `custom_cqgi.set_param_values()` raises `InvalidParameterError` for a build parameter that is not a top-level assignment in the script, because such a name is one nobody will ever read and is almost always a typo. That collided with the requirement above — a part can now be *obliged* to declare a tolerance while the script that builds its geometry has no use for it.

The part type now tells the wrapper which names it contributed (`request["object_type_parameters"]`, from `PartFactory.object_type_parameter_names()`), and `custom_cqgi.filter_optional_params()` drops one **only** when it is in that list *and* the parsed script has no top-level assignment for it. A script that does assign `material` still receives its value, which is the point of passing them through.

`set_param_values()` itself is byte-for-byte unchanged, and everything else stays strict: a typo'd ordinary parameter still raises, and so does a typo *of* an object-type name (`matrial` is not an exact match). An absent or empty list leaves behaviour bit-identical — which is what sketches get.

Only `wrapper_cadquery.py` and `wrapper_build123d.py` needed it. `wrapper_sdf.py` also parses through CQGI, but at lines 94-99 it strips each build parameter's own assignment and prepends `name = repr(value)`, so every one of them is already a declared top-level parameter by the time CQGI sees the script. `extrude` forwards no parameters and `stl` has no script.

The filter is a module-level function in `custom_cqgi.py` rather than `wrapper_common.py` for a practical reason as well as a tidiness one: `custom_cqgi.py` imports only `sys`/`ast`/`traceback`/`time`, while `wrapper_common.py` pulls in OCP — so the filtering and CQGI's strictness are testable without a CAD kernel. `custom_cqgi.py` is a vendored CadQuery file; the addition is marked as such and the vendored classes are untouched.

## Tests

67 cases across `test_object_type_parameters.py`, `test_cam_tolerance.py` and `test_wrapper_object_type_parameters.py`. **26 fail against pre-change code; all 67 pass after.** The rest are regression guards that must not start failing.

Among them, an invariant nothing enforced before: two otherwise-identical parts differing only in a policed parameter get **different cache keys**. `Shape.__init__` already hashed `parameters`, so this was true — it just had nothing holding it true. It is what makes the model correct: inputs key the cache, outputs sit beside it.

Two coverage caveats stated rather than glossed. The "did not disable the check" guards fail pre-change only mechanically, because the new function does not exist yet — their value is as post-change guards. And `CQModel.build()` never runs here, so "the part builds and the script executes" is not covered locally; that is exercised in CI by the existing `test_part_example_cadquery_primitive` / `test_part_example_build123d_primitive`. What is proven locally is the boundary either side of it: the request the real factory builds, and that the real strict setter accepts exactly what the filter produced while still rejecting everything else. The assembly test stubs `get_supply_bom()`, whose real implementation needs a CAD kernel.

## Validation

Unit suite, baseline with `partcad/src` (and `examples`, for the CAM commit) stashed: failures fall from 223 to 207 across the three commits, passes rise correspondingly, errors unchanged at 39. Sorted id diffs show only new tests appearing and **zero new failures** at each step. Other components identical before and after.

`sphinx-build -n -W` with the workflow's exact flags: succeeded, zero warnings, no headings moved.

Host tooling, not the pinned container toolchain — Docker is unavailable in the authoring environment. `black --check` flags three files, all of which were already in that state on `devel` (an over-long `pc_logging.debug` line in each of two factories, and the vendored CQGI file broadly); no line added here is touched by `black --diff`, and no unrelated code was reformatted. `behave` was not run. Packages outside this repo were not surveyed for `material`, `color` or `tolerance` declared on rejecting types.