### PR TITLE
fix(sandbox): decide the sandbox interpreter from the pins, not from the host

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,28 @@ env:
   #    because that is the version most contributors and most users are on.
   OSES_DEEP_ONLY: '["ubuntu-22.04", "ubuntu-22.04-arm", "macos-26"]'
   PYTHONS: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+  # The two ends of the range a *sandbox* can be built at:
+  # sandbox_versions.MIN_PYTHON_VERSION_CADQUERY and MAX_PYTHON_VERSION_CAD.
+  # Keep them in step with those constants.
+  #
+  # This is a different axis from PYTHONS above, which is the range PartCAD
+  # itself is supported on. The two used to be the same thing by accident: a
+  # package that named no 'pythonVersion' was given the version of whatever
+  # interpreter PartCAD was running on, so a matrix leg's Python decided its
+  # sandbox's Python too. It no longer does - a sandbox is built at the version
+  # PartCAD pins - so for the jobs whose subject is the sandbox, running five
+  # host Pythons now builds the same sandbox five times over. They run these
+  # two instead, which are the versions a sandbox can actually come out at.
+  #
+  # Jobs whose subject is PartCAD rather than the sandbox keep the full range:
+  # 'test-pytest' exercises PartCAD's own code on each interpreter, and
+  # 'test-examples-all' is the broad feature sweep.
+  #
+  # NOT filtered by EXCLUDES, deliberately. That list encodes "every image but
+  # ubuntu-latest runs the oldest and the newest Python only", which for this
+  # two-entry list would drop 3.11 everywhere else and leave a single version -
+  # the opposite of testing both bounds.
+  PYTHONS_SANDBOX: '["3.11", "3.14"]'
   # Number of parallel shards the behave suite is split into. Keep in sync with
   # the "shard" list in the set-matrix job's matrix-behave output.
   BEHAVE_SHARDS: 4
@@ -100,13 +122,17 @@ env:
     {"os": "macos-26", "python-version": "3.12"},
     {"os": "macos-26", "python-version": "3.13"}]
   # The sharded 'test-behave' jobs and 'test-pub-repo' (45 min) are by far the
-  # most expensive, so they get a reduced matrix: the '*-latest' images only, on
-  # the oldest and the newest supported Python. Behave then shards each of those
-  # BEHAVE_SHARDS ways. Linux arm64 is deliberately not here: it is covered by
-  # 'test-pytest' and both 'test-examples-*' jobs above, which is what would
-  # catch an architecture specific breakage, and adding it here would multiply
-  # the most expensive jobs in the workflow by BEHAVE_SHARDS.
+  # most expensive, so they get a reduced OS axis: the '*-latest' images only.
+  # Behave then shards each of those BEHAVE_SHARDS ways. Linux arm64 is
+  # deliberately not here: it is covered by 'test-pytest' and both
+  # 'test-examples-*' jobs above, which is what would catch an architecture
+  # specific breakage, and adding it here would multiply the most expensive jobs
+  # in the workflow by BEHAVE_SHARDS.
   OSES_SLIM: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+  # Behave's Python axis: the oldest and the newest PartCAD is supported on.
+  # Behave drives the command line rather than the sandbox, so what matters here
+  # is the interpreter PartCAD itself runs on. 'test-pub-repo', which renders
+  # the public index, uses PYTHONS_SANDBOX instead.
   PYTHONS_SLIM: '["3.10", "3.14"]'
   # The VS Code extension pytest job builds the extension bundle, which vendors
   # partcad's dependencies into 'bundled/libs' with 'pip install --implementation
@@ -162,6 +188,7 @@ jobs:
     if: ${{ github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix-sandbox: ${{ steps.set-matrix.outputs.matrix-sandbox }}
       matrix-slim: ${{ steps.set-matrix.outputs.matrix-slim }}
       matrix-behave: ${{ steps.set-matrix.outputs.matrix-behave }}
       matrix-ide: ${{ steps.set-matrix.outputs.matrix-ide }}
@@ -191,7 +218,14 @@ jobs:
           # simply matches nothing -- and keeps one list to maintain rather than
           # two that have to agree.
           echo 'matrix={"os": '"${OSES}"', "python-version": ${{ env.PYTHONS }}, "exclude": ${{ env.EXCLUDES }}}' >> "${GITHUB_OUTPUT}"
-          echo 'matrix-slim={"os": ${{ env.OSES_SLIM }}, "python-version": ${{ env.PYTHONS_SLIM }}}' >> "${GITHUB_OUTPUT}"
+          # The same OS axis as 'matrix', so it follows the depth too, but the
+          # two versions a sandbox can be built at rather than every version
+          # PartCAD runs on -- and no excludes, which would leave only one of
+          # the two on every image but ubuntu-latest. See PYTHONS_SANDBOX above.
+          echo 'matrix-sandbox={"os": '"${OSES}"', "python-version": ${{ env.PYTHONS_SANDBOX }}}' >> "${GITHUB_OUTPUT}"
+          # 'test-pub-repo' renders the public index, so its subject is the
+          # sandbox as well; only its OS axis is the reduced one.
+          echo 'matrix-slim={"os": ${{ env.OSES_SLIM }}, "python-version": ${{ env.PYTHONS_SANDBOX }}}' >> "${GITHUB_OUTPUT}"
           # Behave is single-process and dominates CI wall-clock, so it runs
           # sharded across parallel jobs. The "shard" axis is derived from
           # BEHAVE_SHARDS (1..N) here, so the number of behave jobs can never
@@ -450,7 +484,11 @@ jobs:
       # - cache-preheat
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
+      # The sandbox matrix: this job renders every part type this repository
+      # defines, so what it is really testing is sandbox provisioning, and a
+      # sandbox no longer varies with the interpreter PartCAD runs on. See
+      # PYTHONS_SANDBOX above.
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix-sandbox) }}
     runs-on: ${{ matrix.os }}
     # 30 -> 75: this job renders the examples, so it populates sandboxes harder
     # than "Examples (All)" and felt the larger OCP 7.9 install the most; the SDF

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -49,7 +49,7 @@ Besides the package properties and, optionally, a list of imported dependencies,
   url: <(optional) package or maintainer's url>
   poc: <(optional) point of contact, maintainer's email>
   partcad: <(optional) required PartCAD version spec string>
-  pythonVersion: <(optional) python version for sandboxing if applicable>
+  pythonVersion: <(optional) python version for sandboxing if applicable; defaults to the version PartCAD pins, not the one it runs on>
   pythonRequirements: <(python scripts only) the list of dependencies to install>
   javascriptVersion: <(optional) Node.js major version for sandboxing if applicable>
   javascriptRequirements: <(JavaScript scripts only) the list of npm dependencies to install>

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -665,6 +665,14 @@ bundle or the snap, or anything else where an older OS version could behave diff
 The ``Standalone`` workflow reads the same marker: without it, a pull request builds five of the eight
 standalone bundles. A release always builds all eight and refuses to publish if any is missing.
 
+The Python axis is not the same for every job, because not every job is testing the same thing. ``Pytest`` and
+``Examples (All)`` run the whole supported range: they exercise PartCAD's own code, so the interpreter it runs
+on is the point. ``Examples (PartCAD)`` and ``Repo //pub`` render packages, so what they are really testing is
+the sandbox -- and a sandbox is built at the version PartCAD pins rather than at the version PartCAD is running
+on, so they run the two ends of the range a sandbox can be built at instead
+(``sandbox_versions.MIN_PYTHON_VERSION_CADQUERY`` and ``MAX_PYTHON_VERSION_CAD``). ``Behave`` drives the command
+line, so it stays on the oldest and newest supported Python.
+
 Implementation Details
 ----------------------
 

--- a/features/add/dependency.feature
+++ b/features/add/dependency.feature
@@ -31,7 +31,6 @@ Feature: `pc add dep` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
         OpenVMP-robots:

--- a/features/add/part.feature
+++ b/features/add/part.feature
@@ -10,7 +10,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should be created with content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -31,7 +30,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -79,7 +77,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -101,7 +98,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -123,7 +119,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -144,7 +139,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -173,7 +167,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -194,7 +187,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -283,7 +275,6 @@ Feature: `pc add part` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -307,7 +298,6 @@ Scenario: Add OBJ Part from "model.obj" file
   And a file named "partcad.yaml" should have YAML content:
     """
     private: true
-    pythonVersion: ">=\\d+\\.\\d+"
     partcad: ">=\\d+\\.\\d+\\.\\d+"
     dependencies:
     sketches:

--- a/features/add/sketch.feature
+++ b/features/add/sketch.feature
@@ -10,7 +10,6 @@ Feature: `pc add sketch` command
     And a file named "partcad.yaml" should be created with content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -77,7 +76,6 @@ Feature: `pc add sketch` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -101,7 +99,6 @@ Feature: `pc add sketch` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -162,7 +159,6 @@ Feature: `pc add sketch` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:
@@ -183,7 +179,6 @@ Feature: `pc add sketch` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:

--- a/features/init.feature
+++ b/features/init.feature
@@ -13,7 +13,6 @@ Feature: `pc init` command
     And STDERR should not contain "PartCAD configuration file is not found"
     And a file named "partcad.yaml" should have YAML content:
       """
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
         pub:
@@ -33,7 +32,6 @@ Feature: `pc init` command
     And a file named "partcad.yaml" should have YAML content:
       """
       private: true
-      pythonVersion: ">=\\d+\\.\\d+"
       partcad: ">=\\d+\\.\\d+\\.\\d+"
       dependencies:
       sketches:

--- a/partcad-cli/src/partcad_cli/click/commands/init.py
+++ b/partcad-cli/src/partcad_cli/click/commands/init.py
@@ -9,7 +9,6 @@
 #
 
 import os
-import sys
 
 import rich_click as click
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
@@ -100,16 +99,6 @@ class DynamicPromptOption(click.Option):
     cls=DynamicPromptOption,
     help="Required PartCAD version spec string",
     prompt="Enter the required PartCAD version spec string",
-    show_envvar=True,
-)
-@click.option(
-    "-pyv",
-    "--python-version",
-    type=str,
-    default=f'>={".".join(map(str, list(sys.version_info)[:2]))}',
-    cls=DynamicPromptOption,
-    help="Python version for sandboxing if applicable",
-    prompt="Enter the python version for sandboxing (if applicable)",
     show_envvar=True,
 )
 @click.option(

--- a/partcad/src/partcad/context.py
+++ b/partcad/src/partcad/context.py
@@ -145,6 +145,9 @@ class Context:
         self.option_create_dirs = False
         self.runtimes_python = {}
         self.runtimes_python_lock = threading.Lock()
+        # Python versions already reported as held down to MAX_PYTHON_VERSION_CAD,
+        # so the warning is said once rather than once per part.
+        self.python_versions_held = set()
         self.runtimes_javascript = {}
         self.runtimes_javascript_lock = threading.Lock()
 
@@ -1095,13 +1098,43 @@ class Context:
     def get_python_runtime(self, version=None, python_runtime=None):
         with self.runtimes_python_lock:
             if version is None:
-                version = "%d.%d" % (
-                    sys.version_info.major,
-                    sys.version_info.minor,
-                )
+                version = sandbox_versions.DEFAULT_PYTHON_VERSION
             # A version like 3.11 declared in YAML arrives as a float; keep it a
             # string so the runtime name below can be built by concatenation.
             version = str(version)
+
+            # Every Python sandbox is given the CAD stack (see
+            # runtime_python.once), so the ceiling belongs here rather than in
+            # the handful of factories that happen to render with it: above it,
+            # pip finds no wheel for anything the sandbox is preloaded with and
+            # every part rendered in it dies on an import of something that was
+            # never installed. Held rather than refused, because a package
+            # asking for a Python newer than these pins is asking for something
+            # reasonable that PartCAD cannot supply yet, and the pins move.
+            #
+            # Only the ceiling. The floor is CadQuery's alone and stays with the
+            # factories that need CadQuery: a 3.10 sandbox is a perfectly good
+            # place to convert an STL.
+            requested = version
+            try:
+                version = sandbox_versions.at_most(version, sandbox_versions.MAX_PYTHON_VERSION_CAD)
+            except ValueError:
+                # The schema's 'pythonVersion' pattern permits a leading ">=",
+                # and 'pc init' writes ">=<the host's version>" into every new
+                # package, so a value that is not a plain "<major>.<minor>" is
+                # something a real package really does carry. It is already not
+                # a version this or the sandbox naming can reason about, and
+                # making the bound the thing that discovers that would turn a
+                # long-standing oddity into a crash. Pass it through untouched,
+                # exactly as before.
+                pass
+            if version != requested and requested not in self.python_versions_held:
+                self.python_versions_held.add(requested)
+                pc_logging.warning(
+                    "Python %s was asked for, but the CAD packages PartCAD pins are built for %s at the newest;"
+                    " using %s instead" % (requested, sandbox_versions.MAX_PYTHON_VERSION_CAD, version)
+                )
+
             if python_runtime is None:
                 python_runtime = self.user_config.python_sandbox
             runtime_name = python_runtime + "-" + version

--- a/partcad/src/partcad/project_config.py
+++ b/partcad/src/partcad/project_config.py
@@ -109,7 +109,7 @@ class Configuration:
         # option: "pythonVersion"
         # description: the version of python to use in sandboxed environments if any
         # values: string (e.g. "3.10")
-        # default: <The major and minor version of the current interpreter>
+        # default: sandbox_versions.DEFAULT_PYTHON_VERSION
         if "pythonVersion" in self.config_obj:
             python_version = self.config_obj["pythonVersion"]
             if not isinstance(python_version, str):
@@ -124,17 +124,26 @@ class Configuration:
                     python_version = "3.10"
             self.python_version = python_version
             # Kept apart from the resolved value below, because "this package
-            # asked for 3.13" and "nobody asked, so whatever interpreter PartCAD
-            # happens to run on" are different answers and one caller has to tell
-            # them apart: an output implementation runs on the interpreter the
-            # package that ships it asked for, and on a fixed default otherwise
-            # (see output.Implementation.python_version()).
+            # asked for 3.13" and "nobody asked, so it got the default" are
+            # different answers and one caller has to tell them apart: an output
+            # implementation runs on the interpreter the package that ships it
+            # asked for, and on a fixed default otherwise (see
+            # output.Implementation.python_version()).
             self.python_version_declared = python_version
         else:
-            self.python_version = "%d.%d" % (
-                sys.version_info.major,
-                sys.version_info.minor,
-            )
+            # NOT the interpreter PartCAD itself is running on, which is what
+            # this used to be. Nothing was gained by matching it: under 'conda'
+            # the sandbox is built from scratch at whatever version is asked
+            # for and the host interpreter is never reused, and under 'none'
+            # the version is ignored altogether (runtime_python_none takes
+            # whatever 'python' is on PATH). All it did was make the sandbox a
+            # property of how PartCAD happened to be installed - so the same
+            # package rendered on a different interpreter for each developer,
+            # changed under one of them when they upgraded their Python, and,
+            # in the standalone bundle, followed whatever Python the release
+            # was frozen with. Pinning it here makes a sandbox as reproducible
+            # as the stack that goes into it.
+            self.python_version = sandbox_versions.DEFAULT_PYTHON_VERSION
             self.python_version_declared = None
 
         # option: "javascriptVersion"

--- a/partcad/src/partcad/sandbox_versions.py
+++ b/partcad/src/partcad/sandbox_versions.py
@@ -188,6 +188,23 @@ DEFAULT_PYTHON_VERSION = "3.11"
 # still has to be rendered on 3.11.
 MIN_PYTHON_VERSION_CADQUERY = "3.11"
 
+# The newest Python the pinned CAD stack is built for. cadquery-ocp 7.9.3.1.1,
+# cadquery 2.8.0, build123d 0.11.1 and nlopt 2.11.0 publish cp310 through cp314
+# and nothing above; a sandbox newer than this has no wheel for pip to find, so
+# every script-defined part in it fails on an import of something that was never
+# installed.
+#
+# The ceiling this is applied as (see Context.get_python_runtime) is not a claim
+# about what PartCAD supports - it is what *these pins* are built for, and it
+# moves with them. The floor above is a different kind of thing: it belongs to
+# CadQuery alone, and is applied only by the factories that need CadQuery, since
+# an 'stl' part on a 3.10 sandbox is perfectly fine.
+#
+# Bump this together with PINNED_REQUIREMENTS, not separately. There is a test
+# that it stays at or above MIN_PYTHON_VERSION_CADQUERY, which is the only part
+# of "keep it honest" a test can check; the rest is reading the wheel lists.
+MAX_PYTHON_VERSION_CAD = "3.14"
+
 # The first Python CPython publishes a free-threaded ("no-GIL") build of, and so
 # the first for which conda-forge carries two ABI variants of one and the same
 # release. See python_abi_requirement() for why that has to be disambiguated.
@@ -228,6 +245,11 @@ def is_at_least(python_version: str, minimum: str) -> bool:
 def at_least(python_version: str, minimum: str) -> str:
     """Return the newer of two "<major>.<minor>" version strings."""
     return python_version if is_at_least(python_version, minimum) else minimum
+
+
+def at_most(python_version: str, maximum: str) -> str:
+    """Return the older of two "<major>.<minor>" version strings."""
+    return python_version if is_at_least(maximum, python_version) else maximum
 
 
 def zstd_requirement(python_version: str) -> str | None:

--- a/partcad/src/partcad/schema/partcad.json
+++ b/partcad/src/partcad/schema/partcad.json
@@ -427,7 +427,8 @@
     },
     "pythonVersion": {
       "type": "string",
-      "pattern": "^(>)?(=)?([0-9]+\\.)?[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+      "pattern": "^(>)?(=)?([0-9]+\\.)?[0-9]+\\.[0-9]+(\\.[0-9]+)?$",
+      "description": "The interpreter this package's sandboxes are built on. Defaults to the one PartCAD pins, not to the one PartCAD is running on, so a package renders on the same Python for everyone who opens it. A version newer than the CAD packages PartCAD pins are built for is held down to the newest that has wheels, and says so."
     },
     "pythonRequirements": {
       "type": "array",

--- a/partcad/tests/unit/test_sandbox_python_version.py
+++ b/partcad/tests/unit/test_sandbox_python_version.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Which interpreter a sandbox ends up on.
+
+Two halves of one question: what a package that names no Python gets, and what
+happens when the version asked for is one the pinned CAD stack has no wheels
+for. The first used to be decided by the interpreter PartCAD itself had been
+installed on, and the second had no answer at all - the version was passed
+through and every part rendered in that sandbox failed on an import of something
+pip had never managed to install.
+"""
+
+import pytest
+
+import partcad as pc
+from partcad import sandbox_versions
+from partcad.project_config import Configuration
+from partcad.user_config import UserConfig
+
+
+def test_a_package_that_names_no_python_gets_the_pinned_one(tmp_path):
+    """Not the one PartCAD is running on, which is what this used to be.
+
+    Matching the host bought nothing - a conda sandbox is built from scratch at
+    whatever version is asked for, and a 'none' sandbox ignores the version
+    entirely - while making the sandbox a property of how PartCAD happened to be
+    installed.
+    """
+    config = Configuration("test", str(tmp_path), config_obj={})
+    assert config.python_version == sandbox_versions.DEFAULT_PYTHON_VERSION
+
+
+def test_a_package_that_names_a_python_keeps_it(tmp_path):
+    config = Configuration("test", str(tmp_path), config_obj={"pythonVersion": "3.12"})
+    assert config.python_version == "3.12"
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    """A context whose sandboxes are the host interpreter, so none get built.
+
+    get_python_runtime() only constructs the runtime object; the sandbox itself
+    is not provisioned until something renders in it.
+    """
+    (tmp_path / "partcad.yaml").write_text("desc: which interpreter\n")
+    user_config = UserConfig()
+    user_config.set("python_sandbox", "none")
+    return pc.Context(str(tmp_path), search_root=False, user_config=user_config)
+
+
+def test_a_python_newer_than_the_pins_is_held_down(ctx):
+    """Every sandbox is preloaded with the CAD stack, so every sandbox is bounded."""
+    assert ctx.get_python_runtime("3.99").version == sandbox_versions.MAX_PYTHON_VERSION_CAD
+
+
+@pytest.mark.parametrize("version", ["3.11", "3.12", sandbox_versions.MAX_PYTHON_VERSION_CAD])
+def test_a_python_the_pins_cover_is_left_alone(ctx, version):
+    assert ctx.get_python_runtime(version).version == version
+
+
+def test_the_floor_is_not_applied_here(ctx):
+    """Only the ceiling is universal. The floor belongs to CadQuery alone.
+
+    CadQuery has no 3.10 release, so the factories that need it render on 3.11 or
+    newer - but a 3.10 sandbox is a perfectly good place to convert an STL, and
+    forcing every one of them up to 3.11 would provision a second sandbox to do
+    what the first could.
+    """
+    assert ctx.get_python_runtime("3.10").version == "3.10"
+
+
+def test_holding_a_version_down_is_said_out_loud_once(ctx, caplog):
+    """Silently rendering on an interpreter nobody asked for is its own bug report."""
+    with caplog.at_level("WARNING"):
+        ctx.get_python_runtime("3.99")
+        ctx.get_python_runtime("3.99")
+
+    said = [record for record in caplog.records if "3.99" in record.message]
+    assert len(said) == 1
+    assert sandbox_versions.MAX_PYTHON_VERSION_CAD in said[0].message
+
+
+def test_no_version_at_all_is_the_pinned_one(ctx):
+    """The same default as a package's, for the callers that name no version."""
+    assert ctx.get_python_runtime().version == sandbox_versions.DEFAULT_PYTHON_VERSION
+
+
+def test_a_version_the_bound_cannot_read_is_passed_through(ctx):
+    """'pc init' writes ">=<host version>", and the schema's pattern allows it.
+
+    Such a value is already one neither the bound nor the sandbox naming can
+    reason about. That is worth fixing somewhere, but not by having the bound be
+    what discovers it: a package carrying one has to keep working exactly as it
+    did.
+    """
+    assert ctx.get_python_runtime(">=3.12").version == ">=3.12"

--- a/partcad/tests/unit/test_sandbox_versions.py
+++ b/partcad/tests/unit/test_sandbox_versions.py
@@ -128,3 +128,40 @@ def test_cadquery_floor_excludes_the_oldest_supported_python():
     """CadQuery publishes nothing for 3.10, so sandboxes there must skip it."""
     assert not sandbox_versions.is_at_least("3.10", sandbox_versions.MIN_PYTHON_VERSION_CADQUERY)
     assert sandbox_versions.is_at_least("3.11", sandbox_versions.MIN_PYTHON_VERSION_CADQUERY)
+
+
+@pytest.mark.parametrize(
+    "asked, maximum, expected",
+    [
+        # Above the ceiling: the ceiling wins.
+        ("3.15", "3.14", "3.14"),
+        ("4.0", "3.14", "3.14"),
+        # At or below it: what the package asked for wins.
+        ("3.14", "3.14", "3.14"),
+        ("3.11", "3.14", "3.11"),
+        # A patch component compares numerically, the way at_least's does: as
+        # strings "3.9" would sort above "3.14".
+        ("3.9", "3.14", "3.9"),
+    ],
+)
+def test_at_most(asked, maximum, expected):
+    assert sandbox_versions.at_most(asked, maximum) == expected
+
+
+def test_the_cad_ceiling_is_above_the_cadquery_floor():
+    """The two bounds have to leave a sandbox somewhere to be.
+
+    They move for unrelated reasons - the floor when CadQuery drops a Python,
+    the ceiling when the pinned wheels gain one - so nothing but this says they
+    have not crossed.
+    """
+    assert sandbox_versions.is_at_least(
+        sandbox_versions.MAX_PYTHON_VERSION_CAD, sandbox_versions.MIN_PYTHON_VERSION_CADQUERY
+    )
+
+
+def test_the_default_python_is_one_the_pins_cover():
+    """Otherwise every package that names no interpreter is silently held down."""
+    assert sandbox_versions.is_at_least(
+        sandbox_versions.MAX_PYTHON_VERSION_CAD, sandbox_versions.DEFAULT_PYTHON_VERSION
+    )


### PR DESCRIPTION
Follow-up to #544, which fixed the *ABI* the 3.14 sandbox was built with. This fixes the two things that put a
sandbox on that interpreter in the first place. Independent of #544 and based on `devel`; the two touch
different regions of `sandbox_versions.py`.

### The sandbox interpreter was the host's

`project_config.py` gave a package that names no `pythonVersion` the version of the interpreter PartCAD itself
is running on:

```python
self.python_version = "%d.%d" % (sys.version_info.major, sys.version_info.minor)
```

That value picks the sandbox — `pc-py-conda-<version>`. And matching the host buys **nothing**: under
`pythonSandbox: conda` the sandbox is a fresh env built at whatever version is asked for, and the host
interpreter is never reused; under `none` the version is ignored entirely (`runtime_python_none.py:23-31` takes
whatever `python` is on `PATH`). All it did was make a sandbox a property of how PartCAD happened to be
installed — the same package rendering on a different Python for each developer, changing under one of them
when they upgrade, and, in the standalone bundle, following whatever Python the release was frozen with.

It now defaults to `DEFAULT_PYTHON_VERSION`, which is what that constant always claimed to be. Until now it was
unreachable for any real package: every code path reading it goes through `ProjectConfiguration`, which never
produced `None`.

### And nothing bounded it from above

`at_least(python_version, MIN_PYTHON_VERSION_CADQUERY)` raises a floor and never lowers; `part_factory_build123d.py`
clamps nothing at all. The pinned stack — cadquery-ocp 7.9.3.1.1, cadquery 2.8.0, build123d 0.11.1, nlopt
2.11.0 — publishes cp310 through cp314 and nothing above. So the first host on 3.15, or the first matrix that
adds `"3.15"`, gets a sandbox with no wheel for anything it is preloaded with, and every part in it dies on an
import of something pip never installed. That is #544's failure with the version standing in for the ABI.

This is not a new kind of guard: `runtime_python.py:387-391` already carries a hand-written one at the *bottom*
end ("CadQuery has no release for Python 3.10, and pip fails the whole install rather than skipping it").
`MAX_PYTHON_VERSION_CAD` is the top end, and it moves with `PINNED_REQUIREMENTS`.

**Where it is applied, and why not in the factories.** `runtime_python.once()` gives the CAD stack to *every*
Python sandbox, not just the ones a CAD factory asked for — so the ceiling belongs at the single choke point,
`Context.get_python_runtime()`, and every sandbox is bounded by construction rather than by remembering to
clamp in each new factory (which is how `part_factory_build123d.py` came to clamp nothing).

**Only the ceiling goes there.** The floor is CadQuery's alone and stays with the factories that need CadQuery:
3.10 is a perfectly good place to convert an STL, and hoisting the floor to the choke point would provision a
second sandbox to do what the first could. `test_the_floor_is_not_applied_here` pins that distinction.

Held rather than refused, with a warning naming both versions, said once per context: a package asking for a
Python newer than these pins is asking for something reasonable that PartCAD cannot supply *yet*.

### `pc init` no longer writes it either

`pc init` defaulted `--python-version` to `>=<the host's version>` and wrote it into every package it created,
which put the coupling back one new package at a time — and in a form the version bound cannot read
(`at_most(">=3.12", ...)` raises `ValueError`) and a Windows sandbox directory name cannot contain. There is a
real default now, so the option has nothing left to default to and is removed; a package that wants a specific
interpreter still says so in its `partcad.yaml`. Eighteen behave expectations asserting the generated file
carried the key go with it, and I ran the four feature files that hold them.

A `pythonVersion` the bound cannot read is still *accepted* and passed through untouched, so a package written
before this keeps working exactly as it does today. There is a test saying so.

### The CI Python axis was one axis doing two jobs

A matrix leg's Python used to decide its sandbox's Python, so fanning every job over five of them covered both
at once. It no longer does, which makes the right axis different per job:

| Job | Python axis | Why |
| --- | --- | --- |
| `Pytest`, `Examples (All)` | `PYTHONS` — the whole supported range | PartCAD's own code is the subject |
| `Examples (PartCAD)`, `Repo //pub` | **`PYTHONS_SANDBOX`** — `["3.11", "3.14"]` | they render packages, so the sandbox is the subject |
| `Behave` | `PYTHONS_SLIM` — oldest and newest | drives the command line |
| `Pytest (IDE)` | `PYTHONS_IDE` | unchanged |

`PYTHONS_SANDBOX` is `MIN_PYTHON_VERSION_CADQUERY` and `MAX_PYTHON_VERSION_CAD` — the two ends of the range a
sandbox can be built at — and is kept in step with them by hand, as the comment says.

It is deliberately **not** filtered by `EXCLUDES`. That list encodes "every image but `ubuntu-latest` runs the
oldest and the newest Python only", which applied to a two-entry list would drop 3.11 everywhere else and leave
a single version — the opposite of testing both bounds.

`Examples (PartCAD)` goes from 21 legs to 16 on a full run, and from 15 to 10 on a pull request, with both
bounds covered on every image. `Repo //pub` stays at 6 legs and moves from `[3.10, 3.14]` to `[3.11, 3.14]`.

### Verification

`at_most()` parametrized; the two bounds asserted not to have crossed and the default asserted to sit under the
ceiling (they move for unrelated reasons, so nothing else says so); and `test_sandbox_python_version.py` for
the behaviour — the default, an explicit version kept, a too-new version held down and reported once, the floor
*not* applied, and a `">=3.12"` passed through.

Full `pre-commit --config dev-tools/pre-commit-config.yaml` clean in the dev container, `Validate GitHub
Workflows` included. `behave features/init.feature features/add/{part,sketch,dependency}.feature` passes —
23 YAML-content assertions executed. `pc init` in a scratch directory writes `partcad:` and no
`pythonVersion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
