### PR TITLE
feat(ci): build the VS Code extension once and release the ".vsix"

### DIFF
--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -392,6 +392,16 @@ jobs:
         with:
           python-version: "3.13"
 
+      # "build.sh" packages the PartCAD extension with `nox --session
+      # build_package` -- the same command ".github/workflows/nox.yml" uses for
+      # the released package -- so that "bundled/libs" is populated with wheels
+      # frozen for *this* platform. It checks for nox rather than installing it,
+      # so install it here. Deliberately not folded into the step below, which is
+      # `continue-on-error` for the optional icon renderers: a failure to install
+      # this one has to fail the job.
+      - name: Install nox
+        run: python -m pip install nox
+
       # Xvfb: installing an extension runs the editor, which wants a display
       # even when it never opens a window. Cairo: the icons are rendered from
       # the project's logo. Neither is available on the Windows runner, and the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,3 +173,17 @@ jobs:
           python -m pip install -r docs/requirements.txt
           sphinx-build  -M html docs/source docs/build -n -W
           mamba deactivate
+
+  # The VS Code extension, built once -- one Linux runner, one ".vsix", the same
+  # package "deploy.yml" attaches to the release. It is not part of the matrix
+  # above: the matrix says which OS and Python the *wheels* have to build on, and
+  # the extension is packaged with `vsce` on whatever host does it.
+  #
+  # The workflow it calls used to run on its own "push"/"pull_request" triggers.
+  # Those are gone, so this is the only thing that builds it on a pull request or
+  # a push -- which also means a push to "devel" that is not a version bump
+  # skips it, exactly as it skips everything else here.
+  build-vscode-extension:
+    name: "VS Code extension"
+    if: ${{ github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
+    uses: ./.github/workflows/nox.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,13 @@ jobs:
     with:
       tools_in_this_run: true
 
+  # The VS Code extension: one ".vsix", built once on a Linux runner, attached to
+  # the same release. Independent of everything above -- the IDE builds its own
+  # copy per platform, because "bundled/libs" inside the package carries compiled
+  # wheels and the one built here is a Linux one.
+  build-vscode-extension:
+    uses: ./.github/workflows/nox.yml
+
   # Keep the "build" job identical to "python-build.yml".
   # TODO(clairbee): include "python-build.yml" instead
   build:
@@ -162,6 +169,10 @@ jobs:
       # Blocking for the same reason: "install.sh --ide" installs from this
       # release too.
       - build-ide
+      # Blocking too, though nothing installs the extension automatically: a
+      # release that is missing an asset the documentation points at is a
+      # release someone has to go and fix by hand.
+      - build-vscode-extension
     runs-on: ubuntu-24.04
     environment:
       name: pypi
@@ -228,6 +239,15 @@ jobs:
           merge-multiple: true
           path: ide
 
+      # By name, not by pattern: there is exactly one of these, and the two
+      # patterns above already claim every other "partcad-*" artifact this run
+      # produces.
+      - name: Download the VS Code extension
+        uses: actions/download-artifact@v8
+        with:
+          name: partcad-vsix
+          path: vsix
+
       # "install.sh" derives an asset name from `uname` and fails for the user
       # if that asset is not on the release. Downloading artifacts does not fail
       # when none match, so check here, before the release exists, rather than
@@ -271,6 +291,16 @@ jobs:
                 -printf "%p %s bytes\n"
             fi
           done
+          # And the extension. One file, no platform in its name -- but the
+          # upload below globs "vsix/**", and an empty glob would fail there,
+          # after the release has already been created.
+          vsix="$(find vsix -type f -name "partcad-*.vsix" | head -n 1)"
+          if [ -z "${vsix}" ]; then
+            echo "::error::no VS Code extension package"
+            missing=1
+          else
+            echo "${vsix} $(stat -c%s "${vsix}") bytes"
+          fi
           exit "${missing}"
 
       # What the release carries, written down for the clients that download
@@ -303,6 +333,7 @@ jobs:
           gh release upload '${{ env.MERGED_TAG }}' dist/** --repo '${{ github.repository }}'
           gh release upload '${{ env.MERGED_TAG }}' standalone/** --repo '${{ github.repository }}'
           gh release upload '${{ env.MERGED_TAG }}' ide/** --repo '${{ github.repository }}'
+          gh release upload '${{ env.MERGED_TAG }}' vsix/** --repo '${{ github.repository }}'
           gh release upload '${{ env.MERGED_TAG }}' platforms.json --repo '${{ github.repository }}'
 
       - name: Publish distribution to PyPI

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -1,16 +1,21 @@
-# Minimalistic workflow to build the VS Code extension
-# TODO(clairbee): build the extension as part of the "build" and "deploy" workflows
-name: nox
+# The VS Code extension: one build, one ".vsix".
+#
+# Called by "build.yml" (CD) and by "deploy.yml", which uploads the package to
+# the GitHub release. It deliberately has no "push"/"pull_request" triggers of
+# its own: it used to, and adding it to those two workflows on top would build
+# the same package twice per commit. Exactly one run owns the build -- the same
+# arrangement "build-ide-standalone.yml" documents for the command line bundles.
+name: Extension # Keep the action badge icon short
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - devel
-  pull_request:
-    branches:
-      - devel
+  workflow_call:
+
+# No "concurrency" block, on purpose. A called workflow evaluates
+# `github.workflow` as the *caller's* name, so a group keyed on it would compute
+# the group the caller is already holding and `cancel-in-progress` would kill the
+# run that started this one. See the note on `concurrency` in
+# "build-standalone.yml", which is where that was learned.
 
 jobs:
   build:
@@ -42,8 +47,44 @@ jobs:
         run: pip install --upgrade attrs
       - working-directory: partcad-ide-vscode
         run: python -m pip install nox
-      - working-directory: partcad-ide-vscode
-        run: nox --session setup
-      - working-directory: partcad-ide-vscode
+
+      # One command, not "setup" and then "build_package": the latter runs
+      # "_setup_template_environment" itself (see "noxfile.py"), so it populates
+      # "bundled/libs" before it packages, and running "setup" first only paid
+      # for the same pip-compile and the same install twice.
+      #
+      # It is also exactly what "partcad-ide-standalone/build.sh" runs, so the
+      # extension that ships inside the IDE is built the same way as the one
+      # released here -- including "bundled/libs", which the language server
+      # puts first on its `sys.path`.
+      - name: Package the extension
+        working-directory: partcad-ide-vscode
         run: nox --session build_package
       # TODO(clairbee): run VSCode tests (that depend on the PartCAD Python module)
+
+      # "npm run vsce-package" writes a fixed "partcad.vsix", because
+      # "partcad-ide-standalone/build.sh" looks for that exact name. A release
+      # asset cannot be version-less though -- every other asset on the release
+      # carries the version -- so the copy that gets uploaded is renamed here
+      # rather than by changing the script the IDE build depends on.
+      - name: Name the package after the version
+        working-directory: partcad-ide-vscode
+        run: |
+          version="$(jq -r .version package.json)"
+          if [ -z "${version}" ] || [ "${version}" = "null" ]; then
+            echo "::error::no version in partcad-ide-vscode/package.json"
+            exit 1
+          fi
+          cp partcad.vsix "partcad-${version}.vsix"
+          ls -l "partcad-${version}.vsix"
+
+      - name: Upload the extension
+        uses: actions/upload-artifact@v7
+        with:
+          # Deliberately neither "partcad-ide-*" nor "partcad-standalone-*":
+          # "deploy.yml" downloads those two by pattern, each into its own
+          # directory, and a third name matching either would be merged into the
+          # wrong one.
+          name: partcad-vsix
+          path: partcad-ide-vscode/partcad-*.vsix
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,17 +154,18 @@ Lint/format (Python): `black`, `flake8`, `isort` — configured in `pyproject.to
 
 ### Packaging
 
-Four artifacts ship from this repo: the Python wheels (`partcad`, `partcad-cli` on PyPI), the standalone
-PyInstaller bundles for users who have no Python, the PartCAD IDE, which carries those bundles inside it, and
-the snap, which wraps the Linux bundle and is built but not published yet. Adding a runtime dependency, an
-optional extra, or a file that is read at runtime can be invisible to the frozen bundle and break it while the
-wheels stay fine — see `dev-tools/pyinstaller/README.md` before doing any of those. Note that the bundles fan
-out over *OS versions* (`ubuntu-22.04-x86_64`, `macos-26-arm64`, …), and that the same platform list appears in
-three places that nothing keeps in sync; the README says which, and which of them a pull request skips without
-`#deepTest`. Changing `.vscode/extensions.json` changes what the IDE ships with — see
-`partcad-ide-standalone/README.md`. The snap carries whatever the bundle carries, so it needs nothing extra of
-its own; `dev-tools/snap/README.md` covers what is specific to it (confinement, aliases, the base, its state
-directory).
+Five artifacts ship from this repo: the Python wheels (`partcad`, `partcad-cli` on PyPI), the standalone PyInstaller
+bundles for users who have no Python, the PartCAD IDE, which carries those bundles inside it, the VS Code extension's
+`.vsix`, and the snap, which wraps the Linux bundle and is built but not published yet. Adding a runtime dependency,
+an optional extra, or a file that is read at runtime can be invisible to the frozen bundle and break it while the
+wheels stay fine — see `dev-tools/pyinstaller/README.md` before doing any of those. Note that the bundles fan out over
+*OS versions* (`ubuntu-22.04-x86_64`, `macos-26-arm64`, …), and that the same platform list appears in three places
+that nothing keeps in sync; the README says which, and which of them a pull request skips without `#deepTest`. The
+`.vsix` is built once, on Linux, by `.github/workflows/nox.yml`, which `build.yml` and `deploy.yml` both call;
+`partcad-ide-standalone/build.sh` runs the same `nox` session per platform, because the `bundled/libs` inside the
+package holds compiled wheels. Changing `.vscode/extensions.json` changes what the IDE ships with — see
+`partcad-ide-standalone/README.md`. The snap carries whatever the bundle carries, so it needs nothing extra of its
+own; `dev-tools/snap/README.md` covers what is specific to it (confinement, aliases, the base, its state directory).
 
 ### Committing
 

--- a/partcad-ide-standalone/AGENTS.md
+++ b/partcad-ide-standalone/AGENTS.md
@@ -19,9 +19,11 @@ partcad-ide-standalone/build.sh --help
 ```
 
 `--with-cli-bundle` takes what `dev-tools/pyinstaller/build.sh --no-archive` leaves in `dist/standalone/partcad`.
-Node.js is needed (the extensions are packaged with `vsce`); `cairosvg`, `Pillow`, `rcedit` and -- on Windows --
-Inno Setup 6.3+ (`ISCC.exe`, for `installer/partcad-ide.iss`) are optional, and the build reports what it
-skipped without them. Output lands in `dist/ide/`.
+Node.js is needed (the extensions are packaged with `vsce`), and `nox` unless `--vsix` points at an
+already-built PartCAD extension -- see "Build / package" in `../partcad-ide-vscode/AGENTS.md` for why the
+extension is built with `nox --session build_package` here and not with npm. `cairosvg`, `Pillow`, `rcedit` and
+-- on Windows -- Inno Setup 6.3+ (`ISCC.exe`, for `installer/partcad-ide.iss`) are optional, and the build
+reports what it skipped without them. Output lands in `dist/ide/`.
 
 ## Test
 

--- a/partcad-ide-standalone/build.sh
+++ b/partcad-ide-standalone/build.sh
@@ -68,8 +68,8 @@ Options:
                            IDE is built without them, and asks the user to
                            download them on first use.
   --vsix <path>            The PartCAD extension to install. Defaults to
-                           `partcad-ide-vscode/partcad.vsix`, built with npm if
-                           it is not there yet.
+                           `partcad-ide-vscode/partcad.vsix`, built with `nox`
+                           if it is not there yet.
   --vscodium-version <tag> Build from this VSCodium release instead of the one
                            `vscodium.json` pins (or the latest, when it pins
                            none).
@@ -376,7 +376,26 @@ if [ "${INSTALL_EXTENSIONS}" = "1" ]; then
     EXTENSION_VSIX="${REPO_ROOT}/partcad-ide-vscode/partcad.vsix"
     if [ ! -f "${EXTENSION_VSIX}" ]; then
       log "==> Building the PartCAD extension (no ${EXTENSION_VSIX} yet)"
-      (cd "${REPO_ROOT}/partcad-ide-vscode" && npm install && npm run vsce-package)
+      # `nox --session build_package`, and not the `npm install && npm run
+      # vsce-package` this used to run. The npm script packages whatever is in
+      # the tree; it does not create `bundled/libs`, which is gitignored and
+      # only the nox session populates. That directory is the language server's
+      # vendored dependencies -- `bundled/tool/lsp_server.py` puts it first on
+      # its `sys.path` -- so without it the IDE shipped an extension whose
+      # language server could not import `pygls`.
+      #
+      # It is also the one command ".github/workflows/nox.yml" runs to build the
+      # package that goes on the release, so the extension inside the IDE and the
+      # released one are built the same way. It has to run here, per platform,
+      # rather than reusing that one package: `bundled/libs` holds compiled
+      # wheels (pygit2, aiohttp, cffi), so each IDE needs the ones frozen for its
+      # own OS.
+      #
+      # Checked rather than installed, in the same spirit as the `npx` check
+      # above -- and only on this path, so `--vsix` still works without it.
+      "${PYTHON}" -c 'import nox' >/dev/null 2>&1 ||
+        fail "nox is needed to build the PartCAD extension: '${PYTHON} -m pip install nox', or pass --vsix"
+      (cd "${REPO_ROOT}/partcad-ide-vscode" && "${PYTHON}" -m nox --session build_package)
     fi
   fi
   [ -f "${EXTENSION_VSIX}" ] || fail "no PartCAD extension at ${EXTENSION_VSIX}"

--- a/partcad-ide-vscode/AGENTS.md
+++ b/partcad-ide-vscode/AGENTS.md
@@ -141,6 +141,14 @@ nox --session build_package   # builds partcad.vsix (also runs npm install)
 code --install-extension partcad.vsix
 ```
 
+`nox --session build_package` and not `npm run vsce-package`: the nox session populates `bundled/libs` first,
+which is gitignored, holds the language server's vendored dependencies, and is what
+`bundled/tool/lsp_server.py` puts at the front of its `sys.path`. It is the only command that builds this
+package anywhere -- `.github/workflows/nox.yml` runs it once on Linux and attaches `partcad-<version>.vsix` to
+the GitHub release, and `partcad-ide-standalone/build.sh` runs it again per platform for the copy that ships
+inside the PartCAD IDE. Per platform because `bundled/libs` holds compiled wheels (`pygit2`, `aiohttp`,
+`cffi`), so the released Linux package is not the one a macOS or Windows IDE can carry.
+
 After changing `partcad` core code while developing through this extension, click "Restart PartCAD" in the
 PartCAD `Context` view (or restart VS Code) to pick up the change.
 


### PR DESCRIPTION
Closes the TODO that `.github/workflows/nox.yml` has carried since it was written: *"build the extension as
part of the `build` and `deploy` workflows"*. The `.vsix` is now built once per commit and attached to the
GitHub release.

## What changed

**`.github/workflows/nox.yml`** — extended into the single extension build (`name: nox` → `Extension`):

- `on:` is now `workflow_dispatch` + `workflow_call`. Dropping its own `push`/`pull_request` is what makes it
  build *once*; keeping them alongside the two new callers would have built the same package twice per commit —
  the duplication `build-ide-standalone.yml` documents at length for the command line bundles.
- No `concurrency:` block, with a comment saying why: a called workflow evaluates `github.workflow` as the
  *caller's* name, so a group keyed on it would compute the group the caller is already holding and
  `cancel-in-progress` would kill the run that started it. Same lesson as `build-standalone.yml`.
- `nox --session setup` dropped. `build_package` runs `_setup_template_environment` itself, so running `setup`
  first only paid for the same `pip-compile` and the same install twice.
- New steps: copy `partcad.vsix` → `partcad-<version>.vsix` (version read from `package.json`), upload as
  artifact `partcad-vsix` with `if-no-files-found: error`.

**`build.yml`** — one `build-vscode-extension` job calling it, with the same `if:` guard as the other jobs.

**`deploy.yml`** — the same call; `publish-to-pypi` gains it in `needs`, downloads `partcad-vsix` into `vsix/`,
checks the file is there in the existing pre-release completeness step, and `gh release upload`s it.

**`partcad-ide-standalone/build.sh`** — the extension fallback is now `"${PYTHON}" -m nox --session
build_package` instead of `npm install && npm run vsce-package`, so the copy inside the IDE carries
`bundled/libs` too. nox is checked for rather than installed, in the style of the existing `npx` check, and only
on that path so `--vsix` still works without it. `build-ide-standalone.yml` gains an `Install nox` step, kept
separate from the `continue-on-error` icon-renderer step so a failure there fails the job.

**Docs** — the packaging section of `AGENTS.md`/`CLAUDE.md` (four artifacts → five, and where the `.vsix` comes
from), plus the build sections of `partcad-ide-vscode/AGENTS.md` and `partcad-ide-standalone/AGENTS.md`.

## Why `build.sh` changed too

`npm run vsce-package` packages whatever is in the tree. It never creates `bundled/libs`, which is gitignored
and only the nox session populates — and that directory is the language server's vendored dependencies, which
`bundled/tool/lsp_server.py` puts at the front of its `sys.path`. So the IDE was shipping an extension whose
bundled language server had nothing to import. Both places now run the same one command.

The IDE still builds its own copy per platform rather than reusing the released one, and it has to:
`bundled/libs` holds compiled wheels. The Linux package carries `pygit2.libs/libssl-fb7fb2a0.so.3`.

## Verification

Run in the dev container:

- `nox --session build_package` → exit 0, `Packaged: partcad.vsix (1656 files, 16.12 MB)`.
- The package contains **1565** `extension/bundled/libs/` entries — `pygls-1.3.1`, `aiohttp-3.14.3`, `yaml`, and
  `pygit2.libs/libssl-fb7fb2a0.so.3`.
- `ls partcad-*.vsix` matched only the versioned copy, so the artifact glob will not also pick up
  `partcad.vsix`.
- `pre-commit run` on the changed files: all Passed, including "Validate GitHub Workflows" and ShellCheck.
- `pytest partcad-ide-standalone/tests`: 36 passed.

## Worth a look before merging

1. **The workflow rename `nox` → `Extension` changes the check name.** If `nox` is configured as a required
   status check on `devel`, branch protection needs updating with this merge. Happy to revert the name instead.
2. **The released `.vsix` is a Linux build.** `bundled/libs` carries manylinux binaries, so on Windows/macOS the
   bundled language server cannot import them. This matches what CI already produced; it is called out because
   the package is now something users can download. Not addressed here.
3. **A push to `devel` that is not a version bump no longer builds the extension**, because the whole CD
   workflow is skipped on those. Pull requests and the merge queue still build it.
4. **`build.sh` now rewrites `partcad-ide-vscode/requirements.txt`** when it builds the extension, since
   `pip-compile` runs as part of the nox session and its output depends on the interpreter. Harmless in CI
   (fresh checkout), but a local `build.sh` run now dirties a tracked file where before it only touched
   `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
