### PR TITLE
Version updated from 0.7.193 to 0.8.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:bookworm
 
-ARG IMAGE_VERSION=0.7.193
+ARG IMAGE_VERSION=0.8.0
 
 # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "PartCAD Development Environment",
-  "image": "ghcr.io/partcad/partcad-devcontainer:0.7.193",
+  "image": "ghcr.io/partcad/partcad-devcontainer:0.8.0",
   "remoteEnv": {
     // TODO: @alexanderilyin do not patch PATH here but make `mamba` discoverable.
     "PATH": "${containerEnv:PATH}:/home/vscode/miniforge3/bin",

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 
 env:
-  VERSION: 0.7.193
+  VERSION: 0.8.0
   CONTAINER_REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-devcontainer
   TOTAL_TIMEOUT: 900

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ env:
   # extension is actually validated against.
   # TODO(clairbee): restore 3.13/3.14 here once the bundle can ship pygit2.
   PYTHONS_IDE: '["3.10", "3.11", "3.12"]'
-  VERSION: 0.7.193
+  VERSION: 0.8.0
   CONTAINER_REGISTRY: ghcr.io
   PC_TELEMETRY_ENV: test
   PC_TELEMETRY_PERFORMANCE: false

--- a/dev-tools/bumpversion.toml
+++ b/dev-tools/bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.7.193"
+current_version = "0.8.0"
 commit = "true"
 commit_args = "--no-verify"
 tag = "true"

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -419,7 +419,7 @@ are downloaded Poetry will also install current package in editable mode, and yo
 
 .. code-block::
 
-  Installing the current project: partcad-dev (0.7.193)
+  Installing the current project: partcad-dev (0.8.0)
 
 Activate Environment
 --------------------

--- a/examples/partcad.yaml
+++ b/examples/partcad.yaml
@@ -9,7 +9,7 @@
 
 # In most cases the path prefix should match what is expected in the real production use case.
 name: //pub/examples/partcad
-partcad: ">=0.7.193"
+partcad: ">=0.8.0"
 manufacturable: false
 
 cover:

--- a/partcad-cad-freecad/package.xml
+++ b/partcad-cad-freecad/package.xml
@@ -15,7 +15,7 @@
     (partcad-json-rpc), which the addon downloads on first use, so FreeCAD's
     Python needs no PartCAD installation of its own.
   </description>
-  <version>0.7.193</version>
+  <version>0.8.0</version>
   <date>2026-08-12</date>
 
   <maintainer email="support@partcad.org">PartCAD</maintainer>

--- a/partcad-cad-freecad/partcad_freecad/__init__.py
+++ b/partcad-cad-freecad/partcad_freecad/__init__.py
@@ -11,4 +11,4 @@ service provisioning, the package/object model and the parameter model -- is
 plain Python and is unit tested without FreeCAD installed.
 """
 
-__version__: str = "0.7.193"
+__version__: str = "0.8.0"

--- a/partcad-cli/pyproject.toml
+++ b/partcad-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "partcad-cli"
-version = "0.7.193"
+version = "0.8.0"
 description = "Command-line interface to PartCAD"
 readme = "README.md"
 keywords = ["cadquery", "build123d", "sdf", "cad", "design", "openscad", "step", "stl"]

--- a/partcad-cli/requirements-aws.txt
+++ b/partcad-cli/requirements-aws.txt
@@ -1,1 +1,1 @@
-partcad[aws]==0.7.193
+partcad[aws]==0.8.0

--- a/partcad-cli/requirements-lint.txt
+++ b/partcad-cli/requirements-lint.txt
@@ -1,1 +1,1 @@
-partcad[lint]==0.7.193
+partcad[lint]==0.8.0

--- a/partcad-cli/requirements-memcache.txt
+++ b/partcad-cli/requirements-memcache.txt
@@ -1,1 +1,1 @@
-partcad[memcache]==0.7.193
+partcad[memcache]==0.8.0

--- a/partcad-cli/requirements.txt
+++ b/partcad-cli/requirements.txt
@@ -1,6 +1,6 @@
 click==8.4.2
-partcad==0.7.193
-partcad-client==0.7.193
-partcad-service-json-rpc==0.7.193
-partcad-utils==0.7.193
+partcad==0.8.0
+partcad-client==0.8.0
+partcad-service-json-rpc==0.8.0
+partcad-utils==0.8.0
 rich-click==1.9.8

--- a/partcad-cli/src/partcad_cli/__init__.py
+++ b/partcad-cli/src/partcad_cli/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "0.7.193"
+__version__: str = "0.8.0"

--- a/partcad-client/pyproject.toml
+++ b/partcad-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "partcad-client"
-version = "0.7.193"
+version = "0.8.0"
 description = "The PartCAD client: daemon discovery and connection, and upgrading the installation"
 readme = "README.md"
 keywords = ["cad", "partcad", "client", "daemon", "update"]

--- a/partcad-client/requirements.txt
+++ b/partcad-client/requirements.txt
@@ -1,2 +1,2 @@
-partcad-utils==0.7.193
+partcad-utils==0.8.0
 packaging>=23.0

--- a/partcad-client/src/partcad_client/__init__.py
+++ b/partcad-client/src/partcad_client/__init__.py
@@ -33,4 +33,4 @@ reference caller; the VS Code extension reaches the same code by running `pc`
 rather than by reimplementing it in TypeScript.
 """
 
-__version__ = "0.7.193"
+__version__ = "0.8.0"

--- a/partcad-ide-client/pyproject.toml
+++ b/partcad-ide-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "partcad-ide-client"
-version = "0.7.193"
+version = "0.8.0"
 description = "Client library connecting PartCAD to the PartCAD IDE viewer"
 readme = "README.md"
 keywords = ["partcad", "cad", "vscode", "viewer", "gltf"]

--- a/partcad-ide-client/src/partcad_ide_client/__init__.py
+++ b/partcad-ide-client/src/partcad_ide_client/__init__.py
@@ -32,7 +32,7 @@ from .protocol import (
     make_object,
 )
 
-__version__ = "0.7.193"
+__version__ = "0.8.0"
 
 __all__ = [
     "CONNECT_TIMEOUT",

--- a/partcad-ide-vscode/bundled/tool/lsp_server.py
+++ b/partcad-ide-vscode/bundled/tool/lsp_server.py
@@ -71,7 +71,7 @@ RUNNER = pathlib.Path(__file__).parent / "lsp_runner.py"
 
 MAX_WORKERS = 5
 # TODO: Update the language server name and version.
-LSP_SERVER = server.LanguageServer(name="PartCAD", version="0.7.193", max_workers=MAX_WORKERS)
+LSP_SERVER = server.LanguageServer(name="PartCAD", version="0.8.0", max_workers=MAX_WORKERS)
 
 
 # **********************************************************

--- a/partcad-ide-vscode/package.json
+++ b/partcad-ide-vscode/package.json
@@ -4,7 +4,7 @@
   "description": "Build system and package manager for CAD files, and assembly modeling framework",
   "markdown": "github",
   "icon": "resources/logo_128x128.png",
-  "version": "0.7.193",
+  "version": "0.8.0",
   "serverInfo": {
     "name": "PartCAD",
     "module": "partcad"
@@ -863,7 +863,7 @@
       },
       {
         "view": "partcadExplorer",
-        "contents": "PartCAD Python module v0.7.193 is not found.\n\nPartCAD Python module has to be installed in the current Python environment for the PartCAD VS Code Extension to work properly.\n\nPartCAD is the first package manager for CAD files. Learn more about PartCAD in our [GitHub repository](https://github.com/openvmp/partcad) or [documentation](https://partcad.readthedocs.io/).\n\n[Install or update PartCAD](command:partcad.startInstall)",
+        "contents": "PartCAD Python module v0.8.0 is not found.\n\nPartCAD Python module has to be installed in the current Python environment for the PartCAD VS Code Extension to work properly.\n\nPartCAD is the first package manager for CAD files. Learn more about PartCAD in our [GitHub repository](https://github.com/openvmp/partcad) or [documentation](https://partcad.readthedocs.io/).\n\n[Install or update PartCAD](command:partcad.startInstall)",
         "when": "partcad.activated && !partcad.installed && !partcad.beingInstalled"
       },
       {

--- a/partcad-service-json-rpc/pyproject.toml
+++ b/partcad-service-json-rpc/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "partcad-service-json-rpc"
-version = "0.7.193"
+version = "0.8.0"
 description = "JSON-RPC service interface to PartCAD"
 readme = "README.md"
 keywords = ["cad", "json-rpc", "partcad", "service", "ide"]

--- a/partcad-service-json-rpc/requirements.txt
+++ b/partcad-service-json-rpc/requirements.txt
@@ -1,3 +1,3 @@
-partcad-utils==0.7.193
-partcad==0.7.193
+partcad-utils==0.8.0
+partcad==0.8.0
 aiohttp

--- a/partcad-service-json-rpc/src/partcad_service_json_rpc/__init__.py
+++ b/partcad-service-json-rpc/src/partcad_service_json_rpc/__init__.py
@@ -18,4 +18,4 @@ work itself: those runtimes belong to the daemon's environment and need not
 exist on the client side at all.
 """
 
-__version__ = "0.7.193"
+__version__ = "0.8.0"

--- a/partcad-service-json-rpc/src/partcad_service_json_rpc/core/operations.py
+++ b/partcad-service-json-rpc/src/partcad_service_json_rpc/core/operations.py
@@ -1093,7 +1093,7 @@ def activate(session, params):
     """Load PartCAD, verify version, run health checks, and signal readiness."""
     try:
         session.load_partcad()
-        if session.partcad.__version__ not in SpecifierSet(">=0.7.193"):
+        if session.partcad.__version__ not in SpecifierSet(">=0.8.0"):
             session.emitter.error("Failed to activate PartCAD: PartCAD Python module is not up-to-date.")
             session.emitter.signal(events.ACTIVATE_FAILED)
             return None

--- a/partcad-utils/pyproject.toml
+++ b/partcad-utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "partcad-utils"
-version = "0.7.193"
+version = "0.8.0"
 description = "Shared lightweight utilities for PartCAD (logging, telemetry, user config, ASSY checking)"
 readme = "README.md"
 keywords = ["cad", "partcad", "logging", "telemetry", "config"]

--- a/partcad-utils/src/partcad_utils/__init__.py
+++ b/partcad-utils/src/partcad_utils/__init__.py
@@ -16,4 +16,4 @@ render streamed daemon output without paying the ~1.6s cost of importing
 is ``partcad_utils.logging``), so existing imports keep working unchanged.
 """
 
-__version__ = "0.7.193"
+__version__ = "0.8.0"

--- a/partcad/pyproject.toml
+++ b/partcad/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "partcad"
-version = "0.7.193"
+version = "0.8.0"
 description = "Package manager for CAD models and a modelling framework"
 readme = "README.md"
 keywords = ["cadquery", "build123d", "sdf", "cad", "design", "openscad", "step", "stl"]

--- a/partcad/requirements.txt
+++ b/partcad/requirements.txt
@@ -6,7 +6,7 @@
 # things that need a CAD library present in this process are handing back live
 # build123d/cadquery objects (convert("build123d"/"cadquery")) and show(); both
 # are opt-in, import their library lazily, and warn if it is not installed.
-partcad-utils==0.7.193
+partcad-utils==0.8.0
 # sdf-fork  # installed on demand into the sandbox runtime (see part_factory_sdf.py)
 pyyaml>=6.0.1
 # Pinned, not floored. pygit2 follows libgit2 and drops deprecated API across

--- a/partcad/src/partcad/__init__.py
+++ b/partcad/src/partcad/__init__.py
@@ -5,7 +5,7 @@
 # Licensed under Apache License, Version 2.0.
 #
 
-__version__: str = "0.7.193"
+__version__: str = "0.8.0"
 
 # Must come before anything that can pull OCP in. VTK, which the OCP build we
 # use links against, bundles its own older copy of expat and exports it under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ cache-dir = "/tmp/.prepare_partcad-dev"
 
 [tool.poetry]
 name = "partcad-dev"
-version = "0.7.193"
+version = "0.8.0"
 description = "Development Environment for PartCAD"
 authors = [
   "PartCAD <support@partcad.org>",

--- a/tools/containers/python/Dockerfile
+++ b/tools/containers/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/partcad/partcad-devcontainer:0.7.193
+FROM ghcr.io/partcad/partcad-devcontainer:0.8.0
 
 USER vscode
 RUN /home/vscode/miniforge3/bin/conda create --yes --name pc-env python=3.12 pip


### PR DESCRIPTION
## Copilot Summary

Bumps the monorepo's single release version from `0.7.193` to `0.8.0` — a minor bump.

Produced by running the repo's own tooling, so the file set is exactly what the `version-bump` workflow would have written:

```
bump-my-version bump --config-file dev-tools/bumpversion.toml --no-commit --no-tag minor
```

33 files: `current_version` in `dev-tools/bumpversion.toml`, every package version and `__version__`, every inter-package pin (`requirements*.txt`, including the CLI's `[lint]`/`[memcache]`/`[aws]` pass-throughs), the VS Code extension's `package.json` and `lsp_server.py`, the FreeCAD addon's `package.xml`, the daemon's minimum-`partcad` bound in `core/operations.py`, `VERSION` in `test.yml`/`test-dev.yml`, the devcontainer image tag, and the version quoted in `docs/source/contributing.rst` and `examples/partcad.yaml`.

### Validation

Docker was unavailable in this environment, so the dev container (and with it `pytest`/`behave`/`pre-commit`) could not be run. Checked statically instead, replicating what `partcad-cli/tests/unit/test_versions.py` asserts:

- every `[[tool.bumpversion.files]]` entry's `search` string still matches the file it names, at the new version (all 38);
- every package's `__version__` and `pyproject.toml` version equals `current_version`;
- every package is declared in `bumpversion.toml`;
- `package.json`, `package.xml` and the TOML files still parse, and carry `0.8.0`;
- no `0.7.193` reference is left anywhere in the tree.

### Two things this PR cannot do for itself

The bump is normally made by the `version-bump` workflow, which produces the commit **and** the matching git tag atomically. Doing it in a PR splits those:

1. **Merge so the head commit message keeps the `Version updated` prefix** (a squash merge with this PR's title does). `version-bump.yml` skips such commits, so `devel` will not be bumped a second time to `0.8.1`; the release jobs in `build.yml`/`test.yml` gate on the same prefix and will build `0.8.0`. A merge commit titled `Merge pull request …` would do the opposite on both counts.
2. **Tag the merge commit `0.8.0`** (`git tag 0.8.0 <sha> && git push origin 0.8.0`). The workflow normally creates this tag, and `deploy.yml` resolves the GitHub release name with `git describe --abbrev=0` when `main` is pushed — without the tag it would resolve to `0.7.193`, which already has a release.

The zero-touch alternative, if preferred over this PR: land any ordinary change on `devel` under a `[FEATURE]` title and the workflow does the minor bump, the commit and the tag by itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5cGam1EBdUVMzBBoKuB1r)_