### PR TITLE
Split Python flags for wrappers and provisioning commands

### DIFF
--- a/src/partcad/AGENTS.md
+++ b/src/partcad/AGENTS.md
@@ -67,11 +67,16 @@ isort --check src/partcad tests/partcad
 
   Below `sandbox_versions.MIN_PYTHON_VERSION_SAFE_PATH` the environment does *not* cover it: `PYTHONSAFEPATH`
   arrived in 3.11 and an older interpreter ignores it, which would leave the directory PartCAD runs from first
-  on `sys.path` for the `-m venv`/`-m pip` calls that provision a sandbox. Those versions keep `-I` and go on
-  ignoring `PYTHONHASHSEED` — no flag pins a hash seed, so isolation and reproducibility cannot both be had
-  there. `tests/partcad/unit/test_python_env.py` asserts the outcome (a `venv.py`/`pip.py` beside the interpreter never
-  wins) on whichever version is running, so both branches are covered by the CI matrix rather than by a
-  comment.
+  on `sys.path` for the `-m venv`/`-m pip` calls that provision a sandbox. Those calls — and only those — keep
+  `-I` there, which is why `PythonRuntime` carries two flag lists (`python_flags` for a wrapper,
+  `python_provisioning_flags` for a `-m` command) and picks between them in `flags_for()`. A wrapper is run by
+  path, so its `sys.path[0]` is PartCAD's own `wrappers/` directory rather than anything a user writes to;
+  giving it `-I` would buy no isolation and would cost it `PYTHONHASHSEED`, since `-I` implies `-E`. So do not
+  collapse the two lists back into one, and do not hand `-I` to anything but a `-m` command.
+  `tests/partcad/unit/test_python_env.py` asserts the outcomes (a `venv.py`/`pip.py` beside the interpreter
+  never wins; a wrapper's sibling import is never shadowed by a file in PartCAD's working directory; the hash
+  seed is honored on every version) on whichever version is running, so both branches are covered by the CI
+  matrix rather than by a comment.
 
 ## Schemas and linting
 

--- a/src/partcad/python_env.py
+++ b/src/partcad/python_env.py
@@ -56,9 +56,11 @@ PARTCAD_PYTHON_ENV = {
     #
     # It only arrived in 3.11, and an older interpreter ignores it in silence
     # rather than refusing it. So this does not protect a 3.10 sandbox, and
-    # nothing here can: see PythonRuntime.__init__, which falls back to "-I"
-    # below sandbox_versions.MIN_PYTHON_VERSION_SAFE_PATH and gives up the hash
-    # seed there in exchange.
+    # nothing here can: see PythonRuntime.__init__, which falls back to "-I" on
+    # the commands that need it below sandbox_versions.MIN_PYTHON_VERSION_SAFE_PATH.
+    # Those commands -- "-m venv" and "-m pip" -- are the only ones whose
+    # sys.path[0] is a directory a user can write to, and they are also the only
+    # ones with nothing to gain from the pinned seed "-I" costs them.
     "PYTHONSAFEPATH": "1",
 }
 

--- a/src/partcad/runtime_python.py
+++ b/src/partcad/runtime_python.py
@@ -265,14 +265,27 @@ class PythonRuntime(runtime.Runtime):
         # channel open; PYTHONSAFEPATH stands in for "-P".
         #
         # Except below 3.11, where PYTHONSAFEPATH does not exist and is ignored
-        # in silence. Provisioning runs "-m venv" and "-m pip" from whatever
-        # directory PartCAD itself was started in, and for a "-m" command
-        # sys.path[0] is that directory -- so a "venv.py" or "pip.py" sitting in
-        # it is imported instead of the module meant. An interpreter that old
-        # therefore keeps "-I", and with it keeps ignoring PYTHONHASHSEED,
-        # exactly as every version did before this. No flag pins a hash seed,
-        # so below 3.11 the isolation and the reproducibility cannot both be
-        # had; the isolation wins, and 3.10 is left no worse off than it was.
+        # in silence. There what "-P" stands for has to be had from "-I"
+        # instead -- but only on the commands that need it, which is not every
+        # command a sandbox runs:
+        #
+        # * Provisioning ("-m venv", "-m pip") inherits the directory PartCAD
+        #   itself was started in, and for a "-m" command sys.path[0] is that
+        #   directory. A "venv.py" or "pip.py" sitting in it is imported instead
+        #   of the module meant, so provisioning keeps "-I" below 3.11.
+        # * Everything else is a wrapper, run by path. For a script sys.path[0]
+        #   is the *script's* directory -- PartCAD's own 'wrappers/', never a
+        #   directory a user writes to -- so there is nothing there for "-P" to
+        #   keep out, and "-I" adds no isolation that "-s" and the sanitized
+        #   environment do not already provide.
+        #
+        # Keeping the two apart is what lets an old interpreter have both. "-I"
+        # implies "-E", so a command carrying it ignores PYTHONHASHSEED and
+        # hashes with a random seed; confined to provisioning that costs
+        # nothing, as pip and venv have no output whose order anyone compares.
+        # Carried by the wrapper runs as well -- as it was until this split --
+        # it cost every sandbox below 3.11 its reproducibility, and bought
+        # protection for a directory that was never on sys.path to begin with.
         try:
             has_safe_path = sandbox_versions.is_at_least(self.version, sandbox_versions.MIN_PYTHON_VERSION_SAFE_PATH)
         except ValueError:
@@ -283,7 +296,8 @@ class PythonRuntime(runtime.Runtime):
             # way an old interpreter does rather than trusting a variable that
             # may be ignored.
             has_safe_path = False
-        self.python_flags = ["-sOOu"] if has_safe_path else ["-sOOIu"]
+        self.python_flags = ["-sOOu"]
+        self.python_provisioning_flags = ["-sOOu"] if has_safe_path else ["-sOOIu"]
 
         # TODO(clairbee): To improve portability, warn about uses of default encoding
         # self.python_flags += ["-X", "warn_default_encoding=1"]
@@ -294,6 +308,22 @@ class PythonRuntime(runtime.Runtime):
             self.pip_install_flags += ["--no-warn-script-location"]
 
         self.constraints_path = None
+
+    def flags_for(self, cmd):
+        """The interpreter flags a sandbox command line runs with.
+
+        Below 3.11 provisioning is isolated with "-I" and everything else is
+        not (see __init__ for why), and provisioning is exactly the set of
+        commands spelled "-m venv" / "-m pip". Reading that off the command
+        rather than off the caller keeps the two from drifting apart: a
+        provisioning call site added later is isolated without anyone having to
+        remember to ask for it, and a wrapper run cannot acquire "-I" -- and
+        with it a random hash seed -- by accident.
+
+        At 3.11 and above the two are the same list, since PYTHONSAFEPATH
+        covers both.
+        """
+        return self.python_provisioning_flags if cmd and cmd[0] == "-m" else self.python_flags
 
     def get_constraints_flags(self):
         """Return the pip flags that apply PIP_CONSTRAINTS to an install.
@@ -500,7 +530,7 @@ class PythonRuntime(runtime.Runtime):
                         self.check_deps_onced_locked(path=session["path"])
 
             python_path = self.get_venv_python_path(session, path)
-            cmd = [python_path, *self.python_flags, *cmd]
+            cmd = [python_path, *self.flags_for(cmd), *cmd]
             pc_logging.debug("Running: %s", cmd)
             # pc_logging.debug("stdin: %s", stdin)
             with telemetry.start_as_current_span("PythonRuntime.run_onced.*{subprocess.Popen}") as span:
@@ -593,7 +623,7 @@ class PythonRuntime(runtime.Runtime):
                 self.check_deps_onced_locked(path=session["path"])
 
         python_path = self.get_venv_python_path(session, path)
-        cmd = [python_path, *self.python_flags, *cmd]
+        cmd = [python_path, *self.flags_for(cmd), *cmd]
         pc_logging.debug("Running: %s", cmd)
         # pc_logging.debug("stdin: %s", stdin)
         exitcode, stdout, stderr = super().run(cmd, stdin=stdin, cwd=cwd)
@@ -646,7 +676,7 @@ class PythonRuntime(runtime.Runtime):
                         await self.check_deps_async_onced_locked(path=session["path"])
 
             python_path = self.get_venv_python_path(session, path)
-            cmd = [python_path, *self.python_flags, *cmd]
+            cmd = [python_path, *self.flags_for(cmd), *cmd]
             pc_logging.debug("Running: %s", cmd)
             # pc_logging.debug("stdin: %s", stdin)
             with telemetry.start_as_current_span("PythonRuntime.run_async_onced.*{subprocess.Popen}") as span:
@@ -738,7 +768,7 @@ class PythonRuntime(runtime.Runtime):
                 await self.check_deps_async_onced_locked(path=session["path"])
 
         python_path = self.get_venv_python_path(session, path)
-        cmd = [python_path, *self.python_flags, *cmd]
+        cmd = [python_path, *self.flags_for(cmd), *cmd]
         pc_logging.debug("Running: %s", cmd)
         exitcode, stdout, stderr = await super().run_async(cmd, stdin=stdin, cwd=cwd)
         return exitcode, stdout, stderr

--- a/tests/partcad/unit/test_python_env.py
+++ b/tests/partcad/unit/test_python_env.py
@@ -17,8 +17,8 @@ from partcad import python_env
 from partcad.runtime_python import PythonRuntime
 
 
-def _flags_for(tmp_path, version=None):
-    """The flags a real PythonRuntime hands to a sandbox interpreter.
+def _runtime_for(tmp_path, version=None):
+    """A real PythonRuntime, built for whichever sandbox version is asked for.
 
     Built through __init__, since the flags are what __init__ decides; the
     context only has to answer where the sandbox would live.
@@ -27,13 +27,29 @@ def _flags_for(tmp_path, version=None):
     class _Ctx:
         user_config = types.SimpleNamespace(internal_state_dir=str(tmp_path))
 
-    return PythonRuntime(_Ctx(), "none", version).python_flags
+    return PythonRuntime(_Ctx(), "none", version)
+
+
+def _flags_for(tmp_path, version=None):
+    """The flags a sandbox interpreter runs a wrapper with."""
+    return _runtime_for(tmp_path, version).python_flags
+
+
+def _provisioning_flags_for(tmp_path, version=None):
+    """The flags a sandbox interpreter runs "-m venv"/"-m pip" with."""
+    return _runtime_for(tmp_path, version).python_provisioning_flags
 
 
 @pytest.fixture
 def sandbox_python_flags(tmp_path):
-    """The flags for a sandbox on the interpreter running these tests."""
+    """The wrapper flags for a sandbox on the interpreter running these tests."""
     return _flags_for(tmp_path)
+
+
+@pytest.fixture
+def sandbox_provisioning_flags(tmp_path):
+    """The provisioning flags for a sandbox on the interpreter running these tests."""
+    return _provisioning_flags_for(tmp_path)
 
 
 def test_sanitize_drops_every_python_variable():
@@ -79,17 +95,29 @@ def test_importing_partcad_sanitized_this_process():
 
 @pytest.mark.parametrize("version", ["3.11", "3.12", "3.13", "3.14"])
 def test_sandbox_interpreter_flags_drop_isolated_mode_where_the_environment_can_replace_it(tmp_path, version):
-    """'-I' is gone, but the half of it no environment variable can express is not."""
+    """'-I' is gone, but the half of it no environment variable can express is not.
+
+    Where PYTHONSAFEPATH is honored it covers provisioning too, so both command
+    kinds run with one and the same list.
+    """
     flags = _flags_for(tmp_path, version)
 
     assert flags == ["-sOOu"]
+    assert _provisioning_flags_for(tmp_path, version) == flags
     assert "I" not in "".join(flags)
 
 
 @pytest.mark.parametrize("version", ["3.9", "3.10"])
-def test_sandbox_interpreter_flags_keep_isolated_mode_below_safe_path(tmp_path, version):
-    """PYTHONSAFEPATH is ignored before 3.11, so there '-I' is the only isolation."""
-    assert _flags_for(tmp_path, version) == ["-sOOIu"]
+def test_sandbox_interpreter_flags_keep_isolated_mode_where_only_provisioning_needs_it(tmp_path, version):
+    """PYTHONSAFEPATH is ignored before 3.11, so there '-I' stands in for it.
+
+    Only on the commands whose sys.path[0] is PartCAD's own working directory,
+    which is the "-m" ones. A wrapper is run by path, so its sys.path[0] is the
+    wrapper's directory and there is nothing for '-I' to keep out -- and
+    charging it '-I' would cost it PYTHONHASHSEED, which '-E' ignores.
+    """
+    assert _provisioning_flags_for(tmp_path, version) == ["-sOOIu"]
+    assert _flags_for(tmp_path, version) == ["-sOOu"]
 
 
 def test_a_version_the_bound_cannot_read_isolates_the_old_way(tmp_path):
@@ -97,17 +125,36 @@ def test_a_version_the_bound_cannot_read_isolates_the_old_way(tmp_path):
 
     Nothing between the schema and here trims that into a version this can
     compare, so it must not be the thing that discovers it -- and, since it
-    cannot be shown to understand PYTHONSAFEPATH, it gets the isolation that
-    needs no variable.
+    cannot be shown to understand PYTHONSAFEPATH, its provisioning gets the
+    isolation that needs no variable.
     """
-    assert _flags_for(tmp_path, ">=3.12") == ["-sOOIu"]
+    assert _provisioning_flags_for(tmp_path, ">=3.12") == ["-sOOIu"]
+    assert _flags_for(tmp_path, ">=3.12") == ["-sOOu"]
+
+
+@pytest.mark.parametrize(
+    "cmd, provisioning",
+    [
+        (["-m", "venv", "--upgrade-deps", "/somewhere"], True),
+        (["-m", "pip", "check"], True),
+        (["/somewhere/wrapper_part_type.py", "/a/script.py", "/a/package"], False),
+        ([], False),
+    ],
+)
+def test_only_a_module_command_is_treated_as_provisioning(tmp_path, cmd, provisioning):
+    """Which flags a command gets is read off the command, not off the caller."""
+    runtime = _runtime_for(tmp_path, "3.10")
+    expected = runtime.python_provisioning_flags if provisioning else runtime.python_flags
+
+    assert runtime.flags_for(cmd) == expected
 
 
 @pytest.mark.parametrize(
     "expression, expected",
     [
         # PYTHONHASHSEED is honored now, which is the whole point: under '-I' it
-        # was ignored and this came back randomized.
+        # was ignored and this came back randomized. On every version, including
+        # the ones whose provisioning still carries '-I'.
         ("sys.flags.hash_randomization", "0"),
         # ... and the isolation '-I' used to provide is still in force.
         ("sys.flags.no_user_site", "1"),
@@ -152,7 +199,7 @@ def test_a_child_of_this_process_hashes_reproducibly(sandbox_python_flags):
 
 @pytest.mark.parametrize("module", ["venv", "pip"])
 def test_a_shadowing_module_beside_the_sandbox_cannot_hijack_a_provisioning_command(
-    tmp_path, sandbox_python_flags, module
+    tmp_path, sandbox_provisioning_flags, module
 ):
     """The reason 3.10 keeps '-I': provisioning runs "-m", and "-m" reads sys.path[0].
 
@@ -166,7 +213,7 @@ def test_a_shadowing_module_beside_the_sandbox_cannot_hijack_a_provisioning_comm
     (tmp_path / (module + ".py")).write_text("print('SHADOWED')\n")
 
     out = subprocess.run(
-        [sys.executable, *sandbox_python_flags, "-m", module, "--help"],
+        [sys.executable, *sandbox_provisioning_flags, "-m", module, "--help"],
         cwd=str(tmp_path),
         env=os.environ,
         capture_output=True,
@@ -174,3 +221,41 @@ def test_a_shadowing_module_beside_the_sandbox_cannot_hijack_a_provisioning_comm
     )
 
     assert "SHADOWED" not in out.stdout, out.stdout
+
+
+def test_a_file_beside_partcad_cannot_hijack_a_module_a_wrapper_imports(tmp_path, sandbox_python_flags):
+    """And the reason a wrapper does not need '-I': it is run by path, not by "-m".
+
+    A wrapper reaches its siblings the way every wrapper in 'wrappers/' does --
+    by appending its own directory to sys.path -- so what it imports comes from
+    PartCAD's own directory. PartCAD's working directory, which is the one a
+    user can drop files into, is on sys.path for neither branch: below 3.11 it
+    is the script's directory that leads instead, and at 3.11+ PYTHONSAFEPATH
+    leaves the front of sys.path empty.
+    """
+    wrappers = tmp_path / "wrappers"
+    wrappers.mkdir()
+    (wrappers / "sibling.py").write_text("ORIGIN = 'WRAPPER'\n")
+    (wrappers / "wrapper.py").write_text("""import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+import sibling
+
+print(sibling.ORIGIN)
+""")
+
+    working_directory = tmp_path / "cwd"
+    working_directory.mkdir()
+    (working_directory / "sibling.py").write_text("ORIGIN = 'SHADOWED'\n")
+
+    out = subprocess.run(
+        [sys.executable, *sandbox_python_flags, str(wrappers / "wrapper.py")],
+        cwd=str(working_directory),
+        env=os.environ,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert out.stdout.strip() == "WRAPPER"


### PR DESCRIPTION
## Copilot Summary

This change separates Python interpreter flags into two categories: one for wrapper scripts and one for provisioning commands (`-m venv`/`-m pip`). Below Python 3.11, provisioning commands retain the `-I` flag for isolation (since they run with `-m` and inherit `sys.path[0]` from PartCAD&#39;s working directory), while wrapper scripts no longer carry it (since they run by path and have `sys.path[0]` set to their own directory). This allows old Python versions to maintain both isolation and reproducible hash seeds.

> Rebased onto `devel` after #553 (`refactor!: one distribution`), so the paths below are the post-#553 ones. The change itself is unchanged by the rebase; only `src/partcad/AGENTS.md` conflicted, and only over the test path it cites.

## Changes

### `src/partcad/runtime_python.py`
- Split `python_flags` into two separate attributes:
  - `python_flags`: Used for wrapper scripts (always `[&#34;-sOOu&#34;]`)
  - `python_provisioning_flags`: Used for `-m venv`/`-m pip` commands (includes `-I` below 3.11)
- Added `flags_for(cmd)` method that selects the appropriate flags based on whether the command is a module invocation (`-m`)
- Updated all `run_onced`, `run_onced_locked`, `run_async_onced`, and `run_async_onced_locked` methods to use `flags_for(cmd)` instead of directly accessing `python_flags`

### `tests/partcad/unit/test_python_env.py`
- Refactored `_flags_for()` into `_runtime_for()` to return the full `PythonRuntime` object
- Added `_flags_for()` wrapper that returns wrapper flags
- Added `_provisioning_flags_for()` to return provisioning flags
- Added `sandbox_provisioning_flags` fixture
- Updated existing tests to verify both flag types separately
- Added `test_only_a_module_command_is_treated_as_provisioning()` to verify flag selection logic
- Added `test_a_file_beside_partcad_cannot_hijack_a_module_a_wrapper_imports()` to verify wrapper isolation

### `src/partcad/python_env.py`
- Updated comments to clarify that `PYTHONSAFEPATH` only protects provisioning commands below 3.11

### `src/partcad/AGENTS.md`
- Expanded documentation explaining the two-flag approach and why wrappers don&#39;t need `-I`

## Rationale

Below Python 3.11, `PYTHONSAFEPATH` doesn&#39;t exist, so the only way to prevent `sys.path[0]` from exposing the working directory is the `-I` flag. However:
- For provisioning (`-m venv`/`-m pip`): `-I` is necessary because these commands inherit `sys.path[0]` from PartCAD&#39;s working directory
- For wrappers: `-I` provides no benefit (they run by path, so `sys.path[0]` is their own directory) but costs reproducibility by implying `-E`, which ignores `PYTHONHASHSEED`

This split allows old Python versions to maintain both isolation (for provisioning) and reproducible hash seeds (for wrappers).

## Test Plan

Existing and new unit tests in `test_python_env.py` verify:
- Wrapper flags don&#39;t include `-I` on any version
- Provisioning flags include `-I` below 3.11
- The `flags_for()` method correctly identifies `-m` commands
- Wrappers can import siblings without shadowing from the working directory
- Hash seeds are honored on all versions

https://claude.ai/code/session_017mgEgDExsDFRatjEQdcyWr