### PR TITLE
feat(core): context tags and `unless`, and skip the KiCad example on Arm

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -54,6 +54,7 @@ Besides the package properties and, optionally, a list of imported dependencies,
   javascriptVersion: <(optional) Node.js major version for sandboxing if applicable>
   javascriptRequirements: <(JavaScript scripts only) the list of npm dependencies to install>
   chili3dVersion: <(Chili3D parts only) the version of Chili3D to render with>
+  unless: <(optional) the conditions this package does not work under; see "Tags" below>
 
   dependencies:
       <dependency-name>:
@@ -222,6 +223,110 @@ Common Metadata
 ===============
 
 All :ref:`objects` in PartCAD may carry the following metadata:
+
+.. _tags:
+
+Tags
+----
+
+Not everything a package can be built out of exists everywhere. The KiCad
+example is the case this was introduced for: KiCad publishes its official
+container images for ``linux/amd64`` only, so the sandbox PartCAD runs
+``kicad-cli`` in cannot be pulled on an Arm host at all. That is a property of
+the design, not a fault in it, and the package saying so is better than every
+consumer of it finding out at use.
+
+A **tag** is a short string naming something that is true of *here*. Every
+context carries the tags true of itself.
+
+What the machine is:
+
+* the CPU architecture -- ``x86_64`` and ``amd64`` on 64-bit Intel/AMD,
+  ``arm64``, ``aarch64`` and ``arm`` on 64-bit Arm (all of them, so that a
+  package need not know which spelling the host happens to report);
+* the operating system -- ``linux``, ``macos`` (also ``darwin``), ``windows``;
+* the operating system and its version, as ``<os>-<version>``. On Linux that is
+  the distribution rather than the kernel, read from ``/etc/os-release``:
+  ``ubuntu`` and ``ubuntu-24.04``, plus whatever ``ID_LIKE`` names (``debian``).
+  On macOS, ``macos-26`` and ``macos-26.1``. On Windows, ``windows-11``.
+
+How PartCAD is configured to work -- one tag per boolean option, carried in one
+of two spellings, the option's name when it is on and that name prefixed with
+``!`` when it is off:
+
+* ``useDocker`` / ``!useDocker`` -- whether PartCAD may use Docker at all;
+* ``useDockerPython`` / ``!useDockerPython``;
+* ``useDockerKicad`` / ``!useDockerKicad``.
+
+These report each option **as configured**, not as it ends up applying:
+``useDocker`` is a master switch over the other two, so ``useDockerKicad`` and
+``!useDocker`` can hold at once. Both spellings exist so that either answer can
+be named -- a package that cares which way an option is set should not have to
+guess what an absent tag meant. Note that ``!`` is part of a tag's name, not an
+operator: a tag is matched, never evaluated, and ``!`` means nothing anywhere
+else.
+
+Anything PartCAD cannot work out for itself -- that this is the build machine,
+that this host is behind a proxy -- is added by the user, through the ``tags``
+user configuration option (``pc config`` shows it) or the ``PC_TAGS``
+environment variable. ``pc system status`` prints the whole resolved set:
+
+.. code-block:: console
+
+  $ PC_TAGS="build-machine" pc system status
+  INFO: Tags: aarch64, arm, arm64, build-machine, debian, linux, ubuntu, ubuntu-24.04, useDocker, useDockerKicad, !useDockerPython
+
+Tags are matched case-insensitively, and are shown in the spelling PartCAD names
+them by -- which is why ``useDocker`` is camelCase (it is an option name) and
+``arm64`` is not.
+
+A package, or any object of a package, may then declare the conditions it does
+**not** work under, using ``unless``:
+
+.. code-block:: yaml
+
+  # The whole package is skipped on an Arm host that will run KiCad in a
+  # container -- but not on one where KiCad has been configured to run natively
+  unless: [[arm, useDocker, useDockerKicad]]
+
+  parts:
+    pcb:
+      type: kicad
+      # ... or just this one part, and on any Arm host
+      unless: arm
+
+``unless`` is a list of **clauses**, and *any one* of them excluding is enough
+(OR). A clause is either a single tag, or a list of tags that must *all* hold
+together (AND). Either level may be written as a bare tag when there is only
+one, so all of these are valid:
+
+.. code-block:: yaml
+
+  unless: arm64                                   # one tag
+  unless: [arm64, windows]                        # either one excludes
+  unless: [[arm, useDocker], macos]               # both of the first, or macOS
+
+An empty clause is refused rather than ignored: it would hold everywhere.
+
+Wherever a clause holds, the declaration is skipped -- it is not enumerated, not
+listed, and not instantiated -- and PartCAD says so once, at ``INFO``, naming
+the clause that did it:
+
+.. code-block::
+
+  INFO: Skipping the package '//pub/examples/partcad/produce_part_kicad': excluded by 'unless' (arm and useDocker and useDockerKicad)
+
+Skipping a package skips what it brings in: its subfolders and its declared
+dependencies are not imported either.
+
+Note that there is deliberately no inverse condition ("only on"). A declaration
+is expected to work everywhere; naming the exceptions keeps the common case
+unwritten, and keeps a platform that does not exist yet from silently excluding
+everything written before it.
+
+A reference to an object that was skipped does not resolve. An alias or an
+``enrich`` built on an object excluded here has to carry the same ``unless``, or
+it will be left pointing at nothing.
 
 .. _requirements:
 

--- a/examples/produce_part_kicad/partcad.yaml
+++ b/examples/produce_part_kicad/partcad.yaml
@@ -1,6 +1,15 @@
 desc: Example of KiCad integration using Arduino Nano from KiCad Templates
 url: https://gitlab.com/kicad/libraries/kicad-templates/-/tree/master/Projects/Arduino_Nano
 
+# KiCad's official container images are published for 'linux/amd64' only, so on
+# an Arm host there is no image to pull for the sandbox 'kicad-cli' runs in.
+# That is a statement about the container, not about KiCad: KiCad itself ships
+# Arm builds, and somebody who turned the container off ('useDockerKicad', or
+# the 'useDocker' master switch over it) and has 'kicad-cli' installed natively
+# can build this package on Arm perfectly well. Hence the clause rather than a
+# bare 'arm': all three have to hold together for the part to be unbuildable.
+unless: [[arm, useDocker, useDockerKicad]]
+
 parts:
   Arduino_Nano:
    type: kicad

--- a/src/partcad/__init__.py
+++ b/src/partcad/__init__.py
@@ -67,7 +67,7 @@ from . import telemetry
 
 telemetry.init(__version__)
 
-from . import actions, exception, healthcheck, logging, utils
+from . import actions, exception, healthcheck, logging, tags, utils
 from .assembly import Assembly
 from .assembly_connect import ConnectHold, ConnectHow
 from .consts import *
@@ -150,6 +150,7 @@ __all__ = [
     "logging",
     "part",
     "shape",
+    "tags",
     "scene",
     "telemetry",
     "user_config",

--- a/src/partcad/context.py
+++ b/src/partcad/context.py
@@ -23,6 +23,7 @@ from . import output
 from . import runtime_javascript_all
 from . import runtime_python_all
 from . import sandbox_versions
+from . import tags as pc_tags
 from . import project_factory_local as rfl
 from . import project_factory_git as rfg
 from . import project_factory_tar as rft
@@ -93,6 +94,12 @@ class Context:
     current_project_path: str
 
     mates: dict[str, dict[str, Mating]]
+
+    # The tags true of this context: what this machine is (architecture,
+    # operating system, that system's version) plus whatever the user
+    # configuration adds. A package or an object may name the tags it does not
+    # work under ('unless'), and is skipped where one of them is in here.
+    tags: set[str]
 
     class PackageLock(object):
         def __init__(self, ctx, package_name: str):
@@ -175,6 +182,11 @@ class Context:
         self.project_locks_lock = threading.Lock()
         self._projects_being_loaded = {}
         self.user_config = user_config
+
+        # Computed once, here, rather than per package: every 'unless' in the
+        # whole package graph is answered against the same set, and the answer
+        # cannot change while the context lives.
+        self.tags = pc_tags.context_tags(user_config)
 
         self.cache_shapes = ShapeCache(user_config=self.user_config)
         self.cache_tests = Cache("tests", user_config=self.user_config)
@@ -462,6 +474,13 @@ class Context:
             # Found what we are looking for
             return project
 
+        # A skipped package is still addressable - it resolves, empty, above -
+        # but nothing below it is. Skipping a package means skipping what it
+        # brings in, and a child reached through it would otherwise load as if
+        # its parent had never opted out.
+        if project.skipped:
+            return None
+
         # next_import is the next of the import we need to load now
         next_import = import_list[0]
         # import_list is reduced to contain only the items that will remain to
@@ -562,6 +581,14 @@ class Context:
         # bridge to async themselves.
         await project.ensure_enumerated_async()
 
+        # Nothing under a skipped package is imported either. The package itself
+        # already said why, once, when it was loaded. Checked after the
+        # enumeration above rather than before it, because that is where a
+        # plugin-backed package's 'unless' arrives from: its configuration comes
+        # over the wire, not from a file the constructor could read.
+        if project.skipped:
+            return []
+
         # First, iterate all explicitly mentioned "dependencies"s.
         # Do it before iterating subdirectories, as it may kick off a long
         # background task. 'dependencies()' is an accessor so that a plugin
@@ -640,6 +667,12 @@ class Context:
         projects = self.projects.values()
         if parent_name is not None:
             projects = filter(lambda x: x.name.startswith(parent_name), projects)
+
+        # Unconditionally, not only under 'has_stuff': a skipped package holds
+        # no objects, so the filter below would drop it anyway, but a caller
+        # that asks for the empty ones too (the interface listing does) is
+        # asking for packages it can look inside - which this one is not.
+        projects = filter(lambda x: not x.skipped, projects)
 
         if has_stuff:
             # Filter out projects that don't contain anything the user might be interested in.

--- a/src/partcad/project.py
+++ b/src/partcad/project.py
@@ -38,6 +38,7 @@ from . import (
     sketch_config,
 )
 from . import sketch_factory_alias as sfa
+from . import tags as pc_tags
 from . import telemetry
 from .document_pdf import render_pdf_async
 from .exception import EmptyShapesError, NeedsUpdateException
@@ -74,6 +75,11 @@ OBJECT_KIND_SECTIONS = {
 # Such a part is only in 'Project.parts' once the assembly has been built, so
 # 'get_part' builds it on demand (see '_materialize_derived_part').
 PART_PRODUCING_ASSEMBLY_TYPES = ("step", "urdf")
+
+# What '_skipped_by' returns for a declaration whose 'unless' PartCAD could not
+# read. Not a clause - nothing excluded it - but the object is dropped all the
+# same, and recorded as broken so that the reason reaches the user.
+INVALID_UNLESS = "<invalid 'unless'>"
 
 
 @telemetry.instrument()
@@ -187,6 +193,39 @@ class Project(project_config.Configuration):
         # Protect the critical sections from access in different threads
         self.lock = threading.Lock()
 
+        # Objects this package declares but could not instantiate, as
+        # {kind: {name: reason}}. They are kept rather than dropped so that the
+        # package can say what is missing and why: an object that vanishes with
+        # nothing but a line in a log leaves the user staring at an empty
+        # package with no way to tell an empty one from a broken one.
+        self.broken_objects: dict[str, dict[str, str]] = {kind: {} for kind in OBJECT_KINDS}
+
+        # Objects this package declares but which do not apply here, as
+        # {kind: {name: clause}} - the 'unless' clause of theirs that excluded
+        # them, as text. Kept apart from 'broken_objects': nothing failed, and
+        # nothing is to be fixed. See 'partcad.tags'.
+        self.skipped_objects: dict[str, dict[str, str]] = {kind: {} for kind in OBJECT_KINDS}
+
+        # option: "unless"
+        # description: the conditions this package does not work under
+        # values: a tag, or a list whose entries are tags (any one excludes) and
+        #         lists of tags (all of which must hold together to exclude)
+        # default: none
+        #
+        # Decided here rather than in 'Configuration', which has no context and
+        # therefore no tags to decide against. A malformed 'unless' is reported
+        # and then ignored: raising would take the whole package - and every
+        # package underneath it - out of the tree over a typo, which is a far
+        # worse outcome than loading a package that meant to exclude itself.
+        try:
+            self.skipped_by = pc_tags.excluded_by(self.config_obj, ctx.tags, self.name)
+        except ValueError as e:
+            pc_logging.error(str(e))
+            self.skipped_by = None
+        self.skipped = self.skipped_by is not None
+        if self.skipped:
+            pc_logging.info("Skipping the package '%s': excluded by 'unless' (%s)" % (self.name, self.skipped_by))
+
         # self._object_configs[kind] holds the declared configuration of every
         # object of that kind. 'None' means "not enumerated yet": a local
         # package knows everything from its parsed 'partcad.yaml' and populates
@@ -196,13 +235,6 @@ class Project(project_config.Configuration):
         self._object_configs: dict[str, typing.Optional[dict]] = {
             kind: self._initial_object_configs(kind) for kind in OBJECT_KINDS
         }
-
-        # Objects this package declares but could not instantiate, as
-        # {kind: {name: reason}}. They are kept rather than dropped so that the
-        # package can say what is missing and why: an object that vanishes with
-        # nothing but a line in a log leaves the user staring at an empty
-        # package with no way to tell an empty one from a broken one.
-        self.broken_objects: dict[str, dict[str, str]] = {kind: {} for kind in OBJECT_KINDS}
 
         # The instantiated objects of each kind, filled lazily by the getters.
         self.interfaces = {}
@@ -244,7 +276,8 @@ class Project(project_config.Configuration):
         else:
             self.desc = ""
 
-        self._instantiate_objects()
+        if not self.skipped:
+            self._instantiate_objects()
 
     def _initial_object_configs(self, kind: str):
         """The configs of the given kind known at construction time.
@@ -253,8 +286,49 @@ class Project(project_config.Configuration):
         plugin-backed package overrides this to return None, deferring
         enumeration until the data is actually requested.
         """
+        if self.skipped:
+            # A skipped package declares nothing here. Emptying it at the source
+            # is what makes every consumer downstream - the listings, the
+            # counts, the getters - agree that there is nothing in it, without
+            # any of them having to know about tags.
+            return {}
         cfg = self.config_obj.get(OBJECT_KIND_SECTIONS[kind])
-        return {} if cfg is None else cfg
+        return {} if cfg is None else self._filter_skipped(kind, cfg)
+
+    def _skipped_by(self, kind: str, name: str, config) -> typing.Optional[str]:
+        """The 'unless' clause excluding this object here, remembering it, or None.
+
+        A malformed 'unless' is recorded as a broken object rather than raised:
+        the object is dropped either way, and going through 'broken_objects'
+        is what puts the reason in front of the user instead of in a traceback.
+        Returns a value in that case too, because the object must not be
+        instantiated from a declaration PartCAD could not read.
+        """
+        try:
+            clause = pc_tags.excluded_by(config, self.ctx.tags, "%s:%s" % (self.name, name))
+        except ValueError as e:
+            self.record_broken_object(kind, name, e)
+            return INVALID_UNLESS
+        if clause is None:
+            return None
+        self.skipped_objects.setdefault(kind, {})[name] = clause
+        pc_logging.info("Skipping the %s '%s:%s': excluded by 'unless' (%s)" % (kind, self.name, name, clause))
+        return clause
+
+    def _filter_skipped(self, kind: str, configs: dict) -> dict:
+        """'configs' without the objects that do not apply to this context."""
+        if not configs:
+            return configs
+        return {name: config for name, config in configs.items() if self._skipped_by(kind, name, config) is None}
+
+    def get_skipped_object_clause(self, kind: str, name: str) -> typing.Optional[str]:
+        """The 'unless' clause an object was excluded on, or None if it was not.
+
+        The clause as text ('arm64', or 'arm and useDocker'), which is what
+        every caller needs it for and what the user will recognize from their
+        own configuration.
+        """
+        return self.skipped_objects.get(kind, {}).get(name)
 
     def _instantiate_objects(self):
         """Instantiate the package's objects.
@@ -280,7 +354,7 @@ class Project(project_config.Configuration):
         """All declared configs of 'kind', enumerating on demand if needed."""
         configs = self._object_configs.get(kind)
         if configs is None:
-            configs = self._enumerate_object_configs(kind)
+            configs = {} if self.skipped else self._filter_skipped(kind, self._enumerate_object_configs(kind))
             self._object_configs[kind] = configs
         return configs
 
@@ -298,8 +372,13 @@ class Project(project_config.Configuration):
         # fetch. A plugin-backed package can serve objects beyond what it
         # enumerates - e.g. the first page of a large, paginated catalog - so
         # any addressable object remains reachable even when it was not listed.
-        one = self._fetch_object_config(kind, name)
+        one = None if self.skipped else self._fetch_object_config(kind, name)
         if one is not None:
+            # Filtered here as well as in the enumeration above: an object a
+            # plugin-backed package serves without listing reaches the caller
+            # through this path only, and 'unless' has to hold on both.
+            if self._skipped_by(kind, name, one) is not None:
+                return None
             return one
         if configs is None:
             return self.object_configs(kind).get(name)
@@ -386,6 +465,11 @@ class Project(project_config.Configuration):
         intentionally does not enumerate the package's objects.
         """
         info = {"Path": self.name}
+        if self.skipped:
+            # Stated here as well as in the log line at load: by the time
+            # somebody asks a package what it is, the line explaining why it is
+            # empty has long scrolled past.
+            info["Skipped"] = "excluded by 'unless' (%s)" % self.skipped_by
         if "url" in self.config_obj and self.config_obj["url"] is not None:
             info["Url"] = self.config_obj["url"]
         if "importUrl" in self.config_obj and self.config_obj["importUrl"] is not None:
@@ -445,6 +529,11 @@ class Project(project_config.Configuration):
         if self.broken:
             pc_logging.info("Ignoring the broken package: %s" % self.name)
             return
+
+        # Skipping a package skips what it brings in, subfolders and declared
+        # dependencies alike. It already said so once, when it was loaded.
+        if self.skipped:
+            return []
 
         children = list()
         if os.path.isdir(self.config_dir):
@@ -945,7 +1034,23 @@ class Project(project_config.Configuration):
                 # object it did not enumerate (a targeted single fetch).
                 config = get_config(object_name)
                 if config is None:
-                    # We don't know anything about such an object
+                    # We don't know anything about such an object - unless it
+                    # is one this context excluded, which is not an error and
+                    # must not read like one: the package declares it, PartCAD
+                    # left it out on purpose, and saying which tag did that is
+                    # the difference between a user fixing a typo they do not
+                    # have and a user reading the one line that explains it.
+                    clause = self.get_skipped_object_clause(factory_name, object_name)
+                    if clause is not None:
+                        if not quiet:
+                            pc_logging.info(
+                                "The %s '%s:%s' is excluded by 'unless' (%s)",
+                                factory_name,
+                                self.name,
+                                object_name,
+                                clause,
+                            )
+                        return None
                     if not quiet:
                         pc_logging.error(
                             "Object '%s' not found in '%s'",

--- a/src/partcad/project.py
+++ b/src/partcad/project.py
@@ -1085,6 +1085,20 @@ class Project(project_config.Configuration):
             # a plugin-backed package enumerates lazily and may not have
             # instantiated the base yet.
             if base_object_name not in object_configs:
+                # The same distinction the unparametrized branch above makes:
+                # a base this context excluded is not a base that is missing,
+                # and 'gone;width=5' has to read the same way as 'gone'.
+                clause = self.get_skipped_object_clause(factory_name, base_object_name)
+                if clause is not None:
+                    if not quiet:
+                        pc_logging.info(
+                            "The %s '%s:%s' is excluded by 'unless' (%s)",
+                            factory_name,
+                            self.name,
+                            base_object_name,
+                            clause,
+                        )
+                    return None
                 pc_logging.error(
                     "Base object '%s' not found in '%s'",
                     base_object_name,
@@ -1483,6 +1497,13 @@ class Project(project_config.Configuration):
         ignore_manufacturability: bool = False,
     ):
         with pc_logging.Action("RenderPkg", self.name):
+            # A skipped package has nothing to render, and must not be asked to:
+            # its declarations are still in 'config_obj' (nothing rewrites the
+            # file), so enumerating them would resolve every one of them to None
+            # and fail the whole render with an 'EmptyShapesError'.
+            if self.skipped:
+                return
+
             options_project = self.ctx.get_project(options_package) if options_package else None
             if options_package and options_project is None:
                 pc_logging.error("The options package is not found: %s" % options_package)
@@ -1577,15 +1598,24 @@ class Project(project_config.Configuration):
         return names
 
     def _enumerate_shapes(self, sketches, interfaces, parts, assemblies):
-        def get_keys(name):
+        def get_keys(section, kind):
             # A section that is present but empty (e.g. `sketches:` with no
             # entries, as `pc init` writes it) parses as None; treat it as {}.
-            return list((self.config_obj.get(name) or {}).keys()) if name in self.config_obj else []
+            if section not in self.config_obj:
+                return []
+            names = list((self.config_obj.get(section) or {}).keys())
+            # Read from 'config_obj' rather than through 'object_configs()' so
+            # that a plugin-backed package - which declares none of this on disk
+            # - keeps rendering nothing, as it always has. But an object this
+            # context excluded is not one to render: it was never instantiated,
+            # so it would come back None and fail the whole package's render
+            # with an 'EmptyShapesError'.
+            return [name for name in names if self.get_skipped_object_clause(kind, name) is None]
 
-        sketches = sketches or get_keys("sketches")
-        # interfaces = sketches or get_keys("interfaces")
-        parts = parts or get_keys("parts")
-        assemblies = assemblies or get_keys("assemblies")
+        sketches = sketches or get_keys("sketches", "sketch")
+        # interfaces = sketches or get_keys("interfaces", "interface")
+        parts = parts or get_keys("parts", "part")
+        assemblies = assemblies or get_keys("assemblies", "assembly")
 
         shapes = []
         for name in sketches:

--- a/src/partcad/project_config.py
+++ b/src/partcad/project_config.py
@@ -58,6 +58,14 @@ class Configuration:
         self.config_obj = {} if config_obj is None else config_obj
         self.broken = False
 
+        # Whether this package opted out of running here, and on which tag. Set
+        # for real by 'Project', which is the first thing along this chain to
+        # have a context - and therefore a tag set - to decide against. Defined
+        # here so that every package has the attribute even when it never got
+        # that far (a package whose 'partcad.yaml' would not parse, say).
+        self.skipped = False
+        self.skipped_by = None
+
         # 'declared_name' is the identity the package gives itself in its own
         # configuration. It is not necessarily where the package ended up being
         # loaded: the same package may be vendored into another package tree at
@@ -173,6 +181,15 @@ class Configuration:
         # environment and changes nothing for anybody else.
         chili3d_version = self.config_obj.get("chili3dVersion")
         self.chili3d_version = None if chili3d_version is None else str(chili3d_version)
+
+        # option: "unless"
+        # description: the tags this package does not work under. It is skipped
+        #              wherever one of them is a tag of the context - see
+        #              'partcad.tags' and 'Project.__init__', which is where the
+        #              decision is actually made (this class has no context, and
+        #              therefore no tags, to make it against).
+        # values: a tag, or a list of tags
+        # default: none
 
         # option: "manufacturable"
         # description: whether the objects in this package are designed for manufacturing by default

--- a/src/partcad/project_external_repository.py
+++ b/src/partcad/project_external_repository.py
@@ -15,6 +15,7 @@ from .cache_hash import CacheHash
 from .project_plugin import ProjectPlugin
 from .sync_threads import threadpool_manager
 from . import logging as pc_logging
+from . import tags as pc_tags
 
 # Distinguishes "no cached value" from a cached value of None.
 _MISSING = object()
@@ -326,6 +327,21 @@ class ProjectExternalRepository(ProjectPlugin):
             self.desc = meta["desc"].strip()
         if "manufacturable" in meta:
             self.is_manufacturable = bool(meta["manufacturable"])
+        if pc_tags.UNLESS_KEY in meta:
+            # Re-derived here for the same reason as the two above: the
+            # constructor read a 'config_obj' the repository had not filled yet,
+            # so a package that excludes itself only says so once this returns.
+            # Nothing has been enumerated by then - object access is lazy for a
+            # plugin package - so emptying it now is as good as never filling it.
+            try:
+                self.skipped_by = pc_tags.excluded_by(self.config_obj, self.ctx.tags, self.name)
+            except ValueError as e:
+                pc_logging.error(str(e))
+                self.skipped_by = None
+            self.skipped = self.skipped_by is not None
+            if self.skipped:
+                pc_logging.info("Skipping the package '%s': excluded by 'unless' (%s)" % (self.name, self.skipped_by))
+                self._object_configs = {kind: {} for kind in self._object_configs}
 
     # --- Object-access hooks (see Project) sourced from the repository ---
 

--- a/src/partcad/schema/partcad.json
+++ b/src/partcad/schema/partcad.json
@@ -53,6 +53,27 @@
       "type": "string",
       "pattern": "((http|https)://)(www.)?[a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)"
     },
+    "unless": {
+      "description": "The conditions this declaration does not work under. A list of clauses, any one of which excludes it (OR); a clause is a single tag, or a list of tags that must all hold together (AND) - e.g. [[arm, useDocker, useDockerKicad]]. It is skipped, with an INFO line saying so, wherever a clause holds. A tag names something true of the context: the host's architecture ('arm64', 'arm', 'x86_64'), its operating system ('linux', 'macos', 'windows'), that system's version ('ubuntu-24.04', 'macos-26'), a boolean configuration option in one of its two spellings ('useDocker' when on, '!useDocker' when off; likewise 'useDockerPython' and 'useDockerKicad'), or a tag the user configuration adds. '!' is part of a tag's name, not an operator.",
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string", "minLength": 1 },
+              {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 },
+                "minItems": 1,
+                "uniqueItems": true
+              }
+            ]
+          },
+          "uniqueItems": true
+        }
+      ]
+    },
     "shape-properties": {
       "type": "object",
       "description": "What the shape this object produces reports about itself, as opposed to 'parameters', which are what is asked of the object type that produces it. Every entry here is an output: it describes the instantiated shape, and an exporter that has a way to state one writes it out rather than recomputing or losing it.",
@@ -408,6 +429,7 @@
       "type": "boolean",
       "default": false
     },
+    "unless": { "$ref": "#/definitions/unless" },
     "docs": {
       "type": "object",
       "properties": {
@@ -653,6 +675,7 @@
                   "additionalProperties": false
                 },
                 "manufacturable": { "type": "boolean" },
+                "unless": { "$ref": "#/definitions/unless" },
                 "connect": { "$ref": "#/definitions/connect" }
               },
               "required": ["type"],
@@ -672,7 +695,8 @@
                 "fileUrl": { "$ref": "#/definitions/url" },
                 "vendor": { "type": "string", "minLength": 1 },
                 "sku": { "type": "string", "minLength": 1 },
-                "count_per_sku": { "type": "integer", "minimum": 1, "default": 1 }
+                "count_per_sku": { "type": "integer", "minimum": 1, "default": 1 },
+                "unless": { "$ref": "#/definitions/unless" }
               },
               "required": ["type"],
               "additionalProperties": true
@@ -745,6 +769,7 @@
                 "render": { "$ref": "#/definitions/render" },
                 "export": { "$ref": "#/definitions/output-section" },
                 "manufacturable": { "type": "boolean" },
+                "unless": { "$ref": "#/definitions/unless" },
                 "connect": { "$ref": "#/definitions/connect" },
                 "properties": { "$ref": "#/definitions/shape-properties" }
               },
@@ -763,6 +788,7 @@
           "properties": {
             "type": { "type": "string", "enum": ["basic", "dxf", "svg", "cadquery", "build123d", "enrich", "alias"] },
             "desc": { "type": "string", "maxLength": 1000 },
+            "unless": { "$ref": "#/definitions/unless" },
             "path": { "type": "string", "minLength": 1 },
             "fileFrom": { "type": "string", "enum": ["url"] },
             "fileUrl": { "$ref": "#/definitions/url" },
@@ -896,6 +922,7 @@
           "properties": {
             "abstract": { "type": "boolean", "default": false },
             "desc": { "type": "string", "maxLength": 1000 },
+            "unless": { "$ref": "#/definitions/unless" },
             "path": { "type": "string", "minLength": 1 },
             "leadPort": { "type": "string", "minLength": 1 },
             "threadStep": {
@@ -977,6 +1004,7 @@
               "additionalProperties": false
             },
             "abstract": { "type": "boolean", "default": false },
+            "unless": { "$ref": "#/definitions/unless" },
             "parameters": { "$ref": "#/definitions/shape-parameter"}
           },
           "required": ["type"],
@@ -996,6 +1024,7 @@
             "source": { "type": "string", "minLength": 1 },
             "package": { "type": "string", "minLength": 1 },
             "with": { "type": "object" },
+            "unless": { "$ref": "#/definitions/unless" },
             "parameters": { "$ref": "#/definitions/shape-parameter"}
           },
           "required": ["type"],
@@ -1012,6 +1041,7 @@
           "properties": {
             "kind": { "type": "string", "enum": ["wrapper"] },
             "desc": { "type": "string", "maxLength": 1000 },
+            "unless": { "$ref": "#/definitions/unless" },
             "path": { "type": "string", "minLength": 1 },
             "pythonRequirements": { "type": "array", "items": { "type": "string" } }
           },

--- a/src/partcad/tags.py
+++ b/src/partcad/tags.py
@@ -1,0 +1,327 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""Context tags, and the ``unless`` condition that skips what cannot work here.
+
+A *tag* is a short string naming something that is true of *here*: of the
+machine PartCAD is running on, or of how it has been configured to work. The
+context carries the set of tags true of itself (see ``Context.tags``), and any
+declaration in a ``partcad.yaml`` -- the package itself, or one of its
+sketches, parts, assemblies, providers, ... -- may name the tags it does not
+work under::
+
+    unless: [arm64]
+
+The declaration is then skipped wherever one of those tags holds, with an
+``INFO`` line saying so, instead of being loaded and failing at use.
+
+``unless`` is a list of *clauses*, any one of which excludes (**OR**). A clause
+is either a single tag, or a list of tags that must **all** hold together
+(**AND**). That is what lets an exclusion be stated in terms of the machine and
+its configuration at once::
+
+    unless: [[arm, useDocker, useDockerKicad]]
+
+-- "not on an Arm machine that is going to run KiCad in a container", which is
+the KiCad example's actual condition and the case that prompted all of this:
+KiCad's official container images are published for ``linux/amd64`` only, so
+that sandbox cannot be pulled on an Arm host at all. Somebody who turned the
+container off and has ``kicad-cli`` installed natively is not covered by the
+clause and keeps the package. That is a property of the package, not a bug in
+it, and a package saying so is better than every consumer of it discovering it
+the hard way.
+
+What is *not* here, deliberately, is the inverse condition ("only on"). A
+declaration is expected to work everywhere; naming the exceptions keeps the
+common case unwritten, and keeps a new platform from silently excluding
+everything that was written before it existed. Nor is there a negation
+*operator*: ``!useDocker`` is a tag in its own right, one the context carries
+when that option is off, and ``!`` means nothing anywhere else. A tag is
+matched, never evaluated.
+
+The tags a context carries are these. First, what the machine is:
+
+* **Architecture**, as ``platform.machine()`` says it, lowercased -- plus the
+  canonical spelling and the family:
+
+  - ``x86_64`` and ``amd64`` on 64-bit Intel/AMD (both, because the two
+    spellings name the same thing and which one a host reports depends on the
+    operating system);
+  - ``arm64`` and ``aarch64`` on 64-bit Arm, plus the family tag ``arm``;
+  - ``i386`` and ``x86`` on 32-bit Intel, plus the family tag ``x86``;
+  - ``arm`` on 32-bit Arm, alongside the exact ``armv7l``/``armv6l``.
+
+* **Operating system**: ``linux``, ``macos`` (also ``darwin``) or ``windows``.
+
+* **Operating system and version**, ``<os>-<version>``:
+
+  - on Linux, the distribution rather than the kernel, from
+    ``/etc/os-release``: ``ubuntu`` and ``ubuntu-24.04``, plus whatever
+    ``ID_LIKE`` names (``debian``), because "this needs a Debian" is the
+    statement a package actually wants to make;
+  - on macOS, ``macos-26`` and ``macos-26.1``;
+  - on Windows, ``windows-11``.
+
+Then, how PartCAD has been configured to work -- one tag per boolean option in
+``CONFIG_TAGS``, named after the option and carried in one of two spellings:
+``useDocker`` when it is on and ``!useDocker`` when it is off. Both spellings
+exist so that either answer can be named; a package that cares which way an
+option is set should not have to guess what "absent" meant.
+
+These report the option **as configured**, not as it ends up applying:
+``useDocker`` is a master switch over the others, so ``useDockerKicad`` and
+``!useDocker`` can hold at once. It reads oddly until you want exactly that
+distinction, and a package excluding itself usually does -- "the container was
+asked for" and "the container will actually be used" are different questions.
+
+Anything else the user wants to condition on is theirs to add, through the
+``tags`` user configuration option (or ``PC_TAGS``).
+
+Tags are matched case-insensitively and are carried in the spelling PartCAD
+names them by, which is why ``useDocker`` is camelCase (it is an option name)
+while ``arm64`` is not.
+"""
+
+import platform
+from typing import Iterable, Optional
+
+from . import logging as pc_logging
+
+# The key a declaration names its exclusions under.
+UNLESS_KEY = "unless"
+
+# The boolean user-configuration options a context reports as tags, by the name
+# they are configured under and the attribute holding what was configured. Each
+# contributes exactly one tag: the option's name when it is on, and that name
+# prefixed with '!' when it is off.
+#
+# Only options that decide *how the work gets done* belong here. That is what a
+# package can meaningfully exclude itself on; the rest of the configuration
+# (where things are cached, how loud the log is) says nothing about whether a
+# design can be built, and putting it here would turn PartCAD's internals into a
+# compatibility surface.
+CONFIG_TAGS = (
+    ("useDocker", "use_docker"),
+    ("useDockerPython", "use_docker_python_declared"),
+    ("useDockerKicad", "use_docker_kicad_declared"),
+)
+
+
+def _normalize_tag(value) -> str:
+    """The one spelling a tag is compared under: stripped and lowercased."""
+    return str(value).strip().lower()
+
+
+def _arch_tags() -> set[str]:
+    machine = _normalize_tag(platform.machine())
+    if not machine:
+        return set()
+
+    tags = {machine}
+    if machine in ("x86_64", "amd64", "x64"):
+        tags.update(("x86_64", "amd64"))
+    elif machine in ("aarch64", "arm64", "armv8b", "armv8l"):
+        tags.update(("arm64", "aarch64", "arm"))
+    elif machine in ("i386", "i486", "i586", "i686", "x86"):
+        tags.update(("i386", "x86"))
+    elif machine.startswith("arm"):
+        tags.add("arm")
+    return tags
+
+
+def _linux_os_tags() -> set[str]:
+    """The distribution's tags, which on Linux is what '<os>-<version>' means.
+
+    'linux-6.8' would name the kernel, which is not what anybody conditions on;
+    'ubuntu-24.04' is. Read from '/etc/os-release', the one thing every
+    distribution agrees to publish. A container or an image without one (a
+    'scratch'-based image, say) simply contributes no distribution tags.
+    """
+    try:
+        release = platform.freedesktop_os_release()
+    except (OSError, AttributeError):
+        # No '/etc/os-release' (or a Python without the accessor, which none of
+        # the versions PartCAD supports is). Not an error: the OS family tag
+        # above still holds, and that is the tag most declarations name.
+        return set()
+
+    tags = set()
+    distro = _normalize_tag(release.get("ID", ""))
+    if not distro:
+        return tags
+    tags.add(distro)
+
+    # 'ID_LIKE' is a space-separated list of the distributions this one is
+    # derived from. Ubuntu says "debian", so 'unless: [debian]' covers both.
+    for like in _normalize_tag(release.get("ID_LIKE", "")).split():
+        if like:
+            tags.add(like)
+
+    version = _normalize_tag(release.get("VERSION_ID", ""))
+    if version:
+        tags.add("%s-%s" % (distro, version))
+    return tags
+
+
+def _macos_os_tags() -> set[str]:
+    tags = {"macos", "darwin"}
+    version = _normalize_tag(platform.mac_ver()[0])
+    if not version:
+        return tags
+
+    parts = version.split(".")
+    tags.add("macos-%s" % parts[0])
+    if len(parts) > 1:
+        tags.add("macos-%s.%s" % (parts[0], parts[1]))
+    return tags
+
+
+def _windows_os_tags() -> set[str]:
+    tags = {"windows"}
+    release = _normalize_tag(platform.win32_ver()[0])
+    if release:
+        tags.add("windows-%s" % release)
+    return tags
+
+
+def _os_tags() -> set[str]:
+    system = _normalize_tag(platform.system())
+    if system == "linux":
+        return {"linux"} | _linux_os_tags()
+    if system == "darwin":
+        return _macos_os_tags()
+    if system == "windows":
+        return _windows_os_tags()
+    # Something PartCAD has never run on. Report what it calls itself rather
+    # than nothing, so that a package can still exclude it by name.
+    return {system} if system else set()
+
+
+def host_tags() -> set[str]:
+    """Every tag true of the machine this process runs on."""
+    return _arch_tags() | _os_tags()
+
+
+def parse_tags(value) -> list[str]:
+    """The tags in a user-supplied list, or in a whitespace/comma-separated string.
+
+    Spelling is left as the user wrote it - matching is case-insensitive, so
+    nothing is gained by folding it here and something is lost: these are shown
+    back to the user by 'pc system status'.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = value.replace(",", " ").split()
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return []
+    return [tag for tag in (str(item).strip() for item in value) if tag]
+
+
+def config_tags(user_config=None) -> set[str]:
+    """How PartCAD is configured to work, as tags: 'useDocker' or '!useDocker'.
+
+    An option this build does not have contributes nothing rather than
+    defaulting to one answer or the other: neither 'useDocker' nor '!useDocker'
+    is true of a PartCAD that has no such option, and claiming either would make
+    a package exclude itself over a question that was never asked.
+    """
+    tags = set()
+    for option, attribute in CONFIG_TAGS:
+        value = getattr(user_config, attribute, None)
+        if value is None:
+            continue
+        tags.add(option if value else "!" + option)
+    return tags
+
+
+def context_tags(user_config=None) -> set[str]:
+    """The tag set a context starts with: this host's, this configuration's, and
+    whatever the user adds on top."""
+    tags = host_tags() | config_tags(user_config)
+    extra = parse_tags(getattr(user_config, "tags", None))
+    if extra:
+        tags.update(extra)
+    pc_logging.debug("Context tags: %s" % ", ".join(sorted(tags)))
+    return tags
+
+
+def parse_unless(value, where: str) -> list[list[str]]:
+    """The clauses an ``unless`` declaration excludes on.
+
+    Returns a list of clauses; a clause is a list of tags. A clause holds when
+    **every** tag in it holds (AND), and the declaration is excluded when
+    **any** clause holds (OR). So::
+
+        unless: arm64                            -> [[arm64]]
+        unless: [arm64, windows]                 -> [[arm64], [windows]]
+        unless: [[arm, useDocker], macos]        -> [[arm, useDocker], [macos]]
+
+    A single tag may be written on its own at either level, because
+    ``unless: arm64`` is what a one-tag exclusion is written as by everybody who
+    writes one, and a one-tag clause reads better as ``macos`` than ``[macos]``.
+
+    Raises ``ValueError`` on anything else, including an empty clause: a clause
+    with no tags holds vacuously, so it would exclude the declaration
+    everywhere, which nobody writes on purpose. A misspelled *tag* cannot be
+    caught -- a tag is any string, and the set of them is open -- but a
+    misshapen declaration can be, and it has to be: an ``unless`` that silently
+    means nothing is an exclusion that silently does not happen.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    elif not isinstance(value, (list, tuple)):
+        raise ValueError("%s: '%s' must be a tag, or a list of tags and tag lists" % (where, UNLESS_KEY))
+
+    clauses = []
+    for item in value:
+        if isinstance(item, str):
+            item = [item]
+        elif isinstance(item, (list, tuple)):
+            item = list(item)
+            if not item:
+                raise ValueError("%s: '%s' must not contain an empty list of tags" % (where, UNLESS_KEY))
+        else:
+            raise ValueError("%s: '%s' must contain tags and lists of tags" % (where, UNLESS_KEY))
+        for tag in item:
+            if not isinstance(tag, str) or not tag.strip():
+                raise ValueError("%s: '%s' must contain non-empty tags" % (where, UNLESS_KEY))
+        clauses.append([tag.strip() for tag in item])
+    return clauses
+
+
+def describe_clause(clause: Iterable[str]) -> str:
+    """A clause as it goes into a message: 'arm64', or 'arm and useDocker'."""
+    return " and ".join(clause)
+
+
+def excluded_by(config, tags: Iterable[str], where: str) -> Optional[str]:
+    """The clause that excludes this declaration here, or None if none does.
+
+    Returned as the text of the clause rather than as a list, because every
+    caller of this wants it for a message. The tags come back in the spelling
+    the declaration used, which is the one the user will go looking for.
+
+    'config' is a declaration's configuration object. A declaration written in
+    the shorthand form (a bare string, e.g. a part declared as just its path)
+    carries no keys and is therefore never excluded.
+    """
+    if not isinstance(config, dict):
+        return None
+    clauses = parse_unless(config.get(UNLESS_KEY), where)
+    if not clauses:
+        return None
+    # Normalized here rather than held normalized on the context, so that the
+    # tags a context reports stay in the spelling PartCAD names them by. Paid
+    # for only by a declaration that has an 'unless' at all, which is why the
+    # early return above comes first.
+    present = {_normalize_tag(tag) for tag in tags}
+    for clause in clauses:
+        if all(_normalize_tag(tag) in present for tag in clause):
+            return describe_clause(clause)
+    return None

--- a/src/partcad_cli/click/commands/system/status.py
+++ b/src/partcad_cli/click/commands/system/status.py
@@ -77,6 +77,12 @@ def cli(cli_ctx: CliContext) -> None:
 
             pc.logging.info(f"PartCAD version: {pc.__version__}")
 
+            # The tags this machine has, and therefore what a package's
+            # 'unless' is answered against here. Worth stating: a package
+            # skipping itself is a decision made from these, and "which tags do
+            # I have?" is otherwise only answerable by reading the source.
+            pc.logging.info("Tags: %s" % ", ".join(sorted(pc.tags.context_tags(pc.user_config))))
+
             # TODO-108: @alexanderilyin: show detail about loaded partcad.yaml
             pc.logging.info("Internal data storage location: %s" % path)
 

--- a/src/partcad_utils/user_config.py
+++ b/src/partcad_utils/user_config.py
@@ -304,8 +304,10 @@ OPTION_KEYS = (
     "git.clone.timeout",
     "git.clone.retry.max",
     "git.clone.retry.patience",
+    "useDocker",
     "useDockerPython",
     "useDockerKicad",
+    "tags",
 )
 
 # The nested sections, by the path each configuration view reads. 'git.auth'
@@ -527,8 +529,10 @@ class UserConfig(vyper.Vyper):
         # default: 180
         self.set_default("git.clone.timeout", 180)
 
+        self.set_default("useDocker", True)
         self.set_default("useDockerPython", False)
         self.set_default("useDockerKicad", True)
+        self.set_default("tags", "")
 
         self.set_env_prefix("pc")
 
@@ -823,17 +827,55 @@ class UserConfig(vyper.Vyper):
         self.bind_env("offline", "PC_OFFLINE")
         self.offline = self.get_bool("offline")
 
+        # option: useDocker
+        # description: whether PartCAD may use Docker at all. The master switch
+        #              over every "useDocker*" option below: turning this off
+        #              turns all of them off, whatever they say, which is what
+        #              lets a machine with no Docker say so once instead of once
+        #              per subject.
+        # values: [True | False]
+        # default: True
+        self.use_docker = self.get_bool("useDocker")
+
         # option: useDockerPython
         # description: use a Docker container for running Python scripts
         # values: [True | False]
         # default: False
-        self.use_docker_python = self.get_bool("useDockerPython")
+        #
+        # Two attributes, because two questions have different answers and both
+        # are asked: '*_declared' is what the configuration says (which is what
+        # the 'useDockerPython' tag reports, so that a package can tell "not
+        # asked for" from "asked for but unavailable"), and the plain attribute
+        # is what actually happens once 'useDocker' has had its say.
+        self.use_docker_python_declared = self.get_bool("useDockerPython")
+        self.use_docker_python = self.use_docker and self.use_docker_python_declared
 
         # option: useDockerKicad
         # description: use a Docker container for KiCad
         # values: [True | False]
         # default: True
-        self.use_docker_kicad = self.get_bool("useDockerKicad")
+        self.use_docker_kicad_declared = self.get_bool("useDockerKicad")
+        self.use_docker_kicad = self.use_docker and self.use_docker_kicad_declared
+
+        # option: tags
+        # description: extra tags to add to the ones PartCAD works out about
+        #              this machine (its architecture, its operating system and
+        #              that system's version). A package, or one of its objects,
+        #              may name the tags it does not work under ("unless:") and
+        #              is then skipped wherever one of them applies. This is how
+        #              a user states something PartCAD cannot see for itself -
+        #              that this host has no Docker, that this is the build
+        #              machine, that KiCad is not installed here.
+        # values: a list of tags, or a string of them separated by commas or
+        #         whitespace (which is what PC_TAGS has to carry)
+        # default: none
+        #
+        # The tags PartCAD derives are NOT here: they are a property of the
+        # machine the work runs on, and are worked out there. This option is
+        # user intent, so it travels with the rest of the configuration - a
+        # daemon serving this caller honours the tags the caller declared.
+        self.bind_env("tags", "PC_TAGS")
+        self.tags = self.get("tags")
 
 
 user_config = UserConfig()

--- a/tests/partcad/unit/test_config_booleans.py
+++ b/tests/partcad/unit/test_config_booleans.py
@@ -47,8 +47,9 @@ BOOLEAN_OPTIONS = [
 # The boolean options with no environment binding, settable in config.yaml only.
 # They read through the same get_bool, so they are covered there instead.
 CONFIG_ONLY_OPTIONS = [
-    ("useDockerPython", "use_docker_python"),
-    ("useDockerKicad", "use_docker_kicad"),
+    ("useDocker", "use_docker"),
+    ("useDockerPython", "use_docker_python_declared"),
+    ("useDockerKicad", "use_docker_kicad_declared"),
 ]
 
 # The booleans TelemetryConfig reads, which go through the same get_bool.
@@ -165,8 +166,11 @@ def test_config_file_values_read_the_same_way(config_home, monkeypatch, key, att
         ("cache_memory", True),
         ("cache_remote", False),
         ("cache_s3", False),
+        ("use_docker", True),
         ("use_docker_kicad", True),
+        ("use_docker_kicad_declared", True),
         ("use_docker_python", False),
+        ("use_docker_python_declared", False),
         ("force_update", False),
         ("devel_index", False),
         ("offline", False),
@@ -177,6 +181,39 @@ def test_config_file_values_read_the_same_way(config_home, monkeypatch, key, att
 def test_an_option_nobody_set_keeps_its_default(config_home, monkeypatch, attribute, expected):
     """The reading changed; what an unset option means did not."""
     assert getattr(build_config(monkeypatch), attribute) is expected
+
+
+# ---- the master switch -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "declared_option,declared_attribute,effective_attribute",
+    [
+        ("useDockerPython", "use_docker_python_declared", "use_docker_python"),
+        ("useDockerKicad", "use_docker_kicad_declared", "use_docker_kicad"),
+    ],
+)
+def test_use_docker_off_turns_off_what_it_governs(
+    config_home, monkeypatch, declared_option, declared_attribute, effective_attribute
+):
+    """'useDocker: false' is how a machine with no Docker says so once, rather
+    than once per subject. What each option was *set* to is still readable, and
+    is what the tags report, so a package can tell the two apart."""
+    (config_home / ".partcad").mkdir(exist_ok=True)
+    (config_home / ".partcad" / "config.yaml").write_text("useDocker: false\n%s: true\n" % declared_option)
+
+    config = build_config(monkeypatch)
+    assert getattr(config, declared_attribute) is True
+    assert getattr(config, effective_attribute) is False
+
+
+def test_use_docker_on_leaves_each_option_to_itself(config_home, monkeypatch):
+    (config_home / ".partcad").mkdir(exist_ok=True)
+    (config_home / ".partcad" / "config.yaml").write_text("useDocker: true\nuseDockerPython: true\n")
+
+    config = build_config(monkeypatch)
+    assert config.use_docker_python is True
+    assert config.use_docker_kicad is True  # its own default
 
 
 # ---- the option that was bound but never read --------------------------------

--- a/tests/partcad/unit/test_part.py
+++ b/tests/partcad/unit/test_part.py
@@ -233,6 +233,13 @@ def test_part_example_kicad():
         if sys.platform == "win32":
             pytest.skip("Docker does not support nested virtualization on Windows in GitHub Actions")
     ctx = pc.init("examples")
+    # The example declares 'unless: [arm64]', because KiCad publishes no arm64
+    # container image for the sandbox to run 'kicad-cli' in. Asserting on the
+    # package rather than on the architecture is what keeps this test and the
+    # example's own declaration from drifting apart.
+    kicad_package = ctx.get_project("//produce_part_kicad")
+    if kicad_package.skipped:
+        pytest.skip("//produce_part_kicad is excluded here: tag '%s'" % kicad_package.skipped_by)
     nano = ctx.get_part("//produce_part_kicad:Arduino_Nano")
     assert nano is not None
 

--- a/tests/partcad/unit/test_tags.py
+++ b/tests/partcad/unit/test_tags.py
@@ -18,6 +18,7 @@ used, which is a fact about the configuration and not about the machine. Hence
 '[[arm, useDocker, useDockerKicad]]', and hence tags for both.
 """
 
+import asyncio
 import platform
 
 import pytest
@@ -25,6 +26,7 @@ import yaml
 
 import partcad as pc
 from partcad import tags as pc_tags
+from partcad_utils.user_config import UserConfig
 
 CUBE = "import cadquery as cq\nshape = cq.Workplane('front').box(1, 1, 1)\nshow_object(shape)\n"
 
@@ -41,6 +43,17 @@ def write_package(path, config, with_cube=True):
 def here():
     """A tag this host really has, so that 'unless' on it excludes for real."""
     return sorted(pc_tags.host_tags())[0]
+
+
+@pytest.fixture
+def also_here():
+    """A second one, for the clauses that need two tags that both hold.
+
+    From the host rather than from the configuration: every host has an
+    architecture and an operating system, whereas which way 'useDocker' is set
+    is a property of whoever is running the tests.
+    """
+    return sorted(pc_tags.host_tags())[1]
 
 
 # The tags a host reports about itself
@@ -155,13 +168,13 @@ def test_the_master_switch_is_reported_apart_from_what_it_governs():
 # Clauses: any one excludes (OR), all the tags in one must hold (AND)
 
 
-def test_a_clause_excludes_only_when_all_of_its_tags_hold(tmp_path, here):
+def test_a_clause_excludes_only_when_all_of_its_tags_hold(tmp_path, here, also_here):
     write_package(
         tmp_path,
         {
             "name": "//test",
             "parts": {
-                "gone": {"type": "cadquery", "path": "cube.py", "unless": [[here, "useDocker"]]},
+                "gone": {"type": "cadquery", "path": "cube.py", "unless": [[here, also_here]]},
                 "kept": {"type": "cadquery", "path": "cube.py", "unless": [[here, "no-such-tag"]]},
             },
         },
@@ -169,7 +182,7 @@ def test_a_clause_excludes_only_when_all_of_its_tags_hold(tmp_path, here):
     project = pc.Context(str(tmp_path)).get_project("//")
 
     assert project.object_names("part") == ["kept"]
-    assert project.get_skipped_object_clause("part", "gone") == "%s and useDocker" % here
+    assert project.get_skipped_object_clause("part", "gone") == "%s and %s" % (here, also_here)
 
 
 def test_any_one_clause_is_enough(tmp_path, here):
@@ -305,6 +318,72 @@ def test_a_misshapen_unless_is_reported_against_the_object(tmp_path):
     assert "unless" in project.get_broken_object_reason("part", "bad")
 
 
+def test_a_parametrized_name_whose_base_is_excluded_says_so(tmp_path, here, caplog):
+    """'gone;width=5' has to read the way 'gone' does.
+
+    The parametrized path looks the base up in the filtered declarations, where
+    an excluded object is absent - which used to come back as an ERROR saying
+    the base was not found, sending the user hunting for a typo they do not
+    have.
+    """
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "parts": {
+                "gone": {
+                    "type": "cadquery",
+                    "path": "cube.py",
+                    "unless": here,
+                    "parameters": {"width": {"type": "float", "default": 1.0}},
+                }
+            },
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    with caplog.at_level("INFO", logger="partcad"):
+        assert project.get_part("gone;width=5") is None
+    assert "excluded by 'unless'" in caplog.text
+    assert "not found" not in caplog.text
+
+
+def test_a_genuinely_missing_base_is_still_an_error(tmp_path, caplog):
+    """The distinction above must not swallow the case it was carved out of."""
+    write_package(tmp_path, {"name": "//test", "parts": {"kept": {"type": "cadquery", "path": "cube.py"}}})
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    with caplog.at_level("INFO", logger="partcad"):
+        assert project.get_part("nosuch;width=5") is None
+    assert "not found" in caplog.text
+
+
+def test_rendering_a_package_does_not_trip_over_its_excluded_objects(tmp_path, here):
+    """An excluded object is not a shape to render.
+
+    'render_async' enumerates a package's shapes from its configuration, which
+    still lists everything - nothing rewrites the file. An excluded one resolves
+    to None, and a None among the shapes fails the whole package's render with
+    'EmptyShapesError'.
+    """
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "parts": {
+                "kept": {"type": "cadquery", "path": "cube.py"},
+                "gone": {"type": "cadquery", "path": "cube.py", "unless": here},
+            },
+            "render": {"svg": None},
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    shapes = project._enumerate_shapes(None, None, None, None)
+    assert None not in shapes
+    assert [shape.name for shape in shapes] == ["kept"]
+
+
 # 'unless' on a package
 
 
@@ -319,6 +398,25 @@ def test_a_package_excluded_by_a_tag_declares_nothing(tmp_path, here):
     assert project.skipped_by == here
     assert project.object_names("part") == []
     assert project.parts == {}
+
+
+def test_rendering_a_skipped_package_is_a_no_op(tmp_path, here):
+    """Not an 'EmptyShapesError'. Its declarations are all still in
+    'config_obj', so enumerating them would resolve every one to None."""
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "unless": here,
+            "parts": {"gone": {"type": "cadquery", "path": "cube.py"}},
+            "render": {"svg": None},
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+    assert project.skipped
+
+    asyncio.run(project.render_async(output_dir=str(tmp_path)))
+    assert not list(tmp_path.glob("*.svg"))
 
 
 def test_a_skipped_package_is_not_listed(tmp_path, here):
@@ -433,15 +531,30 @@ def test_the_kicad_example_is_declared_the_way_it_is_skipped():
     assert pc_tags.parse_unless(config.get("unless"), "kicad example") == [KICAD_CLAUSE]
 
 
+def kicad_container_config(**overrides):
+    """A configuration with the two Docker switches pinned, not inherited.
+
+    The tags a context carries come from the user configuration it resolves, so
+    a developer whose own '~/.partcad/config.yaml' turns either switch off would
+    otherwise fail these tests over a machine setting rather than over the code.
+    """
+    config = UserConfig()
+    config.use_docker = overrides.get("use_docker", True)
+    config.use_docker_kicad_declared = overrides.get("use_docker_kicad_declared", True)
+    config.use_docker_python_declared = False
+    config.tags = ""
+    return config
+
+
 def test_the_kicad_example_is_skipped_on_an_arm_host_using_the_container(monkeypatch):
     """The whole point, exercised on every host rather than only on Arm ones.
 
     'platform.machine()' is the one thing that decides the architecture, so
     standing in for it is enough to put a context on the far side of the
-    condition CI hits: an Arm machine with 'useDockerKicad' at its default.
+    condition CI hits: an Arm machine with the KiCad container in use.
     """
     monkeypatch.setattr(platform, "machine", lambda: "aarch64")
-    ctx = pc.init("examples")
+    ctx = pc.Context("examples", user_config=kicad_container_config())
     assert {"arm64", "aarch64", "arm"} <= ctx.tags
     assert {"useDocker", "useDockerKicad"} <= ctx.tags
 
@@ -454,8 +567,8 @@ def test_the_kicad_example_is_skipped_on_an_arm_host_using_the_container(monkeyp
     assert "//produce_part_kicad" not in listed
 
 
-@pytest.mark.parametrize("option", ["useDocker", "useDockerKicad"])
-def test_an_arm_host_running_kicad_natively_keeps_the_example(monkeypatch, option):
+@pytest.mark.parametrize("off", ["use_docker", "use_docker_kicad_declared"])
+def test_an_arm_host_running_kicad_natively_keeps_the_example(monkeypatch, off):
     """Turning the container off - either switch - takes the exclusion away.
 
     KiCad does ship Arm builds, so somebody who has 'kicad-cli' installed
@@ -463,16 +576,16 @@ def test_an_arm_host_running_kicad_natively_keeps_the_example(monkeypatch, optio
     is the case a bare 'unless: [arm]' would have got wrong.
     """
     monkeypatch.setattr(platform, "machine", lambda: "aarch64")
+    ctx = pc.Context("examples", user_config=kicad_container_config(**{off: False}))
 
-    tags = pc_tags.context_tags(pc.user_config) | {"!" + option}
-    tags.discard(option)
-    with open("examples/produce_part_kicad/partcad.yaml", encoding="utf-8") as f:
-        config = yaml.safe_load(f)
-
-    assert pc_tags.excluded_by(config, tags, "kicad example") is None
+    project = ctx.get_project("//produce_part_kicad")
+    assert not project.skipped
+    assert "Arduino_Nano" in project.object_names("part")
 
 
 def test_the_kicad_example_is_skipped_exactly_where_it_says():
+    """Against whatever this machine actually resolves to, ambient configuration
+    included - which is why it branches rather than asserting one outcome."""
     ctx = pc.init("examples")
     project = ctx.get_project("//produce_part_kicad")
     excluded = all(tag in ctx.tags for tag in KICAD_CLAUSE)

--- a/tests/partcad/unit/test_tags.py
+++ b/tests/partcad/unit/test_tags.py
@@ -1,0 +1,485 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""What a context is tagged with, and what 'unless' does with those tags.
+
+A package - or one object of a package - may declare the conditions it does not
+work under. It is then skipped where one holds, rather than loaded and left to
+fail at use. A condition is a clause: one tag, or several that must hold
+together; any clause excluding is enough.
+
+The case that prompted this is the KiCad example. KiCad's official container
+images are 'linux/amd64' only, so the sandbox PartCAD runs 'kicad-cli' in cannot
+be pulled on an Arm host - but only when that container is what is going to be
+used, which is a fact about the configuration and not about the machine. Hence
+'[[arm, useDocker, useDockerKicad]]', and hence tags for both.
+"""
+
+import platform
+
+import pytest
+import yaml
+
+import partcad as pc
+from partcad import tags as pc_tags
+
+CUBE = "import cadquery as cq\nshape = cq.Workplane('front').box(1, 1, 1)\nshow_object(shape)\n"
+
+
+def write_package(path, config, with_cube=True):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "partcad.yaml").write_text(yaml.safe_dump(config))
+    if with_cube:
+        (path / "cube.py").write_text(CUBE)
+    return path
+
+
+@pytest.fixture
+def here():
+    """A tag this host really has, so that 'unless' on it excludes for real."""
+    return sorted(pc_tags.host_tags())[0]
+
+
+# The tags a host reports about itself
+
+
+def test_the_host_is_tagged_with_its_own_architecture():
+    assert platform.machine().lower() in pc_tags.host_tags()
+
+
+def test_the_two_spellings_of_an_architecture_are_both_tags():
+    """'amd64' and 'x86_64' name the same thing; which one a host reports is
+    the operating system's choice, and no package should have to know it."""
+    tags = pc_tags.host_tags()
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        assert {"x86_64", "amd64"} <= tags
+    elif machine in ("aarch64", "arm64"):
+        # Plus the family, so that 'unless: [arm]' covers 64-bit Arm too.
+        assert {"arm64", "aarch64", "arm"} <= tags
+
+
+def test_the_host_is_tagged_with_its_operating_system():
+    tags = pc_tags.host_tags()
+    expected = {"Linux": "linux", "Darwin": "macos", "Windows": "windows"}[platform.system()]
+    assert expected in tags
+
+
+def test_the_host_is_tagged_with_its_operating_system_version():
+    """One tag of the form '<os>-<version>' - 'ubuntu-24.04', 'macos-26'.
+
+    On Linux that is the distribution rather than the kernel, read from
+    '/etc/os-release'. A container without one contributes none, which is why
+    this asserts the shape of what is there rather than that something is.
+    """
+    versioned = [tag for tag in pc_tags.host_tags() if "-" in tag and not tag.startswith("-")]
+    for tag in versioned:
+        name, _, version = tag.partition("-")
+        assert name and version
+        assert name in pc_tags.host_tags(), "'%s' should imply the tag '%s'" % (tag, name)
+
+
+def test_a_context_carries_the_host_tags():
+    ctx = pc.Context()
+    assert pc_tags.host_tags() <= ctx.tags
+
+
+def test_the_user_configuration_adds_tags():
+    class FakeUserConfig:
+        tags = "no-kicad, build-machine"
+
+    tags = pc_tags.context_tags(FakeUserConfig())
+    assert {"no-kicad", "build-machine"} <= tags
+    assert pc_tags.host_tags() <= tags
+
+
+def test_tags_are_matched_regardless_of_spelling():
+    """Kept as written - 'pc system status' shows these back - but matched
+    case-insensitively, so neither side has to know how the other typed it."""
+
+    class FakeUserConfig:
+        tags = ["  No-KiCad  "]
+
+    tags = pc_tags.context_tags(FakeUserConfig())
+    assert "No-KiCad" in tags
+    assert pc_tags.excluded_by({"unless": "no-kicad"}, tags, "x") == "no-kicad"
+
+
+# The tags a configuration contributes
+
+
+def test_a_boolean_option_is_a_tag_in_one_of_its_two_spellings():
+    class FakeUserConfig:
+        use_docker = True
+        use_docker_python_declared = False
+        use_docker_kicad_declared = True
+
+    assert pc_tags.config_tags(FakeUserConfig()) == {"useDocker", "!useDockerPython", "useDockerKicad"}
+
+
+def test_an_option_this_build_does_not_have_contributes_nothing():
+    """Neither 'useDocker' nor '!useDocker' is true of a PartCAD with no such
+    option, and claiming either would exclude on a question never asked."""
+
+    class FakeUserConfig:
+        pass
+
+    assert pc_tags.config_tags(FakeUserConfig()) == set()
+
+
+def test_a_real_configuration_contributes_its_docker_tags():
+    ctx = pc.Context()
+    for option, _attribute in pc_tags.CONFIG_TAGS:
+        assert (option in ctx.tags) != ("!" + option in ctx.tags), option
+
+
+def test_the_master_switch_is_reported_apart_from_what_it_governs():
+    """'useDocker' off with 'useDockerKicad' on is a real state, and the pair of
+    tags has to be able to say so - it is the state the KiCad example's first
+    clause used to be written for."""
+    from partcad_utils.user_config import UserConfig
+
+    config = UserConfig()
+    config.use_docker = False
+    config.use_docker_kicad_declared = True
+    config.use_docker_python_declared = False
+
+    tags = pc_tags.config_tags(config)
+    assert "!useDocker" in tags
+    assert "useDockerKicad" in tags
+
+
+# Clauses: any one excludes (OR), all the tags in one must hold (AND)
+
+
+def test_a_clause_excludes_only_when_all_of_its_tags_hold(tmp_path, here):
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "parts": {
+                "gone": {"type": "cadquery", "path": "cube.py", "unless": [[here, "useDocker"]]},
+                "kept": {"type": "cadquery", "path": "cube.py", "unless": [[here, "no-such-tag"]]},
+            },
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert project.object_names("part") == ["kept"]
+    assert project.get_skipped_object_clause("part", "gone") == "%s and useDocker" % here
+
+
+def test_any_one_clause_is_enough(tmp_path, here):
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "parts": {
+                "gone": {
+                    "type": "cadquery",
+                    "path": "cube.py",
+                    "unless": [["no-such-tag", "nor-this"], [here]],
+                }
+            },
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert project.object_names("part") == []
+    assert project.get_skipped_object_clause("part", "gone") == here
+
+
+def test_clauses_and_bare_tags_mix_in_one_list(tmp_path, here):
+    assert pc_tags.parse_unless([["arm", "useDocker"], "macos"], "x") == [["arm", "useDocker"], ["macos"]]
+    assert pc_tags.parse_unless("arm64", "x") == [["arm64"]]
+    assert pc_tags.parse_unless(["arm64", "windows"], "x") == [["arm64"], ["windows"]]
+
+
+def test_an_empty_clause_is_refused():
+    """It holds vacuously, so it would exclude everywhere. Nobody writes that."""
+    with pytest.raises(ValueError):
+        pc_tags.parse_unless([[]], "x")
+
+
+def test_a_clause_of_something_other_than_tags_is_refused():
+    with pytest.raises(ValueError):
+        pc_tags.parse_unless([{"arm": True}], "x")
+    with pytest.raises(ValueError):
+        pc_tags.parse_unless([[17]], "x")
+
+
+# 'unless' on an object
+
+
+def test_an_object_excluded_by_a_tag_is_not_declared(tmp_path, here):
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "parts": {
+                "kept": {"type": "cadquery", "path": "cube.py"},
+                "gone": {"type": "cadquery", "path": "cube.py", "unless": [here]},
+            },
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert project.object_names("part") == ["kept"]
+    assert "gone" not in project.parts
+    # Skipped, not broken: nothing failed and there is nothing to fix.
+    assert project.broken_objects["part"] == {}
+    assert project.get_skipped_object_clause("part", "gone") == here
+
+
+def test_an_object_excluded_by_a_tag_resolves_to_nothing(tmp_path, here):
+    write_package(
+        tmp_path,
+        {"name": "//test", "parts": {"gone": {"type": "cadquery", "path": "cube.py", "unless": here}}},
+    )
+    ctx = pc.Context(str(tmp_path))
+
+    assert ctx.get_part("//:gone") is None
+
+
+def test_a_single_tag_need_not_be_written_as_a_list(tmp_path, here):
+    write_package(
+        tmp_path,
+        {"name": "//test", "parts": {"gone": {"type": "cadquery", "path": "cube.py", "unless": here}}},
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert project.object_names("part") == []
+
+
+def test_an_object_is_kept_where_no_tag_of_its_own_holds(tmp_path):
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "parts": {"kept": {"type": "cadquery", "path": "cube.py", "unless": ["no-such-tag", "另一个"]}},
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert project.object_names("part") == ["kept"]
+    assert project.get_skipped_object_clause("part", "kept") is None
+
+
+def test_objects_of_every_kind_can_be_excluded(tmp_path, here):
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "sketches": {"s": {"type": "basic", "circle": 5, "unless": here}},
+            "parts": {"p": {"type": "cadquery", "path": "cube.py", "unless": here}},
+            "assemblies": {"a": {"type": "assy", "path": "a.assy", "unless": here}},
+            "interfaces": {"i": {"abstract": True, "unless": here}},
+            "providers": {"v": {"type": "store", "unless": here}},
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    for kind in ("sketch", "part", "assembly", "interface", "provider"):
+        assert project.object_names(kind) == [], kind
+
+
+def test_a_misshapen_unless_is_reported_against_the_object(tmp_path):
+    """A typo must not pass for "excludes nothing" - that is an exclusion that
+    silently does not happen. The object is dropped and the reason recorded."""
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "parts": {
+                "bad": {"type": "cadquery", "path": "cube.py", "unless": 17},
+                "good": {"type": "cadquery", "path": "cube.py"},
+            },
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert project.object_names("part") == ["good"]
+    assert "unless" in project.get_broken_object_reason("part", "bad")
+
+
+# 'unless' on a package
+
+
+def test_a_package_excluded_by_a_tag_declares_nothing(tmp_path, here):
+    write_package(
+        tmp_path,
+        {"name": "//test", "unless": [here], "parts": {"gone": {"type": "cadquery", "path": "cube.py"}}},
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert project.skipped
+    assert project.skipped_by == here
+    assert project.object_names("part") == []
+    assert project.parts == {}
+
+
+def test_a_skipped_package_is_not_listed(tmp_path, here):
+    write_package(tmp_path, {"name": "//test"})
+    write_package(tmp_path / "kept", {"desc": "kept"})
+    write_package(tmp_path / "gone", {"desc": "gone", "unless": [here]})
+    ctx = pc.Context(str(tmp_path))
+
+    listed = [package["name"] for package in ctx.get_all_packages(has_stuff=False)]
+    assert "//test/kept" in listed
+    assert "//test/gone" not in listed
+
+
+def test_nothing_under_a_skipped_package_is_reachable(tmp_path, here):
+    """Skipping a package skips what it brings in. A child reached through it
+    would otherwise load as if its parent had never opted out."""
+    write_package(tmp_path, {"name": "//test"})
+    write_package(tmp_path / "gone", {"desc": "gone", "unless": [here]})
+    write_package(tmp_path / "gone" / "below", {"parts": {"p": {"type": "cadquery", "path": "cube.py"}}})
+    ctx = pc.Context(str(tmp_path))
+
+    assert ctx.get_project("//test/gone").skipped
+    assert ctx.get_project("//test/gone/below") is None
+    assert ctx.get_project("//test/gone").get_child_project_names() == []
+    listed = [package["name"] for package in ctx.get_all_packages(has_stuff=False)]
+    assert not any(name.startswith("//test/gone") for name in listed)
+
+
+def test_a_package_is_kept_where_no_tag_of_its_own_holds(tmp_path):
+    write_package(
+        tmp_path,
+        {
+            "name": "//test",
+            "unless": ["no-such-tag"],
+            "parts": {"kept": {"type": "cadquery", "path": "cube.py"}},
+        },
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert not project.skipped
+    assert project.object_names("part") == ["kept"]
+
+
+def test_a_misshapen_unless_does_not_take_the_package_out_of_the_tree(tmp_path):
+    """Reported and then ignored: losing a package - and everything under it -
+    over a typo is a far worse outcome than loading one that meant to opt out."""
+    write_package(
+        tmp_path,
+        {"name": "//test", "unless": {"arm64": True}, "parts": {"kept": {"type": "cadquery", "path": "cube.py"}}},
+    )
+    project = pc.Context(str(tmp_path)).get_project("//")
+
+    assert not project.skipped
+    assert project.object_names("part") == ["kept"]
+
+
+# A plugin-backed package, whose configuration arrives over the wire
+
+
+def _external_package(ctx, data):
+    """A plugin-backed package standing on a fake repository (see
+    'test_project_external_repository' for the same fixture in full)."""
+    from partcad.project_external_repository import ProjectExternalRepository
+
+    class FakeRepository:
+        async def get_data(self, key):
+            return data.get(key)
+
+    package = ProjectExternalRepository(ctx, "//ext", "/tmp/ext", config_obj={})
+    package._repository = FakeRepository()
+    return package
+
+
+def test_a_plugin_backed_package_can_exclude_itself(tmp_path, here):
+    """Its configuration is not a file the constructor could read: 'meta'
+    arrives from the repository, so the exclusion is decided when it does."""
+    import asyncio
+
+    write_package(tmp_path, {"name": "//test"}, with_cube=False)
+    ctx = pc.Context(str(tmp_path))
+    package = _external_package(ctx, {"meta": {"desc": "over the wire", "unless": [here]}})
+
+    assert not package.skipped  # nothing has been fetched yet
+    asyncio.run(package.ensure_enumerated_async())
+
+    assert package.skipped
+    assert package.skipped_by == here
+
+
+def test_a_plugin_backed_package_can_exclude_one_object(tmp_path, here):
+    write_package(tmp_path, {"name": "//test"}, with_cube=False)
+    ctx = pc.Context(str(tmp_path))
+    package = _external_package(
+        ctx,
+        {"objects/part": {"kept": {"type": "step"}, "gone": {"type": "step", "unless": here}}},
+    )
+
+    assert package.object_names("part") == ["kept"]
+    assert package.object_config("part", "gone") is None
+
+
+# The KiCad example, which is what all of this is for
+
+
+KICAD_CLAUSE = ["arm", "useDocker", "useDockerKicad"]
+
+
+def test_the_kicad_example_is_declared_the_way_it_is_skipped():
+    with open("examples/produce_part_kicad/partcad.yaml", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    assert pc_tags.parse_unless(config.get("unless"), "kicad example") == [KICAD_CLAUSE]
+
+
+def test_the_kicad_example_is_skipped_on_an_arm_host_using_the_container(monkeypatch):
+    """The whole point, exercised on every host rather than only on Arm ones.
+
+    'platform.machine()' is the one thing that decides the architecture, so
+    standing in for it is enough to put a context on the far side of the
+    condition CI hits: an Arm machine with 'useDockerKicad' at its default.
+    """
+    monkeypatch.setattr(platform, "machine", lambda: "aarch64")
+    ctx = pc.init("examples")
+    assert {"arm64", "aarch64", "arm"} <= ctx.tags
+    assert {"useDocker", "useDockerKicad"} <= ctx.tags
+
+    project = ctx.get_project("//produce_part_kicad")
+    assert project.skipped
+    assert project.skipped_by == "arm and useDocker and useDockerKicad"
+    assert project.object_names("part") == []
+    assert ctx.get_part("//produce_part_kicad:Arduino_Nano") is None
+    listed = [package["name"] for package in ctx.get_packages(has_stuff=False)]
+    assert "//produce_part_kicad" not in listed
+
+
+@pytest.mark.parametrize("option", ["useDocker", "useDockerKicad"])
+def test_an_arm_host_running_kicad_natively_keeps_the_example(monkeypatch, option):
+    """Turning the container off - either switch - takes the exclusion away.
+
+    KiCad does ship Arm builds, so somebody who has 'kicad-cli' installed
+    natively can build this on Arm. The clause is about the container, and this
+    is the case a bare 'unless: [arm]' would have got wrong.
+    """
+    monkeypatch.setattr(platform, "machine", lambda: "aarch64")
+
+    tags = pc_tags.context_tags(pc.user_config) | {"!" + option}
+    tags.discard(option)
+    with open("examples/produce_part_kicad/partcad.yaml", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    assert pc_tags.excluded_by(config, tags, "kicad example") is None
+
+
+def test_the_kicad_example_is_skipped_exactly_where_it_says():
+    ctx = pc.init("examples")
+    project = ctx.get_project("//produce_part_kicad")
+    excluded = all(tag in ctx.tags for tag in KICAD_CLAUSE)
+
+    if excluded:
+        assert project.skipped
+        assert project.object_names("part") == []
+    else:
+        assert not project.skipped
+        assert "Arduino_Nano" in project.object_names("part")

--- a/tools/containers/kicad/README.md
+++ b/tools/containers/kicad/README.md
@@ -20,6 +20,39 @@ parts:
     type: kicad
 ```
 
+## Platforms
+
+The sandbox is **linux/amd64 only**, and so is everything PartCAD builds it out
+of:
+
+* `kicad/kicad`, the base image, is published for `linux/amd64` alone -- the
+  `9.0` manifest list holds that one platform, and `8.0` (what this Dockerfile
+  pins) is a single-architecture manifest;
+* this Dockerfile then installs the `x86_64` Miniforge build by name.
+
+There is therefore no image to pull on an Arm host, and nothing to run if there
+were. It is also why `ghcr.io/partcad/partcad-container-kicad` is built by one
+`amd64` CI job rather than as a multi-platform image.
+
+KiCad itself is another matter: it ships Arm builds for macOS and Linux
+distributions package it for arm64, so a user who has `kicad-cli` installed can
+run it directly with `useDockerKicad: false` (or the `useDocker` master switch
+over it) and build a `kicad` part on Arm perfectly well.
+
+The KiCad example says exactly that, in the two things the context knows about
+-- what the machine is, and how PartCAD is configured to work (see "Tags" in the
+configuration documentation):
+
+```yaml
+unless: [[arm, useDocker, useDockerKicad]]
+```
+
+All three have to hold together: an Arm machine, *and* Docker in use, *and*
+Docker in use for KiCad. Where they do, the container is what would be reached
+for and there is none to reach for, so the package is skipped with a line saying
+so instead of failing at use. Where the container has been turned off, nothing
+is excluded and the native `kicad-cli` is used as it is anywhere else.
+
 ## Current Status
 
 The manufacturability of the PCBs is only implemented through the providers of type `store`. This means that the vendor


### PR DESCRIPTION
## Copilot Summary

### The failure

The arm64 legs of CI fail on `test_part_example_kicad` with

```
OSError: [Errno 113] Connect call failed ('172.17.0.2', 5000)
```

which is the KiCad sandbox never coming up. KiCad is not available for that platform **in the form PartCAD uses it**:

* `kicad/kicad` is published for `linux/amd64` alone — the `9.0` manifest list holds that one platform, and the `8.0` this repo pins is a single-architecture manifest;
* `tools/containers/kicad/Dockerfile` then installs the `x86_64` Miniforge by name.

There is no image to pull on arm64, so the container starts nothing and the client times out against it. That is a property of the package, not a fault in it — so this gives a package a way to say so.

### Tags

A **tag** is a short string naming something true of *here*. A context carries the tags true of itself:

* **What the machine is** — the architecture (`arm64`/`aarch64`/`arm`, `x86_64`/`amd64`), the operating system (`linux`, `macos`, `windows`), and the operating system with its version (`ubuntu-24.04` — the distribution rather than the kernel, from `/etc/os-release` — `macos-26`, `windows-11`).
* **How PartCAD is configured to work** — one tag per boolean option that decides that, in one of two spellings: `useDocker` when it is on and `!useDocker` when it is off; likewise `useDockerPython` and `useDockerKicad`. `!` is part of a tag's name, not an operator — a tag is matched, never evaluated — so both spellings have to exist for either answer to be nameable. They report each option **as configured** rather than as it ends up applying, which is what lets `useDockerKicad` and `!useDocker` hold at once, and lets a package tell "the container was asked for" from "the container will be used".
* **Whatever the user adds**, through the new `tags` option (or `PC_TAGS`).

`pc system status` prints the resolved set.

`useDocker` is new: a master switch over the other two, defaulting to `true` so nothing changes, honoured by ANDing it into the effective `use_docker_python`/`use_docker_kicad`. It is how a machine with no Docker says so once instead of once per subject. What each option was set to stays readable as `*_declared`, which is what the tags report.

### `unless`

A package — or any of its sketches, parts, assemblies, interfaces, providers, repositories or partTypes — may declare the conditions it does not work under. `unless` is a list of **clauses**: any one clause excluding is enough (OR), and a clause is a single tag or a list of tags that must all hold together (AND). Either level may be written bare when there is only one:

```yaml
unless: arm64                          # one tag
unless: [arm64, windows]               # either one excludes
unless: [[arm, useDocker], macos]      # both of the first, or macOS
```

Wherever a clause holds, the declaration is skipped with an `INFO` line naming the clause: it is not enumerated, not listed, not counted and not instantiated. Skipping a package skips its subfolders and its declared dependencies too. A skipped object is kept apart from a broken one — nothing failed and there is nothing to fix — and asking for one by name says so rather than reporting it missing.

There is deliberately no inverse ("only on"): naming the exceptions keeps the common case unwritten, and keeps a platform that does not exist yet from silently excluding everything written before it.

A misshapen `unless` is reported rather than treated as excluding nothing — including an empty clause, which would hold vacuously and so exclude everywhere. On an object it is recorded as broken, through the machinery that already exists for that; on a package it is logged and ignored, because losing a package and its whole subtree over a typo is worse than loading one that meant to opt out.

### The KiCad example

```yaml
unless: [[arm, useDocker, useDockerKicad]]
```

Only the *container* is unavailable on Arm. KiCad itself ships Arm builds and distributions package it, so somebody who turned the container off and has `kicad-cli` installed builds this package on Arm perfectly well, and is not excluded along with everybody else. All three tags have to hold together for the part to be unbuildable — a mix of architecture and configuration granularity rather than capability granularity: PartCAD still does not check whether `kicad-cli` is really there.

This is what takes the arm64 legs of CI back to green.

### Verification

Behaviour of the real example, over `pc list parts //pub/examples/partcad/produce_part_kicad`:

| host | `useDocker` | `useDockerKicad` | result |
| --- | --- | --- | --- |
| x86_64 | on | on | kept (`Total: 1`) |
| Arm | on | on | **skipped** — `excluded by 'unless' (arm and useDocker and useDockerKicad)` |
| Arm | on | off | kept |
| Arm | off | on | kept |

`pc lint` accepts the new key; the JSON schema takes it at the package level and in every object section, and refuses a non-list, an empty clause, a non-string tag and duplicates.

Tests: 34 cases in the new `tests/partcad/unit/test_tags.py` — including an Arm host simulated via `monkeypatch`, so the condition CI hits is exercised on every runner — plus new master-switch cases in `test_config_booleans.py`. `tests/partcad_*` and `cad/freecad` are 571 passed / 1 skipped. Over the CAD-heavy files the failure set is byte-identical to `origin/devel` run in the same container (29 pre-existing failures, all missing-sandbox or no-network in this environment) — no regressions.

Rebased onto `devel` after #553; the two development commits are squashed into one.

### Note for the reviewer

The example's clause is the **inverse** of the one sketched when this was discussed: `[[arm, !useDocker], [arm, useDocker, !useDockerKicad]]` reduces to *arm AND NOT(useDocker AND useDockerKicad)* — skip on Arm exactly when the container is *not* used. The failing CI leg is `ubuntu-24.04-arm` with `useDockerKicad` at its default `true`, so under that expression neither clause holds, the package is not skipped, and the failure comes back unchanged. Flipping it back is one line in `examples/produce_part_kicad/partcad.yaml` plus the `KICAD_CLAUSE` constant in `test_tags.py`.
