### PR TITLE
perf(sandbox): let wrappers of one sandbox run at the same time

### DIFF
--- a/dev-tools/pre-commit-config.yaml
+++ b/dev-tools/pre-commit-config.yaml
@@ -68,17 +68,26 @@ repos:
         language: system
         pass_filenames: false
         files: ^examples/
+      # 'pass_filenames: false' on both: the scripts ignore what they are
+      # handed and run the whole suite. Left on, pre-commit splits the staged
+      # files into as many batches as it has cores and runs the hook once per
+      # batch *concurrently* -- so a commit touching a handful of Python files
+      # ran the entire suite four times over, four times the cost, with four
+      # sessions racing each other over the paths a test writes (test_file.py
+      # downloads into 'examples/bolt.step' and deletes it again).
       - id: behave
         name: "Poetry: behave"
         entry: .devcontainer/behave_hook.sh
         language: system
         types: [python]
+        pass_filenames: false
         description: Run Behave tests in parallel using behavex
       - id: pytest
         name: "Poetry: pytest"
         entry: .devcontainer/pytest_hook.sh
         language: system
         types: [python]
+        pass_filenames: false
         description: Run pytest tests in parallel using xdist
   - repo: https://github.com/hadolint/hadolint
     rev: v2.14.0

--- a/src/partcad/AGENTS.md
+++ b/src/partcad/AGENTS.md
@@ -42,7 +42,19 @@ isort --check src/partcad tests/partcad
 - **Async naming**: every externally visible coroutine has a name ending in `_async`, paired with a synchronous
   wrapper of the same name without the suffix. Coroutines run on asyncio's event loop; CPU-heavy work runs on a
   separate thread pool (sized to CPU cores minus 1). Tasks on the thread pool must not call coroutines that use
-  `asyncio.Lock()`.
+  `asyncio.Lock()`. An assembly is instantiated on the *unconstrained* pool instead: it computes nothing itself,
+  it waits for its parts, and each of those takes a thread from the constrained one -- assemblies waiting there
+  is how enough of them at once run it out of threads, every one waiting for a part with nowhere left to run.
+
+- **Sandbox concurrency**: a wrapper runs in a sandbox *environment* -- the runtime's own conda prefix, or the
+  session v-env of a package that has requirements of its own -- and `sandbox_lock.py` is what holds those
+  apart. `EnvironmentLock` is a readers/writer lock keyed on the environment's path: running a wrapper reads it,
+  installing into it or creating it writes, so any number of wrappers share an environment while an install has
+  it to itself. `process_slots` caps how many sandbox interpreters run at once, because a wrapper is a whole CAD
+  process and it is the machine, not the thread pool, that decides how many fit; `threadsMax` sizes it. Both are
+  polled rather than blocked on: they are taken from several event loops at once (a part is instantiated on a
+  worker thread running a loop of its own), and a task that blocked its own loop waiting for a lock the task
+  beside it is about to release would never see it released.
 - **Location/coordinate format**: 3D locations (OpenCASCADE `TopLoc_Location`) are represented as
   `[[x, y, z], [rx, ry, rz], angle]` — translation in mm, then an axis vector and rotation angle (degrees)
   around it.

--- a/src/partcad/assembly.py
+++ b/src/partcad/assembly.py
@@ -76,7 +76,14 @@ class Assembly(Shape):
     async def do_instantiate(self):
         if len(self.children) == 0:
             self._wrapped = None  # Invalidate if any
-            await threadpool_manager.run(self.instantiate, self)
+            # Detached, not constrained: an assembly does not compute anything
+            # itself, it waits for the parts it is made of - and each of those
+            # takes a thread out of the constrained pool. Assemblies waiting in
+            # that same pool is how a render of enough of them at once runs it
+            # out of threads, with every one of them waiting for a part that
+            # has nowhere left to run. Now that a recursive render admits
+            # several packages at a time, that is no longer hypothetical.
+            await threadpool_manager.run_detached(self.instantiate, self)
             if len(self.children) == 0:
                 pc_logging.warning(f"The assembly {self.project_name}:{self.name} is empty")
 

--- a/src/partcad/part_factory_extrude.py
+++ b/src/partcad/part_factory_extrude.py
@@ -58,6 +58,14 @@ class PartFactoryExtrude(PartFactoryHomogen):
             self.source_sketch_spec = self.source_project_name + ":" + self.source_sketch_name
 
             self._create(config)
+            # Which sketch is extruded, and how far. The sketch has to be in
+            # there: a shape's hash is seeded with nothing that identifies the
+            # shape itself (see Shape.__init__), so without it every extrude
+            # part of a package that shares a depth shares a cache entry, and
+            # whichever of them the cache is asked for first is what all of
+            # them get back. What is still missing is the sketch's *content*,
+            # which is what the broken-dependencies flag below stands for.
+            self.part.hash.add_string(self.source_sketch_spec)
             self.part.hash.add_string(str(self.depth))
             # TODO(clairbee): add dependency tracking for Extrude (PC-313)
             self.part.cache_dependencies_broken = True

--- a/src/partcad/part_factory_sweep.py
+++ b/src/partcad/part_factory_sweep.py
@@ -64,6 +64,10 @@ class PartFactorySweep(PartFactory):
                 sweep_config["axisCoords"] = self.axis
             if "ratio" in config:
                 sweep_config["ratio"] = self.ratio
+            # Which sketch is swept, for the reason spelled out in
+            # PartFactoryExtrude: two parts that differ only in their sketch
+            # otherwise hash the same and share one cache entry.
+            self.part.hash.add_string(self.source_sketch_spec)
             self.part.hash.add_dict(sweep_config)
             # TODO(clairbee): add dependency tracking for Sweep (PC-313)
             self.part.cache_dependencies_broken = True

--- a/src/partcad/runtime.py
+++ b/src/partcad/runtime.py
@@ -17,6 +17,7 @@ import base64
 from .runtime_json_rpc import RuntimeJsonRpcClient
 from . import logging as pc_logging
 from .process_output import decode as decode_output
+from . import sandbox_lock
 
 
 async def wait_for_port(host, port, timeout=30):
@@ -184,21 +185,22 @@ class Runtime:
                     else:
                         pc_logging.error(f"Unsolicited output file: {file_name}")
         else:
-            p = subprocess.Popen(
-                cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                shell=False,
-                encoding="utf-8",
-                # TODO(clairbee): creationflags=subprocess.CREATE_NO_WINDOW,
-                cwd=cwd,
-                env=env,
-            )
-            stdout, stderr = p.communicate(
-                input=stdin,
-                # TODO(clairbee): add timeout
-            )
+            with sandbox_lock.process_slots.slot():
+                p = subprocess.Popen(
+                    cmd,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    shell=False,
+                    encoding="utf-8",
+                    # TODO(clairbee): creationflags=subprocess.CREATE_NO_WINDOW,
+                    cwd=cwd,
+                    env=env,
+                )
+                stdout, stderr = p.communicate(
+                    input=stdin,
+                    # TODO(clairbee): add timeout
+                )
 
         if stdout:
             pc_logging.debug("Output of %s: %s" % (cmd, stdout))
@@ -267,21 +269,22 @@ class Runtime:
                     else:
                         pc_logging.error(f"Unsolicited output file: {file_name}")
         else:
-            p = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                shell=False,
-                # TODO(clairbee): creationflags=subprocess.CREATE_NO_WINDOW,
-                cwd=cwd,
-                env=env,
-            )
-            stdout, stderr = await p.communicate(
-                # TODO(clairbee): add timeout
-                input=stdin.encode(),
-                # TODO(clairbee): add timeout
-            )
+            async with sandbox_lock.process_slots.slot_async():
+                p = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    shell=False,
+                    # TODO(clairbee): creationflags=subprocess.CREATE_NO_WINDOW,
+                    cwd=cwd,
+                    env=env,
+                )
+                stdout, stderr = await p.communicate(
+                    # TODO(clairbee): add timeout
+                    input=stdin.encode(),
+                    # TODO(clairbee): add timeout
+                )
 
             stdout = decode_output(stdout)
             stderr = decode_output(stderr)

--- a/src/partcad/runtime_javascript.py
+++ b/src/partcad/runtime_javascript.py
@@ -230,7 +230,13 @@ def link_or_copy(source: str, destination: str) -> None:
 
 
 class NodeEnvLock:
-    """A file lock over one Node.js environment, the VenvLock twin."""
+    """A file lock over one Node.js environment.
+
+    Keyed on the environment directory, which is what the Python side now keys
+    its own on too (see sandbox_lock.EnvironmentLock). What it does not have
+    yet is that lock's distinction between running out of an environment and
+    installing into it, so Node.js wrappers still run one at a time.
+    """
 
     lock: FileLock
 

--- a/src/partcad/runtime_python.py
+++ b/src/partcad/runtime_python.py
@@ -16,14 +16,17 @@ import platform
 import signal
 import subprocess
 import sys
-import threading
-from filelock import FileLock
 
+from . import sandbox_lock
 from . import sandbox_versions
 from . import runtime
 from . import logging as pc_logging
 from .process_output import decode as decode_output
 from . import telemetry
+
+# Every session v-env directory is named this way, which is what lets the
+# environment lock recover the session hash from the path alone.
+VENV_PREFIX = "v-env-"
 
 
 def get_local_partcad_pkg(dep: str) -> str:
@@ -200,39 +203,9 @@ def environment_requirements(project, config) -> list[str]:
     return [sandbox_versions.reconcile_requirement(requirement)[0] for requirement in requirements]
 
 
-class VenvLock:
-    lock: FileLock
-
-    def __init__(self, runtime: "PythonRuntime", venv: str):
-        runtime.venv_locks_lock.acquire()
-
-        # Setup lock for given venv.
-        # If venv is None then use default (no venv)
-        if venv is None:
-            venv = f"{runtime.sandbox_dir}.default"
-            venv_lock_name = f".{venv}.lock"
-        else:
-            venv_lock_name = f".{runtime.sandbox_dir}.{venv}.lock"
-        if venv not in runtime.venv_locks:
-            runtime.venv_locks[venv] = FileLock(
-                os.path.join(runtime.ctx.user_config.internal_state_dir, venv_lock_name), thread_local=False
-            )
-        self.lock = runtime.venv_locks[venv]
-        runtime.venv_locks_lock.release()
-
-    def __enter__(self, *_args):
-        self.lock.acquire()
-
-    def __exit__(self, *_args):
-        self.lock.release()
-
-
 @telemetry.instrument()
 class PythonRuntime(runtime.Runtime):
     def __init__(self, ctx, sandbox, version=None):
-        self.venv_locks = {}
-        self.venv_locks_lock = threading.Lock()
-
         if version is None:
             version = "%d.%d" % (sys.version_info.major, sys.version_info.minor)
         super().__init__(ctx, "py-" + sandbox + "-" + version)
@@ -240,10 +213,13 @@ class PythonRuntime(runtime.Runtime):
         self.version = version
         self.is_mamba = False
 
-        # Runtimes are meant to be executed from dedicated threads, outside of
-        # the asyncio event loop. So a threading lock is appropriate here.
-        self.lock = threading.RLock()
-        self.tls = threading.local()
+        # Whether once() has run to completion in this process. The sandbox
+        # itself is provisioned once and for all, but every run_async(),
+        # ensure_async() and prepare_for_*() used to re-enter once() to find
+        # that out -- taking the runtime lock, and, under conda, spawning an
+        # interpreter to ask the prefix its version -- several times for every
+        # single file rendered.
+        self.provisioned = False
 
         # Requirements already reported as superseded by the pinned CAD stack,
         # so the warning is emitted once per runtime instead of once per part.
@@ -371,32 +347,62 @@ class PythonRuntime(runtime.Runtime):
         exitcode, stdout, stderr = await self.run_async_onced_locked(["-m", "pip", "check"], path=path)
         self.report_dependency_conflicts(exitcode, stdout, stderr, path=path)
 
-    def get_async_lock(self):
-        if not hasattr(self.tls, "async_locks"):
-            self.tls.async_locks = {}
-        self_id = id(self)
-        loop = asyncio.get_event_loop()
-        loop_id = id(loop)
-        if self_id not in self.tls.async_locks or self.tls.async_locks[self_id][1] != loop_id:
-            self.tls.async_locks[self_id] = (asyncio.Lock(), loop_id)
-        return self.tls.async_locks[self_id][0]
+    def environment_path(self, session=None, path=None) -> str:
+        """The environment a command with these arguments runs out of.
+
+        The same three-way choice get_venv_python_path() makes, and it has to
+        stay that way: this is what the environment lock is keyed on, so a
+        command that locks one environment and runs in another is a command
+        running unlocked.
+        """
+        if path is not None:
+            return path
+        if session is not None and session["dirty"]:
+            return session["path"]
+        return self.path
+
+    def environment_lock(self, session=None, path=None):
+        """The lock over the environment a command runs out of.
+
+        The lock file keeps the names the per-session v-env lock used, so that
+        an installing PartCAD of either vintage running beside this one still
+        contends over the same file: a v-env is named by the hash in its
+        directory name, and the runtime's own environment is "default".
+
+        What has changed is which of them a given command takes -- the
+        environment it runs in, rather than the session it was asked for, which
+        for every package without requirements of its own was a lock over an
+        environment nobody used.
+        """
+        environment_path = self.environment_path(session, path)
+        name = os.path.basename(os.path.normpath(environment_path))
+        if name.startswith(VENV_PREFIX):
+            name = name[len(VENV_PREFIX) :]
+        elif os.path.normpath(environment_path) == os.path.normpath(self.path):
+            name = "default"
+        else:
+            name = hashlib.sha256(environment_path.encode()).hexdigest()[:16]
+        lock_path = os.path.join(self.ctx.user_config.internal_state_dir, f".{self.sandbox_dir}.{name}.lock")
+        return sandbox_lock.get(lock_path)
 
     @contextlib.contextmanager
-    def sync_lock(self, session=None):
-        """Lock the runtime and the venv environment for executing a command"""
-        with self.lock:
-            venv = session["hash"] if session is not None else None
-            with VenvLock(self, venv):
-                yield
+    def sync_lock(self, session=None, path=None, write=False):
+        """Hold the environment a command runs out of.
+
+        'write' for anything that installs into the environment or creates it,
+        which excludes everyone else; without it the environment is only being
+        read, and any number of wrappers may read it at once. That is the whole
+        of the difference between this and the single per-runtime mutex it
+        replaces, which held every wrapper of every environment in one queue.
+        """
+        with self.environment_lock(session, path).acquire(write=write):
+            yield
 
     @contextlib.asynccontextmanager
-    async def async_lock(self, session=None):
-        """Lock the runtime and the venv environment for executing a command"""
-        async with self.get_async_lock():
-            with self.lock:
-                venv = session["hash"] if session is not None else None
-                with VenvLock(self, venv):
-                    yield
+    async def async_lock(self, session=None, path=None, write=False):
+        """The asynchronous twin of sync_lock()."""
+        async with self.environment_lock(session, path).acquire_async(write=write):
+            yield
 
     @contextlib.contextmanager
     def sync_lock_install(self, session=None):
@@ -432,7 +438,9 @@ class PythonRuntime(runtime.Runtime):
             await self.ensure_async_onced_locked(zstd)
 
     def once(self):
-        with self.sync_lock():
+        if self.provisioned:
+            return
+        with self.sync_lock(write=True):
             with self.sync_lock_install():
                 self.ensure_zstd_onced_locked()
                 if not self.initialized:
@@ -454,9 +462,12 @@ class PythonRuntime(runtime.Runtime):
                     # 'cadquery-ocp-novtk' dependency has just replaced.
                     self.ensure_onced_locked(sandbox_versions.CADQUERY_OCP)
                     self.initialized = True
+        self.provisioned = True
 
     async def once_async(self):
-        async with self.async_lock():
+        if self.provisioned:
+            return
+        async with self.async_lock(write=True):
             with self.sync_lock_install():
                 await self.ensure_zstd_onced_locked_async()
                 if not self.initialized:
@@ -474,6 +485,7 @@ class PythonRuntime(runtime.Runtime):
                     # 'cadquery-ocp-novtk' dependency has just replaced.
                     await self.ensure_async_onced_locked(sandbox_versions.CADQUERY_OCP)
                     self.initialized = True
+        self.provisioned = True
 
     def _subprocess_env(self):
         """Environment for a spawned sandbox process, or None to inherit ours.
@@ -489,7 +501,7 @@ class PythonRuntime(runtime.Runtime):
         return self.run_onced(cmd, stdin=stdin, cwd=cwd, session=session)
 
     def run_onced(self, cmd, stdin="", cwd=None, session=None, path=None):
-        # Hold the venv-scoped lock across BOTH provisioning and execution so a
+        # Hold the environment lock across BOTH provisioning and execution so a
         # session's package installs and its interpreter run are one atomic
         # critical section. Two parts of the same package (e.g. a CadQuery part
         # and a build123d part) share a session v-env; if the install loop is
@@ -501,9 +513,15 @@ class PythonRuntime(runtime.Runtime):
         # ImportError (e.g. a missing 'vtkmodules'). The guard bookkeeping makes
         # the VTK build win once all installs settle, but not necessarily at the
         # instant a run starts; serializing install+run per v-env closes that
-        # window. See run_async_onced() for the async twin.
-        with self.sync_lock(session):
-            if session and session["dirty"]:
+        # window.
+        #
+        # It is taken for writing only while that is still ahead: a session
+        # whose v-env has been provisioned, and every session that runs out of
+        # the runtime's own environment, is only reading what is installed, and
+        # any number of those may read it at once. See run_async_onced() for
+        # the async twin.
+        with self.sync_lock(session, path=path, write=self.session_needs_install(session)):
+            if self.session_needs_install(session):
                 # The venv environment has to be created
                 venv_created = not os.path.exists(session["path"])
                 if venv_created:
@@ -529,12 +547,16 @@ class PythonRuntime(runtime.Runtime):
                         self.ensure_onced_locked(dep, path=session["path"])
                     if venv_created:
                         self.check_deps_onced_locked(path=session["path"])
+                session["installed"].update(session["deps"])
 
             python_path = self.get_venv_python_path(session, path)
             cmd = [python_path, *self.flags_for(cmd), *cmd]
             pc_logging.debug("Running: %s", cmd)
             # pc_logging.debug("stdin: %s", stdin)
-            with telemetry.start_as_current_span("PythonRuntime.run_onced.*{subprocess.Popen}") as span:
+            with (
+                sandbox_lock.process_slots.slot(),
+                telemetry.start_as_current_span("PythonRuntime.run_onced.*{subprocess.Popen}") as span,
+            ):
                 # Strip user home directory from the path, if any
                 sanitized_cmd = copy.copy(cmd)
                 sanitized_cmd[0] = os.path.join("...", os.path.basename(sanitized_cmd[0]))
@@ -635,7 +657,7 @@ class PythonRuntime(runtime.Runtime):
         return await self.run_async_onced(cmd, stdin=stdin, cwd=cwd, session=session)
 
     async def run_async_onced(self, cmd, stdin="", cwd=None, session=None, path=None):
-        # Hold the venv-scoped lock across BOTH provisioning and execution so a
+        # Hold the environment lock across BOTH provisioning and execution so a
         # session's package installs and its interpreter run are one atomic
         # critical section. Two parts of the same package (e.g. a CadQuery part
         # and a build123d part) share a session v-env; if the install loop is
@@ -648,8 +670,13 @@ class PythonRuntime(runtime.Runtime):
         # the VTK build win once all installs settle, but not necessarily at the
         # instant a run starts; serializing install+run per v-env closes that
         # window.
-        async with self.async_lock(session):
-            if session and session["dirty"]:
+        #
+        # It is taken for writing only while that is still ahead: a session
+        # whose v-env has been provisioned, and every session that runs out of
+        # the runtime's own environment, is only reading what is installed, and
+        # any number of those may read it at once.
+        async with self.async_lock(session, path=path, write=self.session_needs_install(session)):
+            if self.session_needs_install(session):
                 # The venv environment has to be created
                 venv_created = not os.path.exists(session["path"])
                 if venv_created:
@@ -675,30 +702,32 @@ class PythonRuntime(runtime.Runtime):
                         await self.ensure_async_onced_locked(dep, path=session["path"])
                     if venv_created:
                         await self.check_deps_async_onced_locked(path=session["path"])
+                session["installed"].update(session["deps"])
 
             python_path = self.get_venv_python_path(session, path)
             cmd = [python_path, *self.flags_for(cmd), *cmd]
             pc_logging.debug("Running: %s", cmd)
             # pc_logging.debug("stdin: %s", stdin)
-            with telemetry.start_as_current_span("PythonRuntime.run_async_onced.*{subprocess.Popen}") as span:
-                # Strip user home directory from the path, if any
-                sanitized_cmd = copy.copy(cmd)
-                sanitized_cmd[0] = os.path.join("...", os.path.basename(sanitized_cmd[0]))
-                span.set_attribute("cmd", " ".join(sanitized_cmd))
-                p = await asyncio.create_subprocess_exec(
-                    *cmd,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    shell=False,
-                    env=self._subprocess_env(),
-                    # TODO(clairbee): creationflags=subprocess.CREATE_NO_WINDOW,
-                    cwd=cwd,
-                )
-                stdout, stderr = await p.communicate(
-                    input=stdin.encode(),
-                    # TODO(clairbee): add timeout
-                )
+            async with sandbox_lock.process_slots.slot_async():
+                with telemetry.start_as_current_span("PythonRuntime.run_async_onced.*{subprocess.Popen}") as span:
+                    # Strip user home directory from the path, if any
+                    sanitized_cmd = copy.copy(cmd)
+                    sanitized_cmd[0] = os.path.join("...", os.path.basename(sanitized_cmd[0]))
+                    span.set_attribute("cmd", " ".join(sanitized_cmd))
+                    p = await asyncio.create_subprocess_exec(
+                        *cmd,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        shell=False,
+                        env=self._subprocess_env(),
+                        # TODO(clairbee): creationflags=subprocess.CREATE_NO_WINDOW,
+                        cwd=cwd,
+                    )
+                    stdout, stderr = await p.communicate(
+                        input=stdin.encode(),
+                        # TODO(clairbee): add timeout
+                    )
 
             stdout = decode_output(stdout)
             stderr = decode_output(stderr)
@@ -807,79 +836,91 @@ class PythonRuntime(runtime.Runtime):
         if path is None:
             path = self.path
 
-        guard_path = get_guard_path(path, python_package)
         force = force or needs_reassert(path, python_package)
         if session:
             # Add the dependency to the session dependencies
             session["deps"].append(python_package)
-            if not os.path.exists(guard_path):
+            if not self.installed_onced(python_package, path):
                 # Mark this session as needed if the dependency is not met by the runtime environment
                 session["dirty"] = True
-        else:
-            with self.sync_lock():
+        elif not self.installed_onced(python_package, path, force):
+            with self.sync_lock(path=path, write=True):
                 with self.sync_lock_install():
-                    if not os.path.exists(guard_path):
-                        item = python_package
-                        if item == "partcad":
-                            item = get_local_partcad_pkg(item)
-                        if not path is None:
-                            item += " in " + path
-                        with pc_logging.Action("PipInst", self.version, item):
-                            self.run_onced_locked(
-                                [
-                                    "-m",
-                                    "pip",
-                                    *self.pip_flags,
-                                    "install",
-                                    *self.pip_install_flags,
-                                    *self.get_constraints_flags(),
-                                    *(FORCE_REINSTALL_FLAGS if force else []),
-                                    python_package,
-                                ],
-                                path=path,
-                            )
-                        pathlib.Path(guard_path).touch()
-                        clear_reassert(path, python_package)
-                        invalidate_dependent_guards(path, python_package)
-                invalidate_dependent_guards(path, python_package)
+                    self.install_onced_locked(python_package, path, force)
+
+    def installed_onced(self, python_package, path, force=False) -> bool:
+        """Whether 'path' already holds this package.
+
+        The install guard is the record, and reading it is the whole of the
+        fast path: only a requirement that is genuinely missing makes a caller
+        take the environment's write lock and so wait behind every wrapper
+        running out of it. Every requirement of every file rendered used to
+        take that lock to find out there was nothing to do.
+        """
+        if force:
+            return False
+        return os.path.exists(get_guard_path(path, python_package))
+
+    def install_label(self, python_package, path):
+        item = get_local_partcad_pkg(python_package) if python_package == "partcad" else python_package
+        return item if path is None else item + " in " + path
+
+    def pip_install_command(self, python_package, force):
+        return [
+            "-m",
+            "pip",
+            *self.pip_flags,
+            "install",
+            *self.pip_install_flags,
+            *self.get_constraints_flags(),
+            *(FORCE_REINSTALL_FLAGS if force else []),
+            python_package,
+        ]
+
+    def record_install(self, python_package, path):
+        """Note that a package is in 'path', and what that install clobbered.
+
+        Only ever called after an install has actually run. The dependent
+        guards say "these packages have just had their files overwritten", so
+        dropping them when nothing was installed asks for the next render to
+        re-install a package that was never touched -- which, since build123d
+        invalidates cadquery-ocp and every image file type installs both, is a
+        forced re-install of the whole of OCP per rendered file.
+        """
+        pathlib.Path(get_guard_path(path, python_package)).touch()
+        clear_reassert(path, python_package)
+        invalidate_dependent_guards(path, python_package)
+
+    def install_onced_locked(self, python_package, path, force=False):
+        """Install one package. The environment's write lock is already held."""
+        if self.installed_onced(python_package, path, force):
+            return
+        with pc_logging.Action("PipInst", self.version, self.install_label(python_package, path)):
+            self.run_onced_locked(self.pip_install_command(python_package, force), path=path)
+        self.record_install(python_package, path)
+
+    async def install_async_onced_locked(self, python_package, path, force=False):
+        """The asynchronous twin of install_onced_locked()."""
+        if self.installed_onced(python_package, path, force):
+            return
+        with pc_logging.Action("PipInst", self.version, self.install_label(python_package, path)):
+            await self.run_async_onced_locked(self.pip_install_command(python_package, force), path=path)
+        self.record_install(python_package, path)
 
     def ensure_onced_locked(self, python_package, session=None, path=None, force=False):
         python_package = self.reconcile_requirement(python_package)
         if path is None:
             path = self.path
 
-        guard_path = get_guard_path(path, python_package)
         force = force or needs_reassert(path, python_package)
         if session:
             # Add the dependency to the session dependencies
             session["deps"].append(python_package)
-            if not os.path.exists(guard_path):
+            if not self.installed_onced(python_package, path):
                 # Mark this session as needed if the dependency is not met by the runtime environment
                 session["dirty"] = True
         else:
-            if not os.path.exists(guard_path):
-                item = python_package
-                if item == "partcad":
-                    item = get_local_partcad_pkg(item)
-                if not path is None:
-                    item += " in " + path
-                with pc_logging.Action("PipInst", self.version, item):
-                    self.run_onced_locked(
-                        [
-                            "-m",
-                            "pip",
-                            *self.pip_flags,
-                            "install",
-                            *self.pip_install_flags,
-                            *self.get_constraints_flags(),
-                            *(FORCE_REINSTALL_FLAGS if force else []),
-                            python_package,
-                        ],
-                        path=path,
-                    )
-                pathlib.Path(guard_path).touch()
-                clear_reassert(path, python_package)
-                invalidate_dependent_guards(path, python_package)
+            self.install_onced_locked(python_package, path, force)
 
     async def ensure_async(self, python_package, session=None, path=None, force=False):
         await self.once_async()
@@ -891,41 +932,17 @@ class PythonRuntime(runtime.Runtime):
             path = self.path
 
         # TODO(clairbee): expire the guard file after a certain time
-        guard_path = get_guard_path(path, python_package)
         force = force or needs_reassert(path, python_package)
         if session:
             # Add the dependency to the session dependencies
             session["deps"].append(python_package)
-            if not os.path.exists(guard_path):
+            if not self.installed_onced(python_package, path):
                 # Mark this session as needed if the dependency is not met by the runtime environment
                 session["dirty"] = True
-        else:
-            async with self.async_lock():
+        elif not self.installed_onced(python_package, path, force):
+            async with self.async_lock(path=path, write=True):
                 with self.sync_lock_install():
-                    if not os.path.exists(guard_path):
-                        item = python_package
-                        if item == "partcad":
-                            item = get_local_partcad_pkg(item)
-                        if not path is None:
-                            item += " in " + path
-                        with pc_logging.Action("PipInst", self.version, item):
-                            await self.run_async_onced_locked(
-                                [
-                                    "-m",
-                                    "pip",
-                                    *self.pip_flags,
-                                    "install",
-                                    *self.pip_install_flags,
-                                    *self.get_constraints_flags(),
-                                    *(FORCE_REINSTALL_FLAGS if force else []),
-                                    python_package,
-                                ],
-                                path=path,
-                            )
-                        pathlib.Path(guard_path).touch()
-                        clear_reassert(path, python_package)
-                        invalidate_dependent_guards(path, python_package)
-                invalidate_dependent_guards(path, python_package)
+                    await self.install_async_onced_locked(python_package, path, force)
 
     async def ensure_async_onced_locked(self, python_package, session=None, path=None, force=False):
         python_package = self.reconcile_requirement(python_package)
@@ -934,38 +951,15 @@ class PythonRuntime(runtime.Runtime):
 
         # TODO(clairbee): expire the guard file after a certain time
 
-        guard_path = get_guard_path(path, python_package)
         force = force or needs_reassert(path, python_package)
         if session:
             # Add the dependency to the session dependencies
             session["deps"].append(python_package)
-            if not os.path.exists(guard_path):
+            if not self.installed_onced(python_package, path):
                 # Mark this session as needed if the dependency is not met by the runtime environment
                 session["dirty"] = True
         else:
-            if not os.path.exists(guard_path):
-                item = python_package
-                if item == "partcad":
-                    item = get_local_partcad_pkg(item)
-                if not path is None:
-                    item += " in " + path
-                with pc_logging.Action("PipInst", self.version, item):
-                    await self.run_async_onced_locked(
-                        [
-                            "-m",
-                            "pip",
-                            *self.pip_flags,
-                            "install",
-                            *self.pip_install_flags,
-                            *self.get_constraints_flags(),
-                            *(FORCE_REINSTALL_FLAGS if force else []),
-                            python_package,
-                        ],
-                        path=path,
-                    )
-                pathlib.Path(guard_path).touch()
-                clear_reassert(path, python_package)
-                invalidate_dependent_guards(path, python_package)
+            await self.install_async_onced_locked(python_package, path, force)
 
     async def prepare_for_package(self, project, session=None):
         await self.once_async()
@@ -998,7 +992,7 @@ class PythonRuntime(runtime.Runtime):
                 use_venv = True
         else:
             # This can be either a venv path or a conda path.
-            if str(os.path.basename(path)).startswith("v-env-"):
+            if str(os.path.basename(path)).startswith(VENV_PREFIX):
                 use_venv = True
             else:
                 use_venv = False
@@ -1013,10 +1007,30 @@ class PythonRuntime(runtime.Runtime):
 
         return python_path
 
+    def session_needs_install(self, session=None) -> bool:
+        """Whether running this session still has to install anything.
+
+        Which is the same question as whether the run needs the environment for
+        writing, so the two must be asked the same way: a run that installs
+        while holding the environment for reading is a run installing behind
+        the back of every wrapper reading it.
+
+        A session goes dirty the moment a requirement of its package is not
+        already met by the runtime environment, and stays dirty for good --
+        'dirty' is also what says the session runs out of its own v-env rather
+        than the runtime's, so it cannot be cleared once the v-env exists. What
+        the install pass leaves behind instead is the set of requirements it put
+        there; while that covers what the session asks for, its runs are readers
+        like any other, and a requirement added afterwards puts it back.
+        """
+        if not session or not session["dirty"]:
+            return False
+        return not set(session["deps"]).issubset(session["installed"])
+
     def get_session(self, name: str):
         """Create a context to describe the venv environment in case it is needed"""
         name_hash = hashlib.sha256(name.encode()).hexdigest()[:16]
-        venv_path = os.path.join(self.path, "v-env-" + name_hash)
+        venv_path = os.path.join(self.path, VENV_PREFIX + name_hash)
 
         # A v-env is created by "python -m venv" without --system-site-packages,
         # so it does not see what the sandbox around it has installed: zstd has
@@ -1039,4 +1053,8 @@ class PythonRuntime(runtime.Runtime):
             "path": venv_path,
             "dirty": False,
             "deps": deps,
+            # What the v-env has been given so far. Once it covers 'deps', the
+            # runs that follow share the v-env instead of taking it exclusively
+            # one at a time (see session_needs_install()).
+            "installed": set(),
         }

--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -206,12 +206,21 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
         return env
 
     def once(self):
-        with self.sync_lock():
+        # 'provisioned' is raised by the base implementation below, once the
+        # whole of this has run. Without the check, every command run in this
+        # sandbox re-entered once_conda_locked(), which spawns an interpreter
+        # to ask the prefix what version it is (see verify_conda) -- an extra
+        # process per requirement checked and per file rendered.
+        if self.provisioned:
+            return
+        with self.sync_lock(write=True):
             self.once_conda_locked()
         super().once()
 
     async def once_async(self):
-        async with self.async_lock():
+        if self.provisioned:
+            return
+        async with self.async_lock(write=True):
             self.once_conda_locked()
         await super().once_async()
 

--- a/src/partcad/sandbox_lock.py
+++ b/src/partcad/sandbox_lock.py
@@ -1,0 +1,234 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Concurrency control over the sandboxes that wrappers run in.
+
+Two things are shared by everything that runs a wrapper, and both used to be
+guarded by a single mutex per runtime, held across the whole subprocess:
+
+  * A sandbox *environment* -- a conda prefix or a v-env. Every wrapper that
+    runs in it reads its package set; every install into it rewrites that set.
+    Readers do not conflict with each other, only with an install, so this is a
+    readers/writer lock rather than a mutex. It is keyed on the environment's
+    path, which is what a wrapper actually runs out of. The v-env lock it
+    replaces was keyed on the session, which gave two packages sharing the base
+    environment two different locks over the same files, and gave the same
+    environment two names depending on who asked for it.
+
+  * The machine. A wrapper is a full CAD interpreter, several hundred megabytes
+    of it, so it is the number of concurrent *processes* and not the number of
+    threads that decides whether a render keeps the box busy or swaps it to
+    death. 'process_slots' is that budget. It was previously implicit: the
+    runtime mutex allowed exactly one.
+
+Both are held across 'await's, and both are taken from more than one event loop
+at a time -- a part is instantiated on a worker thread that runs a loop of its
+own (see sync_threads). So neither can be an asyncio primitive, which belongs
+to one loop, and neither may block the loop it is taken from: a task that
+blocks its own loop waiting for a lock that another task on that same loop is
+about to release deadlocks outright. The asynchronous acquires therefore await
+a poll of a non-blocking try, which is what lets one implementation serve every
+loop without a thread per waiter.
+"""
+
+import asyncio
+import contextlib
+import os
+import threading
+import time
+
+from filelock import FileLock, Timeout
+
+from .user_config import user_config
+
+# How long a contended acquire waits between attempts. Contention only happens
+# around an install, which takes seconds, so the upper bound costs nothing and
+# the lower bound keeps an uncontended-but-just-missed acquire prompt.
+_POLL_MIN = 0.002
+_POLL_MAX = 0.1
+
+
+class EnvironmentLock:
+    """A readers/writer lock over one sandbox environment.
+
+    Readers run wrappers out of the environment; writers install into it or
+    create it. Readers share it, a writer excludes everyone.
+
+    Within this process that is the whole story. Across processes only the
+    writers are held apart, by the file lock below - which is what the
+    per-environment lock file has always been for: two pip installs into one
+    prefix are what actually leaves an environment broken. A wrapper reading an
+    environment that another process is installing into is not covered, and was
+    not covered before either for anything running out of the runtime's own
+    environment, since installs into it took one lock file and runs out of it
+    took another.
+
+    Closing that gap needs a lock file a reader can hold in *shared* mode.
+    Holding this exclusive one for reading would do it, but it would also mean
+    a busy render in one workspace stopping every other PartCAD process on the
+    machine for as long as it runs, reader against reader included - a worse
+    bargain than the gap. filelock's SQLite-backed ReadWriteLock is what to
+    reach for when its floor can be raised.
+
+    Only one instance may exist per lock file, which is what 'get()' is for:
+    filelock counts recursive acquires per object, so two objects over one path
+    would each believe they hold it.
+    """
+
+    def __init__(self, lock_path: str):
+        self.lock_path = lock_path
+        # thread_local=False: what holds this is a group of readers or one
+        # writer, neither of which is a thread.
+        self._file_lock = FileLock(lock_path, thread_local=False)
+        self._mutex = threading.Lock()
+        self._readers = 0
+        self._writer = False
+        # Readers defer to a writer that is already waiting, so that a steady
+        # stream of wrappers cannot starve the install one of them is waiting
+        # for. Safe against the deadlock a bounded thread pool would introduce
+        # here because waiters poll rather than occupy anything.
+        self._writers_waiting = 0
+
+    def _try_acquire(self, write: bool) -> bool:
+        with self._mutex:
+            if write:
+                if self._writer or self._readers:
+                    return False
+                try:
+                    self._file_lock.acquire(blocking=False)
+                except Timeout:
+                    # Another process is installing into this environment.
+                    return False
+                self._writer = True
+            else:
+                if self._writer or self._writers_waiting:
+                    return False
+                self._readers += 1
+            return True
+
+    def _release(self, write: bool) -> None:
+        with self._mutex:
+            if write:
+                self._writer = False
+                self._file_lock.release()
+            else:
+                self._readers -= 1
+
+    def _wait_sync(self, write: bool) -> None:
+        if self._try_acquire(write):
+            return
+        if write:
+            with self._mutex:
+                self._writers_waiting += 1
+        try:
+            delay = _POLL_MIN
+            while not self._try_acquire(write):
+                time.sleep(delay)
+                delay = min(delay * 2, _POLL_MAX)
+        finally:
+            if write:
+                with self._mutex:
+                    self._writers_waiting -= 1
+
+    async def _wait_async(self, write: bool) -> None:
+        if self._try_acquire(write):
+            return
+        if write:
+            with self._mutex:
+                self._writers_waiting += 1
+        try:
+            delay = _POLL_MIN
+            while not self._try_acquire(write):
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, _POLL_MAX)
+        finally:
+            if write:
+                with self._mutex:
+                    self._writers_waiting -= 1
+
+    @contextlib.contextmanager
+    def acquire(self, write: bool = False):
+        self._wait_sync(write)
+        try:
+            yield
+        finally:
+            self._release(write)
+
+    @contextlib.asynccontextmanager
+    async def acquire_async(self, write: bool = False):
+        await self._wait_async(write)
+        try:
+            yield
+        finally:
+            self._release(write)
+
+
+_environment_locks: dict[str, EnvironmentLock] = {}
+_environment_locks_lock = threading.Lock()
+
+
+def get(lock_path: str) -> EnvironmentLock:
+    """The one lock over the environment this lock file stands for."""
+    with _environment_locks_lock:
+        if lock_path not in _environment_locks:
+            _environment_locks[lock_path] = EnvironmentLock(lock_path)
+        return _environment_locks[lock_path]
+
+
+class ProcessSlots:
+    """How many sandbox interpreters may run at once.
+
+    A wrapper is a process, not a thread, and a CAD one at that: the ceiling
+    that matters is the machine's, not the thread pool's. Without this a
+    recursive render would fan out over every package, every shape and every
+    file type at once and ask the machine for hundreds of OpenCASCADE
+    interpreters.
+
+    Taken *inside* whatever environment lock the caller holds and released
+    before that lock is, so the two can never wait on each other: a slot holder
+    is always running, never waiting for a lock.
+    """
+
+    def __init__(self, count: int):
+        self.count = count
+        self._semaphore = threading.BoundedSemaphore(count)
+
+    @contextlib.contextmanager
+    def slot(self):
+        if not self._semaphore.acquire(blocking=False):
+            delay = _POLL_MIN
+            while not self._semaphore.acquire(blocking=False):
+                time.sleep(delay)
+                delay = min(delay * 2, _POLL_MAX)
+        try:
+            yield
+        finally:
+            self._semaphore.release()
+
+    @contextlib.asynccontextmanager
+    async def slot_async(self):
+        if not self._semaphore.acquire(blocking=False):
+            delay = _POLL_MIN
+            while not self._semaphore.acquire(blocking=False):
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, _POLL_MAX)
+        try:
+            yield
+        finally:
+            self._semaphore.release()
+
+
+def _process_slot_count() -> int:
+    """One interpreter per core, or whatever 'threadsMax' says instead.
+
+    'threadsMax' is the user's statement of how much of the machine PartCAD may
+    have; it named threads because threads were all there was to name.
+    """
+    if user_config.threads_max is not None:
+        return max(1, user_config.threads_max)
+    return max(2, os.cpu_count() or 1)
+
+
+process_slots = ProcessSlots(_process_slot_count())

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -242,9 +242,15 @@ class Shape(ShapeConfiguration):
         if not hasattr(self.tls, "async_shape_locks"):
             self.tls.async_shape_locks = {}
         self_id = id(self)
-        if self_id not in self.tls.async_shape_locks:
-            self.tls.async_shape_locks[self_id] = asyncio.Lock()
-        return self.tls.async_shape_locks[self_id]
+        # Keyed on the loop as well as the shape, the way the runtime keys its
+        # own (see runtime_python.PythonRuntime). A worker thread runs one
+        # 'asyncio.run()' per instantiation, so a thread that is handed a
+        # second one gets a second loop, and an asyncio.Lock that was awaited
+        # under the first refuses to be awaited under the second.
+        loop_id = id(asyncio.get_event_loop())
+        if self_id not in self.tls.async_shape_locks or self.tls.async_shape_locks[self_id][1] != loop_id:
+            self.tls.async_shape_locks[self_id] = (asyncio.Lock(), loop_id)
+        return self.tls.async_shape_locks[self_id][0]
 
     async def get_components(self, ctx):
         if len(self.components) == 0:

--- a/src/partcad_service_json_rpc/core/operations.py
+++ b/src/partcad_service_json_rpc/core/operations.py
@@ -1666,6 +1666,8 @@ def _render_objects(
     ignore_manufacturability,
 ):
     """The body of 'render_objects', once the request has been made sense of."""
+    import asyncio
+
     if params.get("recursive"):
         packages = [p["name"] for p in ctx.get_all_packages(parent_name=package, has_stuff=True)]
     else:
@@ -1680,39 +1682,103 @@ def _render_objects(
         validated_packages.append(options_package)
     _validate_output_format(pc, ctx, fmt, validated_packages)
 
-    for package in packages:
-        if object_name is not None:
-            package, object_name = pc.utils.resolve_resource_path(package, object_name)
+    asyncio.run(
+        _render_packages_async(
+            pc,
+            ctx,
+            params,
+            packages,
+            fmt,
+            output_dir,
+            object_name,
+            options_package,
+            ignore_manufacturability,
+        )
+    )
 
-        if object_name is None:
-            ctx.render(
-                project_path=package,
-                format=fmt,
-                output_dir=output_dir,
-                options_package=options_package,
-                ignore_manufacturability=ignore_manufacturability,
-            )
-        else:
-            sketches, interfaces, parts, assemblies = [], [], [], []
-            if params.get("sketch"):
-                sketches.append(object_name)
-            elif params.get("interface"):
-                interfaces.append(object_name)
-            elif params.get("assembly"):
-                assemblies.append(object_name)
+
+async def _render_packages_async(
+    pc,
+    ctx,
+    params,
+    packages,
+    fmt,
+    output_dir,
+    object_name,
+    options_package,
+    ignore_manufacturability,
+):
+    """Render the given packages, several at a time.
+
+    A package used to be rendered by its own 'asyncio.run()' after the previous
+    one had finished, so a recursive render cost the sum of its packages even
+    though nothing relates one package's files to another's. They are gathered
+    here instead, the way a recursive test and a recursive lint already gather
+    theirs.
+
+    Bounded, because a package admits every one of its shapes and every file
+    type of each at once: what keeps the machine busy is the sandbox process
+    budget (see partcad.sandbox_lock), and enough packages to keep that budget
+    full is all the concurrency there is any use for.
+
+    Nothing is cancelled when one package fails. A render writes files, and a
+    package interrupted half way through writing them is worse than one that
+    finishes and reports; the first failure is raised once they are all done,
+    which is what the caller would have seen anyway.
+    """
+    import asyncio
+
+    from partcad.sandbox_lock import process_slots
+
+    # The packages PartCAD ships inside itself are loaded on demand, by the
+    # first thing that asks what file types exist (see
+    # Context._get_builtin_project). Ask once here, before anything runs, so
+    # that several packages arriving at that question together do not each
+    # import them.
+    pc.output.all_formats(ctx)
+
+    at_once = asyncio.Semaphore(max(1, process_slots.count))
+
+    async def render_package(package):
+        object_in_package = object_name
+        if object_in_package is not None:
+            package, object_in_package = pc.utils.resolve_resource_path(package, object_in_package)
+
+        async with at_once:
+            if object_in_package is None:
+                await ctx.render_async(
+                    project_path=package,
+                    format=fmt,
+                    output_dir=output_dir,
+                    options_package=options_package,
+                    ignore_manufacturability=ignore_manufacturability,
+                )
             else:
-                parts.append(object_name)
-            prj = ctx.get_project(package)
-            prj.render(
-                sketches=sketches,
-                interfaces=interfaces,
-                parts=parts,
-                assemblies=assemblies,
-                format=fmt,
-                output_dir=output_dir,
-                options_package=options_package,
-                ignore_manufacturability=ignore_manufacturability,
-            )
+                sketches, interfaces, parts, assemblies = [], [], [], []
+                if params.get("sketch"):
+                    sketches.append(object_in_package)
+                elif params.get("interface"):
+                    interfaces.append(object_in_package)
+                elif params.get("assembly"):
+                    assemblies.append(object_in_package)
+                else:
+                    parts.append(object_in_package)
+                prj = ctx.get_project(package)
+                await prj.render_async(
+                    sketches=sketches,
+                    interfaces=interfaces,
+                    parts=parts,
+                    assemblies=assemblies,
+                    format=fmt,
+                    output_dir=output_dir,
+                    options_package=options_package,
+                    ignore_manufacturability=ignore_manufacturability,
+                )
+
+    results = await asyncio.gather(*[render_package(package) for package in packages], return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
 
 
 def convert_object(session, params):

--- a/src/partcad_utils/user_config.py
+++ b/src/partcad_utils/user_config.py
@@ -537,9 +537,11 @@ class UserConfig(vyper.Vyper):
         self.set_env_prefix("pc")
 
         # option: threadsMax
-        # description: the maximum number of processing threads to use (not a strict limit)
+        # description: how much of the machine PartCAD may use. Sizes the thread
+        #              pools (not a strict limit) and, strictly, how many sandbox
+        #              interpreters run at once (partcad.sandbox_lock)
         # values: >2
-        # default: min(7, <cpu threads count - 1>)
+        # default: min(7, <cpu threads count - 1>) threads, <cpu threads count> sandbox processes
         self.bind_env("threadsMax", "PC_THREADS_MAX")
         self.threads_max = None
         if self.is_set("threadsMax"):

--- a/tests/partcad/unit/test_cache_key_collisions.py
+++ b/tests/partcad/unit/test_cache_key_collisions.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Two different objects must not share a cache entry.
+
+A shape's hash is seeded with nothing that identifies the shape itself (see
+Shape.__init__), so everything that tells two of them apart has to be added by
+the factory that builds them. Where it is not, the cache hands whichever of
+them asks first the geometry of another -- silently, and only once the cache is
+warm, which is why it survived being rendered.
+"""
+
+import asyncio
+
+import pytest
+
+import partcad as pc
+
+
+@pytest.fixture
+def ctx():
+    return pc.Context("examples")
+
+
+def _keys(ctx, package, names):
+    async def collect():
+        return [await ctx.get_part("%s:%s" % (package, name)).get_cache_key_async() for name in names]
+
+    return asyncio.run(collect())
+
+
+def test_extruded_parts_of_one_package_are_cached_apart(ctx):
+    """'cylinder' and 'clock' are both an extrusion 1mm deep of another sketch."""
+    keys = _keys(ctx, "//pub/examples/partcad/produce_part_extrude", ["cylinder", "clock", "dxf"])
+    assert None not in keys
+    assert len(set(keys)) == len(keys), "extruded parts share a cache entry: %s" % keys
+
+
+def test_swept_parts_of_one_package_are_cached_apart(ctx):
+    keys = _keys(ctx, "//pub/examples/partcad/produce_part_sweep", ["pipe", "clock", "dxf"])
+    assert None not in keys
+    assert len(set(keys)) == len(keys), "swept parts share a cache entry: %s" % keys

--- a/tests/partcad/unit/test_runtime_python_deps.py
+++ b/tests/partcad/unit/test_runtime_python_deps.py
@@ -6,6 +6,7 @@
 #
 
 import asyncio
+import contextlib
 import os
 import pathlib
 import re
@@ -355,3 +356,152 @@ def test_no_factory_pins_its_own_version_of_the_shared_cad_stack():
             if sandbox_versions.distribution_name(literal) in pinned_names:
                 offenders.append("%s: %s" % (path.name, literal))
     assert offenders == [], offenders
+
+
+class _StubUserConfig:
+    def __init__(self, internal_state_dir):
+        self.internal_state_dir = str(internal_state_dir)
+
+
+class _StubContext:
+    def __init__(self, internal_state_dir):
+        self.user_config = _StubUserConfig(internal_state_dir)
+
+
+def _locking_runtime(tmp_path):
+    """A bare runtime with the little more that the environment lock reads."""
+    runtime = _bare_runtime(tmp_path / "sandbox")
+    runtime.version = "3.11"
+    runtime.sandbox_dir = "pc-py-conda-3.11"
+    runtime.ctx = _StubContext(tmp_path)
+    runtime.superseded_requirements = set()
+    runtime.pip_flags = []
+    runtime.pip_install_flags = []
+    return runtime
+
+
+def test_the_environment_locked_is_the_one_run_in(tmp_path):
+    """A lock over an environment nobody runs in locks nothing.
+
+    The v-env lock this replaces was keyed on the session, but a session whose
+    package asks for nothing of its own runs the runtime's own interpreter --
+    so two such packages took two different locks over the one environment they
+    were both reading, and an install into it took a third.
+    """
+    runtime = _locking_runtime(tmp_path)
+    session = PythonRuntime.get_session(runtime, "//some:package")
+
+    assert PythonRuntime.environment_path(runtime, session) == runtime.path
+    assert PythonRuntime.environment_path(runtime, None) == runtime.path
+    assert PythonRuntime.environment_lock(runtime, session) is PythonRuntime.environment_lock(runtime, None)
+    assert PythonRuntime.environment_lock(runtime, session).lock_path.endswith(
+        os.path.join("", ".pc-py-conda-3.11.default.lock")
+    )
+
+
+def test_a_session_with_a_venv_locks_the_venv(tmp_path):
+    runtime = _locking_runtime(tmp_path)
+    session = PythonRuntime.get_session(runtime, "//some:package")
+    session["dirty"] = True
+
+    assert PythonRuntime.environment_path(runtime, session) == session["path"]
+    # The name the per-session lock used, so a PartCAD of either vintage
+    # running beside this one contends over the same file.
+    assert PythonRuntime.environment_lock(runtime, session).lock_path.endswith(
+        ".pc-py-conda-3.11.%s.lock" % session["hash"]
+    )
+    assert PythonRuntime.environment_lock(runtime, session) is not PythonRuntime.environment_lock(runtime, None)
+
+
+def test_a_session_needs_the_environment_for_writing_only_until_it_is_provisioned(tmp_path):
+    """Which is what lets a package's parts render together rather than in turn."""
+    runtime = _locking_runtime(tmp_path)
+    session = PythonRuntime.get_session(runtime, "//some:package")
+
+    assert not PythonRuntime.session_needs_install(runtime, None)
+    assert not PythonRuntime.session_needs_install(runtime, session)
+
+    session["dirty"] = True
+    assert PythonRuntime.session_needs_install(runtime, session)
+
+    session["installed"].update(session["deps"])
+    assert not PythonRuntime.session_needs_install(runtime, session)
+
+    session["deps"].append("something-else==1.0")
+    assert PythonRuntime.session_needs_install(runtime, session)
+
+
+def _forbid_locking(runtime, monkeypatch):
+    """Make taking the environment lock a test failure."""
+
+    def refuse(*_args, **_kwargs):
+        raise AssertionError("the environment lock was taken with nothing to install")
+
+    monkeypatch.setattr(type(runtime), "sync_lock", refuse, raising=False)
+    monkeypatch.setattr(type(runtime), "async_lock", refuse, raising=False)
+
+
+def test_an_installed_requirement_takes_no_lock(tmp_path, monkeypatch):
+    """The fast path: a warm sandbox renders without ever queueing on it."""
+    runtime = _locking_runtime(tmp_path)
+    os.makedirs(runtime.path, exist_ok=True)
+    pathlib.Path(get_guard_path(runtime.path, sandbox_versions.CADQUERY_OCP)).touch()
+    _forbid_locking(runtime, monkeypatch)
+
+    PythonRuntime.ensure_onced(runtime, sandbox_versions.CADQUERY_OCP)
+    asyncio.run(PythonRuntime.ensure_async_onced(runtime, sandbox_versions.CADQUERY_OCP))
+
+
+def test_a_missing_requirement_still_takes_the_lock_for_writing(tmp_path, monkeypatch):
+    runtime = _locking_runtime(tmp_path)
+    os.makedirs(runtime.path, exist_ok=True)
+    taken = []
+
+    @contextlib.contextmanager
+    def sync_lock(self, session=None, path=None, write=False):
+        taken.append(write)
+        yield
+
+    monkeypatch.setattr(type(runtime), "sync_lock", sync_lock, raising=False)
+    monkeypatch.setattr(type(runtime), "install_onced_locked", lambda *a, **k: None, raising=False)
+
+    PythonRuntime.ensure_onced(runtime, sandbox_versions.CADQUERY_OCP)
+
+    assert taken == [True]
+
+
+def test_ensure_does_not_reassert_what_it_did_not_install(tmp_path, monkeypatch):
+    """Regression guard for a forced reinstall of OCP per rendered file.
+
+    Every image file type installs build123d and then cadquery-ocp, and
+    build123d's install is what demands that cadquery-ocp be re-asserted. When
+    that demand was raised whether or not build123d had just been installed,
+    the cadquery-ocp that followed it was force-reinstalled every single time.
+    """
+    runtime = _locking_runtime(tmp_path)
+    os.makedirs(runtime.path, exist_ok=True)
+    pathlib.Path(get_guard_path(runtime.path, sandbox_versions.BUILD123D)).touch()
+    ocp_guard = get_guard_path(runtime.path, sandbox_versions.CADQUERY_OCP)
+    pathlib.Path(ocp_guard).touch()
+    _forbid_locking(runtime, monkeypatch)
+
+    PythonRuntime.ensure_onced(runtime, sandbox_versions.BUILD123D)
+    asyncio.run(PythonRuntime.ensure_async_onced(runtime, sandbox_versions.BUILD123D))
+
+    assert os.path.exists(ocp_guard)
+    assert not needs_reassert(runtime.path, sandbox_versions.CADQUERY_OCP)
+
+
+def test_an_install_still_reasserts_what_it_clobbered(tmp_path, monkeypatch):
+    """The other half: a build123d that really is installed must demand it."""
+    runtime = _locking_runtime(tmp_path)
+    os.makedirs(runtime.path, exist_ok=True)
+    ocp_guard = get_guard_path(runtime.path, sandbox_versions.CADQUERY_OCP)
+    pathlib.Path(ocp_guard).touch()
+    monkeypatch.setattr(type(runtime), "run_onced_locked", lambda *a, **k: (0, "", ""), raising=False)
+
+    PythonRuntime.install_onced_locked(runtime, sandbox_versions.BUILD123D, runtime.path)
+
+    assert os.path.exists(get_guard_path(runtime.path, sandbox_versions.BUILD123D))
+    assert not os.path.exists(ocp_guard)
+    assert needs_reassert(runtime.path, sandbox_versions.CADQUERY_OCP)

--- a/tests/partcad/unit/test_sandbox_lock.py
+++ b/tests/partcad/unit/test_sandbox_lock.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""What the sandbox environment lock and the process budget promise.
+
+These are what let a render run more than one wrapper at a time, so what is
+worth pinning down is both halves of that: that wrappers reading one
+environment do run together, and that an install into it still gets the
+environment to itself.
+"""
+
+import asyncio
+
+import pytest
+
+from partcad.sandbox_lock import EnvironmentLock, ProcessSlots
+from partcad import sandbox_lock
+
+
+def _lock(tmp_path, name="env"):
+    return EnvironmentLock(str(tmp_path / (name + ".lock")))
+
+
+def test_get_returns_one_lock_per_path(tmp_path):
+    """Two objects over one lock file would each believe they held it.
+
+    filelock counts recursive acquires per object, so the second would take the
+    file lock while the first still holds it and release it out from under it.
+    """
+    path = str(tmp_path / "env.lock")
+    assert sandbox_lock.get(path) is sandbox_lock.get(path)
+    assert sandbox_lock.get(path) is not sandbox_lock.get(str(tmp_path / "other.lock"))
+
+
+def test_readers_share_the_environment(tmp_path):
+    lock = _lock(tmp_path)
+    with lock.acquire(write=False):
+        with lock.acquire(write=False):
+            with lock.acquire(write=False):
+                pass
+
+
+def test_a_writer_excludes_a_reader(tmp_path):
+    lock = _lock(tmp_path)
+    with lock.acquire(write=True):
+        assert not lock._try_acquire(write=False)
+        assert not lock._try_acquire(write=True)
+
+
+def test_a_reader_excludes_a_writer(tmp_path):
+    lock = _lock(tmp_path)
+    with lock.acquire(write=False):
+        assert not lock._try_acquire(write=True)
+
+
+def test_the_environment_is_free_again_afterwards(tmp_path):
+    lock = _lock(tmp_path)
+    with lock.acquire(write=True):
+        pass
+    with lock.acquire(write=False):
+        pass
+    assert lock._try_acquire(write=True)
+    lock._release(write=True)
+
+
+def test_a_reader_waiting_defers_to_a_writer_waiting(tmp_path):
+    """Otherwise a stream of wrappers starves the install one of them needs."""
+    lock = _lock(tmp_path)
+    with lock.acquire(write=False):
+        lock._writers_waiting += 1
+        try:
+            assert not lock._try_acquire(write=False)
+        finally:
+            lock._writers_waiting -= 1
+
+
+def test_another_process_is_kept_out_of_an_install(tmp_path):
+    """Two installs into one environment are what actually leave it broken.
+
+    A second EnvironmentLock over the same file stands in for a second PartCAD:
+    filelock opens a descriptor of its own, and an flock over that conflicts
+    with this one exactly as another process's would.
+    """
+    path = str(tmp_path / "env.lock")
+    mine, theirs = EnvironmentLock(path), EnvironmentLock(path)
+    with mine.acquire(write=True):
+        assert not theirs._try_acquire(write=True)
+    assert theirs._try_acquire(write=True)
+    theirs._release(write=True)
+
+
+def test_another_process_reading_is_not_kept_out(tmp_path):
+    """Deliberate: reader against reader needs no exclusion at all.
+
+    Paying for it with the one exclusive lock file there is would mean a busy
+    render in one workspace stopping every other PartCAD process on the machine
+    for as long as it runs. What that gives up is stated in sandbox_lock.
+    """
+    path = str(tmp_path / "env.lock")
+    mine, theirs = EnvironmentLock(path), EnvironmentLock(path)
+    with mine.acquire(write=False):
+        assert theirs._try_acquire(write=False)
+        theirs._release(write=False)
+
+
+def test_a_reader_does_not_block_the_loop_a_writer_runs_on(tmp_path):
+    """The reason waiting polls instead of blocking.
+
+    A part is instantiated on a worker thread with an event loop of its own, so
+    the same lock is taken from several loops -- but two tasks of one loop take
+    it too, and a task that blocked its thread waiting for the task beside it to
+    release would never see it released.
+    """
+    lock = _lock(tmp_path)
+    order = []
+
+    async def writer():
+        async with lock.acquire_async(write=True):
+            order.append("write-in")
+            await asyncio.sleep(0.05)
+            order.append("write-out")
+
+    async def reader():
+        await asyncio.sleep(0.01)
+        async with lock.acquire_async(write=False):
+            order.append("read")
+
+    async def both():
+        await asyncio.wait_for(asyncio.gather(writer(), reader()), timeout=10)
+
+    asyncio.run(both())
+    assert order == ["write-in", "write-out", "read"]
+
+
+def test_readers_on_one_loop_do_not_wait_for_each_other(tmp_path):
+    lock = _lock(tmp_path)
+
+    async def reader(started, release):
+        async with lock.acquire_async(write=False):
+            started.set()
+            await release.wait()
+
+    async def both():
+        release = asyncio.Event()
+        first_started, second_started = asyncio.Event(), asyncio.Event()
+        tasks = [
+            asyncio.create_task(reader(first_started, release)),
+            asyncio.create_task(reader(second_started, release)),
+        ]
+        await asyncio.wait_for(asyncio.gather(first_started.wait(), second_started.wait()), timeout=10)
+        release.set()
+        await asyncio.gather(*tasks)
+
+    asyncio.run(both())
+
+
+def test_process_slots_are_a_ceiling():
+    slots = ProcessSlots(2)
+    with slots.slot(), slots.slot():
+        assert not slots._semaphore.acquire(blocking=False)
+    with slots.slot():
+        pass
+
+
+def test_process_slots_wait_rather_than_fail():
+    slots = ProcessSlots(1)
+    running, peak = 0, 0
+
+    async def work():
+        nonlocal running, peak
+        async with slots.slot_async():
+            running += 1
+            peak = max(peak, running)
+            await asyncio.sleep(0.01)
+            running -= 1
+
+    async def all_of_them():
+        await asyncio.wait_for(asyncio.gather(*[work() for _ in range(5)]), timeout=10)
+
+    asyncio.run(all_of_them())
+    assert peak == 1
+
+
+def test_a_cancelled_wait_leaves_nothing_behind():
+    """A slot nobody got must not be released, or the ceiling drifts upwards."""
+    slots = ProcessSlots(1)
+
+    async def hold(started):
+        async with slots.slot_async():
+            started.set()
+            await asyncio.sleep(0.2)
+
+    async def scenario():
+        started = asyncio.Event()
+        holder = asyncio.create_task(hold(started))
+        await started.wait()
+
+        async def waiter():
+            async with slots.slot_async():
+                pass
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(waiter(), timeout=0.02)
+        await holder
+
+    asyncio.run(scenario())
+    # One holder released one slot: exactly one is free, not two.
+    assert slots._semaphore.acquire(blocking=False)
+    assert not slots._semaphore.acquire(blocking=False)


### PR DESCRIPTION
`pc render -r` over `./examples` ran **one CAD wrapper at a time**, whatever the machine had.
Three things held it that way, and all three are here.

## What was in the way

**One mutex across every wrapper subprocess.** `PythonRuntime` held a process-wide `threading.RLock`
for the whole of `run_async_onced()` — the `create_subprocess_exec` and the `communicate()` after it.
Every part, every file type and every package queued behind it. The per-v-env `FileLock` beside it
looked like it granted finer access, but `filelock` counts recursive acquires per process, so
in-process it excluded nobody; the mutex was doing all of the work. It was also keyed on the
*session*, so two packages with no requirements of their own took two different locks over the one
environment they were both reading, while an install into that environment took a third.

`sandbox_lock.EnvironmentLock` replaces it: a readers/writer lock keyed on the **environment a
wrapper actually runs out of** — a conda prefix, or a session v-env. Running a wrapper reads;
installing into the environment or creating it writes. `PythonRuntime.environment_path()` answers
that question the same way `get_venv_python_path()` does, so a command cannot lock one environment
and run in another.

**No ceiling once the mutex was gone.** The mutex *was* the ceiling, at one. `sandbox_lock.process_slots`
makes it explicit, because a wrapper is a whole CAD interpreter and it is the machine, not the thread
pool, that decides how many fit. `threadsMax` sizes it.

**A recursive render ran one package at a time**: `for package in packages: asyncio.run(...)`, so it
cost the sum of its packages though nothing relates one package's files to another's. It now gathers
them, the way a recursive test and a recursive lint already gather theirs.

**And a lock taken to find out there was nothing to do.** Every requirement of every rendered file
re-entered `once()` — which under conda spawns an interpreter to ask the prefix what version it is —
and then took the lock to read an install guard that was already there. Both are now checked before
anything is locked.

## Two bugs that fell out of the same paths

**A forced re-install of OCP per image rendered.** `ensure()` dropped a package's dependent guards
whether or not it had just installed anything. build123d invalidates cadquery-ocp and every image
file type installs both, so every `svg`/`png`/`jpeg`/`dxf`/`gltf` output ran
`pip install --force-reinstall cadquery-ocp`. The `*_locked` twins never did this; the non-locked
ones now match them.

**Two parts of one package sharing a cache entry.** An extruded or swept part hashed its depth and
axis but not the sketch it was made from — and a shape's hash is seeded with nothing that identifies
the shape — so `produce_part_extrude:cylinder` and `:clock` both keyed to `e0d531ac…` and whichever
asked first decided what both of them got. Pre-existing (reproduced on unmodified `devel` with a warm
cache) and invisible until a cache is warm, which a faster render makes far easier to reach — the
baseline run measured for the table below reproduced it on this very tip of `devel`, rewriting
`examples/produce_part_extrude/cylinder.svg` with the clock's geometry.
`tests/partcad/unit/test_cache_key_collisions.py` fails without the fix.

## Also here

A separate commit fixes the pre-commit test hooks. Neither hook script reads the filenames it is
handed — both run the whole suite — but both declared that they take them, so pre-commit split the
staged files into one batch per core and ran the **entire** suite once per batch, concurrently. Four
times the cost, and four sessions racing over the paths a test writes; that is what makes
`test_file.py::test_file_url_part_1` fail at random (it downloads into `examples/bolt.step` and
asserts on the way in that the file is not there yet). `pass_filenames: false` is what the
`example-images` hook beside them already says.

## Measured

`pc render -r` over `./examples`, 32 cores, fresh daemon per run, warm sandboxes, both columns
measured on this PR's base (`b6aea13b`, 0.8.6) with the shape cache cleared first:

| | `devel` | this branch |
| --- | --- | --- |
| wall clock | 1193.4 s | **126.5 s** (9.4x) |
| concurrent wrappers | 1 | 32 |
| of the wall clock, some wrapper running | 55 % | 79 % |

A second run with the cache warm is 124.0 s. On the 0.8.2 base the same pair read 1530.1 s -> 316.1 s
cold and 1214.9 s -> 124.0 s warm.

The unit suite is a beneficiary too: `pytest tests/partcad -n 4` goes from 508 s to 104 s.

## Testing

- `pytest tests cad/freecad -x --dist no` — **1970 passed, 23 skipped**.
- `behave` — 39 features, **202 scenarios passed, 1 failed**. The failure is `install.feature:44`
  ("Install packages with ssh"), which reproduces on unmodified `devel`: the CLI-launched dev
  container has no SSH key to clone with.
- `cd examples && pc render -r` twice: everything CI watches is byte-identical. The two files that do
  change, `feature_render_custom/bracket.{svg,pdf}`, are the pair already on that job's `UNSTABLE`
  list (draftwright's glyph order and its PDF timestamp).
- New: `tests/partcad/unit/test_sandbox_lock.py` (15 cases) and `test_cache_key_collisions.py`, plus
  7 added to `test_runtime_python_deps.py`.

## A check that is red, and was red before this

`Examples (PartCAD)` fails on three cells here. It fails on `devel` too — run 33031454317,
`ubuntu-latest, 3.11` — with the same diff: `produce_sketch_cadquery/sketch.svg` rendered with
`width: 4.0, length: 5.0` in place of its own `3.0 / 4.0`.

Those are the values `feature_enrich:sketch` enriches it with, and the cause is not caching. An enrich
builds its clone by registering the augmented configuration *into the source package*:

```python
self.source_project.init_sketch_by_config(augmented_config)   # sketch_factory_enrich.py
source = self.source_project.get_sketch(sketch.name)
```

`augmented_config["name"]` is the source's own name and `init_object_by_config` overwrites
unconditionally, so instantiating the enrich replaces `produce_sketch_cadquery:sketch` with the
enriched object — in both orders:

```
enrich-first  produce_sketch_cadquery:sketch -> {'width': 4.0, 'length': 5.0}
source-first  produce_sketch_cadquery:sketch -> {'width': 4.0, 'length': 5.0}
```

What has kept the checked-in file right is that a sequential render reaches `produce_sketch_cadquery`
before `feature_enrich`. This branch removes that accident, which is why one red cell becomes three.
The fix belongs in the three `*_factory_enrich.py` files and changes what an enriched clone is named,
so it is not folded in here.

One cell also flagged a third file, `produce_assembly_urdf/robot.svg`, differing only in the order of
its paths — the same geometry, permuted. It did not reproduce in eight local runs (five of that
package alone, three full `pc render -r` with the shape cache cleared), and it is not something this
branch can reorder: the URDF factory's `handle_node_list` is a sequential `for` loop that appends
children in order, and the path order in the file comes from build123d's `project_to_viewport`
inside the render wrapper — a process of its own, single-threaded, with the hash seed pinned. It
looks like the same third-party projection instability as the four raster projections and the
draftwright glyphs already excluded from that check. Worth watching for a recurrence.

## Worth a reviewer's attention

- **The cross-process file lock is now taken by writers only.** Reader-against-reader needs no
  exclusion, and paying for it with the one exclusive lock file there is would mean a busy render in
  one workspace stalling every other PartCAD process on the machine for as long as it runs. What that
  gives up — a wrapper reading an environment another process is installing into — is stated in
  `sandbox_lock.py`; the runtime's own environment never had that protection anyway, since installs
  into it locked one name and runs out of it locked another. Closing it properly wants a lock file a
  reader can hold in *shared* mode, which is what `filelock`'s SQLite-backed `ReadWriteLock` is; that
  needs the dependency floor raised, so it is left for later.
- **Both locks poll rather than block.** They are taken from several event loops at once — a part is
  instantiated on a worker thread running a loop of its own — and a task that blocked its own loop
  waiting for a lock the task beside it is about to release would never see it released.
- An assembly is now instantiated on the *unconstrained* thread pool. It computes nothing itself and
  waits for parts that each take a thread from the constrained one; with several packages in flight,
  assemblies waiting there is how that pool runs out of threads with every one of them waiting for a
  part that has nowhere left to run.
- The JavaScript runtime still has a global lock of its own, so Node.js wrappers still run one at a
  time. Out of scope here; noted where it lives.
- Consider `#deepTest` on this one before merge — the environment lock's file naming and the
  semaphores are code that behaves differently on Windows, and the reduced PR matrix is thinner there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
