### PR TITLE
fix(dev): repair the development environment after the one-distribution refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,8 +133,16 @@ Everything below is written as the command to pass to `exec`.
 Dependencies are already installed in the image. Only re-run this if you change `pyproject.toml`:
 
 ```bash
-poetry install        # installs partcad + partcad-cli in editable mode
+poetry install        # installs the `partcad` distribution -- all six packages -- in editable mode
 ```
+
+**If `pc` fails with `ModuleNotFoundError: No module named 'partcad_cli.click.command'`, the `.venv` predates
+the one-wheel layout.** It still holds the editable install of the old root project, `partcad-dev`, whose `.pth`
+points at the six deleted `<package>/src` directories and whose `pc` script points at the pre-rename entry point.
+`poetry install` does not replace it, because the distribution was renamed and Poetry does not know it is there;
+`pip uninstall partcad-dev` refuses to remove it. The old source tree lingers too: `git` leaves `partcad/`,
+`partcad-cli/` and their four siblings behind when the only files left in them are ignored ones. Delete both and
+install again — the `.. warning::` beside `poetry install` in `docs/source/contributing.rst` has the commands.
 
 The project virtualenv is not auto-activated, and `pytest`, `pc`, and `partcad` are **not** on `PATH` — prefix
 project commands with `poetry run`.
@@ -264,6 +272,27 @@ ln -sf /run/host-gpg-agent.sock /run/user/$(id -u)/gnupg/S.gpg-agent
 ```
 
 Verify with `gpg --list-secret-keys` — your key should appear, served by the forwarded host agent.
+
+**If `pre-commit` fails to install a hook with `Permission denied (publickey)`**, a rewrite rule in your
+gitconfig is turning its fetch of the hook repository into an SSH fetch. `url."ssh://git@github.com/".insteadOf
+= https://github.com/` is a common setup, and the VS Code extension copies your gitconfig into the container,
+rewrite rules included — so pre-commit clones `https://github.com/...` and git dials `git@github.com`. A VS Code
+terminal has the forwarded SSH agent and succeeds; a `devcontainer exec` shell has no agent and does not. Two
+ways out, on the host:
+
+* Scope the rule to `pushInsteadOf` rather than `insteadOf`, which is usually what the rule is for anyway: push
+  over SSH, fetch anonymously over https.
+* Or forward the SSH agent the way the GPG one is forwarded above,
+  `--mount "type=bind,source=$SSH_AUTH_SOCK,target=/run/host-ssh-agent.sock"`, and
+  `export SSH_AUTH_SOCK=/run/host-ssh-agent.sock` in the container. Adding a mount means recreating the
+  container, and recreating it with the CLI is what leaves it with no gitconfig at all — hence the repo-local
+  identity above.
+
+`GIT_CONFIG_GLOBAL=/dev/null` does not work around it: pre-commit strips `GIT_*` from the environment of the git
+it runs, keeping only `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_*`/`GIT_CONFIG_VALUE_*`, and those can only add
+configuration, not remove a rewrite. Note that this only bites on a hook repository that is not in
+`~/.cache/pre-commit` yet — a new `rev:`, or a fresh cache volume. The four Poetry hooks are declared
+`repo: local` in `dev-tools/pre-commit-config.yaml` precisely so that they need no repository at all.
 
 ### Verifying a commit landed
 

--- a/dev-tools/pre-commit-config.yaml
+++ b/dev-tools/pre-commit-config.yaml
@@ -32,12 +32,53 @@ repos:
       - id: check-github-actions
       - id: check-github-workflows
         args: ["--verbose"]
-  - repo: https://github.com/python-poetry/poetry
-    rev: 1.8.0
+  # Poetry's four hooks are declared here rather than pulled from
+  # `https://github.com/python-poetry/poetry`, for two reasons the
+  # one-distribution refactor made concrete.
+  #
+  # A hook repository is pinned by git tag, and the tag pinned here was 1.8.0 --
+  # a Poetry that predates PEP 621. It does not read `[project]`, so it took the
+  # `[tool.poetry.group.*]` tables in `pyproject.toml` for the package's own
+  # metadata and failed with "The fields ['authors', 'description', 'name',
+  # 'version'] are required in package mode" on every commit that touched that
+  # file. The version now sits in the open, next to what it is pinned to: the
+  # Poetry that generated `poetry.lock`.
+  #
+  # And a hook repository has to be cloned. A developer whose gitconfig rewrites
+  # `https://github.com/` to SSH -- the VS Code dev container copies the host's
+  # gitconfig in, rewrite rules included -- has pre-commit's fetch of it turned
+  # into an SSH fetch, which fails in a shell with no agent behind it (a
+  # `devcontainer exec` session, a CI runner). `additional_dependencies` comes
+  # from PyPI over https and is not rewritten.
+  #
+  # `poetry-plugin-export` is named because `poetry export` left core Poetry in
+  # 2.0. What it exports is byte-identical to what 1.8 exported.
+  - repo: local
     hooks:
       - id: poetry-check
+        name: poetry-check
+        description: run poetry check to validate config
+        entry: poetry check
+        language: python
+        additional_dependencies: ["poetry==2.3.3"]
+        pass_filenames: false
+        files: ^(.*/)?pyproject\.toml$
       - id: poetry-lock
+        name: poetry-lock
+        description: run poetry lock to update lock file
+        entry: poetry lock
+        language: python
+        additional_dependencies: ["poetry==2.3.3"]
+        pass_filenames: false
+        files: ^(.*/)?(poetry\.lock|pyproject\.toml)$
       - id: poetry-export
+        name: poetry-export
+        description: run poetry export to sync lock file with requirements.txt
+        entry: poetry export
+        language: python
+        additional_dependencies: ["poetry==2.3.3", "poetry-plugin-export==1.10.0"]
+        pass_filenames: false
+        files: ^(.*/)?poetry\.lock$
         args: [
             "--format=requirements.txt",
             "--output=.devcontainer/requirements.txt",
@@ -47,6 +88,14 @@ repos:
             "--with=docs",
           ]
       - id: poetry-install
+        name: poetry-install
+        description: run poetry install to install dependencies from the lock file
+        entry: poetry install
+        language: python
+        additional_dependencies: ["poetry==2.3.3"]
+        pass_filenames: false
+        stages: [post-checkout, post-merge]
+        always_run: true
   - repo: local
     hooks:
       - id: shellcheck

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -421,6 +421,34 @@ are downloaded Poetry will also install current package in editable mode, and yo
 
   Installing the current project: partcad (0.8.6)
 
+.. warning::
+
+    **A checkout that predates the one-wheel layout needs cleaning out first.** This repository used to hold six
+    Python distributions in six top-level directories -- ``partcad/``, ``partcad-cli/``, ``partcad-client/``,
+    ``partcad-ide-client/``, ``partcad-service-json-rpc/``, ``partcad-utils/`` -- and to install a seventh,
+    ``partcad-dev``, as the root project. Switching to the branch that collapsed them into ``src/`` leaves both
+    behind, and neither goes away on its own:
+
+    * ``git`` does not remove the old directories, because the only files still in them are ignored ones
+      (``__pycache__/``, ``*.egg-info/``). They look empty and are not.
+    * ``.venv`` keeps the ``partcad-dev`` install. Its ``.pth`` still puts the six deleted ``*/src`` directories on
+      ``sys.path`` and its ``pc`` still points at the pre-rename entry point, so ``pc`` fails with
+      ``ModuleNotFoundError: No module named 'partcad_cli.click.command'``. ``poetry install`` does not replace it
+      -- the distribution was renamed, so Poetry does not know it is there -- and ``pip uninstall partcad-dev``
+      refuses to remove it, with ``ValueError: ('Invalid group name', 'poetry-multiproject-plugin')``, because the
+      metadata it left behind names an entry point group that is not valid.
+
+    Delete both from the repository root, then install again:
+
+    .. code-block:: bash
+
+      $ rm -rf partcad partcad-cli partcad-client partcad-ide-client partcad-service-json-rpc partcad-utils
+      $ rm -rf .venv/lib/python*/site-packages/partcad_dev.pth \
+               .venv/lib/python*/site-packages/partcad_dev-*.dist-info
+      $ poetry install
+
+    A fresh clone needs none of this.
+
 Activate Environment
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,25 @@ strictListInference = true  # Use union types when inferring types of lists elem
 [tool.ruff.lint]
 ignore = ["F401", "F403", "F405"]
 
+# `poetry install` installs the root project editable, and it resolves what to
+# put on `sys.path` with poetry-core, not with the `[tool.setuptools]` config
+# above. Left to auto-detection it would look for a single package named after
+# the project -- and it looks in the project root *before* `src/`, so a stray
+# `./partcad/` directory left over from the pre-monorepo layout (git leaves the
+# directory behind when the only files still in it are ignored ones like
+# `__pycache__/`) makes `poetry install` fail with "partcad is not a package."
+# and install nothing. Naming the six explicitly says the same thing
+# `[tool.setuptools.packages.find]` does, and cannot be shadowed.
+[tool.poetry]
+packages = [
+    { include = "partcad", from = "src" },
+    { include = "partcad_cli", from = "src" },
+    { include = "partcad_client", from = "src" },
+    { include = "partcad_ide_client", from = "src" },
+    { include = "partcad_service_json_rpc", from = "src" },
+    { include = "partcad_utils", from = "src" },
+]
+
 #
 # The development environment. Poetry 2 reads the `[project]` metadata above for
 # the package itself and these groups for everything around it. There is no
@@ -330,4 +349,3 @@ rich-click = "^1.9.8"
 
 [tool.poetry.group.performance.dependencies]
 snakeviz = "^2.2.2"
-


### PR DESCRIPTION
## Copilot Summary

Two things the one-distribution refactor (#553) left broken in the development environment, plus the
migration note neither of them can replace.

### `poetry install` installed nothing

Poetry resolves the root project's packages with poetry-core, not with `[tool.setuptools]`, and poetry-core
looks for a package named after the project **in the repository root before it looks in `src/`**. Switching a
checkout to the one-wheel layout leaves `./partcad/` behind — git does not remove a directory whose remaining
files are all ignored ones (`__pycache__/`, `*.egg-info/`), so it looks empty and is not. poetry-core found
that, saw no `.py` in it, and exited 1:

```
Installing the current project: partcad (0.8.6)

partcad is not a package.
```

`[tool.poetry] packages` now names the six explicitly, the way the old `partcad-dev` project did. Verified by
restoring the stray directory deliberately: `poetry install` succeeds with it present. The published wheel is
unaffected — setuptools is still the build backend, and a rebuild still yields six top-level packages and the
three console scripts.

### `poetry-check` failed on every commit touching `pyproject.toml`

```
The Poetry configuration is invalid:
  - The fields ['authors', 'description', 'name', 'version'] are required in package mode.
```

The hooks were pinned to the upstream repository at `rev: 1.8.0` — a Poetry that predates PEP 621. It does not
read `[project]`, where those four fields have lived since #553, so it took the `[tool.poetry.group.*]` tables
for the package's own metadata and demanded them there. This fails on unmodified `devel`; nothing caught it
because the `pre-commit` job in `test-dev.yml` is commented out.

The four hooks are now `repo: local`, which

* pins the Poetry version in the open — `2.3.3`, the version that generated `poetry.lock`, rather than a git
  tag nobody chose deliberately, and
* installs it from PyPI instead of cloning a repository. A `url."ssh://git@github.com/".insteadOf` rule in a
  developer's gitconfig — which the VS Code dev container copies in from the host, rewrite rules included —
  turns pre-commit's hook-repo fetch into an SSH fetch, which fails with `Permission denied (publickey)` in
  any shell with no agent behind it (`devcontainer exec`, a CI runner). `additional_dependencies` comes over
  https and is not rewritten.

`poetry-plugin-export` is named explicitly because `poetry export` left core Poetry in 2.0. What it writes is
byte-identical to what 1.8 wrote — `.devcontainer/requirements.txt` is unchanged in this PR.

### The part that has to be done by hand

Neither fix repairs a `.venv` that predates the refactor, and nothing in the repository can. It still holds the
editable install of the old root project, `partcad-dev`, whose `.pth` puts the six deleted `<package>/src`
directories on `sys.path` and whose `pc` points at the pre-rename entry point:

```
ModuleNotFoundError: No module named 'partcad_cli.click.command'
```

`poetry install` does not replace it — the distribution was *renamed*, so Poetry does not know it is there —
and `pip uninstall partcad-dev` refuses, because the old metadata declares an entry-point group
`poetry-multiproject-plugin` that is not a valid group name. `docs/source/contributing.rst` gains a warning
beside `poetry install` with the two `rm -rf` lines; `AGENTS.md` points at it from the symptom, and documents
the gitconfig rewrite beside the existing GPG-agent note. A fresh clone needs none of it.

### Verification

* `poetry install` → root project installed, `partcad.pth` → `src`, three console scripts regenerated with the
  correct entry points; all six packages import.
* `pc version`, `pc list parts`, `pc system status` run.
* `pre-commit run` over every file this PR touches: all green, `poetry-check` **Passed** where it previously
  failed. `poetry-lock` and `poetry-export` run clean and leave no diff.
* Wheel rebuilt: six packages, `pc`/`partcad`/`partcad-json-rpc` unchanged.
* `tests/partcad_cli` and `ide/standalone/tests` pass (101 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
