### PR TITLE
Fix conda lock deadlock in async contexts

### DIFF
--- a/src/partcad/runtime_javascript.py
+++ b/src/partcad/runtime_javascript.py
@@ -474,7 +474,7 @@ class JavaScriptRuntime(runtime.Runtime):
     async def once_async(self):
         """Asynchronous counterpart of once()."""
         async with self.async_lock():
-            with self.sync_lock_install():
+            async with self.async_lock_install():
                 if not self.initialized:
                     self.prepare_env_locked(os.path.join(self.path, BASE_ENV_DIR))
                     self.initialized = True
@@ -572,7 +572,7 @@ class JavaScriptRuntime(runtime.Runtime):
             with pc_logging.Action("v-env", self.version, session["name"]):
                 pc_logging.debug("Creating a Node.js environment: %s" % env_path)
                 self.prepare_env_locked(env_path)
-        with self.sync_lock_install():
+        async with self.async_lock_install():
             for dep in session["deps"]:
                 await self.ensure_async_onced_locked(dep, path=env_path)
 
@@ -748,7 +748,7 @@ class JavaScriptRuntime(runtime.Runtime):
         if path is None:
             path = os.path.join(self.path, BASE_ENV_DIR)
         async with self.async_lock(path=path):
-            with self.sync_lock_install():
+            async with self.async_lock_install():
                 if not os.path.exists(get_guard_path(path, js_package)):
                     await self.install_async_onced_locked(js_package, path, force or needs_reassert(path, js_package))
 

--- a/src/partcad/runtime_javascript_conda.py
+++ b/src/partcad/runtime_javascript_conda.py
@@ -19,10 +19,9 @@ import shutil
 import subprocess
 import sys
 
-from filelock import FileLock
-
 from . import runtime_javascript
 from . import runtime_python_conda
+from . import sandbox_lock
 from . import logging as pc_logging
 from . import telemetry
 
@@ -32,10 +31,11 @@ class CondaJavaScriptRuntime(runtime_javascript.JavaScriptRuntime):
     def __init__(self, ctx, version=None):
         super().__init__(ctx, "conda", version)
 
-        # Shared with the Python conda runtimes on purpose: conda serializes
-        # poorly against itself whatever it is installing, and the lock is over
-        # conda rather than over a particular environment.
-        self.global_conda_lock = FileLock(os.path.join(ctx.user_config.internal_state_dir, ".conda.lock"))
+        # Shared with the Python conda runtimes on purpose, and now actually
+        # the same object as theirs: conda serializes poorly against itself
+        # whatever it is installing, and the lock is over conda rather than over
+        # a particular environment (see sandbox_lock.conda).
+        self.global_conda_lock = sandbox_lock.conda(ctx.user_config.internal_state_dir)
         self.conda_initialized = self.initialized
 
         self.conda_path = runtime_python_conda.CondaPythonRuntime.find_conda_executable()
@@ -88,12 +88,18 @@ class CondaJavaScriptRuntime(runtime_javascript.JavaScriptRuntime):
 
     @contextlib.contextmanager
     def sync_lock_install(self, session=None):
-        with self.global_conda_lock:
+        with self.global_conda_lock.acquire(write=True):
             yield
 
     @contextlib.asynccontextmanager
     async def async_lock_install(self, session=None):
-        with self.global_conda_lock:
+        """The asynchronous twin of sync_lock_install().
+
+        Waits for conda asynchronously, for the reason CondaPythonRuntime's
+        does: the lock is held across 'await's, so a task waiting for it by
+        blocking would be blocking the loop the holder runs on.
+        """
+        async with self.global_conda_lock.acquire_async(write=True):
             yield
 
     def _subprocess_env(self):
@@ -120,22 +126,34 @@ class CondaJavaScriptRuntime(runtime_javascript.JavaScriptRuntime):
 
     async def once_async(self):
         async with self.async_lock():
-            self.once_conda_locked()
+            await self.once_conda_locked_async()
         await super().once_async()
 
     def once_conda_locked(self):
         with self.sync_lock_install():
-            # See if it just got created
-            if os.path.exists(self.path):
-                self.verify_conda()
+            self.once_conda_holding_install_lock()
 
+    async def once_conda_locked_async(self):
+        """once_conda_locked() for a caller that is running on an event loop.
+
+        Only the wait is asynchronous; see CondaPythonRuntime's counterpart.
+        """
+        async with self.async_lock_install():
+            self.once_conda_holding_install_lock()
+
+    def once_conda_holding_install_lock(self):
+        """Create the conda environment. The conda lock is already held."""
+        # See if it just got created
+        if os.path.exists(self.path):
+            self.verify_conda()
+
+        if not self.conda_initialized:
+            self.once_conda_locked_attempt()
             if not self.conda_initialized:
+                # Sometimes it fails to create from the first attempt
                 self.once_conda_locked_attempt()
-                if not self.conda_initialized:
-                    # Sometimes it fails to create from the first attempt
-                    self.once_conda_locked_attempt()
-                if not self.conda_initialized:
-                    raise Exception("ERROR: Conda environment initialization failed")
+            if not self.conda_initialized:
+                raise Exception("ERROR: Conda environment initialization failed")
 
     def once_conda_locked_attempt(self):
         with pc_logging.Action("Conda", "create", "node-" + self.version):

--- a/src/partcad/runtime_python.py
+++ b/src/partcad/runtime_python.py
@@ -468,7 +468,7 @@ class PythonRuntime(runtime.Runtime):
         if self.provisioned:
             return
         async with self.async_lock(write=True):
-            with self.sync_lock_install():
+            async with self.async_lock_install():
                 await self.ensure_zstd_onced_locked_async()
                 if not self.initialized:
                     # Preinstall the most common packages to avoid
@@ -695,7 +695,7 @@ class PythonRuntime(runtime.Runtime):
                 # venv lock, so use the *_locked ensure and take the install
                 # lock explicitly; the resulting order (venv lock, then the
                 # conda global lock) matches once()/ensure and cannot deadlock.
-                with self.sync_lock_install():
+                async with self.async_lock_install():
                     for dep in session["deps"]:
                         if dep == "partcad":
                             dep = get_local_partcad_pkg(dep)
@@ -941,7 +941,7 @@ class PythonRuntime(runtime.Runtime):
                 session["dirty"] = True
         elif not self.installed_onced(python_package, path, force):
             async with self.async_lock(path=path, write=True):
-                with self.sync_lock_install():
+                async with self.async_lock_install():
                     await self.install_async_onced_locked(python_package, path, force)
 
     async def ensure_async_onced_locked(self, python_package, session=None, path=None, force=False):

--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -8,7 +8,6 @@
 
 import contextlib
 import copy
-from filelock import FileLock
 import importlib
 import os
 import shutil
@@ -17,11 +16,10 @@ import sys
 import json
 
 from . import runtime_python
+from . import sandbox_lock
 from . import sandbox_versions
 from . import logging as pc_logging
 from . import telemetry
-
-# Global lock for conda that can be shared across threads
 
 
 @telemetry.instrument()
@@ -35,7 +33,10 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
             self.variant_packages = [f"{variant}"]
         super().__init__(ctx, sandbox_type_name, version)
 
-        self.global_conda_lock = FileLock(os.path.join(ctx.user_config.internal_state_dir, ".conda.lock"))
+        # One object for the whole process, shared with every other conda
+        # sandbox -- the Python ones of the other versions and the Node.js
+        # one (see sandbox_lock.conda).
+        self.global_conda_lock = sandbox_lock.conda(ctx.user_config.internal_state_dir)
         self.conda_initialized = self.initialized
         # Set by verify_conda() when the sandbox on disk turns out to hold a
         # free-threaded interpreter, which nothing but a rebuild can fix.
@@ -178,12 +179,19 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
 
     @contextlib.contextmanager
     def sync_lock_install(self, session=None):
-        with self.global_conda_lock:
+        with self.global_conda_lock.acquire(write=True):
             yield
 
     @contextlib.asynccontextmanager
     async def async_lock_install(self, session=None):
-        with self.global_conda_lock:
+        """The asynchronous twin of sync_lock_install().
+
+        Not 'with self.global_conda_lock.acquire(...)': conda runs for minutes
+        and this lock is held across the 'await's that wait for it, so a task
+        that waited for it by blocking would be blocking the loop the holder
+        needs in order to finish and release.
+        """
+        async with self.global_conda_lock.acquire_async(write=True):
             yield
 
     def _subprocess_env(self):
@@ -221,35 +229,50 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
         if self.provisioned:
             return
         async with self.async_lock(write=True):
-            self.once_conda_locked()
+            await self.once_conda_locked_async()
         await super().once_async()
 
     def once_conda_locked(self):
         with self.sync_lock_install():
-            # See if it just got created
-            if os.path.exists(self.path):
+            self.once_conda_holding_install_lock()
+
+    async def once_conda_locked_async(self):
+        """once_conda_locked() for a caller that is running on an event loop.
+
+        Only the wait for the conda lock is asynchronous. What happens under it
+        is the same synchronous conda run: it spawns processes and waits for
+        them, and giving it an asynchronous form is a separate change (see the
+        TODO on once_conda_locked_attempt).
+        """
+        async with self.async_lock_install():
+            self.once_conda_holding_install_lock()
+
+    def once_conda_holding_install_lock(self):
+        """Create the conda prefix. The conda lock is already held."""
+        # See if it just got created
+        if os.path.exists(self.path):
+            self.verify_conda()
+            self.discard_if_free_threaded()
+
+        # TODO(clairbee): Does it make sense to retry more than once?
+        attempts = 0
+        while not self.conda_initialized and attempts < 2:
+            # Sometimes it fails to create from the first attempt
+            attempts += 1
+            self.once_conda_locked_attempt()
+            if self.conda_initialized:
+                # An attempt reports success from the exit code of the last
+                # command it ran, which says nothing about *which*
+                # interpreter ended up in the prefix. Ask the prefix itself,
+                # so a create that quietly produced the wrong one is caught
+                # here rather than by the next process to open this sandbox
+                # -- which is what turned this into a rebuild every sandbox
+                # of every run repeated and none of them fixed.
                 self.verify_conda()
                 self.discard_if_free_threaded()
 
-            # TODO(clairbee): Does it make sense to retry more than once?
-            attempts = 0
-            while not self.conda_initialized and attempts < 2:
-                # Sometimes it fails to create from the first attempt
-                attempts += 1
-                self.once_conda_locked_attempt()
-                if self.conda_initialized:
-                    # An attempt reports success from the exit code of the last
-                    # command it ran, which says nothing about *which*
-                    # interpreter ended up in the prefix. Ask the prefix itself,
-                    # so a create that quietly produced the wrong one is caught
-                    # here rather than by the next process to open this sandbox
-                    # -- which is what turned this into a rebuild every sandbox
-                    # of every run repeated and none of them fixed.
-                    self.verify_conda()
-                    self.discard_if_free_threaded()
-
-            if not self.conda_initialized:
-                raise Exception("ERROR: Conda environment initialization failed")
+        if not self.conda_initialized:
+            raise Exception("ERROR: Conda environment initialization failed")
 
     # TODO(clairbee): Make an async version of this function
     def once_conda_locked_attempt(self):

--- a/src/partcad/sandbox_lock.py
+++ b/src/partcad/sandbox_lock.py
@@ -177,6 +177,39 @@ def get(lock_path: str) -> EnvironmentLock:
         return _environment_locks[lock_path]
 
 
+# conda serializes poorly against itself whatever it is installing -- the
+# package cache and the solver's own state are shared by every prefix -- so what
+# this stands for is conda, not any one environment. Named here rather than in
+# the runtimes so that the Python and the JavaScript conda sandboxes cannot
+# drift into naming two files and believing they share one.
+CONDA_LOCK_NAME = ".conda.lock"
+
+
+def conda(internal_state_dir: str) -> EnvironmentLock:
+    """The one lock over conda itself, whatever is being provisioned with it.
+
+    Always taken for writing: everything conda is asked to do here creates or
+    installs into a prefix, so there is no reader half to share.
+
+    A lock over conda has to be one object, and used to be one per runtime: the
+    Python 3.11 sandbox, the Python 3.13 sandbox and the Node.js sandbox each
+    built a FileLock of their own over this path. Across processes that still
+    worked, and across threads it worked by accident -- the second thread waited
+    on the file. Two of them on one event loop did not: a render holds this lock
+    across an 'await' while conda runs, so the next task to reach it was the
+    same thread asking for a lock it already held through another object, which
+    filelock refuses outright ("Deadlock: ... already held by a different
+    FileLock instance in this thread"). Refusing was the kind thing to do; the
+    alternative was hanging.
+
+    So the fix is not to talk filelock out of noticing -- 'is_singleton=True'
+    would hand the second task the lock, which is the one outcome worse than
+    either -- but to make the lock what it always claimed to be: one object,
+    shared, with the waiting done by EnvironmentLock rather than by the file.
+    """
+    return get(os.path.join(internal_state_dir, CONDA_LOCK_NAME))
+
+
 class ProcessSlots:
     """How many sandbox interpreters may run at once.
 

--- a/tests/partcad/unit/test_sandbox_lock_conda.py
+++ b/tests/partcad/unit/test_sandbox_lock_conda.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""That the lock over conda is one lock, held by whoever is running conda.
+
+There is one conda per machine and one package cache under it, so every conda
+sandbox -- the Python one of each version, and the Node.js one -- has to be
+provisioned behind the same lock. Each of them used to build a FileLock of its
+own over the one lock file instead, which held across processes and, by
+accident, across threads. It did not hold across the tasks of one event loop,
+which is what a render actually is: the second task to reach conda was the same
+*thread* asking filelock for a lock it already held through another object, and
+filelock refuses that outright rather than hanging on it. So a render that
+provisioned two conda sandboxes died with
+
+    Deadlock: lock '~/.partcad/.conda.lock' is already held by a different
+    FileLock instance in this thread.
+
+What is tested here is therefore both halves: that the second acquire does not
+raise, and that it does not simply walk in either -- 'is_singleton=True', the
+fix filelock's message suggests, would have made that error go away by letting
+two conda installs run at once, which is the thing the lock exists to prevent.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+from partcad import sandbox_lock
+
+
+def test_every_conda_sandbox_shares_one_lock(tmp_path):
+    """The Python sandboxes of two versions and the Node.js one, one object."""
+    python_311 = sandbox_lock.conda(str(tmp_path))
+    python_313 = sandbox_lock.conda(str(tmp_path))
+    javascript = sandbox_lock.conda(str(tmp_path))
+
+    assert python_311 is python_313
+    assert python_311 is javascript
+    assert python_311.lock_path.endswith(sandbox_lock.CONDA_LOCK_NAME)
+
+
+def test_a_second_workspace_gets_a_lock_of_its_own(tmp_path):
+    assert sandbox_lock.conda(str(tmp_path)) is not sandbox_lock.conda(str(tmp_path / "elsewhere"))
+
+
+def test_two_provisions_on_one_loop_do_not_raise(tmp_path):
+    """The failure this reproduces: two conda sandboxes in one render.
+
+    Both tasks run on the loop of one thread and both hold the lock across an
+    'await', which is what made filelock's per-thread deadlock check fire.
+    """
+    lock = sandbox_lock.conda(str(tmp_path))
+    inside = 0
+    peak = 0
+
+    async def provision():
+        nonlocal inside, peak
+        async with lock.acquire_async(write=True):
+            inside += 1
+            peak = max(peak, inside)
+            await asyncio.sleep(0.01)
+            inside -= 1
+
+    async def both():
+        await asyncio.wait_for(asyncio.gather(provision(), provision()), timeout=10)
+
+    asyncio.run(both())
+
+    # Not raising is only half of it: one at a time is what the lock is for.
+    assert peak == 1
+
+
+def test_a_provision_waiting_leaves_the_loop_free(tmp_path):
+    """Waiting is what has to be asynchronous.
+
+    conda runs for minutes under this lock, so a task that waited for it by
+    blocking would be blocking the loop the holder needs in order to finish.
+    """
+    lock = sandbox_lock.conda(str(tmp_path))
+    order = []
+
+    async def holder():
+        async with lock.acquire_async(write=True):
+            order.append("conda-in")
+            await asyncio.sleep(0.05)
+            order.append("conda-out")
+
+    async def waiter():
+        await asyncio.sleep(0.01)
+        async with lock.acquire_async(write=True):
+            order.append("npm")
+
+    async def both():
+        await asyncio.wait_for(asyncio.gather(holder(), waiter()), timeout=10)
+
+    asyncio.run(both())
+    assert order == ["conda-in", "conda-out", "npm"]
+
+
+def _conda_runtimes(tmp_path):
+    """The three conda sandboxes a render can want at once.
+
+    Constructed for real, because what is being tested is what __init__ hands
+    them. Nothing conda-related runs: the sandbox directories do not exist, so
+    each of them stops at "not initialized" and provisioning is never entered.
+    """
+    from partcad.runtime_javascript_conda import CondaJavaScriptRuntime
+    from partcad.runtime_python_conda import CondaPythonRuntime
+
+    ctx = SimpleNamespace(user_config=SimpleNamespace(internal_state_dir=str(tmp_path)))
+    return (
+        CondaPythonRuntime(ctx, "3.11"),
+        CondaPythonRuntime(ctx, "3.13"),
+        CondaJavaScriptRuntime(ctx, "22"),
+    )
+
+
+def test_the_conda_runtimes_hold_the_same_lock(tmp_path):
+    """Two Python versions and a Node.js: one conda, so one lock object."""
+    python_311, python_313, javascript = _conda_runtimes(tmp_path)
+
+    assert python_311.global_conda_lock is python_313.global_conda_lock
+    assert python_311.global_conda_lock is javascript.global_conda_lock
+    assert python_311.global_conda_lock is sandbox_lock.conda(str(tmp_path))
+
+
+def test_two_runtimes_provisioning_on_one_loop(tmp_path):
+    """The CI failure itself, through the runtimes' own install lock.
+
+    Rendering the examples provisions a 3.11 sandbox and a 3.13 one, and the
+    tasks that do it share a thread. Before the lock was shared this raised
+    filelock's "already held by a different FileLock instance in this thread".
+    """
+    python_311, python_313, javascript = _conda_runtimes(tmp_path)
+    inside = 0
+    peak = 0
+
+    async def provision(runtime):
+        nonlocal inside, peak
+        async with runtime.async_lock_install():
+            inside += 1
+            peak = max(peak, inside)
+            await asyncio.sleep(0.01)
+            inside -= 1
+
+    async def all_of_them():
+        await asyncio.wait_for(
+            asyncio.gather(provision(python_311), provision(python_313), provision(javascript)),
+            timeout=10,
+        )
+
+    asyncio.run(all_of_them())
+
+    assert peak == 1


### PR DESCRIPTION
## Copilot Summary

This PR fixes a deadlock that occurs when multiple conda sandboxes are provisioned concurrently on a single event loop. The issue was that each runtime created its own `FileLock` instance over the same lock file, causing `filelock` to detect a deadlock when the same thread tried to acquire the lock through different objects.

The fix introduces a shared `EnvironmentLock`-based conda lock mechanism that:
1. Creates a single lock object per workspace (via `sandbox_lock.conda()`)
2. Shares this lock across all conda runtimes (Python 3.11, 3.13, Node.js)
3. Provides proper async support via `acquire_async()` so waiting doesn't block the event loop
4. Prevents concurrent conda operations while allowing tasks to yield control while waiting

## Changes

### New Module: `sandbox_lock.conda()`
- Added `CONDA_LOCK_NAME` constant and `conda()` function to `sandbox_lock.py`
- Returns a shared `EnvironmentLock` instance per workspace directory
- Ensures all conda sandboxes use the same lock object, not separate `FileLock` instances

### Updated Runtimes
- **`CondaPythonRuntime`**: Replaced `FileLock` with `sandbox_lock.conda()`
  - Updated `async_lock_install()` to use `acquire_async()` instead of blocking
  - Added `once_conda_locked_async()` to properly await the async lock
  - Refactored conda initialization logic into `once_conda_holding_install_lock()`

- **`CondaJavaScriptRuntime`**: Same changes as Python runtime
  - Now shares the exact same lock object as Python runtimes
  - Uses async lock acquisition in async contexts

- **`JavaScriptRuntime` and `PythonRuntime`**: Fixed `once_async()` to use `async_lock_install()` instead of `sync_lock_install()` in async contexts

### Test Coverage
Added comprehensive unit tests in `test_sandbox_lock_conda.py`:
- Verifies all conda sandboxes share a single lock object
- Tests that concurrent provisions don't raise deadlock errors
- Confirms serialization (only one task holds the lock at a time)
- Validates that waiting tasks don't block the event loop
- Tests the actual runtime integration with multiple conda environments

## Why This Matters

Previously, rendering examples that provisioned multiple conda sandboxes (e.g., Python 3.11 + 3.13) would fail with:
```
Deadlock: lock '~/.partcad/.conda.lock' is already held by a different FileLock instance in this thread.
```

This happened because:
1. Each runtime created its own `FileLock` object pointing to the same file
2. On an event loop, two tasks could both hold the lock through different objects
3. `filelock` detects this as a deadlock and refuses the second acquire

The fix ensures there is truly one lock object, shared across all conda operations, with proper async support so the event loop isn't blocked while waiting.

https://claude.ai/code/session_0138Cw9gR4S3f4DPR1Xdggbc