### PR TITLE
Fix mocked_git_open fixture scope to prevent macOS test failures

### DIFF
--- a/tests/partcad/conftest.py
+++ b/tests/partcad/conftest.py
@@ -6,6 +6,7 @@
 
 import copy
 import os
+from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -37,6 +38,34 @@ def restore_parameter_config():
         del parameter_config[key]
     for key, value in saved.items():
         parameter_config[key] = value
+
+
+@pytest.fixture
+def mocked_git_open():
+    """Mock the ``open()`` that ``partcad.project_factory_git`` uses, and only that one.
+
+    A test that mocks the clone itself leaves the repository cache directory
+    uncreated, so the guard file that ``project_factory_git`` writes beside the
+    clone has nowhere to go and the write has to be mocked away.
+
+    Patch the name in that module rather than ``builtins.open``: a global
+    ``open()`` mock is also handed to the standard library, and the standard
+    library opens files during ``pc.Context()`` on some platforms. On macOS
+    ``Context.__init__`` computes the host tags, which reads the OS version out
+    of ``/System/Library/CoreServices/SystemVersion.plist``; ``plistlib`` reads
+    it in binary mode, so a mock handing back ``str`` fails there with
+    ``TypeError: startswith first arg must be str or a tuple of str, not bytes``.
+    That is invisible on Linux, so keep the mock where it belongs.
+
+    ``create=True`` because ``open`` is a builtin: the module has no global of
+    that name until this puts one there, which is exactly what makes the module
+    find the mock while everyone else keeps the real thing.
+    """
+
+    def _patch():
+        return patch("partcad.project_factory_git.open", mock_open(read_data=""), create=True)
+
+    return _patch
 
 
 @pytest.hookimpl(trylast=True)

--- a/tests/partcad/unit/test_git_ambient_config_fallback.py
+++ b/tests/partcad/unit/test_git_ambient_config_fallback.py
@@ -15,7 +15,7 @@ import pytest
 import pygit2
 from pygit2 import GitError
 from pygit2.enums import ConfigLevel
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import partcad as pc
 from partcad.user_config import UserConfig
@@ -49,7 +49,7 @@ def _ambient_config_ignored() -> bool:
     return pygit2.settings.search_path[ConfigLevel.GLOBAL] == ""
 
 
-def test_clone_falls_back_to_ignoring_ambient_config(user_config):
+def test_clone_falls_back_to_ignoring_ambient_config(user_config, mocked_git_open):
     """A clone that fails while honoring the ambient config succeeds once it is
     ignored, and the search path is restored afterwards."""
 
@@ -64,7 +64,7 @@ def test_clone_falls_back_to_ignoring_ambient_config(user_config):
 
     with (
         patch("partcad.project_factory_git._clone", side_effect=side_effect),
-        patch("builtins.open", mock_open(read_data="")),
+        mocked_git_open(),
     ):
         ctx = pc.Context(user_config=user_config)
         factory = pc.ProjectFactoryGit(ctx, None, test_config_import_git)
@@ -95,7 +95,7 @@ def test_search_path_restored_when_fallback_also_fails(user_config):
     assert pygit2.settings.search_path[ConfigLevel.GLOBAL] == saved
 
 
-def test_successful_clone_never_touches_the_search_path(user_config):
+def test_successful_clone_never_touches_the_search_path(user_config, mocked_git_open):
     """The happy path honors the ambient config and never clears the search
     path, so a clone always sees the user's configuration when it works."""
 
@@ -107,7 +107,7 @@ def test_successful_clone_never_touches_the_search_path(user_config):
 
     with (
         patch("partcad.project_factory_git._clone", side_effect=side_effect),
-        patch("builtins.open", mock_open(read_data="")),
+        mocked_git_open(),
     ):
         ctx = pc.Context(user_config=user_config)
         pc.ProjectFactoryGit(ctx, None, test_config_import_git)

--- a/tests/partcad/unit/test_git_clone_retries.py
+++ b/tests/partcad/unit/test_git_clone_retries.py
@@ -2,7 +2,7 @@ import pytest
 import tempfile
 import partcad as pc
 from pygit2 import GitError
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 from partcad.user_config import UserConfig
 
@@ -76,7 +76,7 @@ def test_project_import_git_clone_retry_failure(git_error: GitError, user_config
     assert mock_clone.call_count == test_git_retry_config["max"] + 1
 
 
-def test_project_import_git_clone_retry_then_success(user_config):
+def test_project_import_git_clone_retry_then_success(user_config, mocked_git_open):
     fail_count = 3
 
     def side_effect(*args, **kwargs):
@@ -89,7 +89,7 @@ def test_project_import_git_clone_retry_then_success(user_config):
 
     with (
         patch("partcad.project_factory_git._clone", side_effect=side_effect) as mock_clone,
-        patch("builtins.open", mock_open(read_data="")),
+        mocked_git_open(),
     ):
 
         ctx = pc.Context(user_config=user_config)

--- a/tests/partcad/unit/test_git_open_mock_is_scoped.py
+++ b/tests/partcad/unit/test_git_open_mock_is_scoped.py
@@ -1,0 +1,33 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""A guard for the 'mocked_git_open' fixture in 'tests/partcad/conftest.py'.
+
+The git tests mock the clone, so the guard file that 'project_factory_git'
+writes beside it has to be mocked away too. Doing that with a 'builtins.open'
+mock hands the mock to the standard library as well, and 'pc.Context()' reads a
+file through the standard library on macOS: 'Context.__init__' computes the host
+tags, 'platform.mac_ver()' parses '/System/Library/CoreServices/SystemVersion.plist',
+and 'plistlib' reads it in binary mode. A mock handing back 'str' fails there
+with "TypeError: startswith first arg must be str or a tuple of str, not bytes",
+which is what turned the 'Pytest' job red on every macOS cell and on no other.
+
+The same 'plistlib' read reproduces the failure on any platform, so this keeps
+the mock's scope covered where the tests actually run.
+"""
+
+import plistlib
+
+
+def test_the_git_open_mock_does_not_reach_the_standard_library(tmp_path, mocked_git_open):
+    """The standard library still opens files for real while the fixture is active."""
+    plist = tmp_path / "SystemVersion.plist"
+    plist.write_bytes(plistlib.dumps({"ProductVersion": "26.0"}))
+
+    with mocked_git_open():
+        # Exactly what 'platform.mac_ver()' does on macOS.
+        with open(plist, "rb") as f:
+            assert plistlib.load(f)["ProductVersion"] == "26.0"


### PR DESCRIPTION
## Copilot Summary

This PR fixes a test fixture scoping issue that was causing failures on macOS by introducing a properly scoped `mocked_git_open` fixture that mocks `open()` only within the `partcad.project_factory_git` module, rather than globally mocking `builtins.open`.

## Problem

Tests that mock git clone operations were using a global `builtins.open` mock to suppress writes of a guard file. However, on macOS, `pc.Context()` initialization reads `/System/Library/CoreServices/SystemVersion.plist` via `plistlib`, which expects binary mode file operations. The global mock was returning `str` instead of `bytes`, causing `TypeError: startswith first arg must be str or a tuple of str, not bytes` failures.

## Solution

- Created a new `mocked_git_open()` fixture in `conftest.py` that patches `open` only in the `partcad.project_factory_git` module using `patch(..., create=True)`, keeping the standard library's real `open()` intact
- Added a guard test (`test_git_open_mock_does_not_reach_the_standard_library`) to verify the mock doesn't interfere with standard library file operations
- Updated existing git tests to use the new fixture instead of patching `builtins.open`

## Changes

- **tests/partcad/conftest.py**: Added `mocked_git_open()` fixture with detailed documentation explaining the macOS issue and the `create=True` parameter
- **tests/partcad/unit/test_git_open_mock_is_scoped.py**: New test file verifying the fixture's scope is correct
- **tests/partcad/unit/test_git_ambient_config_fallback.py**: Updated two tests to use `mocked_git_open()` fixture
- **tests/partcad/unit/test_git_clone_retries.py**: Updated one test to use `mocked_git_open()` fixture

## Test Plan

The new guard test (`test_git_open_mock_is_scoped.py`) verifies that `plistlib.load()` works correctly while the fixture is active, ensuring the mock doesn't leak into the standard library. Existing git tests now pass on all platforms including macOS.

https://claude.ai/code/session_01Fz3SdETeTmbnEUnBHwhFm8