### PR TITLE
fix(ci): pin "build" below 1.6 on Windows, where it cannot make its isolated environment

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -40,18 +40,60 @@ runs:
           PYTHON_ABI=("python_abi==${PYTHON_MAJOR}.${PYTHON_MINOR}=*_cp${PYTHON_MAJOR}${PYTHON_MINOR}")
         fi
 
+        # "build" 1.6.0 (2026-08-27) cannot create its isolated build
+        # environment on the Windows runners, so hold Windows below it and let
+        # every other image keep exercising the current release.
+        #
+        # "build" creates that environment with
+        # "venv.EnvBuilder(symlinks=_fs_supports_symlink(), ...)". Up to and
+        # including 1.5.0 the probe was broken on Windows: it tried to symlink
+        # onto f'{tmp_file}-b', the repr of a NamedTemporaryFile object, so a
+        # name containing "<", ">" and ":" -- characters Windows forbids in a
+        # filename. os.symlink therefore always raised, the probe always
+        # answered False, and every isolated environment was built out of
+        # copies. 1.6.0 fixed the probe to f'{tmp_file.name}-b'; a GitHub
+        # Windows runner can create symlinks, so the answer flipped to True and
+        # the environment is now built out of symlinks -- a layout in which the
+        # conda interpreter these steps run under stops finding the DLLs its
+        # "_ssl.pyd" and "_ctypes.pyd" link against in "<prefix>\Library\bin".
+        #
+        # What the log shows is the far end of that, and it does not name
+        # symlinks anywhere. pip 26.2 pre-imports
+        # "pip._internal.operations.install.wheel" before installing; in the
+        # isolated environment that pre-import dies on "DLL load failed while
+        # importing _ctypes", pip records the module as missing, then raises
+        # "No module named 'pip._internal.operations.install.wheel'" against
+        # itself and exits 2. The "--- Logging error ---" blocks around it are
+        # pip's own console failing for the same reason while reporting the
+        # failure.
+        #
+        # Windows only: elsewhere the probe short-circuits to True and always
+        # did, so those images never took the changed path. Note that
+        # "build<1.6" resolves to 1.5.0 rather than 1.5.1, which is yanked --
+        # which is also why the last green run was on 1.5.0.
+        #
+        # To lift this, drop the pin and watch the Windows cells of "build.yml":
+        # it is still real if "Creating isolated environment: venv+pip" is
+        # followed by a DLL load failure. It goes away when "build" stops
+        # handing a symlinked venv to an interpreter that cannot use one, or
+        # when these steps stop running against a conda interpreter at all.
+        BUILD_REQUIREMENT="build"
+        if [ "${RUNNER_OS}" = "Windows" ]; then
+          BUILD_REQUIREMENT="build<1.6"
+        fi
+
         mamba create -n env-build python==${{ matrix.python-version }} "${PYTHON_ABI[@]}" -y
         mamba activate env-build
         python -m ensurepip --upgrade
         python -m pip install --upgrade pip wheel mypy setuptools
-        python -m pip install --upgrade build
+        python -m pip install --upgrade "${BUILD_REQUIREMENT}"
         mamba deactivate
 
         mamba create -n env-build-cli python==${{ matrix.python-version }} "${PYTHON_ABI[@]}" -y
         mamba activate env-build-cli
         python -m ensurepip --upgrade
         python -m pip install --upgrade pip wheel mypy setuptools
-        python -m pip install --upgrade build
+        python -m pip install --upgrade "${BUILD_REQUIREMENT}"
         mamba deactivate
 
     #################################################  CADQUERY  ####################################################


### PR DESCRIPTION
All six Windows cells of the **CD** matrix (`.github/workflows/build.yml`, job `build`, step "Test building and packaging") fail. They fail on `devel` and on every open pull request — #560, #561 and #562 are red on this too, and it is not their doing.

Nothing in this repository caused it. The last green CD run is [33089287809](https://github.com/partcad/partcad/actions/runs/33089287809) (`d361696c`, 2026-08-27T15:42, all six Windows cells green) and the first red one is [33133330181](https://github.com/partcad/partcad/actions/runs/33133330181) (`0bf94f87`, 2026-08-28T01:35). The only commit between them is a version bump, and the only difference in the two job logs is the version `pip install --upgrade build` resolved: **1.5.0 in the green run, 1.6.0 in the red one**. `build` 1.6.0 was released at 2026-08-27T21:01 UTC, between the two. `pip` (26.2.1) and `setuptools` (84.0.0) are identical in both.

## What breaks

`build` creates its isolated build environment with `venv.EnvBuilder(symlinks=_fs_supports_symlink(), ...)`, and diffing the 1.5.0 and 1.6.0 wheels, that probe is the only behavioural change on the Windows venv-creation path:

```python
# build 1.5.0
dest = f'{tmp_file}-b'        # str() of the NamedTemporaryFile object:
                              # "<tempfile._TemporaryFileWrapper object at 0x...>-b"
# build 1.6.0
dest = f'{tmp_file.name}-b'
```

Up to and including 1.5.0 that name contains `<`, `>` and `:`, which Windows forbids in a filename, so `os.symlink` always raised `OSError`, the probe always answered `False`, and every isolated environment on Windows was built out of **copies**. 1.6.0 fixes the probe; a GitHub Windows runner can create symlinks, so the answer flipped to `True` and the environment is now built out of **symlinks**. The interpreter these steps run under is a conda one, whose `_ssl.pyd` and `_ctypes.pyd` link against DLLs in `<prefix>\Library\bin`, and in the symlinked layout they stop resolving them.

That last step is an evidence-backed explanation rather than something reproduced — there is no Windows host here — but it matches CI exactly: Linux and macOS short-circuit the probe to `True` and always did, so they never took the changed path, and they are green.

## Why the log says something else entirely

The log names neither symlinks nor `build`:

```
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools>=77
...
ImportError: DLL load failed while importing _ssl: The specified module could not be found.
ImportError: DLL load failed while importing _ctypes: The specified module could not be found.
...
ImportError: No module named 'pip._internal.operations.install.wheel'
...
subprocess.CalledProcessError: ... returned non-zero exit status 2
```

pip 26.2 added `_eagerly_import_modules()` in `pip/_internal/commands/install.py`: before installing it pre-imports `pip._internal.operations.install.wheel` and `pip._vendor.rich._windows_renderer`, and records in `_MISSING_MODULES` anything that raises `ImportError`. In the isolated environment's interpreter `import ctypes` and `import ssl` fail with "DLL load failed", so that pre-import fails, the module is recorded as missing, and pip's own audit hook then raises `ImportError: No module named 'pip._internal.operations.install.wheel'` when pip genuinely imports it. pip exits 2. The `--- Logging error ---` blocks around it are pip's `rich` console failing for the same reason while trying to report the failure.

## The change

Hold `build` below 1.6 **on Windows only**, in `.github/actions/setup-build/action.yml`, so Linux and macOS keep exercising the current release — which is where a toolchain regression should still be caught first. The action installs `build` twice, once per environment it creates, so a single `BUILD_REQUIREMENT` computed from `RUNNER_OS` covers both lines. The comment beside it names the version boundary, the symptom, and what to check before lifting the pin.

`build<1.6` resolves to 1.5.0 rather than 1.5.1, which is yanked — which is also why the green run was on 1.5.0 with 1.5.1 available.

Nothing else in `.github/` needs the same treatment. `deploy.yml` installs `build` too, but its `build` job runs on `ubuntu-24.04` with a plain `actions/setup-python` interpreter and its own `python -m venv`, never through this action — **releases were never affected by this**, only the Windows CD matrix cells.

## A related finding, deliberately not fixed here

On Windows, `mamba activate env-build` in these steps is a silent no-op. In the job log `mamba create -n env-build ...` produces no solver output at all — only a `Microsoft Windows [Version ...]` banner and a `D:\a\partcad\partcad>` prompt — and every `pip` line afterwards reports `C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages`. So the Windows CD cells have been building in the `test` environment `conda-incubator/setup-miniconda` activates, not in the `env-build`/`env-build-cli` environments `.github/actions/setup-build` goes to the trouble of creating. That is why a conda interpreter is involved at all.

It is not what turned CI red, and fixing it would not fix this — `env-build` is a conda environment too — so it stays out of this diff. Recording it here so it is on the record.

## Verification

- The 1.5.0 and 1.6.0 wheels differ in `_fs_supports_symlink()` exactly as described, and nowhere else on the Windows venv-creation path.
- PyPI dates `build` 1.6.0 between the green and the red run, and marks 1.5.1 yanked.
- `pip install "build<1.6"` resolves to 1.5.0.
- Both job logs confirm 1.5.0 / 1.6.0, resolved into `envs\test` in both cases.
- The action's YAML parses and its shell fragment passes `bash -n`; dry-running the fragment picks `build<1.6` only when `RUNNER_OS` is `Windows`.
- The repo's `pre-commit` gates pass.

The proof is this PR's own CD run: the six Windows cells must go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
