### PR TITLE
fix(selfupdate): a tar link target is a POSIX path, so posixpath is what reads it

### DIFF
--- a/cad/freecad/partcad_freecad/provision.py
+++ b/cad/freecad/partcad_freecad/provision.py
@@ -35,8 +35,10 @@ read from ``PC_CAD_GITHUB_TOKEN``, ``GITHUB_TOKEN`` or ``GH_TOKEN``; without one
 
 import hashlib
 import json
+import ntpath
 import os
 import platform as _platform
+import posixpath
 import shutil
 import sys
 import tarfile
@@ -473,7 +475,15 @@ def _safe_members(tf, dest: str):
             continue
         if member.issym() or member.islnk():
             link = member.linkname
-            if os.path.isabs(link):
+            # A tar stores a link target as a POSIX path, so `posixpath` is what
+            # decides whether it is absolute -- `os.path` is `ntpath` on
+            # Windows, and since Python 3.13 that no longer calls a rootless
+            # `/etc/passwd` absolute (it is relative to the current drive
+            # there). The Windows anchors that `posixpath` does not know about
+            # -- a drive, a UNC root, a bare leading backslash -- are dropped
+            # everywhere rather than only where they mean something: a bundle's
+            # links are bare relative names, so nothing legitimate is caught.
+            if posixpath.isabs(link) or ntpath.splitdrive(link)[0] or link.startswith("\\"):
                 continue
             # A symlink resolves against its own directory; a hard link name is
             # relative to the archive root.

--- a/cad/freecad/tests/test_provision.py
+++ b/cad/freecad/tests/test_provision.py
@@ -327,6 +327,39 @@ def test_the_tar_member_policy_drops_what_must_not_be_written(tmp_path):
     assert kept == ["partcad/ok"]
 
 
+@pytest.mark.parametrize(
+    "link",
+    [
+        "/etc/passwd",  # absolute, and drive-relative on Windows since 3.13
+        "//server/share/secrets",  # a UNC root, absolute either way
+        "C:/Windows/System32/config/SAM",  # a drive, in the spelling a tar carries
+        "C:\\Windows\\System32\\config\\SAM",  # a drive, in Windows spelling
+        "C:secrets",  # anchored to a drive without a root
+        "\\etc\\passwd",  # the root of the current drive on Windows
+    ],
+)
+def test_the_tar_member_policy_drops_a_link_anchored_anywhere(link, tmp_path):
+    """A link target is a POSIX path, and this runs the same table on both hosts.
+
+    `os.path.isabs` is `ntpath.isabs` on Windows, where Python 3.13 stopped
+    calling a rootless `/etc/passwd` absolute -- so the answer has to come from
+    `posixpath`, plus the Windows anchors it does not know about. Whether an
+    archive is hostile is a property of the archive; running half of this table
+    on one host and half on the other is how the same guard in
+    `partcad_client.selfupdate` came to misreport one of these on Windows alone.
+    """
+    archive = str(tmp_path / "anchored.tar.gz")
+    with tarfile.open(archive, "w:gz") as tf:
+        member = tarfile.TarInfo("partcad/link")
+        member.type = tarfile.SYMTYPE
+        member.linkname = link
+        tf.addfile(member)
+
+    dest = str(tmp_path / "out")
+    with tarfile.open(archive) as tf:
+        assert [m.name for m in provision._safe_members(tf, dest)] == []
+
+
 def test_the_tar_member_policy_keeps_a_normal_bundle(tmp_path):
     archive = _bundle_tar(str(tmp_path / "bundle.tar.gz"), provision.EXE)
     dest = str(tmp_path / "out")

--- a/src/partcad_client/selfupdate.py
+++ b/src/partcad_client/selfupdate.py
@@ -47,8 +47,10 @@ reaper that waits for this process to exit first. See :func:`_reap_after_exit`.
 import contextlib
 import glob
 import json
+import ntpath
 import os
 import platform
+import posixpath
 import re
 import shlex
 import shutil
@@ -894,7 +896,7 @@ def _reject_unsafe_links(members, dest: str) -> None:
         if not (member.issym() or member.islnk()):
             continue
         link = member.linkname
-        if os.path.isabs(link) or (os.name == "nt" and os.path.splitdrive(link)[0]):
+        if _is_absolute_link(link):
             raise SelfUpdateError("the archive contains an absolute link: %s -> %s" % (member.name, link))
         # A symlink resolves against its own directory; a hard link name is
         # relative to the archive root.
@@ -903,6 +905,29 @@ def _reject_unsafe_links(members, dest: str) -> None:
         root = os.path.normpath(dest)
         if resolved != root and not resolved.startswith(root + os.sep):
             raise SelfUpdateError("the archive contains an unsafe link: %s -> %s" % (member.name, link))
+
+
+def _is_absolute_link(link: str) -> bool:
+    """Whether a tar link target names a place of its own rather than one in the archive.
+
+    A tar stores a link target as a POSIX path, whatever host wrote the archive
+    and whatever host unpacks it, so :mod:`posixpath` is what decides whether it
+    is absolute -- not ``os.path``, which is :mod:`ntpath` on Windows. Python
+    3.13 stopped calling a rootless ``/etc/passwd`` absolute there, on the
+    grounds that Windows resolves it against the current drive rather than
+    against a root, and the caller's guard quietly stopped firing for exactly
+    the target it was written for. The archive stayed refused -- the traversal
+    check that follows it catches the same member a line later -- but under the
+    wrong name, so a Windows 3.13+ user was told a hostile bundle was malformed.
+
+    The Windows anchors are then refused everywhere rather than only where they
+    mean something: a drive (``C:\\x``), a UNC root, and a bare leading
+    backslash, which names the root of the current drive there and is an
+    ordinary filename here. An archive is hostile or it is not, and which host
+    happens to unpack it does not change the answer. Nothing legitimate is
+    caught either way -- a bundle's links are bare relative names.
+    """
+    return posixpath.isabs(link) or bool(ntpath.splitdrive(link)[0]) or link.startswith("\\")
 
 
 def _reject_traversal(names, dest: str) -> None:

--- a/tests/partcad_client/test_selfupdate.py
+++ b/tests/partcad_client/test_selfupdate.py
@@ -420,13 +420,17 @@ def test_extract_keeps_the_aliases_that_point_at_pc(tmp_path):
         assert alias.is_file()
 
 
+def _link_member(name, linkname):
+    member = tarfile.TarInfo(name)
+    member.type = tarfile.SYMTYPE
+    member.linkname = linkname
+    return member
+
+
 def _link_archive(path, name, linkname):
     archive = path / "links.tar.gz"
     with tarfile.open(archive, "w:gz") as tf:
-        member = tarfile.TarInfo(name)
-        member.type = tarfile.SYMTYPE
-        member.linkname = linkname
-        tf.addfile(member)
+        tf.addfile(_link_member(name, linkname))
     return archive
 
 
@@ -444,6 +448,50 @@ def test_extract_refuses_an_absolute_link(tmp_path):
     dest.mkdir()
     with pytest.raises(selfupdate.SelfUpdateError, match="absolute link"):
         selfupdate._extract(str(archive), str(dest), "tar.xz")
+
+
+# Every spelling of a link target that names a place of its own rather than one
+# inside the archive. Both hosts run all of them, because the answer is a
+# property of the archive and not of the machine that unpacks it -- and because
+# a table only one host could tell apart is what let this one through.
+#
+# `/etc/passwd` is the case that broke: a tar carries a link target as a POSIX
+# path, but the guard asked `os.path.isabs`, which is `ntpath.isabs` on Windows,
+# and Python 3.13 stopped calling a rootless path absolute there (Windows
+# resolves it against the current drive). So on a Windows 3.13+ the archive was
+# still refused -- by the traversal check a line later -- but as a malformed one
+# rather than a hostile one, and only that host and that interpreter could see
+# it. The four Windows spellings are the mirror image: `posixpath` calls every
+# one of them an ordinary relative filename, and so did the old guard on a POSIX
+# host, which asked for a drive only when `os.name == "nt"`.
+ANCHORED_LINKS = [
+    "/etc/passwd",  # absolute, and drive-relative on Windows since 3.13
+    "//server/share/secrets",  # a UNC root, absolute either way
+    "C:/Windows/System32/config/SAM",  # a drive, in the spelling a tar carries
+    "C:\\Windows\\System32\\config\\SAM",  # a drive, in Windows spelling
+    "C:secrets",  # anchored to a drive without a root
+    "\\etc\\passwd",  # the root of the current drive on Windows
+]
+
+
+@pytest.mark.parametrize("link", ANCHORED_LINKS)
+def test_an_anchored_link_is_refused_as_absolute(link, tmp_path):
+    with pytest.raises(selfupdate.SelfUpdateError, match="absolute link"):
+        selfupdate._reject_unsafe_links([_link_member("partcad/pc", link)], str(tmp_path))
+
+
+@pytest.mark.parametrize("link", ["../../../../etc/passwd", "../../outside", "aliases/../../../outside"])
+def test_a_climbing_link_is_refused_as_unsafe(link, tmp_path):
+    """The other half of the pair: relative, but it walks out of the bundle."""
+    with pytest.raises(selfupdate.SelfUpdateError, match="unsafe link"):
+        selfupdate._reject_unsafe_links([_link_member("partcad/pc", link)], str(tmp_path))
+
+
+def test_the_links_a_bundle_carries_are_accepted(tmp_path):
+    """Nothing above may cost the bundle its aliases: `pc` is a bare name."""
+    members = [_link_member("partcad/" + name, "pc") for name in selfupdate.BUNDLE_EXECUTABLES if name != "pc"]
+    assert members
+    selfupdate._reject_unsafe_links(members, str(tmp_path))
 
 
 def test_checksum_mismatch_is_fatal(monkeypatch, tmp_path):


### PR DESCRIPTION
`_reject_unsafe_links` in `src/partcad_client/selfupdate.py` refuses an archive
whose symlinks or hard links point somewhere other than into the bundle, and it
separates the two ways that happens: a target anchored somewhere of its own
("absolute link") and a target that is relative but climbs out ("unsafe link").
It asked `os.path.isabs` for the first of those.

On Windows `os.path` is `ntpath`, and **Python 3.13 changed `ntpath.isabs` so
that a path beginning with a separator and carrying no drive is no longer
absolute** — `/etc/passwd` and `\etc\passwd` name a place on the *current
drive* there, which is not the same as naming a root. `os.path.splitdrive`
returns no drive for either, so the second half of the guard did not fire
either, and the check went silent for exactly the target it was written for.
Verified on real interpreters rather than assumed:

| interpreter | `ntpath.isabs('/etc/passwd')` | `posixpath.isabs('/etc/passwd')` |
| --- | --- | --- |
| 3.9 / 3.10 / 3.11 / 3.12 | `True` | `True` |
| 3.13.13 / 3.14.7 | `False` | `True` |

### This is not an escape

Nothing got out. The traversal check on the next line resolves the target
against the destination and refuses anything landing outside it, so
`partcad/pc -> /etc/passwd` was still rejected — as *"the archive contains an
unsafe link"* rather than *"an absolute link"*. What was wrong is the
classification, and with it the diagnostic a Windows user would be given for a
hostile bundle: it read as a malformed archive instead of an attack.

### Why only the Windows 3.14 cells report it

The interpreter has to be 3.13+ for `ntpath.isabs` to have changed, the host has
to be Windows for `os.path` to be `ntpath` at all, 3.13 is not in the matrix,
and the Windows 3.10/3.12 cells stop at an earlier failure before `pytest -x`
ever reaches this test. So it shows up on
[`Pytest (windows-latest, 3.14)`](https://github.com/partcad/partcad/actions/runs/33133329988/job/98727984839)
and
[`Pytest (windows-2022, 3.14)`](https://github.com/partcad/partcad/actions/runs/33133329988/job/98727984766)
of run 33133329988 and nowhere else:

```
FAILED tests/partcad_client/test_selfupdate.py::test_extract_refuses_an_absolute_link
  - AssertionError: Regex pattern did not match.
      Expected regex: 'absolute link'
      Actual message: 'the archive contains an unsafe link: partcad/pc -> /etc/passwd'
```

This is the failure that was sitting behind #560: that PR fixed what the 3.10
and 3.12 cells stop at (`test_install_standalone_installs_beside_the_running_bundle`),
and its diff does not touch this test. #560 has since merged, and this branch is
based on top of it, so every Windows cell now reaches this one.

### The fix

A tar stores a link target as a POSIX path whatever host wrote the archive and
whatever host unpacks it, so `posixpath.isabs` is the question that was meant to
be asked, and it gives the same answer on every interpreter and every host. The
Windows anchors `posixpath` knows nothing about are then refused *everywhere*
rather than only where they mean something: a drive (`C:\x`), a UNC root, and a
bare leading backslash. An archive is hostile or it is not, and which machine
happens to unpack it does not change the answer. Nothing legitimate is caught —
the bundle's links are the bare name `pc`, which is why they are extracted
rather than skipped in the first place.

### The tests

They could not tell the two hosts apart, which is how this survived. They now
drive the guard with the whole table of anchored spellings on both, since the
verdict is a property of the archive: `/etc/passwd` is the case only a Windows
3.13+ could see, and the four Windows spellings are the mirror image —
`posixpath` calls every one of them an ordinary relative filename, and so did
the old guard on a POSIX host, which asked for a drive only under
`os.name == "nt"`. Four of the six fail against the old code on a Linux runner,
which was checked by reverting the source and re-running them.

### The other copy, and the ones left alone

`cad/freecad` carries its own copy of this guard — the addon runs inside
FreeCAD's embedded interpreter and cannot import `partcad_client` — and made the
same assumption in `_safe_members`, where the consequence is a member silently
kept rather than a message. It is unreachable today, since that fallback only
runs on interpreters too old to have `filter="data"` and those are also too old
to have the `ntpath` change, but the two copies should say the same thing and be
tested by the same table.

`grep -rn isabs` over the rest of the repository turns up only
`p if isabs(p) else join(base, p)` against local filesystem paths, where the
change is invisible: `ntpath.join` gives a rooted component the drive of the
base, so `join("C:\proj", "/abs/path")` is `C:/abs/path` either way. Those are
left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
