### PR TITLE
fix(sandbox): stop a recovered conda failure from aborting a finished command

### DIFF
--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -21,9 +21,32 @@ from . import sandbox_versions
 from . import logging as pc_logging
 from . import telemetry
 
+# Conda/mamba failures that are the machine, not the request, and that a retry
+# has been observed to clear. Matched against the stderr of "conda create".
+#
+# "Unexpected error N on netlink descriptor M" is not conda's own message at
+# all: it is glibc's, from check_pf.c, where getaddrinfo() enumerates local
+# interfaces over a NETLINK_ROUTE socket. When that socket answers with an
+# unexpected errno (9 is EBADF), glibc calls __libc_fatal() and kills the
+# process outright -- so conda dies mid-solve, through no fault of its own or
+# ours, and leaves no prefix behind. It is a property of the runner's network
+# namespace and it comes and goes; the retry below is the whole remedy.
+_SPORADIC_CONDA_ERRORS = (
+    "Found incorrect download",
+    "libmamba libarchive",
+    "netlink descriptor",
+)
+
 
 @telemetry.instrument()
 class CondaPythonRuntime(runtime_python.PythonRuntime):
+    # The last thing that went wrong while provisioning this sandbox. Every
+    # diagnostic inside an attempt is a warning, because the attempt may be
+    # retried; this is what the exception raised after the last attempt quotes,
+    # so that the fatal message names the cause and not just the fact. A class
+    # attribute so that it is readable however the instance was made.
+    conda_last_error = None
+
     def __init__(self, ctx, version=None, variant=None):
         if variant is None:
             sandbox_type_name = "conda"
@@ -272,7 +295,20 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                 self.discard_if_free_threaded()
 
         if not self.conda_initialized:
-            raise Exception("ERROR: Conda environment initialization failed")
+            # The one fatal point in provisioning, and the only place that gets
+            # to fail the run. Everything an attempt logged on the way here was
+            # a warning, so this message has to carry the cause: a bare
+            # "initialization failed" from a command that then went on to render
+            # everything successfully is what made this unactionable in CI.
+            raise Exception(
+                "ERROR: Conda environment initialization failed for Python %s at %s after %d attempt(s): %s"
+                % (
+                    self.version,
+                    self.path,
+                    attempts,
+                    self.conda_last_error or "no diagnostic was captured",
+                )
+            )
 
     # TODO(clairbee): Make an async version of this function
     def once_conda_locked_attempt(self):
@@ -326,21 +362,22 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                         )
                         stdout, stderr = p.communicate()
 
+                    # Everything reported in here is a *warning*, however bad it
+                    # reads. This is one attempt of several, and whether the
+                    # sandbox ends up usable is decided by the caller
+                    # (once_conda_holding_install_lock), which retries and then
+                    # raises. pc_logging.error() sets the global had_errors flag
+                    # that the CLI turns into a non-zero exit at the very end of
+                    # the command -- so an error logged here failed a run that
+                    # had already recovered, rendered everything and finished.
                     if not stderr is None and stderr.strip() != "":
+                        self.conda_last_error = stderr.strip()
                         # Handle most common sporadic conda/mamba failures
-                        if "Found incorrect download" in stderr:
-                            pc_logging.warn("conda env install error: %s" % stderr)
+                        if any(marker in stderr for marker in _SPORADIC_CONDA_ERRORS):
+                            pc_logging.warning("conda env install error (retrying): %s" % stderr)
                             attempts += 1
                             continue
-                        if "libmamba libarchive" in stderr:
-                            pc_logging.warn("conda env install error: %s" % stderr)
-                            attempts += 1
-                            continue
-                        if "Found incorrect download" in stderr:
-                            pc_logging.warn("conda env install error: %s" % stderr)
-                            attempts += 1
-                            continue
-                        pc_logging.error("conda env install error: %s" % stderr)
+                        pc_logging.warning("conda env install error: %s" % stderr)
                     elif p.returncode != 0:
                         # A failed solve under "--json" is reported *on stdout*,
                         # as {"success": false, "error": ...}, and leaves stderr
@@ -348,7 +385,11 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                         # one is the only thing between a failed create and the
                         # "conda install" below being asked to populate a prefix
                         # that was never made.
-                        pc_logging.error(
+                        self.conda_last_error = "conda env create exited %s: %s" % (
+                            p.returncode,
+                            (stdout or "").strip(),
+                        )
+                        pc_logging.warning(
                             "conda env create failed (exit %s): %s" % (p.returncode, (stdout or "").strip())
                         )
                     break
@@ -408,7 +449,14 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                 if not stderr is None and stderr.strip() != "":
                     pc_logging.warning("conda pip install error: %s" % stderr)
                 if p.returncode != 0:
-                    pc_logging.error("conda pip install return code: %s" % p.returncode)
+                    # A warning for the same reason as the create diagnostics
+                    # above: this only means *this* attempt did not finish, and
+                    # the caller decides whether that is fatal.
+                    self.conda_last_error = "conda pip install exited %s: %s" % (
+                        p.returncode,
+                        (stderr or "").strip(),
+                    )
+                    pc_logging.warning("conda pip install return code: %s" % p.returncode)
                     self.conda_initialized = False
                 else:
                     self.conda_initialized = True

--- a/src/partcad_cli/click/command.py
+++ b/src/partcad_cli/click/command.py
@@ -595,6 +595,17 @@ cli.context_settings = {
 def process_result(click_ctx: click.Context, result, verbose, quiet, no_ansi, path, **kwargs):
     global cli_span
 
+    # Say why the command is about to fail, and say it *before* fini() detaches
+    # the renderer and click prints its bare "Aborted.". This callback runs after
+    # the command has done all of its work, so the error that set the flag can be
+    # thousands of lines back -- and where the code recovered from it, the log
+    # ends with the work succeeding and then an abort that names nothing at all.
+    if pc_logging.had_errors:
+        logging.getLogger("partcad").error(
+            "Exiting with an error status because of: %s",
+            pc_logging.first_error or "an error reported above",
+        )
+
     logging_remote_client.fini()
 
     # Abort if there was at least one error reported during the execution time.

--- a/src/partcad_utils/logging.py
+++ b/src/partcad_utils/logging.py
@@ -17,10 +17,16 @@ import sentry_sdk
 from opentelemetry import trace
 from . import telemetry
 
-
 # Track if any errors occurred during the execution for test purposes and for
 # the main program to know if it should exit with an error code.
 had_errors = False
+
+# The first error that set the flag above, kept so that the exit can name it.
+# The flag is read at the very end of a command, by which time the error that
+# set it may be thousands of lines up the log -- and click's own abort prints
+# "Aborted." and nothing else. Only the first: it is the one that has not been
+# caused by an earlier failure.
+first_error = None
 
 # Other packages (such as 'pip' or 'pytest') may mess with the root logger
 # in a way that we don't want. We create a separate logger for our own use.
@@ -45,17 +51,35 @@ def reset_errors():
     This should be called before running a new test. This function modifies a global variable and should be called
     with appropriate thread safety considerations.
     """
-    global had_errors
+    global had_errors, first_error
     had_errors = False
+    first_error = None
+
+
+def _rendered(args):
+    """The message as the user saw it, for `first_error`.
+
+    Callers use both styles: a pre-formatted string, and the lazy
+    ``("%s failed", name)`` the stdlib takes. Rendering must never be what
+    fails, so anything unexpected falls back to the format string itself.
+    """
+    if not args:
+        return None
+    try:
+        return str(args[0]) % args[1:] if len(args) > 1 else str(args[0])
+    except Exception:
+        return str(args[0])
 
 
 # TODO(clairbee): replace this with some kind of a hook, so that it can be handled differently in CLI and IDE, and ignored in backend jobs
 def _track_error(args):
-    global had_errors
+    global had_errors, first_error
     if args and len(args) > 1:
         if "conda run pythonw" in str(args[0]):
             return
     had_errors = True
+    if first_error is None:
+        first_error = _rendered(args)
 
 
 def error(*args, **kwargs):

--- a/src/partcad_utils/logging_remote_client.py
+++ b/src/partcad_utils/logging_remote_client.py
@@ -64,6 +64,8 @@ def handle(event: dict) -> None:
         # must make the CLI exit non-zero (command.py checks logging.had_errors).
         if levelno >= logging.ERROR:
             _pc_logging.had_errors = True
+            if _pc_logging.first_error is None:
+                _pc_logging.first_error = event.get("message", "")
         # Pass the message as an argument so any '%' in it is never treated as a
         # format specifier.
         logging.getLogger("partcad").log(levelno, "%s", event.get("message", ""))

--- a/tests/partcad/unit/test_logging.py
+++ b/tests/partcad/unit/test_logging.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import partcad.logging as pc_logging
 
-
 # All tests patch ``partcad.logging.sentry_sdk.capture_message`` and
 # ``partcad.logging.sentry_sdk.capture_exception`` directly. This makes the
 # assertions independent of whether a real Sentry backend is configured: even
@@ -26,8 +25,10 @@ def test_exception_with_plain_string_dispatches_capture_message():
     which used to turn the logging call itself into a ValueError. The string
     must be routed to capture_message(..., level="error") instead.
     """
-    with mock.patch("partcad.logging.sentry_sdk.capture_message") as capture_message, \
-         mock.patch("partcad.logging.sentry_sdk.capture_exception") as capture_exception:
+    with (
+        mock.patch("partcad.logging.sentry_sdk.capture_message") as capture_message,
+        mock.patch("partcad.logging.sentry_sdk.capture_exception") as capture_exception,
+    ):
         pc_logging.exception("a plain string, not an exception")
 
     capture_message.assert_called_once_with("a plain string, not an exception", level="error")
@@ -37,8 +38,10 @@ def test_exception_with_plain_string_dispatches_capture_message():
 def test_exception_with_exception_object_dispatches_capture_exception():
     """An actual exception object must go to capture_exception unchanged."""
     err = ValueError("boom")
-    with mock.patch("partcad.logging.sentry_sdk.capture_message") as capture_message, \
-         mock.patch("partcad.logging.sentry_sdk.capture_exception") as capture_exception:
+    with (
+        mock.patch("partcad.logging.sentry_sdk.capture_message") as capture_message,
+        mock.patch("partcad.logging.sentry_sdk.capture_exception") as capture_exception,
+    ):
         try:
             raise err
         except ValueError as e:
@@ -68,10 +71,74 @@ def test_exception_with_format_string_and_arg_dispatches_capture_message():
     being papered over -- the assertion pins the current behavior so a future
     change to it is visible.
     """
-    with mock.patch("partcad.logging.sentry_sdk.capture_message") as capture_message, \
-         mock.patch("partcad.logging.sentry_sdk.capture_exception") as capture_exception:
+    with (
+        mock.patch("partcad.logging.sentry_sdk.capture_message") as capture_message,
+        mock.patch("partcad.logging.sentry_sdk.capture_exception") as capture_exception,
+    ):
         pc_logging.exception("formatted %s", 42)
 
     # Raw format string reaches Sentry; the 42 argument is not substituted.
     capture_message.assert_called_once_with("formatted %s", level="error")
     capture_exception.assert_not_called()
+
+
+# `had_errors` is what turns into the CLI's exit status, and it is read at the
+# very end of a command -- long after the error that set it scrolled past, and
+# in the case that started this, after the run recovered from that error and
+# finished all of its work successfully. `first_error` is what lets the exit say
+# which error it is exiting over instead of click's bare "Aborted.".
+
+
+def test_the_first_error_is_kept_so_the_exit_can_name_it():
+    pc_logging.reset_errors()
+
+    pc_logging.error("conda env install error: netlink descriptor 9")
+
+    assert pc_logging.had_errors is True
+    assert "netlink descriptor 9" in pc_logging.first_error
+
+
+def test_only_the_first_error_is_kept():
+    """Later errors are usually consequences of the first one.
+
+    The conda failure that prompted this logged two: the create that glibc
+    killed, and then "Not a conda environment" from the pip install that was
+    handed the prefix the create never made. The second names the symptom.
+    """
+    pc_logging.reset_errors()
+
+    pc_logging.error("the cause")
+    pc_logging.error("the consequence")
+
+    assert pc_logging.first_error == "the cause"
+
+
+def test_a_lazily_formatted_error_is_rendered():
+    """Callers use both the pre-formatted and the stdlib's deferred style."""
+    pc_logging.reset_errors()
+
+    pc_logging.error("conda pip install return code: %s", 1)
+
+    assert pc_logging.first_error == "conda pip install return code: 1"
+
+
+def test_a_message_that_cannot_be_rendered_falls_back_to_the_format_string():
+    """Recording the message must never be the thing that fails.
+
+    Tested against the renderer rather than through error(): the stdlib logger
+    raises on a mismatched format of its own accord, which is behaviour that
+    predates this and is not what is being guarded here.
+    """
+    assert pc_logging._rendered(("%s and %s", "only one")) == "%s and %s"
+    assert pc_logging._rendered(()) is None
+
+
+def test_reset_errors_clears_the_recorded_error():
+    """The conftest fixture resets between tests; both halves must reset."""
+    pc_logging.error("something")
+    assert pc_logging.first_error is not None
+
+    pc_logging.reset_errors()
+
+    assert pc_logging.had_errors is False
+    assert pc_logging.first_error is None

--- a/tests/partcad/unit/test_logging_remote_client.py
+++ b/tests/partcad/unit/test_logging_remote_client.py
@@ -27,9 +27,7 @@ def test_plain_log_event_written_to_stream():
     buf = io.StringIO()
     remote_client.init(want_ansi=False, stream=buf)
 
-    remote_client.handle(
-        {"kind": "log", "levelno": logging.INFO, "levelname": "INFO", "message": "hello client"}
-    )
+    remote_client.handle({"kind": "log", "levelno": logging.INFO, "levelname": "INFO", "message": "hello client"})
 
     assert "hello client" in buf.getvalue()
 
@@ -45,9 +43,10 @@ def test_plain_mode_ignores_process_events():
 
 def test_ansi_mode_initializes_and_finalizes_ansi_terminal():
     buf = io.StringIO()
-    with mock.patch.object(remote_client.logging_ansi_terminal, "init") as m_init, mock.patch.object(
-        remote_client.logging_ansi_terminal, "fini"
-    ) as m_fini:
+    with (
+        mock.patch.object(remote_client.logging_ansi_terminal, "init") as m_init,
+        mock.patch.object(remote_client.logging_ansi_terminal, "fini") as m_fini,
+    ):
         remote_client.init(want_ansi=True, stream=buf)
         m_init.assert_called_once()
 
@@ -60,9 +59,24 @@ def test_ansi_process_event_replayed_through_ops():
     remote_client.init(want_ansi=True, stream=buf)
     try:
         with mock.patch.object(pc_logging.ops, "process_start") as m:
-            remote_client.handle(
-                {"kind": "process_start", "op": "build", "package": "//pkg", "item": "x"}
-            )
+            remote_client.handle({"kind": "process_start", "op": "build", "package": "//pkg", "item": "x"})
             m.assert_called_once_with("build", "//pkg", "x")
     finally:
         remote_client.fini()
+
+
+def test_an_error_forwarded_from_the_daemon_is_recorded_for_the_exit():
+    """Most of the work runs in the daemon, so most errors arrive this way.
+
+    The flag was already mirrored here; without the message beside it, a
+    command whose only error came from the daemon still exited over an error it
+    could not name.
+    """
+    pc_logging.reset_errors()
+
+    remote_client.handle(
+        {"kind": "log", "levelno": logging.ERROR, "message": "conda env install error: netlink descriptor 9"}
+    )
+
+    assert pc_logging.had_errors is True
+    assert "netlink descriptor 9" in pc_logging.first_error

--- a/tests/partcad/unit/test_runtime_python_conda.py
+++ b/tests/partcad/unit/test_runtime_python_conda.py
@@ -21,6 +21,7 @@ import pathlib
 
 import pytest
 
+from partcad import logging as pc_logging
 from partcad import runtime_python_conda
 from partcad.runtime_python_conda import CondaPythonRuntime
 
@@ -60,6 +61,8 @@ def _bare_runtime(path, version, is_mamba=True):
     runtime.path = str(path / ("pc-py-conda-" + version))
     runtime.variant_packages = []
     runtime.conda_initialized = False
+    runtime.conda_free_threaded = False
+    runtime.conda_last_error = None
     runtime.constraints_path = None
     runtime.initialized = True
     return runtime
@@ -95,7 +98,7 @@ def test_nothing_is_pinned_below_the_free_threaded_builds(tmp_path, recorded_com
 
 @pytest.mark.parametrize("is_mamba", [True, False])
 def test_the_python_spec_is_the_fuzzy_one(tmp_path, recorded_commands, is_mamba):
-    """"python==3.14" does not mean what it looks like it means.
+    """ "python==3.14" does not mean what it looks like it means.
 
     libmamba reads it as the 3.14 release exactly, which is 3.14.0 - the oldest
     patch of the line rather than the newest - and then the next solve wants to
@@ -146,3 +149,135 @@ def test_a_free_threaded_prefix_is_the_only_one_thrown_away(tmp_path):
     runtime.discard_if_free_threaded()
     assert not os.path.exists(runtime.path)
     assert runtime.conda_free_threaded is False
+
+
+class _ScriptedProcess:
+    """A process that says what the script told it to say."""
+
+    def __init__(self, returncode, stdout, stderr):
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    def communicate(self):
+        return self._stdout, self._stderr
+
+
+@pytest.fixture
+def scripted_commands(monkeypatch):
+    """Drive 'subprocess.Popen' from a queue of (returncode, stdout, stderr).
+
+    Returns (commands, script): append outcomes to 'script' before the call and
+    read the commands that were run out of 'commands' afterwards. A call past the
+    end of the script succeeds silently, which is what a healthy conda does.
+    """
+    commands = []
+    script = []
+
+    def popen(args, **kwargs):
+        commands.append(list(args))
+        if script:
+            return _ScriptedProcess(*script.pop(0))
+        return _FakeProcess()
+
+    monkeypatch.setattr(runtime_python_conda.subprocess, "Popen", popen)
+    return commands, script
+
+
+# glibc's, not conda's: check_pf.c calls __libc_fatal() and kills the process
+# when the netlink socket getaddrinfo() enumerates interfaces over answers with
+# an unexpected errno. 9 is EBADF. Seen on ubuntu-24.04 in Standalone job
+# 98777554923, and gone on the retry.
+_NETLINK = "Unexpected error 9 on netlink descriptor 9.\n"
+
+
+def test_a_recovered_conda_create_does_not_fail_the_run(tmp_path, scripted_commands):
+    """A provisioning error the code retries past must not fail the command.
+
+    This is the whole bug. `pc render` in Standalone job 98777554923 hit this,
+    retried, built the sandbox, ran every wrapper out of it and rendered
+    everything -- and then exited 1 with a bare `Aborted.`, because
+    `pc_logging.error()` had set the process-wide `had_errors` flag on the way
+    through and `process_result()` reads it after the work is done. A CLI that
+    renders everything successfully and then aborts is telling the user nothing
+    they can act on.
+    """
+    commands, script = scripted_commands
+    script.append((0, "", _NETLINK))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert runtime.conda_initialized is True
+    assert pc_logging.had_errors is False, "a recovered provisioning error still fails the command"
+    # Two creates: the one glibc killed, and the retry that worked.
+    creates = [command for command in commands if "create" in command]
+    assert len(creates) == 2, commands
+
+
+def test_a_sporadic_create_failure_is_retried_before_pip_is_asked_to_populate_it(tmp_path, scripted_commands):
+    """The retry has to happen before the second command, not after it.
+
+    Falling through to "conda install pip" against a prefix that was never
+    created is what produced the "Not a conda environment" line in that job: a
+    second, louder, wholly derivative failure that named the sandbox rather than
+    the thing that broke it.
+    """
+    commands, script = scripted_commands
+    script.append((0, "", _NETLINK))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert [command[1] for command in commands] == ["create", "create", "install"], commands
+
+
+def test_an_unrecognised_create_failure_is_still_only_a_warning(tmp_path, scripted_commands):
+    """Severity is not the attempt's call to make.
+
+    `once_conda_holding_install_lock()` retries the attempt and then raises. An
+    attempt that reports at error severity has already decided the command
+    fails, whatever the caller goes on to do about it.
+    """
+    commands, script = scripted_commands
+    script.append((0, "", "something nobody has seen before\n"))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert pc_logging.had_errors is False
+    assert [command[1] for command in commands] == ["create", "install"], commands
+
+
+def test_a_failed_pip_install_is_a_warning_and_leaves_the_sandbox_uninitialized(tmp_path, scripted_commands):
+    """The failure is reported by the return value, not by the log severity."""
+    commands, script = scripted_commands
+    script.append((0, "{}", ""))
+    script.append((1, "", "could not install pip\n"))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert runtime.conda_initialized is False
+    assert pc_logging.had_errors is False
+
+
+def test_provisioning_that_never_succeeds_is_fatal_and_names_the_cause(tmp_path, scripted_commands):
+    """The one place that gets to fail the run, and it has to say what failed.
+
+    "ERROR: Conda environment initialization failed" named nothing: not the
+    sandbox, not the interpreter, not the diagnostic. Now that every attempt
+    warns, this message is the only account of the failure there is.
+    """
+    commands, script = scripted_commands
+    for _ in range(8):
+        script.append((1, "", "could not install pip\n"))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    with pytest.raises(Exception) as raised:
+        runtime.once_conda_holding_install_lock()
+
+    message = str(raised.value)
+    assert "3.13" in message, message
+    assert runtime.path in message, message
+    assert "could not install pip" in message, message


### PR DESCRIPTION
## The failure

`Examples PartCAD via bundle (ubuntu-24.04-x86_64)` — job **98777554923**, Standalone run **33149121983** (`314290fc`) — did all of its work and *then* failed:

```
INFO:partcad:DONE: Test: //pub/examples/partcad: 151.04s
ERROR:partcad:conda env install error: Unexpected error 9 on netlink descriptor 9.
WARNING:partcad:conda pip install error: Not a conda environment: /home/runner/.partcad/sandbox/pc-py-conda-3.13
ERROR:partcad:conda pip install return code: 1
...
INFO:partcad:DONE: Render: //pub/examples/partcad: 299.69s
Aborted.
##[error]Process completed with exit code 1.
```

Between the error and the abort, the sandbox **was used successfully** — later lines run `/home/runner/.partcad/sandbox/pc-py-conda-3.13/bin/python .../wrapper_export.py` and produce output, and every object rendered.

## Q1: is the netlink error ours or the runner's? — **The runner's.**

`Unexpected error 9 on netlink descriptor 9.` is **not a conda message at all**. It is glibc's, and it is verifiable directly:

```
$ strings /lib/x86_64-linux-gnu/libc.so.6 | grep "netlink descriptor"
Unexpected error %d on netlink descriptor %d.
Unexpected error %d on netlink descriptor %d (address family %d).
```

It comes from `sysdeps/unix/sysv/linux/check_pf.c`, where `getaddrinfo()` enumerates the local interfaces over a `NETLINK_ROUTE` socket. When that socket answers with an unexpected errno — **9 is `EBADF`** — glibc calls `__libc_fatal()` and kills the process where it stands.

So conda was killed mid-solve by its own libc, through no fault of conda's or ours, and left no prefix behind. That is why the *next* command reported `Not a conda environment` — the consequence, not the cause.

Corroborating that it is intermittent and environmental:

- the same job passed on `0bf94f87` (run 33133330021), `7e00ca82` and `b6aea13b`;
- PartCAD opens no netlink sockets; glibc does, inside `getaddrinfo`, when conda resolves a hostname;
- **the retry that already existed cleared it on the second attempt** — which is exactly why the sandbox was usable for the remaining 300 seconds of rendering.

The earlier `d361696c` failure of this job was the conda **deadlock** fixed by #561, a different thing. The netlink error is new to this run and is not a code defect.

**No code change would prevent it.** What this PR changes is that it no longer *fails the build*.

## Q2: why did the command abort after the work succeeded? — **That part is ours.**

`pc_logging.error()` sets a process-wide `had_errors` flag (`src/partcad_utils/logging.py`). `process_result()` in `src/partcad_cli/click/command.py` reads it *after the command finishes* and raises `click.Abort` — which is where the bare `Aborted.` comes from.

Both diagnostics inside `once_conda_locked_attempt()` were `pc_logging.error()`. So **an attempt was deciding the fate of the whole run** — while its caller, `once_conda_holding_install_lock()`, was already retrying it and raising if every attempt failed:

```python
while not self.conda_initialized and attempts < 2:
    attempts += 1
    self.once_conda_locked_attempt()
    ...
if not self.conda_initialized:
    raise Exception("ERROR: Conda environment initialization failed")
```

Two layers each claimed the decision, and the inner one won by side effect, silently, after the fact. Nothing clears `had_errors` on recovery, so a successful retry has no way to retract it.

### The fix

**The attempt only reports; the caller decides.** Every diagnostic inside `once_conda_locked_attempt()` is now a warning — which is what `verify_conda()` right beside it has always done, and what `runtime_python.py` instructs callers to do in three separate comments, for precisely this reason:

> *"Must stay a warning, not an error. `pc_logging.error()` sets the global `had_errors` flag that the CLI turns into a non-zero exit code"*

The caller keeps the one fatal point it always had, and **that exception now names the cause** — the interpreter, the prefix, the attempt count and the last diagnostic — because with the warnings no longer failing the run, it is the only account of the failure there is.

**The netlink message joins the sporadic-error retry list**, next to `Found incorrect download` and `libmamba libarchive` — a list that had `Found incorrect download` in it *twice*, and so tested it twice and the third condition never. Retrying at that point matters beyond tidiness: without it the code fell through to `conda install pip` against a prefix that was never created, which is where the second, louder, wholly derivative error in that log came from.

**The abort no longer says nothing.** `first_error` records the message that first set the flag (the first, because later ones are usually consequences of it — as `Not a conda environment` was), and `process_result()` prints it on the way out. It has to print it **before `logging_remote_client.fini()`**, which detaches the handler that would render it — that ordering is half of why the CI log ends with `Aborted.` and nothing else. Errors forwarded from the daemon are recorded the same way, which is the path that matters most: a thin client runs almost nothing itself.

## Regression tests

All five new tests in `test_runtime_python_conda.py` **fail against the code as it stands** and pass with the fix:

| test | asserts |
|---|---|
| `test_a_recovered_conda_create_does_not_fail_the_run` | netlink error then a successful retry ⇒ `had_errors` false, sandbox initialized, two creates |
| `test_a_sporadic_create_failure_is_retried_before_pip_is_asked_to_populate_it` | command order is `create, create, install` — not `create, install` |
| `test_an_unrecognised_create_failure_is_still_only_a_warning` | severity is not the attempt's call to make |
| `test_a_failed_pip_install_is_a_warning_and_leaves_the_sandbox_uninitialized` | failure is reported by return value, not log severity |
| `test_provisioning_that_never_succeeds_is_fatal_and_names_the_cause` | the raise quotes version, path and diagnostic |

Plus six in `test_logging.py` / `test_logging_remote_client.py` covering `first_error` — including that only the first is kept, that `reset_errors()` clears both halves, and that an error forwarded from the daemon is recorded.

`test_logging.py` previously had **no test that `error()` sets `had_errors` at all**, and `test_runtime_python_conda.py`'s fake process only ever returned success with empty stderr — so neither the severity choice nor the retry-then-recover path had any coverage.

## Validation

- `pytest tests cad/freecad` — **2045 passed**, 24 skipped.
- 4 failures (`test_status::test_daemon_status_reports_the_daemon_state`, `test_version::test_version`, `test_versions::test_no_partcad_self_pin_is_stale`, `test_versions::test_every_partcad_self_pin_is_declared_in_bumpversion`) reproduce identically on a clean `origin/devel` checkout — pre-existing, not from this change. `test_part_example_kicad` needs a `docker` binary the dev container does not have.
- `pre-commit run --config dev-tools/pre-commit-config.yaml` — applicable hooks pass. `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
