### PR TITLE
fix(sandbox): drop a corrupt conda package cache instead of retrying into it

### DIFF
--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -361,7 +361,22 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     shell=False,
                     encoding="utf-8",
                 )
-                _, stderr = p.communicate(timeout=300)
+                try:
+                    _, stderr = p.communicate(timeout=300)
+                except subprocess.TimeoutExpired:
+                    # communicate() does not kill the child when its timeout
+                    # passes, so simply returning here would leave "conda clean"
+                    # running against the very package cache the retry is about
+                    # to solve from -- two conda processes writing one cache,
+                    # which is a worse position than the corrupt entry that got
+                    # us here. Kill it, then reap it with a second communicate()
+                    # (no input: that is undefined after a timeout) so the pipes
+                    # are closed and the return code is collected before the
+                    # caller moves on.
+                    p.kill()
+                    p.communicate()
+                    pc_logging.warning("conda clean timed out and was killed; the package cache is unchanged")
+                    return
             if p.returncode != 0:
                 pc_logging.warning("conda clean exited %s: %s" % (p.returncode, (stderr or "").strip()))
             else:
@@ -431,13 +446,21 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     # had already recovered, rendered everything and finished.
                     if not stderr is None and stderr.strip() != "":
                         self.conda_last_error = stderr.strip()
+                        # A corrupt cache is asked about first, and not nested
+                        # under the sporadic check: the two lists share only
+                        # "Found incorrect download", so a failure that names
+                        # only the extraction or the record file would fail the
+                        # sporadic test and fall through to a bare warning --
+                        # left uncleaned, and then retried by the caller against
+                        # the very cache that failed it.
+                        if _is_corrupt_cache(stderr):
+                            pc_logging.warning("conda env install error (dropping the cache and retrying): %s" % stderr)
+                            self._clean_package_cache()
+                            attempts += 1
+                            continue
                         # Handle most common sporadic conda/mamba failures
                         if any(marker in stderr for marker in _SPORADIC_CONDA_ERRORS):
                             pc_logging.warning("conda env install error (retrying): %s" % stderr)
-                            # A retry against the same broken cache reproduces
-                            # the same failure, so drop it first.
-                            if _is_corrupt_cache(stderr):
-                                self._clean_package_cache()
                             attempts += 1
                             continue
                         pc_logging.warning("conda env install error: %s" % stderr)

--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -37,6 +37,32 @@ _SPORADIC_CONDA_ERRORS = (
     "netlink descriptor",
 )
 
+# The subset of the above that says the *package cache* is what is broken, not
+# the request: a tarball that did not survive its download, or an extracted
+# directory that cannot be read back. Retrying is futile while the bad entry is
+# still cached -- the next solve finds the same file and fails identically,
+# which is exactly what happened on ubuntu-24.04-arm64 in run 33293181928:
+#
+#   warning  libmamba Extracted package cache '.../pycairo-1.29.1-py311hbe9a378_0'
+#            has invalid 'repodata_record.json' file: [json.exception...]
+#   error    libmamba Error when extracting package: filesystem error:
+#            cannot remove all: Bad file descriptor [.../pycairo-...]
+#   Found incorrect download: pycairo. Aborting
+#
+# Both attempts failed with the same message, three minutes apart. The remedy
+# is to drop the cache before the retry, which is what _clean_package_cache()
+# below does.
+_CORRUPT_CONDA_CACHE_ERRORS = (
+    "Found incorrect download",
+    "repodata_record.json",
+    "Error when extracting package",
+)
+
+
+def _is_corrupt_cache(stderr: str) -> bool:
+    """Whether this failure means the shared package cache is unusable."""
+    return any(marker in stderr for marker in _CORRUPT_CONDA_CACHE_ERRORS)
+
 
 @telemetry.instrument()
 class CondaPythonRuntime(runtime_python.PythonRuntime):
@@ -310,6 +336,39 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                 )
             )
 
+    def _clean_package_cache(self):
+        """Drop conda's shared package cache, best effort.
+
+        Called only when a failure names the cache itself (see
+        ``_is_corrupt_cache``). The cache is shared by every environment conda
+        manages on this machine, so this is not free -- the next solve
+        re-downloads what it needs -- but a corrupt entry is not repaired by
+        anything cheaper, and it fails every environment that wants that
+        package, not just this one.
+
+        Never fatal. It runs while an attempt is already failing, so the worst
+        it can do is leave the caller exactly where it was; a cleanup that
+        raised, or that hung, would replace a recoverable failure with a worse
+        one. Hence the bounded wait and the blanket except.
+        """
+        args = [self.conda_path, "clean", "--packages", "--tarballs", "-y"]
+        try:
+            with telemetry.start_as_current_span("CondaPythonRuntime._clean_package_cache"):
+                p = subprocess.Popen(
+                    args,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    shell=False,
+                    encoding="utf-8",
+                )
+                _, stderr = p.communicate(timeout=300)
+            if p.returncode != 0:
+                pc_logging.warning("conda clean exited %s: %s" % (p.returncode, (stderr or "").strip()))
+            else:
+                pc_logging.warning("Dropped the conda package cache after a corrupt entry; it will be refetched")
+        except Exception as e:
+            pc_logging.warning("conda clean failed: %s" % e)
+
     # TODO(clairbee): Make an async version of this function
     def once_conda_locked_attempt(self):
         with pc_logging.Action("Conda", "create", self.version):
@@ -375,6 +434,10 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                         # Handle most common sporadic conda/mamba failures
                         if any(marker in stderr for marker in _SPORADIC_CONDA_ERRORS):
                             pc_logging.warning("conda env install error (retrying): %s" % stderr)
+                            # A retry against the same broken cache reproduces
+                            # the same failure, so drop it first.
+                            if _is_corrupt_cache(stderr):
+                                self._clean_package_cache()
                             attempts += 1
                             continue
                         pc_logging.warning("conda env install error: %s" % stderr)
@@ -457,6 +520,15 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                         (stderr or "").strip(),
                     )
                     pc_logging.warning("conda pip install return code: %s" % p.returncode)
+                    # This half of the attempt had no equivalent of the create
+                    # loop's sporadic-error handling, so a corrupt cache here
+                    # was retried by the caller against the very same cache and
+                    # failed the same way both times. Dropping it makes the
+                    # caller's next attempt a different attempt rather than a
+                    # repeat of this one. Only the cache is cleaned -- whether
+                    # the failure is fatal stays the caller's call.
+                    if _is_corrupt_cache(stderr or ""):
+                        self._clean_package_cache()
                     self.conda_initialized = False
                 else:
                     self.conda_initialized = True

--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -37,11 +37,14 @@ _SPORADIC_CONDA_ERRORS = (
     "netlink descriptor",
 )
 
-# The subset of the above that says the *package cache* is what is broken, not
-# the request: a tarball that did not survive its download, or an extracted
-# directory that cannot be read back. Retrying is futile while the bad entry is
-# still cached -- the next solve finds the same file and fails identically,
-# which is exactly what happened on ubuntu-24.04-arm64 in run 33293181928:
+# What says the *package cache* is broken rather than the request: a tarball
+# that did not survive its download, or an extracted directory that cannot be
+# read back. It is not a subset of the list above -- the two share only "Found
+# incorrect download", which is why this is asked separately and first.
+#
+# Retrying is futile while the bad entry is still cached -- the next solve
+# finds the same file and fails identically, which is exactly what happened on
+# ubuntu-24.04-arm64 in run 33293181928:
 #
 #   warning  libmamba Extracted package cache '.../pycairo-1.29.1-py311hbe9a378_0'
 #            has invalid 'repodata_record.json' file: [json.exception...]
@@ -467,9 +470,15 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     # share only "Found incorrect download", so a failure naming
                     # only the extraction or the record file would fail that
                     # test and fall through to a bare warning.
+                    # The exit status, and not "stderr said something". libmamba
+                    # reports 'invalid repodata_record.json' on a *warning* line,
+                    # and a create that survived one still produced a usable
+                    # prefix; dropping a cache every conda environment on the
+                    # machine shares, and redoing a create that worked, is not
+                    # the answer to a warning. A cache actually bad enough to
+                    # stop the solve aborts mamba, which exits non-zero.
                     diagnostics = _diagnostics(stdout, stderr)
-                    failed = p.returncode != 0 or (stderr is not None and stderr.strip() != "")
-                    if failed and _is_corrupt_cache(diagnostics):
+                    if p.returncode != 0 and _is_corrupt_cache(diagnostics):
                         self.conda_last_error = diagnostics
                         pc_logging.warning(
                             "conda env install error (dropping the cache and retrying): %s" % diagnostics
@@ -478,7 +487,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                         attempts += 1
                         continue
 
-                    if not stderr is None and stderr.strip() != "":
+                    if stderr is not None and stderr.strip() != "":
                         self.conda_last_error = stderr.strip()
                         # Handle most common sporadic conda/mamba failures
                         if any(marker in stderr for marker in _SPORADIC_CONDA_ERRORS):
@@ -554,7 +563,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     )
                     stdout, stderr = p.communicate()
 
-                if not stderr is None and stderr.strip() != "":
+                if stderr is not None and stderr.strip() != "":
                     pc_logging.warning("conda pip install error: %s" % stderr)
                 if p.returncode != 0:
                     # A warning for the same reason as the create diagnostics

--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -59,9 +59,20 @@ _CORRUPT_CONDA_CACHE_ERRORS = (
 )
 
 
-def _is_corrupt_cache(stderr: str) -> bool:
+def _is_corrupt_cache(diagnostics: str) -> bool:
     """Whether this failure means the shared package cache is unusable."""
-    return any(marker in stderr for marker in _CORRUPT_CONDA_CACHE_ERRORS)
+    return any(marker in diagnostics for marker in _CORRUPT_CONDA_CACHE_ERRORS)
+
+
+def _diagnostics(stdout, stderr) -> str:
+    """Both of a conda command's streams as one text.
+
+    Which one carries the complaint is not fixed: a failed solve under "--json"
+    is reported on *stdout* and leaves stderr empty, while libmamba's own
+    extraction errors go to stderr, and a run can produce both. Anything that
+    asks what went wrong therefore has to look at the pair.
+    """
+    return "\n".join(part for part in ((stdout or "").strip(), (stderr or "").strip()) if part)
 
 
 @telemetry.instrument()
@@ -444,20 +455,31 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     # that the CLI turns into a non-zero exit at the very end of
                     # the command -- so an error logged here failed a run that
                     # had already recovered, rendered everything and finished.
+                    # Asked first, of both streams together. A corrupt cache
+                    # is the failure a retry cannot clear on its own, and the
+                    # marker naming it can arrive on either one -- the branch
+                    # below this pair spells out why stdout carries a failed
+                    # "--json" solve with stderr empty. Gating on stderr alone
+                    # would let exactly that case through uncleaned, to be
+                    # retried against the cache that had just failed it.
+                    #
+                    # Nor is it nested under the sporadic check: the two lists
+                    # share only "Found incorrect download", so a failure naming
+                    # only the extraction or the record file would fail that
+                    # test and fall through to a bare warning.
+                    diagnostics = _diagnostics(stdout, stderr)
+                    failed = p.returncode != 0 or (stderr is not None and stderr.strip() != "")
+                    if failed and _is_corrupt_cache(diagnostics):
+                        self.conda_last_error = diagnostics
+                        pc_logging.warning(
+                            "conda env install error (dropping the cache and retrying): %s" % diagnostics
+                        )
+                        self._clean_package_cache()
+                        attempts += 1
+                        continue
+
                     if not stderr is None and stderr.strip() != "":
                         self.conda_last_error = stderr.strip()
-                        # A corrupt cache is asked about first, and not nested
-                        # under the sporadic check: the two lists share only
-                        # "Found incorrect download", so a failure that names
-                        # only the extraction or the record file would fail the
-                        # sporadic test and fall through to a bare warning --
-                        # left uncleaned, and then retried by the caller against
-                        # the very cache that failed it.
-                        if _is_corrupt_cache(stderr):
-                            pc_logging.warning("conda env install error (dropping the cache and retrying): %s" % stderr)
-                            self._clean_package_cache()
-                            attempts += 1
-                            continue
                         # Handle most common sporadic conda/mamba failures
                         if any(marker in stderr for marker in _SPORADIC_CONDA_ERRORS):
                             pc_logging.warning("conda env install error (retrying): %s" % stderr)
@@ -530,7 +552,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                         shell=False,
                         encoding="utf-8",
                     )
-                    _, stderr = p.communicate()
+                    stdout, stderr = p.communicate()
 
                 if not stderr is None and stderr.strip() != "":
                     pc_logging.warning("conda pip install error: %s" % stderr)
@@ -538,10 +560,8 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     # A warning for the same reason as the create diagnostics
                     # above: this only means *this* attempt did not finish, and
                     # the caller decides whether that is fatal.
-                    self.conda_last_error = "conda pip install exited %s: %s" % (
-                        p.returncode,
-                        (stderr or "").strip(),
-                    )
+                    diagnostics = _diagnostics(stdout, stderr)
+                    self.conda_last_error = "conda pip install exited %s: %s" % (p.returncode, diagnostics)
                     pc_logging.warning("conda pip install return code: %s" % p.returncode)
                     # This half of the attempt had no equivalent of the create
                     # loop's sporadic-error handling, so a corrupt cache here
@@ -550,7 +570,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     # caller's next attempt a different attempt rather than a
                     # repeat of this one. Only the cache is cleaned -- whether
                     # the failure is fatal stays the caller's call.
-                    if _is_corrupt_cache(stderr or ""):
+                    if _is_corrupt_cache(diagnostics):
                         self._clean_package_cache()
                     self.conda_initialized = False
                 else:

--- a/tests/partcad/unit/test_runtime_python_conda.py
+++ b/tests/partcad/unit/test_runtime_python_conda.py
@@ -31,7 +31,9 @@ class _FakeProcess:
 
     returncode = 0
 
-    def communicate(self):
+    # '*args, **kwargs' because the real Popen.communicate takes 'input' and
+    # 'timeout', and callers here pass them.
+    def communicate(self, *args, **kwargs):
         return "{}", ""
 
 
@@ -159,7 +161,7 @@ class _ScriptedProcess:
         self._stdout = stdout
         self._stderr = stderr
 
-    def communicate(self):
+    def communicate(self, *args, **kwargs):
         return self._stdout, self._stderr
 
 
@@ -281,3 +283,133 @@ def test_provisioning_that_never_succeeds_is_fatal_and_names_the_cause(tmp_path,
     assert "3.13" in message, message
     assert runtime.path in message, message
     assert "could not install pip" in message, message
+
+
+# ---- a corrupt package cache -------------------------------------------------
+#
+# The retry that already existed could not clear this one. conda's package cache
+# is shared and lives outside the prefix, so a tarball that did not survive its
+# download, or an extracted directory that cannot be read back, fails every
+# attempt identically -- the next solve finds the same bad file. That is what
+# `Examples PartCAD via bundle (ubuntu-24.04-arm64)` hit twice, three minutes
+# apart, in run 33293181928:
+#
+#   error libmamba Error when extracting package: filesystem error:
+#         cannot remove all: Bad file descriptor [.../pycairo-1.29.1-...]
+#   Found incorrect download: pycairo. Aborting
+
+_CORRUPT_CACHE = (
+    "warning  libmamba Extracted package cache '/home/runner/conda_pkgs_dir/pycairo-1.29.1-py311hbe9a378_0' "
+    "has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null\n"
+    "error    libmamba Error when extracting package: filesystem error: cannot remove all: "
+    "Bad file descriptor [/home/runner/conda_pkgs_dir/pycairo-1.29.1-py311hbe9a378_0]\n"
+    "Found incorrect download: pycairo. Aborting\n"
+)
+
+
+def _cleans(commands):
+    return [command for command in commands if "clean" in command]
+
+
+def test_the_real_failure_is_recognised_as_a_corrupt_cache():
+    assert runtime_python_conda._is_corrupt_cache(_CORRUPT_CACHE) is True
+
+
+def test_an_unrelated_sporadic_failure_is_not_a_corrupt_cache():
+    """The netlink error is the runner's network, not the cache.
+
+    Dropping a shared cache costs every environment on the machine a re-download,
+    so it has to be reserved for the failures it actually repairs.
+    """
+    assert runtime_python_conda._is_corrupt_cache(_NETLINK) is False
+    assert runtime_python_conda._is_corrupt_cache("") is False
+
+
+def test_a_corrupt_cache_is_dropped_before_the_create_is_retried(tmp_path, scripted_commands):
+    """Order is the whole point: cleaning after the retry repairs nothing."""
+    commands, script = scripted_commands
+    script.append((0, "", _CORRUPT_CACHE))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    verbs = [command[1] for command in commands]
+    assert verbs == ["create", "clean", "create", "install"], commands
+    assert pc_logging.had_errors is False
+
+
+def test_a_sporadic_failure_that_is_not_the_cache_retries_without_cleaning(tmp_path, scripted_commands):
+    commands, script = scripted_commands
+    script.append((0, "", _NETLINK))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert _cleans(commands) == [], commands
+    assert [command[1] for command in commands] == ["create", "create", "install"], commands
+
+
+def test_a_corrupt_cache_in_the_pip_install_is_dropped_too(tmp_path, scripted_commands):
+    """The half of the attempt that had no sporadic handling at all.
+
+    The caller retries the whole attempt, so before this the second attempt was
+    a byte-for-byte repeat of the first against the same bad cache. Cleaning
+    here is what makes it a different attempt.
+    """
+    commands, script = scripted_commands
+    script.append((0, "{}", ""))  # create succeeds
+    script.append((1, "", _CORRUPT_CACHE))  # pip install hits the cache
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert runtime.conda_initialized is False, "the attempt still failed; only the cache was repaired"
+    assert _cleans(commands), commands
+    # Cleaned after the install that failed, not before it.
+    assert [command[1] for command in commands] == ["create", "install", "clean"], commands
+    assert pc_logging.had_errors is False
+
+
+def test_a_pip_install_failure_that_is_not_the_cache_cleans_nothing(tmp_path, scripted_commands):
+    commands, script = scripted_commands
+    script.append((0, "{}", ""))
+    script.append((1, "", "could not install pip\n"))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert runtime.conda_initialized is False
+    assert _cleans(commands) == [], commands
+
+
+def test_cleaning_the_cache_is_never_what_fails_the_run(tmp_path, scripted_commands):
+    """It runs while an attempt is already failing, so it may not raise.
+
+    A cleanup that threw would turn a recoverable provisioning failure into an
+    exception out of a code path whose caller is still deciding what to do.
+    """
+    commands, script = scripted_commands
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    def explode(*args, **kwargs):
+        raise OSError("mamba is not on PATH")
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(runtime_python_conda.subprocess, "Popen", explode)
+    try:
+        runtime._clean_package_cache()  # must not raise
+    finally:
+        monkeypatch.undo()
+
+    assert pc_logging.had_errors is False
+
+
+def test_a_clean_that_reports_failure_is_only_a_warning(tmp_path, scripted_commands):
+    commands, script = scripted_commands
+    script.append((1, "", "CondaError: cache is locked\n"))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime._clean_package_cache()
+
+    assert [command[1] for command in commands] == ["clean"], commands
+    assert pc_logging.had_errors is False

--- a/tests/partcad/unit/test_runtime_python_conda.py
+++ b/tests/partcad/unit/test_runtime_python_conda.py
@@ -18,6 +18,7 @@ arguments, and reproducing it for real means a conda solve per case.
 
 import os
 import pathlib
+import subprocess
 
 import pytest
 
@@ -412,4 +413,78 @@ def test_a_clean_that_reports_failure_is_only_a_warning(tmp_path, scripted_comma
     runtime._clean_package_cache()
 
     assert [command[1] for command in commands] == ["clean"], commands
+    assert pc_logging.had_errors is False
+
+
+# ---- each corrupt-cache marker on its own -------------------------------------
+#
+# The two marker lists share only "Found incorrect download". So a create
+# failure naming just the extraction or just the record file passes no sporadic
+# test, and if the cache check were nested under that one it would fall through
+# to a bare warning: uncleaned, then retried by the caller against the cache
+# that failed it. Each marker is therefore driven on its own here rather than
+# through the real three-line message, which happens to carry all of them.
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "Found incorrect download: pycairo. Aborting\n",
+        "warning  libmamba Extracted package cache '/x/pycairo' has invalid 'repodata_record.json' file\n",
+        "error    libmamba Error when extracting package: filesystem error: cannot remove all\n",
+    ],
+)
+def test_each_corrupt_cache_marker_alone_cleans_and_retries_the_create(tmp_path, scripted_commands, stderr):
+    commands, script = scripted_commands
+    script.append((0, "", stderr))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert [command[1] for command in commands] == ["create", "clean", "create", "install"], commands
+    assert pc_logging.had_errors is False
+
+
+# ---- a clean that will not finish ---------------------------------------------
+
+
+class _HangingProcess:
+    """A process whose communicate() times out until it is killed.
+
+    subprocess.communicate() does not kill the child when its timeout passes, so
+    what matters is that the caller does, and then reaps it.
+    """
+
+    returncode = None
+
+    def __init__(self):
+        self.killed = False
+        self.reaped = False
+
+    def communicate(self, *args, **kwargs):
+        if not self.killed:
+            raise subprocess.TimeoutExpired(cmd="conda clean", timeout=kwargs.get("timeout", 300))
+        self.reaped = True
+        self.returncode = -9
+        return "", ""
+
+    def kill(self):
+        self.killed = True
+
+
+def test_a_clean_that_times_out_is_killed_and_reaped(tmp_path, monkeypatch):
+    """Otherwise 'conda clean' keeps writing the cache the retry solves from.
+
+    Two conda processes on one package cache is a worse place to be than the
+    corrupt entry that started this, so the timeout may not simply be reported
+    and walked away from.
+    """
+    hanging = _HangingProcess()
+    monkeypatch.setattr(runtime_python_conda.subprocess, "Popen", lambda *a, **k: hanging)
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime._clean_package_cache()  # must not raise
+
+    assert hanging.killed is True, "a timed-out conda clean was left running"
+    assert hanging.reaped is True, "the killed process was never reaped"
     assert pc_logging.had_errors is False

--- a/tests/partcad/unit/test_runtime_python_conda.py
+++ b/tests/partcad/unit/test_runtime_python_conda.py
@@ -329,7 +329,7 @@ def test_an_unrelated_sporadic_failure_is_not_a_corrupt_cache():
 def test_a_corrupt_cache_is_dropped_before_the_create_is_retried(tmp_path, scripted_commands):
     """Order is the whole point: cleaning after the retry repairs nothing."""
     commands, script = scripted_commands
-    script.append((0, "", _CORRUPT_CACHE))
+    script.append((1, "", _CORRUPT_CACHE))
     runtime = _bare_runtime(tmp_path, "3.13")
 
     runtime.once_conda_locked_attempt()
@@ -348,6 +348,28 @@ def test_a_sporadic_failure_that_is_not_the_cache_retries_without_cleaning(tmp_p
 
     assert _cleans(commands) == [], commands
     assert [command[1] for command in commands] == ["create", "create", "install"], commands
+
+
+def test_a_create_that_exited_zero_is_never_cleaned_up_after(tmp_path, scripted_commands):
+    """The markers on the stderr of a create that *worked* are not a reason to clean.
+
+    libmamba prints the invalid 'repodata_record.json' complaint as a warning and
+    carries on; the prefix it leaves behind is usable. Reading the markers off
+    stderr without asking the exit status would drop a cache every conda
+    environment on the machine shares, and redo a create that had succeeded,
+    on every run that happened to log one.
+    """
+    commands, script = scripted_commands
+    script.append((0, "", _CORRUPT_CACHE))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert _cleans(commands) == [], commands
+    # Still retried -- "Found incorrect download" is a sporadic marker as well --
+    # but retried against the cache rather than after dropping it.
+    assert [command[1] for command in commands] == ["create", "create", "install"], commands
+    assert pc_logging.had_errors is False
 
 
 def test_a_corrupt_cache_in_the_pip_install_is_dropped_too(tmp_path, scripted_commands):
@@ -436,7 +458,7 @@ def test_a_clean_that_reports_failure_is_only_a_warning(tmp_path, scripted_comma
 )
 def test_each_corrupt_cache_marker_alone_cleans_and_retries_the_create(tmp_path, scripted_commands, stderr):
     commands, script = scripted_commands
-    script.append((0, "", stderr))
+    script.append((1, "", stderr))
     runtime = _bare_runtime(tmp_path, "3.13")
 
     runtime.once_conda_locked_attempt()

--- a/tests/partcad/unit/test_runtime_python_conda.py
+++ b/tests/partcad/unit/test_runtime_python_conda.py
@@ -488,3 +488,64 @@ def test_a_clean_that_times_out_is_killed_and_reaped(tmp_path, monkeypatch):
     assert hanging.killed is True, "a timed-out conda clean was left running"
     assert hanging.reaped is True, "the killed process was never reaped"
     assert pc_logging.had_errors is False
+
+
+# ---- the marker can arrive on either stream -----------------------------------
+#
+# Which stream carries the complaint is not fixed. The code's own note on the
+# create path says it: a failed solve under "--json" is reported on *stdout* and
+# leaves stderr empty. Detection gated on stderr alone therefore misses exactly
+# the case conda documents, and the retry goes back into the same cache.
+
+_CORRUPT_ON_STDOUT = (
+    '{"success": false, "error": "Found incorrect download: pycairo. Aborting", '
+    '"caused_by": "Error when extracting package"}\n'
+)
+
+
+def test_a_corrupt_cache_named_only_on_stdout_still_cleans_the_create(tmp_path, scripted_commands):
+    commands, script = scripted_commands
+    script.append((1, _CORRUPT_ON_STDOUT, ""))  # non-zero, marker on stdout, stderr empty
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert [command[1] for command in commands] == ["create", "clean", "create", "install"], commands
+    assert pc_logging.had_errors is False
+
+
+def test_a_corrupt_cache_named_only_on_stdout_still_cleans_the_pip_install(tmp_path, scripted_commands):
+    commands, script = scripted_commands
+    script.append((0, "{}", ""))  # create succeeds
+    script.append((1, _CORRUPT_ON_STDOUT, ""))  # pip install fails, marker on stdout
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert runtime.conda_initialized is False
+    assert [command[1] for command in commands] == ["create", "install", "clean"], commands
+    assert pc_logging.had_errors is False
+
+
+def test_what_went_wrong_is_recorded_from_whichever_stream_carried_it(tmp_path, scripted_commands):
+    """The fatal message quotes conda_last_error, so it must not lose stdout."""
+    commands, script = scripted_commands
+    script.append((0, "{}", ""))
+    script.append((1, '{"success": false, "error": "no such package"}\n', ""))
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert "no such package" in (runtime.conda_last_error or "")
+
+
+def test_a_clean_run_that_merely_mentions_a_marker_is_not_treated_as_a_failure(tmp_path, scripted_commands):
+    """Cleaning a shared cache costs every environment on the machine, so it is
+    reserved for runs that actually failed."""
+    commands, script = scripted_commands
+    script.append((0, _CORRUPT_ON_STDOUT, ""))  # exit 0, nothing wrong
+    runtime = _bare_runtime(tmp_path, "3.13")
+
+    runtime.once_conda_locked_attempt()
+
+    assert [command[1] for command in commands] == ["create", "install"], commands


### PR DESCRIPTION
## Copilot Summary

Recognize the conda failures that name the shared **package cache**, and drop it before retrying — a retry against the same corrupt cache reproduces the same failure, which is why the existing retry could not clear it.

## The failure

`Examples PartCAD via bundle (ubuntu-24.04-arm64)` — job [99208516790](https://github.com/partcad/partcad/actions/runs/33293181928/job/99208516790), run 33293181928, on #565's head. It failed **twice, three minutes apart, with the same three lines**:

```
warning  libmamba Extracted package cache '/home/runner/conda_pkgs_dir/pycairo-1.29.1-py311hbe9a378_0'
         has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
error    libmamba Error when extracting package: filesystem error: cannot remove all:
         Bad file descriptor [/home/runner/conda_pkgs_dir/pycairo-1.29.1-py311hbe9a378_0]
Found incorrect download: pycairo. Aborting
```

The diagnostic naming the cause is #567's, working as intended — before it, this was a bare `Aborted.`

## Why the existing retry could not help

`conda_pkgs_dir` is **shared and lives outside the prefix**. Discarding the prefix and solving again finds the same corrupt tarball and fails identically. The message says it plainly: *"after 2 attempt(s)"* — both outer attempts ran, both hit the same bad file.

## Correcting something I said earlier

When I first spotted this I said the gap was that `Found incorrect download` is in `_SPORADIC_CONDA_ERRORS` but only the `conda create` branch consults it, and that closing that gap "would likely have retried this away." **That was wrong.** The `conda install pip` branch has no in-attempt retry, but `once_conda_holding_install_lock()` retries the whole attempt twice — so it *was* retried, and retrying is simply not the remedy for this failure. The remedy is dropping the cache.

## The change

- **`_is_corrupt_cache()`** — the subset of failures that mean the cache itself is unusable: `Found incorrect download`, `repodata_record.json`, `Error when extracting package`. Deliberately narrow. The `netlink descriptor` error next door is the runner's *network*, and dropping a shared cache costs every environment on the machine a re-download, so it must not fire for that.
- **`_clean_package_cache()`** — `conda clean --packages --tarballs -y`, bounded and best-effort. It runs while an attempt is already failing, so anything it raises is warned and swallowed: a cleanup that threw would replace a recoverable provisioning failure with a worse one. Whether the failure is fatal stays the caller's decision, as it has been since #567 sorted out the severities.
- **Both halves of the attempt** now reach it. The `create` branch cleans *before* `continue`, so the retry is against a clean cache. The `pip install` branch — which had no sporadic handling at all — cleans before handing back `conda_initialized = False`, so the caller's next attempt is a different attempt rather than a repeat.

## Tests

8 new tests. **6 of the 8 fail against the current source** (verified by reverting `runtime_python_conda.py` and re-running); the 2 that pass are the negative guards, which is their job — they assert the cache is *not* dropped for a network flake or an ordinary pip failure, so an over-broad marker list gets caught.

| test | asserts |
|---|---|
| `test_the_real_failure_is_recognised_as_a_corrupt_cache` | the verbatim CI stderr is classified |
| `test_an_unrelated_sporadic_failure_is_not_a_corrupt_cache` | the netlink error is not |
| `test_a_corrupt_cache_is_dropped_before_the_create_is_retried` | command order is `create, clean, create, install` — cleaning after the retry repairs nothing |
| `test_a_sporadic_failure_that_is_not_the_cache_retries_without_cleaning` | `create, create, install`, no clean |
| `test_a_corrupt_cache_in_the_pip_install_is_dropped_too` | `create, install, clean`, and the attempt still reports failure |
| `test_a_pip_install_failure_that_is_not_the_cache_cleans_nothing` | no clean on an ordinary pip failure |
| `test_cleaning_the_cache_is_never_what_fails_the_run` | a raising `Popen` does not propagate |
| `test_a_clean_that_reports_failure_is_only_a_warning` | non-zero `conda clean` does not set `had_errors` |

The two process doubles now accept `*args, **kwargs` on `communicate()`, matching the real `Popen.communicate(input=, timeout=)`.

## Validation

- `pytest tests/partcad/unit/test_runtime_python_conda.py tests/partcad/unit/test_logging.py tests/partcad_service_json_rpc/` — 238 passed.
- `black` clean. `flake8` at the project's 120 columns reports 3 findings in this file (`F541`, two `E714`) that are **identical on the base branch** — pre-existing style, untouched here.

## What this does not claim

It does not make the arm64 bundle job reliable. That job also hits the separate arm64 hang (`Shape.get_wrapped` / `Assembly.do_instantiate` holding a thread-owned `RLock` across an `await` that dispatches to another thread), which is unrelated to conda and not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFKLCHD36rCPJRtbyswnWt)_