### PR TITLE
feat(render): viewing angles on the command line, and `pc adhoc render`

### DIFF
--- a/.devcontainer/pytest_hook.sh
+++ b/.devcontainer/pytest_hook.sh
@@ -6,6 +6,31 @@ WORKERS=$(( CORES < 1 ? 1 : (CORES < 5 ? CORES : 4) ))
 echo "Detected $CORES cores"
 echo "Running tests with $WORKERS workers"
 
+# How long one test may take before it is called a hang.
+#
+# This is a hang detector and nothing else, so it has to clear the slowest thing
+# a passing test legitimately does - and for this suite that is not the test, it
+# is the CAD sandbox underneath it. A test whose part is scripted (build123d,
+# CadQuery, SDF, OpenSCAD) runs in a managed Python environment that PartCAD
+# provisions on first use: a fresh interpreter plus a pip install of the CAD
+# stack, minutes of work, paid once and then cached in ~/.partcad. Whichever
+# test happens to be the first to need a given sandbox pays for it.
+#
+# The budget is per test, so a warm cache never comes near it and raising it
+# does not slow a passing run down; what it buys is a gate that reports the
+# commit rather than the state of the cache. A genuine hang is still caught,
+# 15 minutes later.
+#
+# It is not what keeps a gate from failing on a different test each run -- that
+# is 'pass_filenames: false' in dev-tools/pre-commit-config.yaml, without which
+# 'pre-commit' runs this hook once per partition of the staged file list, several
+# whole suites at once over one working tree. This budget only ever hid how slow
+# those runs made each other.
+#
+# Override it for a slower machine, or lower it deliberately when hunting one:
+#   PC_PYTEST_TIMEOUT=1800 git commit ...
+TIMEOUT="${PC_PYTEST_TIMEOUT:-900}"
+
 # pytest has been observed to exit 0 despite failures on some platforms (Windows
 # in particular), so the exit code alone cannot be trusted. Instead the pytest
 # session writes an explicit verdict to a marker file (see conftest.py), and this
@@ -16,7 +41,11 @@ MARKER="${TMPDIR:-/tmp}/partcad-pytest-result-$$"
 export PYTEST_RESULT_MARKER="$MARKER"
 rm -f "$MARKER"
 
-poetry run pytest tests/partcad -n "$WORKERS" -m "not slow" --timeout 300
+# One definition of the run, so that what is executed and what the failure
+# message tells the user to execute cannot drift apart.
+PYTEST_ARGS=(tests/partcad -n "$WORKERS" -m "not slow" --timeout "$TIMEOUT")
+
+poetry run pytest "${PYTEST_ARGS[@]}"
 rc=$?
 
 result=$(cat "$MARKER" 2>/dev/null)
@@ -27,8 +56,17 @@ if [ "$result" != "success" ]; then
 Tests did not pass (pytest exit code $rc, recorded result '${result:-none}').
 
 Please make sure all tests pass by debugging and fixing any errors before committing your changes.
-Use the command below to run the same tests locally with $WORKERS workers and a 5 minute timeout:
-    poetry run pytest tests/partcad -n $WORKERS -m \"not slow\" --timeout 300
+Use the command below to run the same tests locally:"
+    # '%q' per element rather than "${PYTEST_ARGS[*]}": the marker expression is
+    # one argument here ('not slow'), and joining the array unquoted prints it as
+    # two words, so what the message offers to be copied is not what was run.
+    printf '    poetry run pytest'
+    printf ' %q' "${PYTEST_ARGS[@]}"
+    printf '\n'
+    echo "
+A first run on a cold cache is slow: every scripted part builds its CAD sandbox
+before it can be rendered. If a test was reported as timing out, run it again
+before looking for a bug in it - the sandbox it waited for is now built.
 "
     exit 1
 fi

--- a/ai-agents/README.md
+++ b/ai-agents/README.md
@@ -46,18 +46,49 @@ The plugin folder is named `claude`, but the command namespace comes from
   assembly, or a 2D sketch and follows the matching flow below.
 - **`/pc:gen-part <description>`** — generates a single part: the agent picks a
   representation (build123d / cadquery / openscad / sdf), authors the CAD script
-  itself, and validates it by rendering with `pc render`. Supersedes the legacy
-  `pc add part --ai` pipeline (the agent is the model; no provider/API key).
+  itself, and validates it by rendering **four views** (`front`, `top`, `right`,
+  `iso`) and checking each against the description — `pc test` only proves the
+  geometry instantiates, and one projection hides whatever is behind it.
+  Supersedes the legacy `pc add part --ai` pipeline (the agent is the model; no
+  provider/API key).
 - **`/pc:gen-assembly <description>`** — generates an assembly: reuses or
   generates the component parts, authors the `.assy` (explicit placement or
-  interface mates), and validates by rendering. New capability — PartCAD had no
-  AI assembly path.
+  interface mates), and validates the same four ways — a component offset along
+  the viewing direction sits perfectly in the one view that hides the offset. New
+  capability — PartCAD had no AI assembly path.
 - **`/pc:gen-sketch <description>`** — generates a 2D sketch: the agent picks a
   representation (build123d / cadquery / dxf / svg), authors the sketch, and
   validates by rendering to SVG.
+- **`/pc:export <object> <format>`** — writes a 3D/CAD file out of an object a
+  package declares (`pc export`) and changes nothing in `partcad.yaml`. This is
+  what "export it as STEP" almost always means. It reaches more formats than
+  `pc convert` does — `urdf`, plus any file type a package implements itself.
+- **`/pc:convert <what> <to what>`** — changes what something *is*. For an
+  object in a package that is `pc convert`, which writes the file **and**
+  rewrites the object's definition to point at it; for a file that belongs to no
+  package it is `pc adhoc convert`, which touches no package at all.
+- **`/pc:render <what> <from where>`** — writes a 2D projection to look at
+  (`png`, `jpeg`, `svg`, `dxf`): `pc render` for an object in a package, so the
+  package's own `render:` options apply, and `pc adhoc render` for a bare file.
+  The viewing angle is `--view front|top|iso|…`, or `--viewport-origin` /
+  `--viewport-up` for an arbitrary one — the same two keys a `render:` file type
+  is configured with in `partcad.yaml`. `--with-ports` / `--with-interfaces` /
+  `--with-all` draw the connection metadata on top of the projection, which is
+  the only way any of it becomes visible.
+
+  All three begin the same way, because the answer to "which command" is the
+  same question in each: is there a package, and does what the user named
+  resolve to an object in it (by name, or as the file an object is built from)?
+  If so the package command is right; if not it is the `adhoc` one, and
+  `pc export` has no `adhoc` form because `pc adhoc convert` already is it.
 - **`/pc:describe <object>`** — writes a narratable description of an existing
-  part, assembly, or sketch by rendering and examining it, and stores it in the
-  object's `summary:`. Reproduces the retired built-in AI shape-summary.
+  part, assembly, or sketch, and stores it in the object's `summary:`.
+  Reproduces the retired built-in AI shape-summary. It renders **three views**
+  (`front`, `top`, `iso`) rather than one, since a single projection hides
+  everything behind it — and for a part it also asks
+  `//pub/feature/render/draftwright` (through `pc render -e`) for a dimensioned
+  technical drawing, so the numbers in the description are read off the drawing
+  instead of estimated from pixels.
 - **`/pc:search <query>`** — finds existing parts and assemblies in the catalog
   whose name, description, or source matches the query (`pc search parts` /
   `pc search assemblies`), lists the matches, and can inspect or render a chosen

--- a/ai-agents/common/skills/convert/SKILL.md
+++ b/ai-agents/common/skills/convert/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: convert
+description: Convert a CAD file or a PartCAD object to another geometry format - STEP, BREP, STL, 3MF, OBJ, IGES, glTF, three.js, SVG, DXF, URDF, ASSY - with `pc convert` for an object a package declares (which changes what that object is) or `pc adhoc convert` for a file that belongs to no package. Use for /pc:convert or when the user asks to convert, translate, re-save, or change the format of a CAD file, part, sketch or assembly. For a 2D picture use /pc:render; to write a file without changing the package use /pc:export.
+---
+
+# pc:convert
+
+Turn geometry into another geometry format. `$ARGUMENTS` says what to convert and
+to what.
+
+Two commands do this, and picking the right one is most of the job:
+
+- **`pc convert`** — an object a package declares. It writes the file **and
+  rewrites the object's definition** in `partcad.yaml` to point at it: the part
+  *becomes* the new format.
+- **`pc adhoc convert`** — a file that belongs to no package. File in, file out;
+  no package is created, read, or changed.
+
+If the user wants a file *without* changing what the object is, that is
+`/pc:export`. If they want a picture, that is `/pc:render`.
+
+## 1. Work out which case you are in
+
+Do this before running anything. It is the same first step in `/pc:render` and
+`/pc:export`.
+
+1. **Is there a package?** PartCAD searches upward for `partcad.yaml`, so look in
+   the current directory and above. `pc --no-ansi list` lists what the package
+   holds; if there is no package it says so.
+2. **Does the reference name an object?** Check it against
+   `pc --no-ansi list parts` / `list sketches` / `list assemblies`.
+   `pc --no-ansi info <name>` succeeds only for an object that resolves.
+3. **Does a file the user named belong to an object?** Someone who says
+   "convert `bracket.step`" inside a package usually means the part built from
+   it. Read `partcad.yaml` and look for an object whose `path:` is that file —
+   and note that a file-backed object *without* a `path:` is `<name>` plus the
+   type's extension, so a part `bracket` of type `step` is `bracket.step`
+   whether or not the path is written down.
+
+**If 2 or 3 matched, it is an object: use `pc convert` (§3).** Converting its
+file behind the package's back would leave `partcad.yaml` describing a format
+that is no longer there.
+
+**If there is no package, or the file is not one an object is built from, it is
+ad-hoc: use `pc adhoc convert` (§4).**
+
+When it is genuinely ambiguous — a package exists and the file sits inside it but
+nothing declares it — say which you picked and why, rather than guessing
+silently.
+
+## 2. Make sure PartCAD is available
+
+Resolve a command as `/pc:init` does (`pc`, then `partcad`, then
+`python -m partcad_cli.click.command`). If none is found, stop and run
+`/pc:install executable` first.
+
+Pass `--no-ansi` on every run so the output is plain text. It is a global flag
+and goes before the subcommand, and it routes the logs to **stderr** — so
+capture both streams when reading them: `pc --no-ansi convert ... 2>&1`.
+
+## 3. An object in a package — `pc convert`
+
+```sh
+pc --no-ansi convert part bracket -t step
+pc --no-ansi convert sketch outline -t dxf
+pc --no-ansi convert assembly gearbox -t urdf
+```
+
+Target formats, by kind:
+
+| kind | `-t` |
+| --- | --- |
+| `part` | `step`, `brep`, `stl`, `3mf`, `threejs`, `obj`, `gltf`, `iges` |
+| `sketch` | `svg`, `dxf` |
+| `assembly` | `assy`, `urdf` |
+
+Options: `-P <package>` for an object in another package, `-O <dir>` for where
+the file goes (the directory must exist; it defaults to the package directory),
+and `--dry-run`.
+
+**This edits `partcad.yaml`. Say so before you run it, and prefer `--dry-run`
+first** — show the user what would change, then run it for real. What is at stake
+is not the file but the object: a `cadquery` part converted to `step` is no longer
+a script, so its parameters and the code that produced it stop being part of the
+package. If the user only wants a STEP file to send someone, they want
+`/pc:export`, not this.
+
+An assembly conversion is the largest of these. To URDF it writes the `.urdf` and
+an STL per distinct shape; to ASSY it writes an `stl` part per URDF link, an
+interface pair per joint, and an `.assy` that connects the parts through them.
+
+## 4. A file with no package — `pc adhoc convert`
+
+PartCAD wraps the file in a throwaway package, converts it, and deletes the
+package again. Types are inferred from the file names; `--input` and `--output`
+say them outright when an extension is missing or misleading:
+
+```sh
+pc --no-ansi adhoc convert part bracket.step bracket.stl
+pc --no-ansi adhoc convert part --input step bracket.dat bracket.stl
+pc --no-ansi adhoc convert part --output 3mf bracket.step      # names the output after the input
+pc --no-ansi adhoc convert sketch outline.svg outline.dxf
+```
+
+- **part** reads `step`, `brep`, `stl`, `3mf`, `threejs`, `obj`, `iges`, `gltf`,
+  `cadquery`, `build123d`, `chili3d`, `sdf`, `scad`, and writes all of those
+  except `chili3d`, `sdf` and `scad` — PartCAD reads those three but has no
+  exporter that writes them back.
+- **sketch** reads and writes `svg`, `dxf`, `cadquery`, `build123d`.
+- `urdf` and `assy` are refused: an ASSY file is a set of references to the parts
+  of a package and a URDF becomes a part per link, so neither means anything
+  without one. A user who has a URDF needs it in a package first
+  (`pc import assembly`) and then `pc convert assembly`.
+
+Nothing here writes a picture: `pc adhoc convert sketch a.svg b.png` is refused
+on purpose. Rendering a bare file is `pc adhoc render`, which is `/pc:render`.
+
+## 5. Report what happened
+
+Name the files that were written, with their paths, and say plainly whether
+`partcad.yaml` changed — it does for `pc convert` and never for
+`pc adhoc convert`. If PartCAD printed an error, surface it verbatim rather than
+working around it: a conversion that fails on the geometry is a fact about the
+model, not something to retry with different flags.

--- a/ai-agents/common/skills/describe/SKILL.md
+++ b/ai-agents/common/skills/describe/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: describe
-description: Write a narratable, accessibility-oriented text description of an existing PartCAD part, assembly, or sketch by rendering it and examining the result. Use for /pc:describe or when the user asks to describe, summarize, or caption a PartCAD object. Reproduces the retired built-in AI shape-summary.
+description: Write a narratable, accessibility-oriented text description of an existing PartCAD part, assembly, or sketch by rendering it from several viewing angles - and, where it is available, from a dimensioned technical drawing - then examining the results. Use for /pc:describe or when the user asks to describe, summarize, or caption a PartCAD object. Reproduces the retired built-in AI shape-summary.
 ---
 
 # pc:describe
@@ -10,34 +10,102 @@ looking at the result — the replacement for PartCAD's retired built-in AI
 summary. The text after the command (`$ARGUMENTS`) names the object to describe
 (optionally with its kind).
 
+One picture is not enough to describe a shape. A single projection hides
+everything behind it, and a description written from one is a description of a
+silhouette. Render **three views** (§2), and where a dimensioned drawing can be
+had, read the numbers off that rather than estimating them (§3).
+
 ## 1. Resolve the object
 
 `$ARGUMENTS` is the object name (a part by default; an assembly or sketch if the
 user says so). Read its `desc:`/`requirements:` from `partcad.yaml` for context.
 Make sure PartCAD is available as `/pc:init` describes.
 
-## 2. Render it
+Pass `--no-ansi` on every run so the output is plain text; it is a global flag,
+goes before the subcommand, and routes the logs to stderr.
+
+This skill describes an object a package declares, because §5 stores the result
+back into that package. To describe a bare CAD file that is in no package, render
+it with `/pc:render` (`pc adhoc render`) and write the description for the user
+instead of storing it.
+
+## 2. Render three views
+
+`front`, `top` and `iso`: two orthographic views to read proportion and features
+from, and one pictorial view that shows how they go together. A rendered file is
+named after the object, so give each view a directory of its own or they
+overwrite each other:
+
+```sh
+for view in front top iso; do
+  mkdir -p /tmp/pc-render/$view
+  pc --no-ansi render -t png --view $view -O /tmp/pc-render/$view <name>   # add -a for an assembly
+done
+```
+
+View all three — `/tmp/pc-render/<view>/<name>.png`.
+
+Add `right` (or `back`, `left`, `bottom`) when the three leave a face
+unaccounted for: a part that is not symmetric about an axis has a side you have
+not seen, and guessing at it is exactly what this skill must not do.
+
+A **sketch** is flat, so it has only one view worth rendering, and SVG suits it
+better than PNG:
 
 ```sh
 mkdir -p /tmp/pc-render
-pc render -t png -O /tmp/pc-render <name>       # a part (default); add -a for an assembly
-pc render -s -t svg -O /tmp/pc-render <name>    # a sketch renders to SVG, not PNG
+pc --no-ansi render -s -t svg -O /tmp/pc-render <name>
 ```
 
-View the produced file — `/tmp/pc-render/<name>.png` for a part or assembly,
-`/tmp/pc-render/<name>.svg` for a sketch.
+## 3. Render a dimensioned drawing (parts, when it is available)
 
-## 3. Write the description
+The projections above show shape but no numbers. `draftwright`, a render
+implementation published in the public PartCAD index, draws a **fully dimensioned
+technical drawing** instead — orthographic views with dimension lines, hole
+callouts, radii, an ISO view, and a title block carrying the material and scale.
+Reading a description off that beats estimating from pixels:
 
-From the image plus the configured `desc`/`requirements`, write a description
+```sh
+mkdir -p /tmp/pc-render/drawing
+pc --no-ansi render -t pdf -e //pub/feature/render/draftwright \
+    -O /tmp/pc-render/drawing <name>
+```
+
+`-e` names the package to read the output configuration from, so this works on
+any object without that object's package knowing about draftwright. Then read
+`/tmp/pc-render/drawing/<name>.pdf` — ask for **`pdf`**, whose pages can be
+looked at directly. Its `svg` draws every character as paths, so no text can be
+read out of that markup.
+
+This is a best-effort extra, not a requirement. It needs the public index among
+the package's `dependencies:` (which `pc init` writes) and a network connection,
+and the first run is slow while PartCAD installs draftwright into a sandbox. It
+is also a *part* drawing — do not expect it of an assembly or a sketch.
+
+draftwright reports what it could not do. When a part has features it cannot
+dimension at the chosen scale it says so and draws the rest, and the command may
+exit non-zero having still written a usable file — so check whether the file
+appeared before giving up on it. If it did not, or anything above failed,
+describe the object from the three views and say in your report that no
+dimensioned drawing was available.
+
+## 4. Write the description
+
+From the images plus the configured `desc`/`requirements`, write a description
 for a reader who has a mechanical-engineering / CAD background but cannot see it:
 
 - Describe both the overall shape and the dimensions; make no assumptions and
-  add as much concrete detail as the render and config support.
-- Refer to it as "this design", not "the image".
+  add as much concrete detail as the renders and config support.
+- Prefer a dimension the drawing states over one you judged from a projection.
+  Where you are reading a proportion off a picture rather than a stated number,
+  say it is approximate rather than inventing a figure.
+- Work through the views: overall form and bounding size first, then the
+  features each view reveals, then how they relate.
+- Refer to it as "this design", not "the image" — and never as "the three
+  images", which is an artifact of how you looked at it.
 - Produce prose that is ready to be narrated as-is (no markdown, no lists).
 
-## 4. Persist it (so `pc inspect` shows it)
+## 5. Persist it (so `pc inspect` shows it)
 
 `pc inspect` reads a shape's `summary:` from its configuration. Write your
 description there so the tool and other agents can reuse it:
@@ -50,4 +118,5 @@ parts:            # or sketches: / assemblies:
       <your description>
 ```
 
-Report the description to the user and confirm where you stored it.
+Report the description to the user, say which views (and whether a dimensioned
+drawing) it was written from, and confirm where you stored it.

--- a/ai-agents/common/skills/export/SKILL.md
+++ b/ai-agents/common/skills/export/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: export
+description: Write a CAD file out of an object a PartCAD package declares - STEP, BREP, STL, 3MF, OBJ, IGES, glTF, three.js, URDF for 3D, SVG or DXF for a sketch, or a file type the package implements itself - using `pc export`, which changes nothing in `partcad.yaml`. Use for /pc:export or when the user asks to export, save out, dump, hand off, or produce a CAD file of a part, sketch, assembly or whole package - for a printer, a supplier, a simulator, or another CAD tool. For a bare file with no package use /pc:convert; for a 2D picture use /pc:render.
+---
+
+# pc:export
+
+Write geometry out of a package, leaving the package exactly as it was.
+`$ARGUMENTS` says what to export and to what.
+
+`pc export` is the close sibling of `pc convert`, and the difference is the whole
+reason to know both:
+
+|  | writes a file | changes `partcad.yaml` | formats |
+| --- | --- | --- | --- |
+| `pc export` | yes | **no** | more — `urdf`, plus any a package implements itself |
+| `pc convert` | yes | **yes** — the object *becomes* the new format | a fixed list per kind |
+
+So this is what to use whenever someone wants a file *out* of a package — to
+print, to quote, to import somewhere else — which is nearly always what "export
+it as STEP" means. `/pc:convert` is for the rarer case where the object itself
+should stop being what it is.
+
+## 1. Work out which case you are in
+
+Do this before running anything. It is the same first step in `/pc:convert` and
+`/pc:render`.
+
+1. **Is there a package?** PartCAD searches upward for `partcad.yaml`, so look in
+   the current directory and above. `pc --no-ansi list` lists what the package
+   holds; if there is no package it says so.
+2. **Does the reference name an object?** Check it against
+   `pc --no-ansi list parts` / `list sketches` / `list assemblies`.
+   `pc --no-ansi info <name>` succeeds only for an object that resolves.
+3. **Does a file the user named belong to an object?** Someone who says "export
+   `bracket.step` as STL" inside a package usually means the part built from it.
+   Read `partcad.yaml` and look for an object whose `path:` is that file — and
+   note that a file-backed object *without* a `path:` is `<name>` plus the type's
+   extension, so a part `bracket` of type `step` is `bracket.step` whether or not
+   the path is written down.
+
+**If 2 or 3 matched, it is an object: use `pc export` (§3).**
+
+**If there is no package, or the file is not one an object is built from, there
+is nothing to export from.** A bare file is converted, not exported: hand it to
+`pc adhoc convert` — that is `/pc:convert` §4, and it is the ad-hoc equivalent of
+this skill, since it too writes a file and changes no package.
+
+## 2. Make sure PartCAD is available
+
+Resolve a command as `/pc:init` does (`pc`, then `partcad`, then
+`python -m partcad_cli.click.command`). If none is found, stop and run
+`/pc:install executable` first.
+
+Pass `--no-ansi` on every run so the output is plain text. It is a global flag
+and goes before the subcommand, and it routes the logs to **stderr** — so
+capture both streams when reading them: `pc --no-ansi export ... 2>&1`.
+
+## 3. Export
+
+```sh
+mkdir -p ./out                                       # -O expects the directory to exist
+pc --no-ansi export -t stl -O ./out bracket          # a part
+pc --no-ansi export -t step -O ./out -a gearbox      # an assembly (-a)
+pc --no-ansi export -t dxf -O ./out -s outline       # a sketch (-s)
+pc --no-ansi export -t stl -O ./out -P //pub/std bolt  # an object in another package
+```
+
+Formats: `step`, `brep`, `stl`, `3mf`, `threejs`, `obj`, `gltf`, `iges`, `urdf`,
+`svg`, `dxf`, plus any file type a package implements itself. `-t urdf` writes a
+`.urdf` plus the directory of mesh files it references — it is the one that
+produces more than one file.
+
+`svg` and `dxf` are the flat pair, and are what a **sketch** exports to: a sketch
+is already 2D, so this is its geometry and not a picture of it. A part or an
+assembly accepts them as well, but what comes back is a projection — if that is
+what is wanted, `/pc:render` is the command that says so, and the viewing-angle
+options exist only there.
+
+Useful options:
+
+- `-O <dir>` — where the files go. The directory must exist; add `-p` to create
+  the structure a configured output path needs.
+- **No object name** exports everything the package declares; `-r` walks the
+  imported packages too. Say what that will produce before running it on a
+  package that imports the public index.
+- `-e <package>` — read another package's `export:` options and implementations,
+  which is how one package's exporter is applied to another's objects.
+
+Each file is named after the object, so exporting several objects into one
+directory is safe — unlike several *views* of one object, which is `/pc:render`.
+
+If the format the user asked for is not in the list, check whether the package
+implements it: read the `export:` and `render:` sections of `partcad.yaml`. A
+package can declare a file type of its own, and it is then nameable with `-t`
+like any other.
+
+## 4. Report what happened
+
+Name the files that were written, with their paths — all of them for `-t urdf`
+or a whole-package export, or a count plus the directory when there are many.
+State that `partcad.yaml` is unchanged, since that is the property that makes
+this command the right one. If PartCAD printed an error, surface it verbatim.

--- a/ai-agents/common/skills/gen-assembly/SKILL.md
+++ b/ai-agents/common/skills/gen-assembly/SKILL.md
@@ -21,7 +21,7 @@ ambiguities.
 ## 2. Inventory or generate the parts
 
 ```sh
-pc list parts          # what already exists to reuse
+pc --no-ansi list parts          # what already exists to reuse
 ```
 
 Reuse existing parts; generate any missing component with the `/pc:gen-part`
@@ -33,7 +33,7 @@ Scaffold (this creates the empty file and the `assemblies:` entry), then write
 `<name>.assy`:
 
 ```sh
-pc add assembly assy <name>.assy
+pc --no-ansi add assembly assy <name>.assy
 ```
 
 An ASSY file is a tree of nodes under `links:` (reference: PartCAD "Assembly YAML"
@@ -176,18 +176,49 @@ making a *part* and mean nothing here.) Marking it manufacturable instead makes
 `pc test` require that every part in it can be bought or made from a declared
 supplier — only do that when that is true.
 
-## 4. Validate, render, iterate
+## 4. Validate, render it from several angles, iterate
 
 ```sh
-pc test -a <name>                               # build gate: geometry instantiates
-mkdir -p /tmp/pc-render                         # the -O directory must already exist
-pc render -a -t png -O /tmp/pc-render <name>    # writes /tmp/pc-render/<name>.png
+pc --no-ansi test -a <name>          # build gate: geometry instantiates
 ```
 
-View `/tmp/pc-render/<name>.png`: check that components are positioned and
-oriented correctly and that nothing interpenetrates unintentionally, then adjust
-placements/mates. Iterate until it matches. `pc inspect -a <name>` gives an
-interactive view.
+That gate passes for an assembly whose parts are all in the wrong place, so the
+design is decided by looking at it — and one picture cannot decide it. An
+assembly is judged on *where* its components are, and position along the viewing
+direction is precisely what a projection collapses: a part offset into the
+screen, mirrored, or turned a quarter turn sits perfectly in the one view that
+hides the error. Render **four** — `front`, `top` and `right` to place things in
+all three axes, `iso` to see the product whole. A rendered file is named after
+the object, so give each view a directory of its own or they overwrite each
+other:
+
+```sh
+for view in front top right iso; do
+  mkdir -p /tmp/pc-render/$view                     # -O expects it to exist
+  pc --no-ansi render -a -t png --view $view -O /tmp/pc-render/$view <name>
+done
+```
+
+Each view directory gets `<name>.png` plus one file per sub-assembly, since a
+sub-assembly is an object in its own right. View all four of `<name>.png` — and
+the sub-assemblies' own views when a nesting is what went wrong — and check
+against the decomposition from §1:
+
+- every component is there, as many times as it should be, and nothing else is;
+- each one is where it belongs in all three axes — a placement is only confirmed
+  by two views that share no viewing direction;
+- each one is oriented as it belongs, including where a symmetric part hides it:
+  a flipped bracket reads the same from the front and differs from the top;
+- nothing interpenetrates that should not, and nothing floats where it should
+  seat — a gap and a contact look alike from the front and separate from the side.
+
+Add `back`, `left` or `bottom` when a component stays hidden behind another in
+all four, and `--viewport-origin X,Y,Z` / `--viewport-up X,Y,Z` to look along a
+joint no named view shows. `/pc:render` covers these options in full.
+
+Where a component is in the wrong place and the ASSY uses `connect:` rather
+than `location:`, the views tell you *that* it is wrong; the next section tells
+you *why*.
 
 ### When a connection comes out wrong
 
@@ -196,16 +227,30 @@ ports and interfaces are not geometry, so nothing about them is on the plain
 render. Draw them:
 
 ```sh
-pc render -a -t png -O /tmp/pc-render --with-ports <name>       # every port of every part
-pc render -a -t png -O /tmp/pc-render --with-interfaces <name>  # every interface, joined to its ports
-pc render -a -t png -O /tmp/pc-render --with-all <name>         # both
+mkdir -p /tmp/pc-render/ports
+# Every port of every part. Add --with-interfaces for each interface joined to
+# its ports, or --with-all for both.
+pc --no-ansi render -a -t png --view iso -O /tmp/pc-render/ports --with-ports <name>
 ```
+
+These write `<name>.png` like any other render, so an overlay needs a directory
+of its own or it lands on top of the plain views from above — and `--no-ansi`
+because the port names are reported on stderr, which is half of what makes the
+picture readable.
 
 On an assembly these walk everything inside it and place each child's ports
 where the assembly put the child, so both ends of a connection are on one
 picture. Each port is a coordinate frame whose **long arrow is `+Z`** — the
 direction a part travels along when it is connected through that port — and each
-is named `<part-instance>:<port>`. Read the picture:
+is named `<part-instance>:<port>`.
+
+Being a frame rather than geometry does not exempt it from what §4 is about: one
+projection still collapses the axis a port is offset along, so two frames a
+millimetre apart along the line of sight are drawn one on top of the other. When
+the `iso` view leaves that ambiguous, render the overlay from the same four
+views the geometry was checked from.
+
+Read the picture:
 
 - **Connected as intended**: the two frames coincide and their `+Z` arrows point
   in **opposite** directions.
@@ -224,7 +269,13 @@ is named `<part-instance>:<port>`. Read the picture:
   four ports, the interface is declared wrong.
 
 Iterate on the `--with-ports` render, not the plain one, for as long as a
-connection is the thing being fixed.
+connection is the thing being fixed. A part whose own port is in the wrong place
+is fixed in the part, not in the ASSY — render that part on its own with
+`--with-all` (`/pc:add-interfaces` covers reading it) before touching the
+assembly that uses it.
+
+Then adjust the placements or mates, re-test, and re-render. Iterate until every
+view matches. `pc inspect -a <name>` gives an interactive view.
 
 ## 5. Finalize
 

--- a/ai-agents/common/skills/gen-part/SKILL.md
+++ b/ai-agents/common/skills/gen-part/SKILL.md
@@ -53,7 +53,7 @@ Write the script file **first** from `$ARGUMENTS` (plain type — never `ai-*`),
 then register it — `pc add part` requires the file to already exist:
 
 ```sh
-pc add part --desc "<the description>" <kind> <name>.<ext>   # e.g. build123d bracket.py
+pc --no-ansi add part --desc "<the description>" <kind> <name>.<ext>   # e.g. build123d bracket.py
 ```
 
 Language conventions for the script:
@@ -87,21 +87,47 @@ only if the geometry instantiates cleanly, and the manufacturability checks are
 skipped.
 
 ```sh
-pc test <name>
+pc --no-ansi test <name>
 ```
 
-## 7. Render, compare, and iterate
+## 7. Render it from several angles, compare, and iterate
 
-Produce an image and compare it against the description and any reference images
-— overall shape and every stated dimension:
+`pc test` proves the geometry instantiates. It says nothing about whether the
+geometry is the part that was asked for — that is decided by looking at it.
+
+One picture is not enough to decide it. A projection hides everything behind it,
+so a hole in the wrong face, a feature on the wrong side, a chamfer that never
+got cut, or a shape that is right in outline and wrong in depth all survive the
+one view that happens to conceal them. Render **four**: `front`, `top` and
+`right` to read proportions and dimensions off, and `iso` to see how the features
+go together. A rendered file is named after the object, so give each view a
+directory of its own or they overwrite each other:
 
 ```sh
-mkdir -p /tmp/pc-render                       # the -O directory must already exist
-pc render -t png -O /tmp/pc-render <name>     # writes /tmp/pc-render/<name>.png
+for view in front top right iso; do
+  mkdir -p /tmp/pc-render/$view                  # -O expects it to exist
+  pc --no-ansi render -t png --view $view -O /tmp/pc-render/$view <name>
+done
 ```
 
-Fix any error or mismatch, then re-test and re-render. Iterate until it is right —
-no fixed retry count.
+Then view all four — `/tmp/pc-render/<view>/<name>.png` — and compare them
+against the description and any reference images:
+
+- the overall form and the bounding size, in all three axes;
+- every dimension the description states — each is measurable in one of the
+  orthographic views, and a dimension no view confirms is one still assumed;
+- every feature that was asked for, on the face it was asked for, and nothing
+  present that was not.
+
+Add `back`, `left` or `bottom` whenever the part is not symmetric about the axis
+in question: an asymmetric part has a face you have not seen, and a face you have
+not seen is a face you are guessing about. When no named view shows the feature
+you need to check, `--viewport-origin X,Y,Z` and `--viewport-up X,Y,Z` look from
+an arbitrary direction. `/pc:render` covers these options in full.
+
+Fix any error or mismatch, then re-test and re-render. Iterate until every view
+matches — no fixed retry count. If the part is right and the numbers are what
+need checking, `/pc:describe` renders a dimensioned drawing of it.
 
 ## 8. Finalize
 
@@ -110,7 +136,19 @@ Summarize what you built — key dimensions and assumptions — and how to view 
 
 If the part is meant to connect to something — a bolt pattern, a plug, a rail —
 say so and offer `/pc:add-interfaces`, which adds the ports and interfaces that
-let PartCAD mate it automatically. Once it has them,
-`pc render -t png --with-all <name>` draws them on the same picture you have
-been comparing against, so a port that is in the wrong place or facing the wrong
-way is visible rather than inferred.
+let PartCAD mate it automatically. Once it has them, `--with-all` draws them on
+the very views you have been comparing against, so a port that is in the wrong
+place or facing the wrong way is visible rather than inferred:
+
+```sh
+for view in front top right iso; do
+  mkdir -p /tmp/pc-render/ports/$view
+  pc --no-ansi render -t png --view $view -O /tmp/pc-render/ports/$view --with-all <name>
+done
+```
+
+Four views again, and for the same reason: a port is a coordinate frame, and one
+projection collapses the axis it is offset along just as it does for geometry.
+`--no-ansi` because every port drawn is also named on stderr, which is where the
+exact string to write in an ASSY file comes from. `/pc:add-interfaces` covers
+reading these drawings in full.

--- a/ai-agents/common/skills/render/SKILL.md
+++ b/ai-agents/common/skills/render/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: render
+description: Render a PartCAD object or a CAD file to a 2D image - PNG, JPEG, SVG or DXF - from one or many viewing angles (front, back, left, right, top, bottom, iso, or an arbitrary direction), with `pc render` for an object a package declares or `pc adhoc render` for a file that belongs to no package. Use for /pc:render or when the user asks to render, draw, screenshot, preview, or produce an image or projection of a part, sketch, assembly or CAD file, or to see it from a particular view, or to draw an object's ports and interfaces on it (--with-ports / --with-interfaces / --with-all). For geometry another CAD tool can open use /pc:export or /pc:convert.
+---
+
+# pc:render
+
+Produce a picture of a shape: a 2D projection, in `png`, `jpeg`, `svg` or `dxf`.
+`$ARGUMENTS` says what to render and, often, from where.
+
+A render is not a conversion. It writes something to look at, not geometry
+another CAD tool can go on working with — that is `/pc:export` (or `/pc:convert`
+when the object should *become* the new format). The viewing angle only means
+anything here.
+
+Two commands do it:
+
+- **`pc render`** — an object a package declares. Reads the package's `render:`
+  configuration, so the object is drawn the way the package publishes it.
+- **`pc adhoc render`** — a file that belongs to no package. PartCAD wraps it in
+  a throwaway package, writes the picture, and deletes the package again.
+
+## 1. Work out which case you are in
+
+Do this before running anything. It is the same first step in `/pc:convert` and
+`/pc:export`.
+
+1. **Is there a package?** PartCAD searches upward for `partcad.yaml`, so look in
+   the current directory and above. `pc --no-ansi list` lists what the package
+   holds; if there is no package it says so.
+2. **Does the reference name an object?** Check it against
+   `pc --no-ansi list parts` / `list sketches` / `list assemblies`.
+   `pc --no-ansi info <name>` succeeds only for an object that resolves.
+3. **Does a file the user named belong to an object?** Someone who says "render
+   `bracket.step`" inside a package usually means the part built from it. Read
+   `partcad.yaml` and look for an object whose `path:` is that file — and note
+   that a file-backed object *without* a `path:` is `<name>` plus the type's
+   extension, so a part `bracket` of type `step` is `bracket.step` whether or not
+   the path is written down.
+
+**If 2 or 3 matched, it is an object: use `pc render` (§3).** That way the
+package's own `render:` options apply — its pixel size, its prefix, the viewport
+it publishes the object with — and the picture matches every other picture of
+that package.
+
+**If there is no package, or the file is not one an object is built from, it is
+ad-hoc: use `pc adhoc render` (§4).**
+
+## 2. Make sure PartCAD is available
+
+Resolve a command as `/pc:init` does (`pc`, then `partcad`, then
+`python -m partcad_cli.click.command`). If none is found, stop and run
+`/pc:install executable` first.
+
+Pass `--no-ansi` on every run so the output is plain text. It is a global flag
+and goes before the subcommand, and it routes the logs to **stderr** — so
+capture both streams when reading them: `pc --no-ansi render ... 2>&1`.
+
+## 3. An object in a package — `pc render`
+
+```sh
+mkdir -p ./out                                          # -O expects the directory to exist
+pc --no-ansi render -t png -O ./out bracket             # a part
+pc --no-ansi render -t png -O ./out -a gearbox          # an assembly (-a)
+pc --no-ansi render -t svg -O ./out -s outline          # a sketch (-s; SVG suits one better than PNG)
+pc --no-ansi render -t png -O ./out -P //pub/std bolt   # an object in another package
+```
+
+Formats: `png`, `jpeg`, `svg`, `dxf`, plus any a package implements itself.
+`-t readme`, `-t pdf` and `-t html` are documents rather than projections (a
+package README, or an assembly's bill of materials and instruction book) — they
+take no viewing angle.
+
+The file is written into `-O` and named after the object. Nothing about the
+package changes.
+
+## 4. A file with no package — `pc adhoc render`
+
+```sh
+pc --no-ansi adhoc render part bracket.step bracket.png
+pc --no-ansi adhoc render part --output svg bracket.step        # names the output after the input
+pc --no-ansi adhoc render part --input step bracket.dat out.png
+pc --no-ansi adhoc render sketch outline.svg outline.png
+```
+
+Both types are inferred from the file names; `--input` and `--output` say them
+outright. The input may be any type PartCAD reads — including the scripted ones
+it cannot write back out (`sdf`, `scad`, `chili3d`), since reading is all a
+picture needs. The output is one of the four projections.
+
+`urdf` and `assy` are refused here: both only mean anything inside a package. Put
+the file in one (`pc import assembly`) and render it with `pc render`.
+
+## 5. Choosing the angle
+
+Both commands take the same three options.
+
+`--view` names a direction — `front`, `back`, `left`, `right`, `top`, `bottom`,
+`iso`. `--viewport-origin X,Y,Z` says where to look from and `--viewport-up
+X,Y,Z` which way is up in the picture; each replaces the vector `--view`
+resolved to, so a named view can be tilted by giving one of them alone:
+
+```sh
+pc --no-ansi render -t png --view front -O ./out bracket
+pc --no-ansi render -t png --view top --viewport-up 0,1,0.5 -O ./out bracket
+pc --no-ansi adhoc render part --viewport-origin 120,-40,60 bracket.step bracket.png
+```
+
+PartCAD is Z-up, with `+Y` pointing away from the front view — so `+X` is to the
+right of it and `+Z` is up. Left unset, a part is drawn from the front-right-top
+corner (`iso`), which is what makes it read as 3D, and a sketch head-on.
+
+These are the same `viewport_origin` and `viewport_up` a `render:` file type is
+configured with in `partcad.yaml`, passed for one command instead of written
+down. If the user wants an object drawn that way *every* time, put it in the
+configuration instead — and note this is only possible for an object in a
+package, which is one more reason to prefer §3 over §4 when both would work:
+
+```yaml
+parts:
+  bracket:
+    type: step
+    path: bracket.step
+    render:
+      png:
+        viewport_origin: [0, -100, 0]
+        viewport_up: [0, 0, 1]
+```
+
+## 6. Several angles at once
+
+A rendered file is named after the object, so views written into one directory
+overwrite each other. Give each its own directory (`pc render`) or its own file
+name (`pc adhoc render`):
+
+```sh
+for view in front top right iso; do
+  mkdir -p ./out/$view
+  pc --no-ansi render -t png --view $view -O ./out/$view bracket
+done
+```
+
+```sh
+for view in front top right iso; do
+  pc --no-ansi adhoc render part --view $view bracket.step bracket-$view.png
+done
+```
+
+Then look at the images. Four views — `front`, `top`, `right`, `iso` — describe
+most parts; add `back`, `left` or `bottom` only when the shape is not symmetric
+about the axis in question.
+
+## 7. Drawing the ports and interfaces
+
+Ports and interfaces are not geometry — a port is a coordinate frame and an
+interface is a named set of them — so nothing about them reaches a projection
+unless it is asked for. `pc render` draws them (`pc adhoc render` does not: a
+file with no package has none):
+
+```sh
+mkdir -p ./out/ports
+pc --no-ansi render -t png --view iso -O ./out/ports --with-ports bracket
+pc --no-ansi render -t png --view iso -O ./out/ports --with-interfaces bracket   # overwrites the above
+pc --no-ansi render -t png --view iso -O ./out/ports --with-all bracket          # both at once
+```
+
+`--with-ports` marks and names every port, `--with-interfaces` names each
+interface instance and joins it to the ports it owns, and `--with-all` draws
+both. On an assembly or a scene all three walk everything inside it and place
+each child's ports where it put the child, which is how a connection that went
+wrong is found: two frames that should have met and did not. Every port drawn is
+also named on stderr, which is where the exact string for an Assembly YAML file
+comes from — so `--no-ansi`, and read both streams.
+
+The overlays are subject to §6 twice over: each writes `<name>.png` like any
+other render and so needs a directory or a name of its own, and a frame offset
+along the line of sight is hidden exactly as a feature would be, so an ambiguous
+port is worth the same several views the shape got.
+
+A package can ask for this permanently instead, with `with_ports:` or
+`with_interfaces:` on one of its `render:` file types. `/pc:add-interfaces`
+covers reading these drawings when the ports themselves are what is being
+worked on.
+
+## 8. Report what happened
+
+Name the files that were written, with their paths, and which view each one is.
+Nothing in this skill changes `partcad.yaml` — say so if the user might have
+expected otherwise. If PartCAD printed an error, surface it verbatim.
+
+When the user wanted a description rather than the pictures themselves,
+`/pc:describe` writes one from a render.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -258,6 +258,39 @@ Object commands
   ``port_label_size`` set how big the markers and the names are, as a fraction of the projection's largest
   dimension.
 
+  A port is a coordinate frame rather than geometry, but it is projected like everything else: the axis it is
+  offset along is the one a given projection collapses, so two frames a millimetre apart along the line of
+  sight are drawn one on top of the other. A port that comes out ambiguous is worth the same second and third
+  ``--view`` below that an ambiguous feature is.
+
+  ``--view`` picks the direction the object is looked at from for this one run: ``front``, ``back``, ``left``,
+  ``right``, ``top``, ``bottom`` or ``iso``. Each name is shorthand for a pair of vectors, which
+  ``--viewport-origin`` and ``--viewport-up`` give as ``X,Y,Z`` instead: the first is where the camera is, the
+  second is which way is up in the resulting picture. Either one replaces the vector the name resolved to, so
+  ``--view top --viewport-up 0,1,0.5`` tilts the top view without spelling the rest of it out:
+
+  .. code-block:: shell
+
+    pc render -t png --view front -O ./ bracket
+    pc render -t png --view top --viewport-up 0,1,0.5 -O ./ bracket
+    pc render -t png --viewport-origin 120,-40,60 -O ./ bracket
+
+  All three are the ``viewport_origin`` and ``viewport_up`` of a render file type in ``partcad.yaml``
+  (see :ref:`output-files`), passed for one command instead of written down — so they layer on top of whatever
+  the package and the object configured, and a file type that does not project (``step``, ``readme``, an
+  assembly instruction book) never reads them. PartCAD is Z-up with ``+Y`` pointing away from the front view,
+  which is what puts ``+X`` on the right of it.
+
+  A rendered file is named after the object, so several views of one object go into directories of their own
+  rather than over each other:
+
+  .. code-block:: shell
+
+    for view in front top iso; do
+      mkdir -p ./views/$view
+      pc render -t png --view $view -O ./views/$view bracket
+    done
+
   ``-t readme`` generates a markdown document instead of a projection: the package document (``README.md``,
   listing what the package declares) or, when ``-a`` names an assembly, that assembly's own document
   (``<assembly>.md``, listing the bill of materials — every part and sub-assembly it is made of, recursively,
@@ -312,10 +345,27 @@ Other commands
 **************
 
 ``pc adhoc``
-  Ad-hoc operations that run on the fly without creating or configuring a package. Subcommand: ``convert``
-  (convert a part or sketch to another format without updating its type). The assembly formats ``assy`` and
-  ``urdf`` are refused here: an ASSY file is a set of references to the parts of a package and a URDF becomes a
-  part per link, so neither means anything without one. Use ``pc convert assembly`` in a package instead.
+  Ad-hoc operations that run on the fly, on a file that belongs to no package: PartCAD declares the file in a
+  throwaway package of its own, produces one output file, and deletes the package again. Nothing is created and
+  nothing is configured. Subcommands, each taking ``part`` or ``sketch``:
+
+  - ``pc adhoc convert`` — write the file back out as another format
+    (``pc adhoc convert part bracket.step bracket.stl``).
+  - ``pc adhoc render`` — write a 2D projection of it: ``svg``, ``png``, ``jpeg`` or ``dxf``
+    (``pc adhoc render part --view top bracket.step bracket.png``).
+
+  Both infer the types from the file names, and take ``--input``/``--output`` to say them outright. ``pc adhoc
+  render`` takes the same ``--view``, ``--viewport-origin`` and ``--viewport-up`` as ``pc render`` — and with no
+  ``partcad.yaml`` to configure a viewport in, they are the only way to aim one. The output file name may be
+  left off when ``--output`` names the type: the file is then named after the input.
+
+  Which of the two to use is which kind of file is wanted, and it is the same distinction as between
+  ``pc export`` and ``pc render``: geometry another CAD tool can go on working with, or a picture. A file type a
+  package implements itself is available to neither, since there is no package here to declare it in.
+
+  The assembly formats ``assy`` and ``urdf`` are refused by both: an ASSY file is a set of references to the
+  parts of a package and a URDF becomes a part per link, so neither means anything without one. Declare it in a
+  package and use ``pc convert assembly``, ``pc export`` or ``pc render`` instead.
 
 ``pc healthcheck``
   Check the host system for known issues. Use ``--dry-run`` to list the available checks, ``--filters`` to run

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2533,6 +2533,13 @@ the object's value wins:
         step:
           comment: Revision C.
 
+A parameter can also be given for one command instead of written down. The two
+that aim a 2D projection -- ``viewport_origin``, which is where the shape is
+looked at from, and ``viewport_up``, which way is up in the picture -- are
+``pc render --viewport-origin``/``--viewport-up``, with ``--view`` naming the
+common directions (see :doc:`cli`). Passed that way they layer on top of
+everything below, package and object alike, for that run only.
+
 Two names are not entirely the package's own.
 
 ``decode`` is not a parameter at all. It is one of the fields PartCAD reads

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -548,6 +548,14 @@ The tests for the CLI module are located in the ``./tests/partcad_cli`` director
 The tests for the IDE viewer client are located in the ``./tests/partcad_ide_client`` directory.
 The tests for the LSP server of VSCode plugin are located in the ``./ide/vscode/src/test/python_tests`` directory.
 
+**The first run is slow, and that is the sandboxes rather than the tests.** A test whose part is scripted
+(build123d, CadQuery, SDF, OpenSCAD) runs in a Python environment PartCAD provisions on first use -- a fresh
+interpreter plus a pip install of the CAD stack -- and whichever test is the first to need a given one pays for
+building it. Once built they are cached under ``~/.partcad`` and reused, so the same suite that took half an
+hour cold takes minutes warm. The ``pytest`` ``pre-commit`` hook allows 15 minutes per test for that reason
+(``PC_PYTEST_TIMEOUT`` overrides it); a test reported as timing out on a cold cache is worth simply running
+again before it is treated as a bug.
+
 Behave
 ^^^^^^
 

--- a/docs/source/use_cases.rst
+++ b/docs/source/use_cases.rst
@@ -131,6 +131,51 @@ switch to ``4:2:0`` when a smaller file matters more than the edges.
 The rendered file is named after the object with the format's own extension,
 so ``jpeg`` produces ``<name>.jpg``.
 
+Which direction the object is looked at from is ``viewport_origin``, and which
+way is up in the resulting picture is ``viewport_up``. Both are accepted by
+every projection above (and by ``dxf``), on the package or on a single object:
+
+.. code-block:: yaml
+
+  render:
+    png:
+      viewport_origin: [0, -100, 0]   # look at it from the front
+      viewport_up: [0, 0, 1]          # with Z up
+
+  parts:
+    cylinder:
+      type: cadquery
+      render:
+        png:
+          viewport_origin: [0, 0, 100]  # ... but look at this one head-on
+          viewport_up: [0, 1, 0]
+
+Left unset, a part is drawn from the front-right-top corner (which is what makes
+it read as 3D) and a sketch head-on. PartCAD is Z-up with ``+Y`` pointing away
+from the front view, which is what puts ``+X`` on the right of it. The distance
+does not matter — the pair names a direction, and the projection is scaled to fit
+whatever it is written into.
+
+``pc render`` takes the same two as ``--viewport-origin``/``--viewport-up``, and
+names the common directions with ``--view`` (``front``, ``back``, ``left``,
+``right``, ``top``, ``bottom``, ``iso``), for a view that belongs to one command
+rather than to the package:
+
+.. code-block:: shell
+
+  pc render -t png --view front -O ./ bracket
+  pc render -t png --viewport-origin 120,-40,60 -O ./ bracket
+
+A file that is not in a package at all is rendered by ``pc adhoc render``, which
+takes the same three options. They are the only way to aim one, there being no
+``partcad.yaml`` to configure a viewport in; left off, the projection comes out
+the way the renderer draws one by default:
+
+.. code-block:: shell
+
+  pc adhoc render part --view top bracket.step bracket.png
+  pc adhoc render sketch outline.svg outline.png
+
 
 =============
 Export models

--- a/features/adhoc/render/part.feature
+++ b/features/adhoc/render/part.feature
@@ -1,0 +1,49 @@
+@cli @pc-adhoc-render @part
+Feature: `pc adhoc render part` command
+
+  Renders a CAD file that belongs to no package. The projection itself is the
+  same one `pc render` writes and is covered there; what these scenarios are for
+  is the ad-hoc half -- that a bare file can be rendered at all, that the
+  viewport reaches it, and that a request which cannot be carried out is refused
+  rather than half-done.
+
+  The input is an example checked into this repository rather than a file
+  written inline: what is being rendered is not the subject, and a STEP known to
+  render keeps a failure here pointing at this command.
+
+  Background: Sandbox
+    Given I am in "/tmp/sandbox/behave" directory
+    And I have temporary $HOME in "/tmp/sandbox/home"
+
+  Scenario: Render a bare STEP file to a PNG from a named view
+    When I run "pc --no-ansi adhoc render part --view top $PARTCAD_ROOT/examples/produce_part_step/bolt.step ./bolt.png"
+    Then the command should exit with a status code of "0"
+    Then a file named "bolt.png" should be created
+    # Nothing was added to any package, which is the whole point of `adhoc`.
+    Then a file named "partcad.yaml" should not exist
+
+  Scenario: Fail on a projection PartCAD does not write
+    When I run "pc --no-ansi adhoc render part $PARTCAD_ROOT/examples/produce_part_step/bolt.step ./bolt.tiff --output tiff"
+    Then the command should exit with a status code of "2"
+    Then a file named "bolt.tiff" should not exist
+
+  Scenario: Fail when the output names a part type rather than a projection
+    When I run "pc --no-ansi adhoc render part $PARTCAD_ROOT/examples/produce_part_step/bolt.step ./bolt.stl"
+    Then the command should exit with a status code of "1"
+    Then STDERR should contain "Cannot infer the projection to render"
+    Then a file named "bolt.stl" should not exist
+
+  Scenario Outline: Fail on a viewport that cannot be made sense of
+    When I run "pc --no-ansi adhoc render part <options> $PARTCAD_ROOT/examples/produce_part_step/bolt.step ./bolt.png"
+    Then the command should exit with a status code of "2"
+    Then a file named "bolt.png" should not exist
+
+    Examples: Bad viewports
+      |                    options |
+      |          --view isometric  |
+      |      --viewport-origin 1,2 |
+      |        --viewport-up 0,0,0 |
+
+  Scenario: Fail when the input file is missing
+    When I run "pc --no-ansi adhoc render part missing.step ./missing.png"
+    Then the command should exit with a status code of "2"

--- a/features/adhoc/render/sketch.feature
+++ b/features/adhoc/render/sketch.feature
@@ -1,0 +1,22 @@
+@cli @pc-adhoc-render @sketch
+Feature: `pc adhoc render sketch` command
+
+  The sketch half of `pc adhoc render`. A sketch is already flat, so rendering
+  one is a drawing of it rather than a projection through it -- and `svg` and
+  `dxf` therefore appear on both sides of this command, meaning the sketch
+  itself as an input and a picture of it as an output.
+
+  Background: Sandbox
+    Given I am in "/tmp/sandbox/behave" directory
+    And I have temporary $HOME in "/tmp/sandbox/home"
+
+  Scenario: Render a bare SVG sketch to a PNG
+    When I run "pc --no-ansi adhoc render sketch $PARTCAD_ROOT/examples/produce_sketch_svg/svg_01.svg ./sketch.png"
+    Then the command should exit with a status code of "0"
+    Then a file named "sketch.png" should be created
+    Then a file named "partcad.yaml" should not exist
+
+  Scenario: Fail on an output type that is not a projection
+    When I run "pc --no-ansi adhoc render sketch $PARTCAD_ROOT/examples/produce_sketch_svg/svg_01.svg ./sketch.py --output cadquery"
+    Then the command should exit with a status code of "2"
+    Then a file named "sketch.py" should not exist

--- a/features/render.feature
+++ b/features/render.feature
@@ -120,6 +120,36 @@ Feature: `pc render` command
     Then a file named "m4.png" should not exist
     Then a file named "m5.png" should not exist
 
+  # The viewing angle of a projection. `--view` is shorthand for the
+  # `viewport_origin`/`viewport_up` pair a `render:` file type is configured
+  # with, so what is worth a CLI round trip here is that the option survives one
+  # and reaches the implementation. Which way each name points, and that the
+  # override beats the configuration, are unit tests.
+  #
+  # `feature_render:cylinder` rather than any other part: it configures a
+  # viewport of its own, so a render that ignored `--view` would still succeed
+  # and this would still be looking at the picture the package asked for.
+  @type-image
+  Scenario: `pc render --view` aims the projection
+    When I run "pc --no-ansi -p $PARTCAD_ROOT/examples render --package //feature_render -t svg --view front -O ./ :cylinder"
+    Then the command should exit with a status code of "0"
+    Then a file named "cylinder.svg" should be created
+    Given a file named "partcad.yaml" does not exist
+    Then STDERR should contain "DONE: Render: //pub/examples/partcad/feature_render:"
+
+  # A request that cannot be aimed is refused before anything is rendered,
+  # rather than producing a picture of something else.
+  Scenario Outline: `pc render` refuses a viewport it cannot make sense of
+    When I run "pc --no-ansi -p $PARTCAD_ROOT/examples render --package //feature_render -t svg <options> -O ./ :cylinder"
+    Then the command should exit with a status code of "2"
+    Then a file named "cylinder.svg" should not exist
+
+    Examples: Bad viewports
+      |                    options |
+      |          --view isometric  |
+      |      --viewport-origin 1,2 |
+      |        --viewport-up 0,0,0 |
+
   @type-guide
   Scenario: `pc render -t pdf` refuses an assembly that is not meant to be built
     When I run "pc --no-ansi -p $PARTCAD_ROOT/examples render --package /produce_assembly_assy -t pdf -O ./ -a :primitive"

--- a/src/partcad/adhoc/adhoc.py
+++ b/src/partcad/adhoc/adhoc.py
@@ -1,0 +1,163 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The throwaway package an ad-hoc command works inside.
+
+`pc adhoc convert` and `pc adhoc render` both operate on a file that belongs to
+no package: PartCAD writes a `partcad.yaml` in a temporary directory declaring
+that one file as its only object, builds a context around it, produces one
+output file, and deletes the directory again.
+
+Everything specific to a verb lives in `convert.py` and `render.py`; what is
+here is the part they share, so that a change to how the throwaway package is
+built cannot mean one thing for a conversion and another for a projection.
+"""
+
+import asyncio
+from pathlib import Path
+import shutil
+import tempfile
+
+from .. import logging as pc_logging
+from ..context import Context
+
+# What a shape of each kind is called inside the throwaway package, and which
+# section of its 'partcad.yaml' declares it. The names are not arbitrary: they
+# are what the object is called, so they reach the user in an error message and
+# (for a render) name the output file when the caller did not.
+KINDS = {
+    "part": ("parts", "input_part"),
+    "sketch": ("sketches", "input_sketch"),
+}
+
+
+def generate_partcad_config(temp_dir: Path, input_type: str, temp_input_path: Path, kind: str = "part") -> None:
+    """
+    Generate a temporary partcad.yaml configuration for processing.
+
+    Args:
+        temp_dir (Path): Temporary directory path.
+        input_type (str): Input file format type.
+        temp_input_path (Path): Path to the copied input file.
+        kind (str): Either "part" or "sketch" (default is "part")
+    """
+    section, name = KINDS[kind]
+
+    # Doubling is how an apostrophe is escaped inside a YAML single-quoted
+    # scalar. The path is the user's own -- '/home/me/part's.step' is a valid
+    # file name -- and without this it closes the scalar early and the
+    # throwaway package fails to parse before the input is ever read.
+    quoted_path = str(temp_input_path).replace("'", "''")
+
+    config = f"""
+{section}:
+  {name}:
+    type: {input_type}
+    path: '{quoted_path}'
+    """
+    config_path = temp_dir / "partcad.yaml"
+    config_path.write_text(config.strip() + "\n", encoding="utf-8")
+
+
+# Formats that describe an assembly rather than a single shape. An ad-hoc
+# operation is a file-in, file-out one with a throwaway package around it; these
+# need a real one. A URDF resolves its meshes against the package that holds them
+# and produces a part per link, and an ASSY is nothing but references to parts of
+# a package - neither means anything on its own.
+PACKAGE_ONLY_TYPES = {
+    "urdf": "a URDF names the meshes of its links and becomes a part per link",
+    "assy": "an ASSY file is a set of references to the parts of a package",
+}
+
+
+def reject_package_only(input_type: str, output_type: str = None, verb: str = "convert", advice: str = None) -> None:
+    """Refuse the formats that only mean something inside a package.
+
+    'verb' and 'advice' are what the caller is doing and what it should do
+    instead; the rest of the message is the same either way, because the reason
+    is the same either way.
+    """
+    if advice is None:
+        advice = "Use 'pc convert assembly' in a package instead."
+    for role, part_type in (("from", input_type), ("to", output_type)):
+        reason = PACKAGE_ONLY_TYPES.get((part_type or "").lower())
+        if reason is not None:
+            raise ValueError(
+                "Cannot %s %s '%s' ad-hoc: %s, so it only means anything inside a package. %s"
+                % (verb, role, part_type, reason, advice)
+            )
+
+
+def write_output_file(
+    input_filename: str,
+    input_type: str,
+    output_filename: str,
+    output_type: str,
+    kind: str = "part",
+    verb: str = "Convert",
+    **options,
+) -> None:
+    """Produce one output file from a CAD file that belongs to no package.
+
+    Args:
+        input_filename: Path to the input file.
+        input_type: Format of the input file.
+        output_filename: Path to write.
+        output_type: The file type to write - a part or sketch format for a
+            conversion, a 2D projection for a render.
+        kind: "part" or "sketch", which decides how the input is declared.
+        verb: What is being done, for the progress label and the error message.
+        options: Export parameters handed to the implementation, overriding what
+            it would otherwise default to. This is where a render's viewport
+            arrives; a conversion passes none.
+
+    Raises:
+        RuntimeError: the input could not be loaded, or the output not written.
+            The cause is in the message and not only in '__cause__', because
+            this is what the CLI prints.
+    """
+    _, object_name = KINDS[kind]
+    input_path = Path(input_filename).resolve()
+    temp_dir = Path(tempfile.mkdtemp())
+
+    try:
+        generate_partcad_config(temp_dir, input_type, input_path, kind=kind)
+
+        ctx = Context(root_path=temp_dir, search_root=False)
+        with pc_logging.Process(verb, "adhoc" if kind == "part" else "adhoc-sketch"):
+            project = ctx.get_project("//")
+            obj = project.get_part(object_name) if kind == "part" else project.get_sketch(object_name)
+            if not obj:
+                raise RuntimeError(f"Failed to load the input {kind}: no {kind} returned")
+
+            shape = asyncio.run(obj.get_wrapped(ctx))
+            # Errors first: when the factory failed - a missing module, a
+            # sandbox that would not install - that is the reason there is no
+            # shape, and it is the one worth reporting. "No shape returned" is
+            # what is left to say when nothing was recorded.
+            if obj.errors:
+                raise RuntimeError(f"Failed to load the input {kind}: {obj.errors}")
+            if not shape:
+                raise RuntimeError(f"Failed to load the input {kind}: no shape returned")
+
+            if kind == "part":
+                pc_logging.info(f"Loaded input part: {input_path}")
+                pc_logging.info(f"Shape: {type(shape)}")
+            else:
+                pc_logging.debug(f"Loaded input sketch: {input_path}")
+
+            obj.render(
+                ctx=ctx,
+                format_name=output_type,
+                project=project,
+                filepath=output_filename,
+                **options,
+            )
+
+    except Exception as e:
+        subject = "" if kind == "part" else " sketch"
+        raise RuntimeError(f"Failed to {verb.lower()}{subject}: {e}") from e
+    finally:
+        shutil.rmtree(temp_dir)

--- a/src/partcad/adhoc/convert.py
+++ b/src/partcad/adhoc/convert.py
@@ -3,59 +3,24 @@
 #
 # Licensed under Apache License, Version 2.0.
 #
+"""Converting a CAD or sketch file that belongs to no package.
 
-import asyncio
-from pathlib import Path
-import shutil
-import tempfile
+File in, file out: the input is wrapped in a throwaway package (see `adhoc.py`)
+and written back out as another format. Nothing is added to any package - that
+is `pc convert`, which also rewrites the object's definition, and `pc export`,
+which writes a file for an object a package already declares.
 
-from .. import logging as pc_logging
-from ..context import Context
+The 2D projections are the sibling module, `render.py`: a picture of a shape is
+not another way of storing it, and `pc adhoc convert` deliberately does not
+write one.
+"""
 
-
-def generate_partcad_config(temp_dir: Path, input_type: str, temp_input_path: Path, kind: str = "part") -> None:
-    """
-    Generate a temporary partcad.yaml configuration for processing.
-
-    Args:
-        temp_dir (Path): Temporary directory path.
-        input_type (str): Input file format type.
-        temp_input_path (Path): Path to the copied input file.
-        kind (str): Either "part" or "sketch" (default is "part")
-    """
-    section = "parts" if kind == "part" else "sketches"
-    name = "input_part" if kind == "part" else "input_sketch"
-
-    config = f"""
-{section}:
-  {name}:
-    type: {input_type}
-    path: '{temp_input_path}'
-    """
-    config_path = temp_dir / "partcad.yaml"
-    config_path.write_text(config.strip() + "\n", encoding="utf-8")
-
-
-# Formats that describe an assembly rather than a single shape. An ad-hoc
-# conversion is a file-in, file-out operation with a throwaway package around it;
-# these need a real one. A URDF resolves its meshes against the package that
-# holds them and produces a part per link, and an ASSY is nothing but references
-# to parts of a package - neither means anything on its own.
-PACKAGE_ONLY_TYPES = {
-    "urdf": "a URDF names the meshes of its links and becomes a part per link",
-    "assy": "an ASSY file is a set of references to the parts of a package",
-}
-
-
-def reject_package_only(input_type: str, output_type: str) -> None:
-    """Refuse the formats that only mean something inside a package."""
-    for role, part_type in (("from", input_type), ("to", output_type)):
-        reason = PACKAGE_ONLY_TYPES.get((part_type or "").lower())
-        if reason is not None:
-            raise ValueError(
-                "Cannot convert %s '%s' ad-hoc: %s, so it only means anything inside a package. "
-                "Use 'pc convert assembly' in a package instead." % (role, part_type, reason)
-            )
+from .adhoc import (  # noqa: F401  (re-exported: the historical import path)
+    PACKAGE_ONLY_TYPES,
+    generate_partcad_config,
+    reject_package_only,
+    write_output_file,
+)
 
 
 def convert_cad_file(input_filename: str, input_type: str, output_filename: str, output_type: str) -> None:
@@ -69,38 +34,7 @@ def convert_cad_file(input_filename: str, input_type: str, output_filename: str,
         output_type (str): Format of the output file.
     """
     reject_package_only(input_type, output_type)
-    input_path = Path(input_filename).resolve()
-    temp_dir = Path(tempfile.mkdtemp())
-
-    try:
-        generate_partcad_config(temp_dir, input_type, input_path, kind="part")
-
-        ctx = Context(root_path=temp_dir, search_root=False)
-        with pc_logging.Process("Convert", "adhoc"):
-            project = ctx.get_project("//")
-            part = project.get_part("input_part")
-            if not part:
-                raise RuntimeError("Failed to load the input part: no part returned")
-
-            shape = asyncio.run(part.get_wrapped(ctx))
-            # Errors first: when the factory failed - a missing module, a
-            # sandbox that would not install - that is the reason there is no
-            # shape, and it is the one worth reporting. "No shape returned" is
-            # what is left to say when nothing was recorded.
-            if part.errors:
-                raise RuntimeError(f"Failed to load the input part: {part.errors}")
-            if not shape:
-                raise RuntimeError("Failed to load the input part: no shape returned")
-
-            pc_logging.info(f"Loaded input part: {input_path}")
-            pc_logging.info(f"Shape: {type(shape)}")
-
-            part.render(ctx=ctx, format_name=output_type, project=project, filepath=output_filename)
-
-    except Exception as e:
-        raise RuntimeError(f"Failed to convert: {e}") from e
-    finally:
-        shutil.rmtree(temp_dir)
+    write_output_file(input_filename, input_type, output_filename, output_type, kind="part", verb="Convert")
 
 
 def convert_sketch_file(input_filename: str, input_type: str, output_filename: str, output_type: str) -> None:
@@ -113,33 +47,4 @@ def convert_sketch_file(input_filename: str, input_type: str, output_filename: s
         output_filename (str): Path to save the output file.
         output_type (str): Format of the output file (e.g., svg, dxf).
     """
-    input_path = Path(input_filename).resolve()
-    temp_dir = Path(tempfile.mkdtemp())
-
-    try:
-        generate_partcad_config(temp_dir, input_type, input_path, kind="sketch")
-
-        ctx = Context(root_path=temp_dir, search_root=False)
-        with pc_logging.Process("Convert", "adhoc-sketch"):
-            project = ctx.get_project("/")
-            sketch = project.get_sketch("input_sketch")
-            if not sketch:
-                raise RuntimeError("Failed to load the input sketch: no sketch returned")
-
-            shape = asyncio.run(sketch.get_wrapped(ctx))
-            # Errors first, for the same reason as in convert_cad_file().
-            if sketch.errors:
-                raise RuntimeError(f"Failed to load the input sketch: {sketch.errors}")
-            if not shape:
-                raise RuntimeError("Failed to load the input sketch: no shape returned")
-
-            pc_logging.debug(f"Loaded input sketch: {input_path}")
-
-            sketch.render(ctx=ctx, format_name=output_type, project=project, filepath=output_filename)
-
-    except Exception as e:
-        # The cause belongs in the message, not only in __cause__: this is what
-        # the CLI prints, and without it every sketch failure reads the same.
-        raise RuntimeError(f"Failed to convert sketch: {e}") from e
-    finally:
-        shutil.rmtree(temp_dir)
+    write_output_file(input_filename, input_type, output_filename, output_type, kind="sketch", verb="Convert")

--- a/src/partcad/adhoc/render.py
+++ b/src/partcad/adhoc/render.py
@@ -1,0 +1,75 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Rendering a CAD or sketch file that belongs to no package.
+
+The counterpart of `convert.py` for the other thing an output file can be. A
+conversion writes geometry another CAD tool goes on working with; a render
+writes a 2D projection to look at, and that is where a viewing angle means
+anything - so this is the one of the two that takes a viewport.
+
+The mechanism is the same throwaway package (`common.py`), which is why
+`pc adhoc render` can aim a projection the way `pc render` does even though
+there is no `partcad.yaml` to configure it in: the viewport arrives as an export
+parameter, on top of what the built-in implementation would otherwise default
+to.
+"""
+
+from .adhoc import reject_package_only, write_output_file
+
+# The 2D projections '//builtin/render' implements, which are the only ones an
+# ad-hoc render can write: a file type a package implements itself is declared
+# in that package, and here there is no package to declare it in.
+PART_RENDER_FORMATS = ["svg", "png", "jpeg", "dxf"]
+
+# The same, for a sketch. A sketch is already flat, so all four mean something
+# for one too - and 'dxf' more than for a part, since a drawing is what a sketch
+# is for.
+SKETCH_RENDER_FORMATS = ["svg", "png", "jpeg", "dxf"]
+
+_ADVICE = "Declare it in a package and use 'pc render' instead."
+
+
+def render_cad_file(input_filename: str, input_type: str, output_filename: str, output_type: str, **options) -> None:
+    """Render a CAD file to a 2D projection.
+
+    Args:
+        input_filename: Path to the input file.
+        input_type: Format of the input file.
+        output_filename: Path to save the projection.
+        output_type: The projection to write - one of PART_RENDER_FORMATS.
+        options: Render parameters, e.g. 'viewport_origin' and 'viewport_up'.
+    """
+    reject_package_only(input_type, verb="render", advice=_ADVICE)
+    write_output_file(
+        input_filename,
+        input_type,
+        output_filename,
+        output_type,
+        kind="part",
+        verb="Render",
+        **options,
+    )
+
+
+def render_sketch_file(input_filename: str, input_type: str, output_filename: str, output_type: str, **options) -> None:
+    """Render a sketch file to a 2D projection.
+
+    Args:
+        input_filename: Path to the input file.
+        input_type: Format of the input file (e.g. svg, dxf).
+        output_filename: Path to save the projection.
+        output_type: The projection to write - one of SKETCH_RENDER_FORMATS.
+        options: Render parameters, e.g. 'viewport_origin' and 'viewport_up'.
+    """
+    write_output_file(
+        input_filename,
+        input_type,
+        output_filename,
+        output_type,
+        kind="sketch",
+        verb="Render",
+        **options,
+    )

--- a/src/partcad/context.py
+++ b/src/partcad/context.py
@@ -1161,6 +1161,7 @@ class Context:
         options_package=None,
         ignore_manufacturability=False,
         overlay=None,
+        render_opts=None,
     ):
         if project_path is None:
             project_path = self.get_current_project_path()
@@ -1172,6 +1173,7 @@ class Context:
             options_package=options_package,
             ignore_manufacturability=ignore_manufacturability,
             overlay=overlay,
+            render_opts=render_opts,
         )
 
     def render(
@@ -1182,6 +1184,7 @@ class Context:
         options_package=None,
         ignore_manufacturability=False,
         overlay=None,
+        render_opts=None,
     ):
         if project_path is None:
             project_path = self.get_current_project_path()
@@ -1193,6 +1196,7 @@ class Context:
             options_package=options_package,
             ignore_manufacturability=ignore_manufacturability,
             overlay=overlay,
+            render_opts=render_opts,
         )
 
     # TODO(clairbee): convert it into: ctx.get_runtime("python", "conda", {"version": "3.11"})

--- a/src/partcad/project.py
+++ b/src/partcad/project.py
@@ -2003,6 +2003,7 @@ class Project(project_config.Configuration):
         ignore_manufacturability: bool = False,
         scenes: Optional[List] = None,
         overlay=None,
+        render_opts: Optional[dict] = None,
     ):
         with pc_logging.Action("RenderPkg", self.name):
             # A skipped package has nothing to render, and must not be asked to:
@@ -2058,6 +2059,15 @@ class Project(project_config.Configuration):
                                     output_dir=output_dir,
                                     options_package=options_package,
                                     overlay=overlay,
+                                    # One run's worth of export parameters (the
+                                    # viewport of 'pc render --view'), on top of
+                                    # everything the configuration resolved to.
+                                    # Handed to every file type: whether one
+                                    # means anything to a projection of a shape
+                                    # is the implementation's to decide, and a
+                                    # package may well implement one of its own
+                                    # that reads it.
+                                    **(render_opts or {}),
                                 )
                             )
 
@@ -2196,6 +2206,7 @@ class Project(project_config.Configuration):
         ignore_manufacturability: bool = False,
         scenes: Optional[list] = None,
         overlay=None,
+        render_opts: Optional[dict] = None,
     ):
         asyncio.run(
             self.render_async(
@@ -2209,6 +2220,7 @@ class Project(project_config.Configuration):
                 ignore_manufacturability,
                 scenes,
                 overlay,
+                render_opts,
             )
         )
 

--- a/src/partcad/render.py
+++ b/src/partcad/render.py
@@ -21,3 +21,115 @@ def render_cfg_merge(a: dict, b: dict, path=[]):
         else:
             a[key] = b[key]
     return a
+
+
+# The named viewing directions of a 2D projection, and what each one is in the
+# terms 'partcad.yaml' already uses: 'viewport_origin' is the point the shape is
+# looked at from, 'viewport_up' is which way is up in the resulting picture.
+#
+# A name is nothing but shorthand for that pair, so that
+#
+#     pc render -t png --view front
+#
+# and
+#
+#     render:
+#       png:
+#         viewport_origin: [0, -100, 0]
+#         viewport_up: [0, 0, 1]
+#
+# ask for the same picture. Keeping the CLI a naming of the configuration, and
+# not a second way to say the same thing, is what lets a package pin the view it
+# publishes and a caller override it for one run.
+#
+# PartCAD is Z-up, with +Y pointing away from whoever is looking at the front of
+# a shape - which is what puts the front camera on -Y and leaves +X to the right
+# of the front view. The distance is arbitrary (a viewport origin says which
+# direction to look from, and the projection is scaled to fit whatever it is
+# written into); it is spelled as 100 to match the wrapper's own defaults.
+VIEWS = {
+    "front": ((0, -100, 0), (0, 0, 1)),
+    "back": ((0, 100, 0), (0, 0, 1)),
+    "left": ((-100, 0, 0), (0, 0, 1)),
+    "right": ((100, 0, 0), (0, 0, 1)),
+    "top": ((0, 0, 100), (0, 1, 0)),
+    # Up is -Y so that +X stays on the right, the way a bottom view is drawn:
+    # the top view flipped about the horizontal axis rather than mirrored.
+    "bottom": ((0, 0, -100), (0, -1, 0)),
+    # Where a part is looked at from when nothing says otherwise - the
+    # front-right-top corner. See 'builtin/render/render_svg.py', which is where
+    # that default lives; naming it here is what makes it selectable again after
+    # a package has configured something else.
+    "iso": ((100, -100, 100), (0, 0, 1)),
+}
+
+VIEW_NAMES = tuple(VIEWS)
+
+
+def _viewport_vector(name: str, value):
+    """One viewport vector, as three floats, or a ValueError explaining why not."""
+    # A string is iterable and three characters long often enough to matter:
+    # '123' would otherwise come through as [1.0, 2.0, 3.0] and aim the camera
+    # somewhere nobody asked for. The CLI parses 'X,Y,Z' into a list before it
+    # gets here; anything still a string at this point is a client that did not.
+    if isinstance(value, (str, bytes)):
+        raise ValueError("%s must be three numbers (X, Y, Z), not a string: %r" % (name, value))
+    try:
+        vector = [float(component) for component in value]
+    except (TypeError, ValueError):
+        raise ValueError("%s must be three numbers, got: %r" % (name, value)) from None
+    if len(vector) != 3:
+        raise ValueError("%s must be three numbers (X, Y, Z), got %d: %r" % (name, len(vector), value))
+    if not any(vector):
+        raise ValueError("%s must not be the zero vector: it names a direction" % name)
+    return vector
+
+
+def resolve_viewport(view=None, viewport_origin=None, viewport_up=None) -> dict:
+    """The viewport overrides one render request asks for, as export parameters.
+
+    'view' names a direction from 'VIEWS'; the two vectors say it outright, and
+    each of them replaces the one the name resolved to - so '--view top' can be
+    tilted by giving an up vector alone, without spelling the pair out again. What comes back is merged into the
+    request the implementation is handed, on top of the configuration - so an
+    empty dict, which is what no arguments produce, changes nothing.
+
+    Raises:
+        ValueError: an unknown view name, or a vector that is not three numbers.
+    """
+    overrides = {}
+    if view is not None:
+        # Checked before the lookup: an unhashable value would raise TypeError
+        # there, and only ValueError is turned into a usage error by the
+        # callers. The CLI constrains this to a choice, but it is not the only
+        # client - the editor extensions speak the protocol directly.
+        if not isinstance(view, str) or view not in VIEWS:
+            raise ValueError("Unknown view %r. Known views: %s" % (view, ", ".join(VIEW_NAMES)))
+        origin, up = VIEWS[view]
+        overrides["viewport_origin"] = list(origin)
+        overrides["viewport_up"] = list(up)
+    if viewport_origin is not None:
+        overrides["viewport_origin"] = _viewport_vector("viewport_origin", viewport_origin)
+    if viewport_up is not None:
+        overrides["viewport_up"] = _viewport_vector("viewport_up", viewport_up)
+
+    # An up vector along the line of sight names no orientation: there is no
+    # rotation of the camera that puts it at the top of the picture. Both
+    # vectors pass their own checks, so this is only visible once they are read
+    # together - which is here, and only when this request settles both of them.
+    # When one comes from the configuration instead, the pair is the
+    # implementation's to reconcile and there is nothing to compare yet.
+    if "viewport_origin" in overrides and "viewport_up" in overrides:
+        origin = overrides["viewport_origin"]
+        up = overrides["viewport_up"]
+        cross = (
+            origin[1] * up[2] - origin[2] * up[1],
+            origin[2] * up[0] - origin[0] * up[2],
+            origin[0] * up[1] - origin[1] * up[0],
+        )
+        if not any(cross):
+            raise ValueError(
+                "viewport_up %r is parallel to the direction the camera looks from (%r): "
+                "it does not say which way is up in the picture" % (up, origin)
+            )
+    return overrides

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -67,12 +67,22 @@ SKETCH_EXTENSION_MAPPING = {
     "build123d": "py",
 }
 
-# File extensions for the render formats whose name is not their extension.
-# Deliberately kept apart from the two mappings above: those also enumerate the
-# part types 'Shape.convert()' accepts, and a rasterized projection is not one
-# of them (it cannot be read back in as a part).
+# The 2D projections '//builtin/render' implements, and the file extension each
+# one writes. Deliberately kept apart from the two mappings above: those also
+# enumerate the part types 'Shape.convert()' accepts, and a projection is not one
+# of them (it cannot be read back in as a part or a sketch).
+#
+# Only 'jpeg' has an extension that differs from its name, which is what this is
+# consulted first for. The other three are listed anyway so that this is the set
+# of built-in projections and not a list of exceptions - 'pc adhoc render' reads
+# it in reverse, to tell from an output file name which projection was asked for.
+# A file type a package implements itself is not here, and is not inferable: it
+# is declared in that package, and an ad-hoc render has no package.
 RENDER_EXTENSION_MAPPING = {
+    "svg": "svg",
+    "png": "png",
     "jpeg": "jpg",
+    "dxf": "dxf",
 }
 
 # The part types 'Shape.convert()' can hand back as a live in-memory CAD object

--- a/src/partcad_cli/click/commands/adhoc/render/__init__.py
+++ b/src/partcad_cli/click/commands/adhoc/render/__init__.py
@@ -1,0 +1,23 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import os
+import rich_click as click
+
+from partcad_cli.click.loader import Loader
+
+
+class RenderCommands(Loader):
+    COMMANDS_FOLDER_PATH = os.path.join(Loader.COMMANDS_FOLDER_PATH, "adhoc/render")
+    COMMANDS_PACKAGE_NAME = Loader.COMMANDS_PACKAGE_NAME + ".adhoc.render"
+
+
+@click.command(
+    cls=RenderCommands,
+    help="Ad-hoc render parts or sketches to a 2D image without adding them to a package.",
+)
+def cli() -> None:
+    pass

--- a/src/partcad_cli/click/commands/adhoc/render/part.py
+++ b/src/partcad_cli/click/commands/adhoc/render/part.py
@@ -1,0 +1,73 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import os
+
+import rich_click as click
+
+from ....service import run
+from ....viewport import viewport_options, viewport_params
+
+# The part types a projection can be made of - the same list 'adhoc/convert/part.py'
+# reads, and inlined for the same reason (the thin CLI must not import the heavy
+# partcad package). Every one of them is an *input* here: unlike a conversion,
+# what comes out is not a part type at all.
+PART_TYPES = [
+    "step",
+    "brep",
+    "stl",
+    "3mf",
+    "threejs",
+    "obj",
+    "iges",
+    "gltf",
+    "cadquery",
+    "build123d",
+    "chili3d",
+    "sdf",
+    "scad",
+]
+
+# The 2D projections '//builtin/render' implements (partcad.shape's
+# RENDER_EXTENSION_MAPPING, and partcad.adhoc.render's PART_RENDER_FORMATS).
+# A file type a package implements itself is not offered: it is declared in that
+# package, and an ad-hoc render has no package.
+RENDER_TYPES = ["svg", "png", "jpeg", "dxf"]
+
+
+@click.command(help="Render a CAD file to a 2D image (ad-hoc mode).")
+@click.option(
+    "--input",
+    "input_type",
+    type=click.Choice(PART_TYPES),
+    help="Input file type. Inferred from filename if not provided.",
+)
+@click.option(
+    "--output",
+    "output_type",
+    type=click.Choice(RENDER_TYPES),
+    help="The projection to write. Inferred from the output filename if not provided.",
+)
+@viewport_options
+@click.argument("input_filename", type=click.Path(exists=True))
+@click.argument("output_filename", type=click.Path(), required=False)
+@click.pass_obj
+def cli(cli_ctx, input_type, output_type, view, viewport_origin, viewport_up, input_filename, output_filename):
+    """Render a CAD file to a 2D image without modifying project configuration."""
+    run(
+        cli_ctx,
+        "adhoc.render",
+        {
+            "kind": "part",
+            "input_type": input_type,
+            "output_type": output_type,
+            # Absolute so the daemon reads/writes in the user's cwd.
+            "input_filename": os.path.abspath(input_filename),
+            "output_filename": os.path.abspath(output_filename) if output_filename else None,
+            **viewport_params(view, viewport_origin, viewport_up),
+        },
+        needs_context=False,
+    )

--- a/src/partcad_cli/click/commands/adhoc/render/sketch.py
+++ b/src/partcad_cli/click/commands/adhoc/render/sketch.py
@@ -1,0 +1,57 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+import os
+
+import rich_click as click
+
+from ....service import run
+from ....viewport import viewport_options, viewport_params
+
+# PartCAD sketch types (partcad.shape.SKETCH_EXTENSION_MAPPING keys), inlined so
+# the thin CLI does not import the heavy partcad package.
+SKETCH_TYPES = ["svg", "dxf", "cadquery", "build123d"]
+
+# The projections that can be written of one. 'svg' and 'dxf' appear on both
+# sides and mean different things there: as an input they are the sketch itself,
+# as an output a drawing of it - which is why 'pc adhoc render sketch a.svg b.svg'
+# is a projection and not a copy.
+RENDER_TYPES = ["svg", "png", "jpeg", "dxf"]
+
+
+@click.command(help="Render a sketch file to a 2D image (ad-hoc mode).")
+@click.option(
+    "--input",
+    "input_type",
+    type=click.Choice(SKETCH_TYPES),
+    help="Input sketch type. Inferred from filename if not provided.",
+)
+@click.option(
+    "--output",
+    "output_type",
+    type=click.Choice(RENDER_TYPES),
+    help="The projection to write. Inferred from the output filename if not provided.",
+)
+@viewport_options
+@click.argument("input_filename", type=click.Path(exists=True))
+@click.argument("output_filename", type=click.Path(), required=False)
+@click.pass_obj
+def cli(cli_ctx, input_type, output_type, view, viewport_origin, viewport_up, input_filename, output_filename):
+    """Render a sketch file to a 2D image without modifying project configuration."""
+    run(
+        cli_ctx,
+        "adhoc.render",
+        {
+            "kind": "sketch",
+            "input_type": input_type,
+            "output_type": output_type,
+            # Absolute so the daemon reads/writes in the user's cwd.
+            "input_filename": os.path.abspath(input_filename),
+            "output_filename": os.path.abspath(output_filename) if output_filename else None,
+            **viewport_params(view, viewport_origin, viewport_up),
+        },
+        needs_context=False,
+    )

--- a/src/partcad_cli/click/commands/render.py
+++ b/src/partcad_cli/click/commands/render.py
@@ -13,6 +13,7 @@ import os
 import rich_click as click
 
 from ..service import run
+from ..viewport import viewport_options, viewport_params
 
 
 # TODO-105: @alexanderilyin: Replace --scene, --interface, --assembly, --sketch with a single option --type
@@ -44,6 +45,7 @@ from ..service import run
     is_flag=True,
     show_envvar=True,
 )
+@viewport_options
 @click.option(
     "-P",
     "--package",
@@ -121,6 +123,9 @@ def cli(
     output_dir,
     format,
     ignore_manufacturability,
+    view,
+    viewport_origin,
+    viewport_up,
     package,
     options_package,
     recursive,
@@ -143,6 +148,7 @@ def cli(
             "output_dir": os.path.abspath(output_dir) if output_dir else None,
             "format": format,
             "ignore_manufacturability": ignore_manufacturability,
+            **viewport_params(view, viewport_origin, viewport_up),
             "package": package,
             "options_package": options_package,
             "recursive": recursive,

--- a/src/partcad_cli/click/viewport.py
+++ b/src/partcad_cli/click/viewport.py
@@ -1,0 +1,94 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The viewing angle options, shared by every command that writes a projection.
+
+`pc render` and `pc adhoc render` offer the same three, and have to: a viewport
+is a property of the projection, not of where the shape came from, and a user
+who has learned `--view top` in one should not find it spelled differently in
+the other.
+
+Only the *names* of the views live here, for `--help` and for rejecting a typo
+without a round trip to the daemon - the same reason `adhoc/convert/part.py`
+inlines its type lists. What each name means is `partcad.render.VIEWS`, which is
+what resolves them, on the daemon side where the heavy package already is.
+"""
+
+import rich_click as click
+
+VIEW_NAMES = ["front", "back", "left", "right", "top", "bottom", "iso"]
+
+
+def viewport_vector(ctx, param, value):
+    """Parse 'X,Y,Z' into three floats, the way a viewport vector is written.
+
+    Rejected here rather than on the daemon so that a typo costs a message and
+    not a round trip. The daemon checks the same things anyway: it also serves
+    the editor extensions, which do not come through this parser.
+    """
+    if value is None:
+        return None
+
+    def refuse(reason):
+        return click.BadParameter("%s: %s" % (reason, value), ctx=ctx, param=param)
+
+    try:
+        vector = [float(component) for component in value.replace(",", " ").split()]
+    except ValueError:
+        raise refuse("expected three numbers as 'X,Y,Z'") from None
+    if len(vector) != 3:
+        raise refuse("expected three numbers as 'X,Y,Z', got %d" % len(vector)) from None
+    if not any(vector):
+        raise refuse("must not be the zero vector, it names a direction") from None
+    return vector
+
+
+_OPTIONS = (
+    click.option(
+        "--view",
+        help=(
+            "Look at the object from a named direction for this run: "
+            "front, back, left, right, top, bottom or iso. "
+            "Shorthand for the '--viewport-origin'/'--viewport-up' pair below, and so for the "
+            "'viewport_origin'/'viewport_up' of a render file type in 'partcad.yaml'"
+        ),
+        type=click.Choice(VIEW_NAMES),
+        show_envvar=True,
+    ),
+    click.option(
+        "--viewport-origin",
+        help="Where the object is looked at from, as 'X,Y,Z'. Overrides '--view' and the configuration",
+        type=str,
+        callback=viewport_vector,
+        show_envvar=True,
+    ),
+    click.option(
+        "--viewport-up",
+        help="Which way is up in the projection, as 'X,Y,Z'. Overrides '--view' and the configuration",
+        type=str,
+        callback=viewport_vector,
+        show_envvar=True,
+    ),
+)
+
+
+def viewport_options(command):
+    """Add '--view', '--viewport-origin' and '--viewport-up' to a command.
+
+    Applied in reverse because click reverses the parameters it collected, which
+    is what makes them read in this order in '--help'.
+    """
+    for option in reversed(_OPTIONS):
+        command = option(command)
+    return command
+
+
+def viewport_params(view, viewport_origin, viewport_up):
+    """The three as JSON-RPC params, so every caller sends the same names."""
+    return {
+        "view": view,
+        "viewport_origin": viewport_origin,
+        "viewport_up": viewport_up,
+    }

--- a/src/partcad_service_json_rpc/core/operations.py
+++ b/src/partcad_service_json_rpc/core/operations.py
@@ -743,6 +743,100 @@ def adhoc_convert(session, params):
     return None
 
 
+def adhoc_render(session, params):
+    """Render a CAD or sketch file to a 2D projection, ad-hoc (no package/context).
+
+    The sibling of ``adhoc_convert`` for the other thing an output file can be,
+    and the same pure file operation: paths arrive absolute from the CLI, and a
+    type the caller left unsaid is inferred from the file name. The input type
+    comes from the part/sketch mappings as it does for a conversion; the *output*
+    type comes from the projections instead, which is the whole difference.
+
+    ``view``, ``viewport_origin`` and ``viewport_up`` aim the projection, exactly
+    as they do for ``render.objects`` -- with no ``partcad.yaml`` to configure a
+    viewport in, this is the only way to ask for one.
+    """
+    from pathlib import Path
+
+    from partcad.shape import RENDER_EXTENSION_MAPPING
+
+    pc = session.ensure_partcad()
+    kind = params.get("kind", "part")
+    if kind == "part":
+        from partcad.adhoc.render import render_cad_file as render_fn
+        from partcad.shape import PART_EXTENSION_MAPPING as input_mapping
+    elif kind == "sketch":
+        from partcad.adhoc.render import render_sketch_file as render_fn
+        from partcad.shape import SKETCH_EXTENSION_MAPPING as input_mapping
+    else:
+        # Named rather than fallen through to the sketch renderer: an assembly
+        # or a scene is exactly what cannot be rendered without the package
+        # that names its contents, so answering with a sketch of it would be
+        # answering a different question. The CLI offers the two subcommands
+        # and nothing else; a client speaking the protocol directly can ask.
+        raise JsonRpcError(USAGE_ERROR, "Cannot render '%s' ad-hoc. Supported kinds: part, sketch" % kind)
+
+    input_path = Path(params["input_filename"])
+    output_filename = params.get("output_filename")
+    output_path = Path(output_filename) if output_filename else None
+
+    input_ext_to_type = {".%s" % v: k for k, v in input_mapping.items()}
+    # '.jpeg' alongside the '.jpg' the mapping declares: the mapping says what
+    # extension a projection is *written* with and so holds one per format, but
+    # a file already named '.jpeg' is just as clearly a JPEG.
+    output_ext_to_type = {".%s" % v: k for k, v in RENDER_EXTENSION_MAPPING.items()}
+    output_ext_to_type[".jpeg"] = "jpeg"
+
+    input_type = params.get("input_type") or input_ext_to_type.get(input_path.suffix.lower())
+    output_type = params.get("output_type") or (
+        output_ext_to_type.get(output_path.suffix.lower()) if output_path else None
+    )
+
+    noun = "sketch type" if kind == "sketch" else "type"
+    if not input_type:
+        pc.logging.error("Cannot infer input %s. Please specify --input explicitly." % noun)
+        return None
+    if not output_type:
+        pc.logging.error("Cannot infer the projection to render. Please specify --output explicitly.")
+        return None
+    if output_type not in RENDER_EXTENSION_MAPPING:
+        # Checked before the extension lookup below, which would otherwise
+        # raise KeyError for a type nobody projects to and turn a bad request
+        # into an internal error.
+        raise JsonRpcError(
+            USAGE_ERROR,
+            "Cannot render to '%s'. Supported projections: %s"
+            % (output_type, ", ".join(sorted(RENDER_EXTENSION_MAPPING))),
+        )
+    if output_path is None:
+        output_path = input_path.with_suffix(".%s" % RENDER_EXTENSION_MAPPING[output_type])
+
+    from partcad.render import resolve_viewport
+
+    try:
+        render_opts = resolve_viewport(
+            params.get("view"),
+            params.get("viewport_origin"),
+            params.get("viewport_up"),
+        )
+    except ValueError as e:
+        raise JsonRpcError(USAGE_ERROR, str(e)) from e
+
+    try:
+        pc.logging.info("Rendering %s (%s) to %s (%s)..." % (input_path, input_type, output_path, output_type))
+        render_fn(str(input_path), input_type, str(output_path), output_type, **render_opts)
+        pc.logging.info("Render complete: %s" % output_path)
+    except ValueError as e:
+        # A format that only means anything inside a package ('.urdf', '.assy')
+        # is inferable from the filename, so it reaches here even though the
+        # CLI's choices exclude it. Nothing was attempted and nothing could have
+        # been: a usage error, not a failed render.
+        raise JsonRpcError(USAGE_ERROR, str(e))
+    except Exception as e:  # pylint: disable=broad-except
+        pc.logging.error("Failed to render: %s" % e)
+    return None
+
+
 async def _test_async(ctx, pc, packages, filter_prefix, sketch, interface, assembly, scene, object_name):
     import asyncio
 
@@ -2074,6 +2168,11 @@ def render_objects(session, params):
     names a further package whose ``export:``/``render:`` sections are read on
     top of the built-in ones, which is how a custom implementation declared in
     one package is used against the objects of another.
+
+    ``view``, ``viewport_origin`` and ``viewport_up`` re-aim the projection for
+    this one run. They resolve to the very parameters a ``render:`` file type
+    configures, so the override lands on top of the configuration rather than
+    beside it, and a file type that does not project never reads them.
     """
     ctx = _ctx(session, params)
     if ctx is None:
@@ -2095,6 +2194,20 @@ def render_objects(session, params):
         options_package = ctx.resolve_package_path(options_package)
         if ctx.get_project(options_package) is None:
             raise JsonRpcError(USAGE_ERROR, "Options package %s is not found" % options_package)
+
+    from partcad.render import resolve_viewport
+
+    try:
+        render_opts = resolve_viewport(
+            params.get("view"),
+            params.get("viewport_origin"),
+            params.get("viewport_up"),
+        )
+    except ValueError as e:
+        # A view nobody offers, or a vector that is not one: the request cannot
+        # be made sense of, so nothing is rendered rather than something aimed
+        # somewhere else.
+        raise JsonRpcError(USAGE_ERROR, str(e)) from e
 
     from partcad.exception import AssemblyDocumentError
     from partcad.render_overlay import Overlay
@@ -2122,6 +2235,7 @@ def render_objects(session, params):
                 options_package,
                 ignore_manufacturability,
                 overlay,
+                render_opts,
             )
         except AssemblyDocumentError as e:
             # Asking for an assembly instruction book of something that has no
@@ -2142,6 +2256,7 @@ def _render_objects(
     options_package,
     ignore_manufacturability,
     overlay=None,
+    render_opts=None,
 ):
     """The body of 'render_objects', once the request has been made sense of."""
     import asyncio
@@ -2172,6 +2287,7 @@ def _render_objects(
             options_package,
             ignore_manufacturability,
             overlay,
+            render_opts,
         )
     )
 
@@ -2187,6 +2303,7 @@ async def _render_packages_async(
     options_package,
     ignore_manufacturability,
     overlay=None,
+    render_opts=None,
 ):
     """Render the given packages, several at a time.
 
@@ -2233,6 +2350,7 @@ async def _render_packages_async(
                     options_package=options_package,
                     ignore_manufacturability=ignore_manufacturability,
                     overlay=overlay,
+                    render_opts=render_opts,
                 )
             else:
                 sketches, interfaces, parts, assemblies, scenes = [], [], [], [], []
@@ -2258,6 +2376,7 @@ async def _render_packages_async(
                     options_package=options_package,
                     ignore_manufacturability=ignore_manufacturability,
                     overlay=overlay,
+                    render_opts=render_opts,
                 )
 
     results = await asyncio.gather(*[render_package(package) for package in packages], return_exceptions=True)

--- a/src/partcad_service_json_rpc/rpc/methods.py
+++ b/src/partcad_service_json_rpc/rpc/methods.py
@@ -49,6 +49,7 @@ _OPERATIONS = {
     "render.objects": operations.render_objects,
     "convert.object": operations.convert_object,
     "adhoc.convert": operations.adhoc_convert,
+    "adhoc.render": operations.adhoc_render,
     "test.run": operations.test_run,
     "lint.run": operations.lint_run,
     "daemon.reset": operations.daemon_reset,

--- a/tests/partcad/unit/test_adhoc_convert_error_order.py
+++ b/tests/partcad/unit/test_adhoc_convert_error_order.py
@@ -5,7 +5,7 @@
 #
 
 """
-Which failure `pc adhoc convert` reports when a factory fails.
+Which failure an ad-hoc command reports when a factory fails.
 
 A factory that fails records the reason in `errors` and returns no shape, so
 both conditions are true at once and only the order of the checks decides what
@@ -14,11 +14,17 @@ the user is told. These tests pin that order: the recorded reason wins, and
 
 They stub the context rather than converting a real file, so they need no CAD
 runtime and no sandbox -- the ordering is the whole subject.
+
+Both verbs are covered. `pc adhoc convert` and `pc adhoc render` build the same
+throwaway package (`partcad.adhoc.adhoc`), so a shape that will not load fails
+identically for either, and what differs is only the verb in the message.
 """
 
 import pytest
 
+from partcad.adhoc import adhoc as adhoc_base
 from partcad.adhoc import convert as adhoc_convert
+from partcad.adhoc import render as adhoc_render
 
 
 class _FakeShape:
@@ -59,28 +65,32 @@ class _FakeContext:
 
 @pytest.fixture
 def stub_context(monkeypatch):
-    """Point `convert.Context` at a fake built from the object under test."""
+    """Point the throwaway package's `Context` at a fake built from the object."""
 
     def install(obj):
-        monkeypatch.setattr(adhoc_convert, "Context", lambda *a, **kw: _FakeContext(obj))
+        monkeypatch.setattr(adhoc_base, "Context", lambda *a, **kw: _FakeContext(obj))
         return obj
 
     return install
 
 
-@pytest.mark.parametrize(
-    "convert, kind",
-    [
-        (adhoc_convert.convert_cad_file, "part"),
-        (adhoc_convert.convert_sketch_file, "sketch"),
-    ],
-)
-def test_a_recorded_error_is_reported_instead_of_the_missing_shape(stub_context, tmp_path, convert, kind):
+# Every ad-hoc entry point, with an output type that makes sense for it: a
+# conversion writes another part or sketch, a render writes a projection.
+ENTRY_POINTS = [
+    pytest.param(adhoc_convert.convert_cad_file, "stl", id="convert-part"),
+    pytest.param(adhoc_convert.convert_sketch_file, "dxf", id="convert-sketch"),
+    pytest.param(adhoc_render.render_cad_file, "png", id="render-part"),
+    pytest.param(adhoc_render.render_sketch_file, "png", id="render-sketch"),
+]
+
+
+@pytest.mark.parametrize("entry_point, output_type", ENTRY_POINTS)
+def test_a_recorded_error_is_reported_instead_of_the_missing_shape(stub_context, tmp_path, entry_point, output_type):
     """A failed factory records why; that reason is what reaches the user."""
     obj = stub_context(_FakeObject(errors=["sandbox install failed: no cadquery wheel"], shape=None))
 
     with pytest.raises(RuntimeError) as excinfo:
-        convert(str(tmp_path / "in.step"), "step", str(tmp_path / "out.stl"), "stl")
+        entry_point(str(tmp_path / "in.step"), "step", str(tmp_path / "out"), output_type)
 
     message = str(excinfo.value)
     assert "sandbox install failed: no cadquery wheel" in message
@@ -88,32 +98,40 @@ def test_a_recorded_error_is_reported_instead_of_the_missing_shape(stub_context,
     assert not obj.rendered
 
 
-@pytest.mark.parametrize(
-    "convert, kind",
-    [
-        (adhoc_convert.convert_cad_file, "part"),
-        (adhoc_convert.convert_sketch_file, "sketch"),
-    ],
-)
-def test_no_shape_and_no_recorded_error_still_says_no_shape(stub_context, tmp_path, convert, kind):
+@pytest.mark.parametrize("entry_point, output_type", ENTRY_POINTS)
+def test_no_shape_and_no_recorded_error_still_says_no_shape(stub_context, tmp_path, entry_point, output_type):
     """With nothing recorded, the fallback message is all there is to say."""
     obj = stub_context(_FakeObject(errors=[], shape=None))
 
     with pytest.raises(RuntimeError) as excinfo:
-        convert(str(tmp_path / "in.step"), "step", str(tmp_path / "out.stl"), "stl")
+        entry_point(str(tmp_path / "in.step"), "step", str(tmp_path / "out"), output_type)
 
     assert "no shape returned" in str(excinfo.value)
     assert not obj.rendered
 
 
-@pytest.mark.parametrize(
-    "convert",
-    [adhoc_convert.convert_cad_file, adhoc_convert.convert_sketch_file],
-)
-def test_a_shape_with_no_errors_is_rendered(stub_context, tmp_path, convert):
-    """The success path is unchanged: no errors and a shape means render."""
+@pytest.mark.parametrize("entry_point, output_type", ENTRY_POINTS)
+def test_a_shape_with_no_errors_is_rendered(stub_context, tmp_path, entry_point, output_type):
+    """The success path is unchanged: no errors and a shape means write the file."""
     obj = stub_context(_FakeObject(errors=[], shape=_FakeShape()))
 
-    convert(str(tmp_path / "in.step"), "step", str(tmp_path / "out.stl"), "stl")
+    entry_point(str(tmp_path / "in.step"), "step", str(tmp_path / "out"), output_type)
 
     assert obj.rendered
+
+
+@pytest.mark.parametrize(
+    "entry_point, expected",
+    [
+        (adhoc_convert.convert_cad_file, "Failed to convert:"),
+        (adhoc_convert.convert_sketch_file, "Failed to convert sketch:"),
+        (adhoc_render.render_cad_file, "Failed to render:"),
+        (adhoc_render.render_sketch_file, "Failed to render sketch:"),
+    ],
+)
+def test_the_message_names_what_was_being_done(stub_context, tmp_path, entry_point, expected):
+    """The CLI prints this line, so it has to say which command failed."""
+    stub_context(_FakeObject(errors=["nope"], shape=None))
+
+    with pytest.raises(RuntimeError, match=expected):
+        entry_point(str(tmp_path / "in.step"), "step", str(tmp_path / "out"), "stl")

--- a/tests/partcad/unit/test_adhoc_render.py
+++ b/tests/partcad/unit/test_adhoc_render.py
@@ -1,0 +1,104 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Unit tests for 'pc adhoc render' -- rendering a file that belongs to no package.
+
+The rendering itself is the same machinery 'pc render' drives and is covered
+there; what is new here is the ad-hoc half. Two things have to hold for it to
+mean anything:
+
+- the projections it offers are the ones PartCAD actually implements, since with
+  no package there is nothing to declare a file type of one's own in, and
+- the formats that only mean something inside a package are refused, pointing at
+  the command that does have one.
+
+None of it needs a sandbox.
+"""
+
+import pytest
+
+import partcad as pc
+from partcad import output
+from partcad.adhoc import render as adhoc_render
+from partcad.shape import PART_EXTENSION_MAPPING, RENDER_EXTENSION_MAPPING, SERIALIZED_PART_TYPES
+
+# What the thin CLI offers. Inlined there so it does not import the heavy
+# partcad package; imported here so the copy cannot drift.
+from partcad_cli.click.commands.adhoc.render.part import PART_TYPES as CLI_PART_INPUT_TYPES
+from partcad_cli.click.commands.adhoc.render.part import RENDER_TYPES as CLI_PART_RENDER_TYPES
+from partcad_cli.click.commands.adhoc.render.sketch import RENDER_TYPES as CLI_SKETCH_RENDER_TYPES
+
+# --------------------------------------------------------------------------- #
+# What can be written                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_the_cli_offers_exactly_the_projections_that_can_be_rendered():
+    assert sorted(CLI_PART_RENDER_TYPES) == sorted(adhoc_render.PART_RENDER_FORMATS)
+    assert sorted(CLI_SKETCH_RENDER_TYPES) == sorted(adhoc_render.SKETCH_RENDER_FORMATS)
+
+
+def test_the_projections_are_the_ones_with_a_known_extension():
+    """The output type is inferred from the file name, so the two have to agree.
+
+    'RENDER_EXTENSION_MAPPING' is what 'adhoc_render' reads in reverse to tell
+    from 'out.png' which projection was asked for. A format offered but missing
+    from it could be asked for by name and never inferred; one in the mapping but
+    not offered would be inferred and then refused.
+    """
+    assert sorted(adhoc_render.PART_RENDER_FORMATS) == sorted(RENDER_EXTENSION_MAPPING)
+
+
+def test_the_extensions_are_what_the_builtin_package_declares():
+    """'//builtin/render' is what actually writes the files, so it decides.
+
+    A drift here is a file written with one extension and looked for under
+    another.
+    """
+    ctx = pc.init("examples")
+    declared = output.builtin_formats(ctx, output.RENDER)
+    for format_name, extension in RENDER_EXTENSION_MAPPING.items():
+        assert declared[format_name]["extension"] == extension, format_name
+
+
+def test_a_projection_is_still_not_a_part_type():
+    """Widening the render mapping must not make 'convert()' offer a picture.
+
+    A projection cannot be read back in as a part, which is why the render
+    formats are a mapping of their own rather than an entry in the part types.
+    """
+    for format_name in ("png", "jpeg"):
+        assert format_name not in PART_EXTENSION_MAPPING
+        assert format_name not in SERIALIZED_PART_TYPES
+
+
+# --------------------------------------------------------------------------- #
+# What cannot be rendered ad-hoc                                              #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("input_type", ["urdf", "assy"])
+def test_an_assembly_format_is_refused_and_points_at_the_package_command(tmp_path, input_type):
+    """Neither means anything without the package its contents are named in."""
+    source = tmp_path / ("robot.%s" % input_type)
+    source.write_text("<robot name='r'><link name='a'/></robot>")
+
+    with pytest.raises(ValueError) as excinfo:
+        adhoc_render.render_cad_file(str(source), input_type, str(tmp_path / "out.png"), "png")
+
+    message = str(excinfo.value)
+    assert "only means anything inside a package" in message
+    # The advice is the render one, not the conversion one: the user asked for a
+    # picture, so 'pc convert assembly' is not what they want next.
+    assert "pc render" in message
+    assert "Cannot render from" in message
+
+
+def test_the_cli_accepts_every_part_type_as_input():
+    """A projection can be made of anything PartCAD can read, including the
+    scripted types it cannot write back out -- 'sdf', 'scad' and 'chili3d' are
+    input-only for a conversion but perfectly renderable."""
+    for input_only in ("sdf", "scad", "chili3d"):
+        assert input_only in CLI_PART_INPUT_TYPES

--- a/tests/partcad/unit/test_render_views.py
+++ b/tests/partcad/unit/test_render_views.py
@@ -1,0 +1,219 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Unit tests for the viewing angle of a 2D projection.
+
+'pc render --view' is meant to be a naming of what 'partcad.yaml' already says,
+not a second way of saying it: what a name resolves to has to be the very
+'viewport_origin'/'viewport_up' pair a 'render:' file type is configured with,
+and it has to reach the implementation on top of that configuration rather than
+beside it. Both halves are checked here without a sandbox.
+"""
+
+import asyncio
+
+import pytest
+
+import partcad as pc
+from partcad.render import VIEWS, VIEW_NAMES, resolve_viewport
+from partcad.shape import Shape
+
+# The names the thin CLI inlines for '--help' and for rejecting a typo without a
+# round trip. Duplicated there on purpose (it must not import the heavy partcad
+# package), and shared by every command that writes a projection - 'pc render'
+# and 'pc adhoc render' - so there is one copy, not one per command. This is what
+# keeps it honest.
+from partcad_cli.click.viewport import VIEW_NAMES as CLI_VIEW_NAMES
+
+# --------------------------------------------------------------------------- #
+# The named views                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_every_view_is_a_pair_of_direction_vectors():
+    for name, (origin, up) in VIEWS.items():
+        assert len(origin) == 3, name
+        assert len(up) == 3, name
+        # A viewport origin says which direction to look from and an up vector
+        # which way is up; neither means anything as the zero vector.
+        assert any(origin), name
+        assert any(up), name
+
+
+def test_up_is_not_parallel_to_the_direction_looked_from():
+    """A view whose up vector lies along the line of sight has no picture in it."""
+    for name, (origin, up) in VIEWS.items():
+        cross = (
+            origin[1] * up[2] - origin[2] * up[1],
+            origin[2] * up[0] - origin[0] * up[2],
+            origin[0] * up[1] - origin[1] * up[0],
+        )
+        assert any(cross), name
+
+
+def test_iso_is_the_default_a_part_is_drawn_from():
+    """'--view iso' names the corner the SVG wrapper looks from on its own.
+
+    That default lives in the wrapper (it is picked from the kind of shape being
+    drawn, which only the wrapper knows). Naming it here is what makes it
+    selectable again once a package has configured something else, so the two
+    have to agree.
+    """
+    assert VIEWS["iso"] == ((100, -100, 100), (0, 0, 1))
+
+
+def test_the_cli_offers_exactly_the_views_that_resolve():
+    assert sorted(CLI_VIEW_NAMES) == sorted(VIEW_NAMES)
+
+
+# --------------------------------------------------------------------------- #
+# Resolution                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_no_arguments_override_nothing():
+    """What a plain 'pc render' sends: the configuration is left alone."""
+    assert resolve_viewport() == {}
+
+
+def test_a_name_resolves_to_the_configuration_keys():
+    assert resolve_viewport("front") == {
+        "viewport_origin": [0, -100, 0],
+        "viewport_up": [0, 0, 1],
+    }
+
+
+@pytest.mark.parametrize("view", VIEW_NAMES)
+def test_every_name_resolves(view):
+    overrides = resolve_viewport(view)
+    assert set(overrides) == {"viewport_origin", "viewport_up"}
+
+
+def test_vectors_win_over_the_name_component_by_component():
+    """'--view top' can be tilted without spelling the whole pair out again."""
+    overrides = resolve_viewport("top", viewport_up=[0, 1, 0.5])
+    assert overrides["viewport_origin"] == [0, 0, 100]
+    assert overrides["viewport_up"] == [0.0, 1.0, 0.5]
+
+
+def test_vectors_alone_need_no_name():
+    assert resolve_viewport(viewport_origin=("1", "2", "3")) == {"viewport_origin": [1.0, 2.0, 3.0]}
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"view": "isometric"}, "Unknown view"),
+        ({"viewport_origin": [1, 2]}, "three numbers"),
+        ({"viewport_origin": [1, 2, 3, 4]}, "three numbers"),
+        ({"viewport_origin": "nonsense"}, "three numbers"),
+        # A three-character string is iterable and three long, so it would
+        # otherwise be read as [1.0, 2.0, 3.0] and aim the camera at something
+        # nobody asked for. Refused rather than silently obeyed.
+        ({"viewport_origin": "123"}, "not a string"),
+        ({"viewport_origin": None, "viewport_up": [0, 0, 0]}, "zero vector"),
+        # Not a string at all: the dictionary lookup would raise TypeError,
+        # which the callers do not turn into a usage error the way they do a
+        # ValueError. The CLI constrains this; the daemon's other clients do not.
+        ({"view": ["front"]}, "Unknown view"),
+        ({"view": 3}, "Unknown view"),
+        # Both vectors pass their own checks and contradict each other: looking
+        # along -Y with "up" also along Y leaves no rotation that puts anything
+        # at the top of the picture.
+        ({"view": "front", "viewport_up": [0, -1, 0]}, "parallel"),
+        ({"viewport_origin": [0, 0, 100], "viewport_up": [0, 0, -2]}, "parallel"),
+    ],
+)
+def test_a_request_that_cannot_be_aimed_is_refused(kwargs, expected):
+    """Rather than rendering something aimed somewhere else."""
+    with pytest.raises(ValueError, match=expected):
+        resolve_viewport(**kwargs)
+
+
+def test_one_vector_alone_is_not_checked_against_the_other():
+    """The pair is only comparable when this request settles both halves of it.
+
+    Given just an up vector, the origin is whatever the configuration resolves
+    to and is not known here, so there is nothing yet to be parallel to.
+    """
+    assert resolve_viewport(viewport_up=[0, 0, 1]) == {"viewport_up": [0.0, 0.0, 1.0]}
+
+
+# --------------------------------------------------------------------------- #
+# Where the overrides land                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_the_overrides_reach_the_request_above_the_configuration():
+    """A render parameter passed per run beats the one the package configured.
+
+    'Shape._output_request()' is the join: the merged configuration first, then
+    the arguments of this one run. Exercised directly, with no shape and no
+    sandbox, because what is under test is the precedence and nothing else.
+    """
+
+    class _Impl:
+        parameters = {"viewport_origin": [0, 0, 100], "line_weight": 2.0}
+
+    class _Fake:
+        name = "part"
+        kind = "part"
+        config = {"type": "cadquery"}
+        project_name = "//pkg"
+
+        _output_request = Shape._output_request
+
+    request = asyncio.run(
+        _Fake()._output_request("wrapped", _Impl(), {"viewport_origin": [0, -100, 0], "viewport_up": None})
+    )
+    assert request["viewport_origin"] == [0, -100, 0]
+    # What this run said nothing about is still what the package configured.
+    assert request["line_weight"] == 2.0
+    # An argument left unset is not an override: 'None' must not erase the
+    # configuration, which is what several callers pass for the options they
+    # were given nothing for.
+    assert "viewport_up" not in request
+
+
+def test_a_package_render_hands_the_overrides_to_every_shape(monkeypatch):
+    """'Project.render_async()' is the caller in between, and has to pass them on.
+
+    Nothing is rendered: 'Shape.render_async' is replaced by a recorder, so this
+    covers the plumbing at the cost of reading a package configuration and
+    without a Python sandbox.
+    """
+    calls = []
+
+    async def _record(self, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(Shape, "render_async", _record)
+
+    ctx = pc.Context("examples")
+    project = ctx.get_project("//produce_part_cadquery_primitive")
+    project.render(parts=["cube"], format="svg", render_opts={"viewport_origin": [0, -100, 0]})
+
+    assert calls, "no shape was asked to render"
+    for call in calls:
+        assert call["viewport_origin"] == [0, -100, 0]
+
+
+def test_a_package_render_without_overrides_passes_none_of_them(monkeypatch):
+    """What a plain 'pc render' does: the configuration is the whole answer."""
+    calls = []
+
+    async def _record(self, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(Shape, "render_async", _record)
+
+    ctx = pc.Context("examples")
+    project = ctx.get_project("//produce_part_cadquery_primitive")
+    project.render(parts=["cube"], format="svg")
+
+    assert calls, "no shape was asked to render"
+    for call in calls:
+        assert "viewport_origin" not in call
+        assert "viewport_up" not in call

--- a/tests/partcad_service_json_rpc/test_operations.py
+++ b/tests/partcad_service_json_rpc/test_operations.py
@@ -1165,6 +1165,29 @@ def install_fake_supply(monkeypatch):
     )
 
 
+# ---- the viewing angle of a render -----------------------------------------
+#
+# `pc render --view` (and the `--viewport-origin`/`--viewport-up` pair it is
+# shorthand for) reaches the daemon as three params, which `render_objects`
+# resolves into the very export parameters a `render:` file type is configured
+# with. What the names mean is `partcad.render`'s to say and is tested there;
+# what is tested here is the glue on either side of it.
+
+
+def _fake_render_module(monkeypatch, resolve_viewport):
+    install_fake_partcad_modules(
+        monkeypatch,
+        {
+            "partcad.render": {"resolve_viewport": resolve_viewport},
+            "partcad.exception": {"AssemblyDocumentError": type("AssemblyDocumentError", (Exception,), {})},
+            "partcad.render_overlay": {"Overlay": types.SimpleNamespace(of=lambda **kw: None)},
+            # How many packages are rendered at once: real here only because
+            # '_render_packages_async' sizes its semaphore from it.
+            "partcad.sandbox_lock": {"process_slots": types.SimpleNamespace(count=1)},
+        },
+    )
+
+
 def make_supply_session(monkeypatch):
     """A package with an assembly of two parts, one of them sold by two stores."""
     install_fake_supply(monkeypatch)
@@ -1318,3 +1341,284 @@ def test_assembly_guide_reports_a_missing_assembly(monkeypatch):
 
     assert operations.assembly_guide(session, {"package": "//", "object": "nope"}) is None
     assert session.partcad.logging.messages("error") == ["Assembly //:nope is not found"]
+
+def test_render_hands_the_resolved_viewport_to_the_context(monkeypatch):
+    resolved = {"viewport_origin": [0, -100, 0], "viewport_up": [0, 0, 1]}
+    _fake_render_module(monkeypatch, lambda view, origin, up: dict(resolved))
+
+    session, _ = make_session()
+    session.partcad.output = types.SimpleNamespace(
+        all_formats=lambda ctx: ["svg"],
+        NON_WRAPPER_FORMATS=set(),
+        SECTIONS=("export", "render"),
+        format_names=lambda section: [],
+    )
+    rendered = []
+
+    async def _render_async(**kwargs):
+        rendered.append(kwargs)
+
+    session.partcad_ctx.render_async = _render_async
+
+    operations.render_objects(session, {"package": "//", "format": "svg", "view": "front"})
+
+    assert rendered and rendered[0]["render_opts"] == resolved
+
+
+def test_render_refuses_a_viewport_it_cannot_make_sense_of(monkeypatch):
+    """Nothing is rendered, rather than something aimed somewhere else.
+
+    The CLI rejects a typo of its own accord, but it is not the only client:
+    the editor extensions speak this protocol directly.
+    """
+
+    def _refuse(view, origin, up):
+        raise ValueError("Unknown view 'isometric'. Known views: front, back")
+
+    _fake_render_module(monkeypatch, _refuse)
+
+    session, _ = make_session()
+    rendered = []
+    session.partcad_ctx.render = lambda **kwargs: rendered.append(kwargs)
+
+    with pytest.raises(operations.JsonRpcError) as excinfo:
+        operations.render_objects(session, {"package": "//", "format": "svg", "view": "isometric"})
+
+    assert excinfo.value.code == operations.USAGE_ERROR
+    assert "Unknown view" in excinfo.value.message
+    assert rendered == []
+
+
+# ---- ad-hoc render ---------------------------------------------------------
+#
+# `pc adhoc render` is the sibling of `pc adhoc convert` for the other thing an
+# output file can be. The glue is the same shape -- infer what was left unsaid,
+# call through, report -- with two differences worth pinning: the *output* type
+# comes from the projections rather than the part/sketch types, and a viewport
+# rides along, because with no `partcad.yaml` there is nowhere else to say it.
+
+
+class FakeRenderer:
+    def __init__(self, error=None):
+        self.calls = []
+        self.error = error
+
+    def __call__(self, input_filename, input_type, output_filename, output_type, **options):
+        self.calls.append((input_filename, input_type, output_filename, output_type, options))
+        if self.error is not None:
+            raise self.error
+
+
+def install_fake_render(monkeypatch, part=None, sketch=None, resolve_viewport=None):
+    part = part if part is not None else FakeRenderer()
+    sketch = sketch if sketch is not None else FakeRenderer()
+    if resolve_viewport is None:
+
+        def resolve_viewport(view, origin, up):
+            return {"viewport_origin": [0, -100, 0], "viewport_up": [0, 0, 1]} if view else {}
+
+    install_fake_partcad_modules(
+        monkeypatch,
+        {
+            "partcad.adhoc.render": {"render_cad_file": part, "render_sketch_file": sketch},
+            "partcad.render": {"resolve_viewport": resolve_viewport},
+            # Mirrors partcad.shape. RENDER_EXTENSION_MAPPING is the set of
+            # built-in projections, which is what the output type is inferred
+            # from -- a part or sketch type never names one.
+            "partcad.shape": {
+                "PART_EXTENSION_MAPPING": {"step": "step", "stl": "stl", "scad": "scad"},
+                "SKETCH_EXTENSION_MAPPING": {"svg": "svg", "dxf": "dxf"},
+                "RENDER_EXTENSION_MAPPING": {"svg": "svg", "png": "png", "jpeg": "jpg", "dxf": "dxf"},
+            },
+        },
+    )
+    return part, sketch
+
+
+def test_adhoc_render_renders_a_part_and_reports_progress(monkeypatch, tmp_path):
+    part, sketch = install_fake_render(monkeypatch)
+    session, _ = make_session()
+    source, target = tmp_path / "bracket.step", tmp_path / "bracket.png"
+
+    operations.adhoc_render(
+        session,
+        {
+            "kind": "part",
+            "input_filename": str(source),
+            "output_filename": str(target),
+            "view": "front",
+        },
+    )
+
+    assert part.calls == [
+        (str(source), "step", str(target), "png", {"viewport_origin": [0, -100, 0], "viewport_up": [0, 0, 1]})
+    ]
+    assert sketch.calls == []
+    assert session.partcad.logging.messages("info") == [
+        "Rendering %s (step) to %s (png)..." % (source, target),
+        "Render complete: %s" % target,
+    ]
+
+
+def test_adhoc_render_without_a_viewport_passes_none(monkeypatch, tmp_path):
+    """A plain `pc adhoc render` leaves the implementation's own default alone."""
+    part, _ = install_fake_render(monkeypatch)
+    session, _ = make_session()
+
+    operations.adhoc_render(
+        session,
+        {
+            "kind": "part",
+            "input_filename": str(tmp_path / "bracket.step"),
+            "output_filename": str(tmp_path / "bracket.png"),
+        },
+    )
+
+    assert part.calls[0][4] == {}
+
+
+def test_adhoc_render_derives_the_output_path_from_the_projection(monkeypatch, tmp_path):
+    """'jpeg' is the format's name but '.jpg' is the file's."""
+    part, _ = install_fake_render(monkeypatch)
+    session, _ = make_session()
+    source = tmp_path / "bracket.step"
+
+    operations.adhoc_render(
+        session,
+        {"kind": "part", "input_filename": str(source), "output_filename": None, "output_type": "jpeg"},
+    )
+
+    expected = tmp_path / "bracket.jpg"
+    assert part.calls[0][2:4] == (str(expected), "jpeg")
+
+
+def test_adhoc_render_infers_jpeg_from_either_spelling(monkeypatch, tmp_path):
+    """A file already named '.jpeg' is as clearly a JPEG as one named '.jpg'."""
+    part, _ = install_fake_render(monkeypatch)
+    session, _ = make_session()
+
+    for name in ("a.jpg", "b.jpeg"):
+        operations.adhoc_render(
+            session,
+            {
+                "kind": "part",
+                "input_filename": str(tmp_path / "bracket.step"),
+                "output_filename": str(tmp_path / name),
+            },
+        )
+
+    assert [call[3] for call in part.calls] == ["jpeg", "jpeg"]
+
+
+def test_adhoc_render_reports_an_output_type_it_cannot_infer(monkeypatch, tmp_path):
+    """A part type is not a projection: '.stl' names nothing this can write."""
+    part, sketch = install_fake_render(monkeypatch)
+    session, _ = make_session()
+
+    operations.adhoc_render(
+        session,
+        {
+            "kind": "part",
+            "input_filename": str(tmp_path / "bracket.step"),
+            "output_filename": str(tmp_path / "bracket.stl"),
+        },
+    )
+
+    assert session.partcad.logging.messages("error") == [
+        "Cannot infer the projection to render. Please specify --output explicitly."
+    ]
+    assert part.calls == [] and sketch.calls == []
+
+
+def test_adhoc_render_refuses_a_kind_it_cannot_render(monkeypatch, tmp_path):
+    """An assembly is exactly what an ad-hoc render has no package for.
+
+    The CLI offers 'part' and 'sketch' as two subcommands and nothing else, so
+    this can only arrive from a client speaking the protocol directly -- and
+    answering it with a sketch of the file would be answering a different
+    question than the one asked.
+    """
+    part, sketch = install_fake_render(monkeypatch)
+    session, _ = make_session()
+
+    with pytest.raises(operations.JsonRpcError) as excinfo:
+        operations.adhoc_render(
+            session,
+            {
+                "kind": "assembly",
+                "input_filename": str(tmp_path / "robot.svg"),
+                "output_filename": str(tmp_path / "robot.png"),
+            },
+        )
+
+    assert excinfo.value.code == operations.USAGE_ERROR
+    assert "part, sketch" in str(excinfo.value)
+    assert part.calls == [] and sketch.calls == []
+
+
+def test_adhoc_render_refuses_a_projection_it_does_not_write(monkeypatch, tmp_path):
+    """Named outright rather than inferred, and with no output file to name it.
+
+    Without the check this reaches the extension lookup that derives the
+    default output path, where an unknown type is a KeyError -- a bad request
+    reported as an internal failure.
+    """
+    part, sketch = install_fake_render(monkeypatch)
+    session, _ = make_session()
+
+    with pytest.raises(operations.JsonRpcError) as excinfo:
+        operations.adhoc_render(
+            session,
+            {
+                "kind": "part",
+                "input_filename": str(tmp_path / "bracket.step"),
+                "output_type": "tiff",
+            },
+        )
+
+    assert excinfo.value.code == operations.USAGE_ERROR
+    assert "tiff" in str(excinfo.value)
+    assert part.calls == [] and sketch.calls == []
+
+
+def test_adhoc_render_refuses_a_viewport_it_cannot_make_sense_of(monkeypatch, tmp_path):
+    """Nothing is rendered, rather than something aimed somewhere else."""
+
+    def _refuse(view, origin, up):
+        raise ValueError("Unknown view 'isometric'. Known views: front, back")
+
+    part, _ = install_fake_render(monkeypatch, resolve_viewport=_refuse)
+    session, _ = make_session()
+
+    with pytest.raises(operations.JsonRpcError) as excinfo:
+        operations.adhoc_render(
+            session,
+            {
+                "kind": "part",
+                "input_filename": str(tmp_path / "bracket.step"),
+                "output_filename": str(tmp_path / "bracket.png"),
+                "view": "isometric",
+            },
+        )
+
+    assert excinfo.value.code == operations.USAGE_ERROR
+    assert part.calls == []
+
+
+def test_adhoc_render_reports_a_failed_render(monkeypatch, tmp_path):
+    install_fake_render(monkeypatch, part=FakeRenderer(error=RuntimeError("shape is empty")))
+    session, _ = make_session()
+
+    result = operations.adhoc_render(
+        session,
+        {
+            "kind": "part",
+            "input_filename": str(tmp_path / "bracket.step"),
+            "output_filename": str(tmp_path / "bracket.png"),
+        },
+    )
+
+    assert result is None
+    log = session.partcad.logging
+    assert log.messages("error") == ["Failed to render: shape is empty"]
+    assert not any(m.startswith("Render complete") for m in log.messages("info"))


### PR DESCRIPTION
#deepTest

## What

Two things a user could not do before, plus the agent skills that teach an agent to use them.

### Viewing angles on the command line

A viewport was configurable in `partcad.yaml` and nowhere else, so asking for one view of one object meant editing the package. `pc render` and the new `pc adhoc render` now name the same two keys as options:

```
--view front|back|left|right|top|bottom|iso
--viewport-origin X,Y,Z
--viewport-up X,Y,Z
```

`--view` resolves to a pair of vectors — where the camera is, and which way is up in the picture. Either one given explicitly replaces the one the name resolved to, so a named view can be tilted without spelling both out:

```sh
pc render -t png --view top --viewport-up 0,1,0.5 -O ./out bracket
```

The names live in `partcad.render.VIEWS`, which resolves them on the daemon side where the heavy package already is. The thin CLI inlines only the list of names — for `--help`, and to reject a typo without a round trip — the way the ad-hoc type lists already do. The options are shared by both commands from one module, since a viewport is a property of the projection and not of where the shape came from.

A request that cannot be aimed is refused before anything is rendered, rather than producing a picture of something else: an unknown view, a vector that is not three numbers, the zero vector, and an up vector parallel to the direction the camera looks from, which names no orientation.

### `pc adhoc render`

What `pc render` is for a file that belongs to no package: wrap the file in a throwaway package, write one picture, delete the package. `part` and `sketch`, to `png`, `jpeg`, `svg` or `dxf`, from any input type PartCAD can read — including the scripted ones it cannot write back out (`sdf`, `scad`, `chili3d`), since reading is all a picture needs.

`urdf` and `assy` are refused, as they already were for a conversion: both only mean anything inside the package that names their contents. The message points at `pc render` rather than `pc convert`, because a picture was what was asked for.

The throwaway-package machinery moves out of `adhoc/convert.py` into `adhoc/adhoc.py`, which both `convert` and `render` read, so rendering does not import the conversion module for it. `adhoc/convert.py` re-exports the four names it used to define; the historical import path still works, and the existing tests that use it are untouched.

### Agent skills

`/pc:render` and `/pc:export` are new; `/pc:convert`, `/pc:describe`, `/pc:gen-part` and `/pc:gen-assembly` are rewritten. `/pc:render` and `/pc:convert` now open with the question that decides the command: is there a package, and does what the user named resolve to an object in it — by name, or as the file an object is built from? If it does, the package command is right and the package's own options apply; if not, the `adhoc` one is. `pc export` has no `adhoc` form because `pc adhoc convert` already is it.

`/pc:gen-part` and `/pc:gen-assembly` validate a design by rendering four views rather than one. `pc test` proves the geometry instantiates; it does not prove the geometry is what was asked for, and one projection hides whatever is behind it. For an assembly the point is sharper: position along the viewing direction is exactly what a projection collapses, so a component offset into the screen sits perfectly in the one view that hides the offset.

### Fitting that to the port/interface overlays from #576

Rebasing brought in `--with-ports`/`--with-interfaces`/`--with-all`, which the same two generation skills had also been taught. The two changes are complementary, and they now reference each other rather than sitting side by side:

- **The multi-view argument covers ports too.** A port is a coordinate frame, so a projection collapses the axis it is offset along exactly as it does a feature's, and two frames a millimetre apart along the line of sight are drawn one on top of the other. An ambiguous port is worth the same several views the shape got.
- **The overlay renders needed directories of their own.** Each writes `<name>.png` like any other render, so the three example invocations in `gen-assembly` wrote over each other — the precise hazard the multi-view section warns about.
- **They pass `--no-ansi`.** Every port drawn is also named on stderr, and that is where the exact string for an ASSY file comes from, so the option matters more here than anywhere else in the skill.
- **`/pc:render` documents the three overlay options**, since both generation skills now point at it as the full reference for what `pc render` can be asked.

## Review feedback

All ten CodeRabbit findings were assessed and nine were fixed; each is covered by a test where it is testable.

- `resolve_viewport` rejected a string vector by iterating it — `"123"` became `[1.0, 2.0, 3.0]` and aimed the camera somewhere nobody asked for. It also let a non-string `view` reach a dict lookup, raising `TypeError` where only `ValueError` is mapped to a usage error.
- An up vector parallel to the line of sight passed both vector checks and named no orientation; it is now refused once both halves of the pair are settled by the same request.
- The throwaway `partcad.yaml` quoted the input path into a YAML single-quoted scalar without escaping, so a valid path containing an apostrophe produced a config that would not parse.
- `adhoc_render` selected the sketch renderer for *any* `kind` that was not `part`, and reached the extension lookup with an unvalidated `output_type`, turning a bad request into a `KeyError`.
- An unused local (`F841`), and two documentation wordings: the CLI reference described both viewport vectors as "an arbitrary direction" when they are a camera location and an image-up vector, and the use-cases page said `pc adhoc render` "needs" the viewport options while its own next example omits them.
- The `/pc:export` skill listed formats that excluded `dxf` while its sketch example used `-t dxf`. Checked against the CLI rather than assumed: `svg` and `dxf` are accepted, and are a sketch's own geometry rather than a picture of it — the list and the description now say so, and note that asking for one for a 3D object gets a projection instead.

The tenth (shell-quoting in the pytest hook's failure message) is fixed too: `-m "not slow"` is one argument, and `"${PYTEST_ARGS[*]}"` printed it as two, so what the message offered to be copied was not what had run.

## Also: the `pre-commit` pytest timeout

The `pass_filenames: false` fix this branch originally carried turned out to have landed on `devel` independently, so only the timeout part remains: 300s to 900s, overridable with `PC_PYTEST_TIMEOUT`. The budget is per test and has to clear the slowest thing a passing test legitimately does, which is not the test but the CAD sandbox underneath it — a scripted part provisions an interpreter and pip-installs a CAD stack on first use, cached afterwards in `~/.partcad`.

## Testing

- `tests/partcad/unit/test_render_views.py` — 29 tests over view resolution, vector overrides, the malformed inputs above, and the CLI/core name lists agreeing.
- `tests/partcad/unit/test_adhoc_render.py` — the offered projections are the ones with a known extension and the ones `//builtin/render` declares; a projection is still not a part type; `urdf`/`assy` refused with the render advice.
- `tests/partcad/unit/test_adhoc_convert_error_order.py` — rewritten for the refactor, covering all four entry points and the message verb.
- `tests/partcad_service_json_rpc/test_operations.py` — 80 tests, including the viewport reaching the context, the refusals above, and the unsupported kind and projection.
- `features/adhoc/render/{part,sketch}.feature` and additions to `features/render.feature`.

Verified by hand that `pc adhoc render part --view front|top|iso bolt.step` produces PNGs byte-identical to the package-based `pc render --view` path, and that `--view` overrides an object's own configured viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
