### PR TITLE
feat(client): open a part in FreeCAD with `pc open` and the Explorer's "Open in..." menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ a CAD addon, or documentation.
 * [src/partcad_client](./src/partcad_client):
 
   What a **client** does, and a daemon must not: discovering the daemon serving a workspace and connecting to
-  it (`daemon`, `client`), and replacing this installation of PartCAD (`selfupdate`).
+  it (`daemon`, `client`), replacing this installation of PartCAD (`selfupdate`), and opening a file in a
+  third-party CAD application on this machine (`external`).
 
   All of it acts on **this machine**, from the process running out of it. A daemon can be remote, where
   "update PartCAD" would mean updating somebody else's installation and "stop the local daemons" somebody
@@ -58,6 +59,13 @@ a CAD addon, or documentation.
 
   It also refuses: `pc upgrade` run inside a bundle the editor extension downloaded errors out and says to
   update the extension instead, since the extension owns that bundle.
+
+  `external` is the same rule applied to a window instead of an installation. `pc open` (and the VS Code
+  extension's per-part "Open in..." menu, by running it) starts FreeCAD on the screen of whoever ran the
+  command — on this machine, with this machine's file, and never over the wire; there is no RPC method for it
+  and none may be added. A machine with no local installation can run the application in a container PartCAD
+  keeps for it, named after the tool (`partcad-freecad`), with the workspace and the daemon's socket mounted
+  at the paths they have here and the host's X display forwarded into it.
 
 * [src/partcad_ide_client](./src/partcad_ide_client/AGENTS.md):
 

--- a/dev-tools/behave_durations.json
+++ b/dev-tools/behave_durations.json
@@ -1,5 +1,5 @@
 {
-  "_source": "Measured in CI run 33149121989 (commit 314290fc), from the timestamps behave prints on each \"Feature:\" line. Each value is the longest of the three cells measured there: windows-latest/3.10, windows-latest/3.14 and ubuntu-latest/3.10 -- Windows is what the 60 minute job timeout binds on, and taking the maximum keeps a feature that is skipped on one OS from being weighed as free on the others. The two 'software' features were added after that run and are scaled from a local measurement against a feature of the same shape measured there ('features/add/sketch.feature' and 'features/list/sketches.feature'), so they are estimates until the table is next re-measured. 'features/add/sketch.feature' is its measurement scaled by the same local ratio, for the URL scenario added to it here.",
+  "_source": "Measured in CI run 33149121989 (commit 314290fc), from the timestamps behave prints on each \"Feature:\" line. Each value is the longest of the three cells measured there: windows-latest/3.10, windows-latest/3.14 and ubuntu-latest/3.10 -- Windows is what the 60 minute job timeout binds on, and taking the maximum keeps a feature that is skipped on one OS from being weighed as free on the others. The two 'software' features were added after that run and are scaled from a local measurement against a feature of the same shape measured there ('features/add/sketch.feature' and 'features/list/sketches.feature'), so they are estimates until the table is next re-measured. 'features/add/sketch.feature' is its measurement scaled by the same local ratio, for the URL scenario added to it here. 'features/open.feature' was added after that run too, and is estimated from 'features/upgrade.feature', which it resembles -- a handful of `pc` invocations that fail before any package is loaded.",
   "_unit": "seconds",
   "_refresh": "Re-measure when the suite's shape changes materially: download the Behave job logs (gh api repos/partcad/partcad/actions/jobs/<id>/logs), take the timestamp of each \"Feature: ... # features/<path>:<line>\" line, and difference consecutive ones. Values only have to be right relative to each other. tests/partcad_cli/unit/test_behave_shard.py fails when a feature file here no longer exists, or when a feature file has no entry.",
   "seconds": {
@@ -35,6 +35,7 @@
     "features/list/sketches.feature": 3.4,
     "features/list/software.feature": 6.0,
     "features/monorepo.feature": 109.0,
+    "features/open.feature": 2.0,
     "features/pc.feature": 12.2,
     "features/render.feature": 769.8,
     "features/search/all.feature": 12.8,

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -70,6 +70,39 @@ Host commands
 
   The "Update PartCAD" command in the VS Code extension runs exactly this, so the two never drift apart.
 
+``pc open``
+  Open a file in a third-party CAD application, on this machine::
+
+    pc open cube.step                       # in a locally installed FreeCAD
+    pc open --use-docker cube.step          # or in a container, when there is none
+
+  ``--with`` names the application (``freecad`` today, and the default). A locally installed one is always
+  used when there is one: the command looks on the ``PATH``, in ``/Applications`` on macOS, under
+  ``Program Files`` on Windows, and for a flatpak on Linux.
+
+  With ``--use-docker``, a machine that has no local installation runs the application in a container instead
+  — one container per application, named after it (``partcad-freecad``), created from the application's image
+  (``--docker-image`` overrides it; FreeCAD's is ``linuxserver/freecad:latest``, since the FreeCAD project
+  publishes no image of its own) the first time and reused afterwards, so a container you have prepared
+  keeps being the one that is used. Remove it (``docker rm -f partcad-freecad``) to have the next ``pc open``
+  create a fresh one. The workspace and the directory holding this workspace's daemon socket are mounted **at
+  the paths they have on the host**, which is what lets one path mean the same thing on both sides. A file
+  that is not in this workspace gets its own workspace mounted instead, so that whatever is mounted always
+  contains the file the application is handed; a container created for one workspace and then used from
+  another says so, and says to remove it, rather than opening a name the container cannot resolve.
+
+  A containerised application draws on the host's X display. On Linux that display is usually a socket, which
+  is shared with the container along with its authority cookie, and nothing needs configuring; a display
+  reached over TCP — a forwarded one, or an X server on macOS or Windows (XQuartz, VcXsrv) — has to be
+  installed and allowed to accept the connection. When there is none, the command says which one to install
+  and what to run rather than starting a container whose window never appears.
+
+  Like ``pc lint --file`` and ``pc upgrade``, this never talks to the daemon — a daemon can be remote, where
+  the window would open on somebody else's screen. That is also why it takes a path rather than a
+  ``<package>:<part>`` name: resolving a name is a package-graph question, which is the round trip this
+  command does not make. ``--json`` prints what happened (or the reason it did not) as one object, which is
+  what the VS Code extension's "Open in..." context menu reads.
+
 ****************
 Package commands
 ****************

--- a/features/open.feature
+++ b/features/open.feature
@@ -1,0 +1,34 @@
+@cli @pc-open
+Feature: `pc open` command
+
+  Background: Create temporary $HOME and working directory
+    Given I am in "/tmp/sandbox/behave" directory
+    And I have temporary $HOME in "/tmp/sandbox/home"
+
+  @failure @pc-open
+  Scenario: An unknown application is refused, and the known ones are named
+    # Checked before anything is looked for, so this says the same thing on
+    # every machine -- including one that has FreeCAD installed, where the
+    # scenarios below must still not open a window.
+    When I run "pc --no-ansi open --with solidworks cube.step"
+    Then the command should exit with a non-zero status code
+    And OUTPUT should contain "Unknown application"
+    And OUTPUT should contain "freecad"
+
+  @failure @pc-open
+  Scenario: A file that is not there is reported rather than opened
+    Given a file named "cube.step" does not exist
+    When I run "pc --no-ansi open cube.step"
+    Then the command should exit with a non-zero status code
+    And OUTPUT should contain "No such file"
+
+  @failure @pc-open
+  Scenario: The reason survives --json, which the editor reads
+    # A failure exits non-zero *and* prints the reason as JSON: the message is
+    # the whole answer (what to install, how to allow a container), and the
+    # VS Code extension's "Open in..." menu has nothing else to show the user.
+    Given a file named "cube.step" does not exist
+    When I run "pc --no-ansi open --json cube.step"
+    Then the command should exit with a non-zero status code
+    And STDOUT should contain '"ok": false'
+    And STDOUT should contain "No such file"

--- a/ide/vscode/AGENTS.md
+++ b/ide/vscode/AGENTS.md
@@ -289,6 +289,35 @@ construct with equally sized filler before parsing, which is what keeps every fi
 column; findings that depend on what the mask hid are dropped rather than guessed. Change the schema or the
 message wording there, not here.
 
+## Opening a file in a third-party application
+
+The Explorer's per-item **"Open in > FreeCAD"** menu (`partcad.openInFreeCAD`, on parts and assemblies that
+have a source file) hands the item's `itemPath` to `partcad.openExternal`, which runs
+`pc --no-ansi open --with freecad [--use-docker] [--docker-image <image>] <path> --json`.
+
+**It never reaches the daemon, and there is no RPC method for it** -- a stronger version of the rule
+`pc lint --file` follows. A daemon can be remote: "open this in FreeCAD" sent to one would put a window on
+somebody else's screen, on a machine that may have no display at all, and the path would name a file only the
+client has. So the finding of the application, the container and the X forwarding are `partcad_client.external`
+and nothing here reimplements them; what stays in TypeScript is the menu, the setting, and showing the failure.
+
+The failure is the interesting half. `pc open` prints its reason as JSON *and* exits non-zero, so
+`JsonRpcBackend.openExternal` reads the JSON with `allowFailure` and throws the message as it came --
+`PartcadExplorer.openWith` shows it verbatim in the error dialog's detail. That message is the answer the user
+needs (which X server to install and what to allow, or how to let PartCAD use a container); replacing it with
+"the command failed" would throw away the whole point of the command.
+
+What is handed over is `config.item_path`, not the item's `itemPath`. The tree sets `itemPath` only for the
+types this editor can *edit* -- the scripts -- so a STEP or BREP part, which is exactly what another CAD
+application is for, has none; `config.item_path` is the file the daemon reported for the object either way.
+The menu is therefore on the same items as "Export" (`part`, `assembly`, with or without code) and an object
+that has no file of its own says so when it is picked, rather than being silently missing from the menu.
+
+`partcad.open.useDocker` and `partcad.open.dockerImage` are read here, on the way to that command line, rather
+than being worked out anywhere in Python: PartCAD decides *how* to run the application, and the settings only
+say what it is allowed to do. Adding a second application is a command, a menu entry and a row in
+`external.TOOLS` -- no new branch in this extension.
+
 ## Setup
 
 ```bash

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -90,6 +90,22 @@ template is rendered, so a schema finding that depends on such a value is left
 out rather than guessed at. Set `partcad.lint.enabled` to `false` to turn this
 off.
 
+## Opening a part in another CAD application
+
+Right-click a part or an assembly in the PartCAD Explorer and pick **Open in > FreeCAD** to open the file it is
+defined by in FreeCAD. It is the object's own source file that is opened, so this is the way to reach it in a
+tool that draws, next to what the extension does with it.
+
+This runs on your machine and never goes anywhere near the PartCAD daemon: the extension runs `pc open`, which
+looks for a FreeCAD installed here and starts it. If there is none, and `partcad.open.useDocker` is on, PartCAD
+runs FreeCAD in a Docker container instead -- one container named `partcad-freecad`, created from
+`linuxserver/freecad:latest` (or `partcad.open.dockerImage`) the first time and reused afterwards, with your
+workspace and the PartCAD daemon's socket mounted at the paths they have here, so one path means the same thing
+on both sides. Its windows come out on your X display. On Linux that is the display you are already using; on
+macOS and Windows it needs an X server (XQuartz, VcXsrv) that PartCAD cannot install for you, so it tells you
+which one to install and what to allow rather than starting a container whose windows go nowhere. Remove the
+container (`docker rm -f partcad-freecad`) to have the next open create a fresh one.
+
 ## Inspecting published PartCAD packages
 
 To see a good example of a package with parts, it is recommended to browse

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -167,6 +167,24 @@
         }
       },
       {
+        "title": "Third-party applications",
+        "order": 2,
+        "properties": {
+          "partcad.open.useDocker": {
+            "default": false,
+            "description": "Let PartCAD run a third-party CAD application (\"Open in...\") in a Docker container when it is not installed on this machine. The container is named after the application ('partcad-freecad'), keeps the workspace mounted at the path it has here, and shows its windows on this machine's X display - which macOS and Windows need an X server for.",
+            "scope": "machine",
+            "type": "boolean"
+          },
+          "partcad.open.dockerImage": {
+            "default": "",
+            "description": "Create that container from this image instead of the application's default one (FreeCAD: 'linuxserver/freecad:latest'). Applies only when the container is created; remove an existing one to have it recreated.",
+            "scope": "machine",
+            "type": "string"
+          }
+        }
+      },
+      {
         "title": "General",
         "order": 3,
         "properties": {
@@ -531,6 +549,13 @@
         "group": "Export",
         "title": "glTF...",
         "icon": "$(export)"
+      },
+      {
+        "command": "partcad.openInFreeCAD",
+        "category": "PartCAD",
+        "group": "Open in",
+        "title": "FreeCAD",
+        "icon": "$(link-external)"
       }
     ],
     "submenus": [
@@ -558,6 +583,11 @@
         "id": "partcad.submenu.export",
         "label": "Export",
         "icon": "$(export)"
+      },
+      {
+        "id": "partcad.submenu.openWith",
+        "label": "Open in",
+        "icon": "$(link-external)"
       }
     ],
     "menus": {
@@ -662,6 +692,11 @@
           "submenu": "partcad.submenu.export",
           "when": "view == partcadExplorer && (viewItem == part || viewItem == partWithAI || viewItem == partWithCode || viewItem == assembly || viewItem == assemblyWithCode)",
           "group": "additional_commands"
+        },
+        {
+          "submenu": "partcad.submenu.openWith",
+          "when": "view == partcadExplorer && (viewItem == part || viewItem == partWithAI || viewItem == partWithCode || viewItem == assembly || viewItem == assemblyWithCode)",
+          "group": "additional_commands"
         }
       ],
       "partcad.submenu.add": [
@@ -764,6 +799,12 @@
         },
         {
           "command": "partcad.exportToGLTF",
+          "when": "view == partcadExplorer"
+        }
+      ],
+      "partcad.submenu.openWith": [
+        {
+          "command": "partcad.openInFreeCAD",
           "when": "view == partcadExplorer"
         }
       ]

--- a/ide/vscode/src/PartcadExplorer.ts
+++ b/ide/vscode/src/PartcadExplorer.ts
@@ -65,6 +65,11 @@ export class PartcadExplorer implements vscode.TreeDataProvider<PartcadItem> {
         vscode.commands.registerCommand(`partcad.exportToIGES`, (item) => this.exportToIGES(item));
         vscode.commands.registerCommand(`partcad.exportToGLTF`, (item) => this.exportToGLTF(item));
 
+        // One command per application rather than one that asks which: a context
+        // menu is where the user says what they want, and a picker on top of a
+        // menu is the same question twice.
+        vscode.commands.registerCommand(`partcad.openInFreeCAD`, (item) => this.openWith('freecad', item));
+
         vscode.commands.registerCommand(`partcad.test`, (item) => this.test(item));
 
         vscode.commands.registerCommand(`partcad.addPartItem`, (item) => this.addPart(item));
@@ -111,6 +116,45 @@ export class PartcadExplorer implements vscode.TreeDataProvider<PartcadItem> {
             packageName: packageName,
             callback: 'partcad.addAssembly2',
         });
+    }
+
+    /**
+     * Open the file a part or an assembly is defined by in a third-party CAD
+     * application ("Open in..." in the context menu).
+     *
+     * It is the item's own source file that is handed over, not a rendering of
+     * it: rendering is the daemon's work, and this deliberately has none in it.
+     * `pc open` runs on the machine the user is sitting at, finds a locally
+     * installed application or (when the setting allows it) a container, and
+     * says what to install when it can find neither -- which is why the failure
+     * is shown as it comes back rather than summarised.
+     */
+    public async openWith(tool: string, item: PartcadItem) {
+        // `config.item_path` rather than `itemPath`: the latter is set only for
+        // the types this editor can edit (scripts), and a STEP or BREP part --
+        // exactly what another CAD application is for -- is not one of them.
+        const path = item?.config?.item_path ?? item?.itemPath;
+        if (path === undefined) {
+            await vscode.window.showWarningMessage(
+                `'${item?.name}' has no file of its own to open in another application.`,
+            );
+            return;
+        }
+        try {
+            // Under a progress notification because the first open of a
+            // containerised application downloads its image, which takes
+            // minutes and would otherwise look like nothing happening.
+            await vscode.window.withProgress(
+                { location: vscode.ProgressLocation.Notification, title: `${item.name}`, cancellable: false },
+                async (progress) => {
+                    progress.report({ message: 'Opening...' });
+                    await vscode.commands.executeCommand('partcad.openExternal', { path: path, tool: tool });
+                },
+            );
+        } catch (e) {
+            const reason = e instanceof Error ? e.message : `${e}`;
+            await vscode.window.showErrorMessage(`Could not open '${item.name}'`, { modal: false, detail: reason });
+        }
     }
 
     public async inspectSource(item: PartcadItem) {

--- a/ide/vscode/src/common/backend.ts
+++ b/ide/vscode/src/common/backend.ts
@@ -233,6 +233,52 @@ class JsonRpcBackend implements PartcadBackend {
     }
 
     /**
+     * Open one file in a third-party application with `pc open`.
+     *
+     * Never over this connection, and there is no RPC method for it: the daemon
+     * can be remote, where the window would open on somebody else's screen and
+     * the path would name a file nobody has. So it is the CLI, run here, on this
+     * machine, with this machine's display -- the same rule as `pc lint --file`.
+     *
+     * Whether a container may be used is the user's setting rather than
+     * something worked out here: PartCAD decides how to run the application, and
+     * this only says what it is allowed to do.
+     */
+    private async openExternal(arg: { path?: string; tool?: string }): Promise<{ detail: string; method: string }> {
+        const config = vscode.workspace.getConfiguration('partcad');
+        const image = (config.get<string>('open.dockerImage') ?? '').trim();
+        const args = [
+            'open',
+            '--with',
+            arg?.tool ?? 'freecad',
+            ...(config.get<boolean>('open.useDocker') === true ? ['--use-docker'] : []),
+            ...(image ? ['--docker-image', image] : []),
+            arg?.path ?? '',
+            '--json',
+        ];
+        const stdout = await runCli(this.cliPath, args, this.cwd, this.outputChannel, undefined, {
+            // The reason for a failure is in the JSON -- which X server to
+            // install, how to allow a container -- and it is the whole answer.
+            // Rejecting on the exit code would throw it away and leave the user
+            // with "the command failed".
+            allowFailure: true,
+        });
+        let parsed: any;
+        try {
+            parsed = JSON.parse(stdout);
+        } catch {
+            // Nothing parseable on stdout: a `pc` too old to know the command
+            // says so on stderr and prints nothing here. Reporting that beats
+            // showing the user a JSON parser error.
+            throw new Error('This PartCAD cannot open files in other applications; update PartCAD and try again.');
+        }
+        if (!parsed?.ok) {
+            throw new Error(parsed?.error ?? 'PartCAD could not open the file.');
+        }
+        return { detail: parsed.detail ?? '', method: parsed.method ?? '' };
+    }
+
+    /**
      * Register the `partcad.*` commands the extension invokes, mapping each to
      * the CLI-shaped JSON-RPC method with translated parameters. This replaces
      * what the LanguageClient's ExecuteCommandFeature did for the LSP backend.
@@ -296,6 +342,10 @@ class JsonRpcBackend implements PartcadBackend {
         // answering when the daemon is down or the package will not load
         // because of the very file being typed into.
         reg('partcad.lintFile', (a) => this.lintFile(typeof a === 'string' ? { path: a } : a));
+        // Through the CLI for the same reason, and a stronger one: a daemon can
+        // be remote, and "open this in FreeCAD" is meaningless anywhere but on
+        // the machine sitting in front of the user.
+        reg('partcad.openExternal', (a) => this.openExternal(typeof a === 'string' ? { path: a } : a));
         reg('partcad.testReal', (a) => this.send('test', { package: a.packageName, object: a.objectName }));
         reg('partcad.getStats', () => this.send('info', {}));
         reg('partcad.activate', () => this.send('activate', {}));

--- a/src/partcad_cli/AGENTS.md
+++ b/src/partcad_cli/AGENTS.md
@@ -53,6 +53,17 @@ file. The checker (`partcad_client.lint`, over `partcad_utils.assy_lint`) is the
 package, so an editor and CI cannot disagree. The VS Code extension runs `pc lint --file`, so the two cannot
 drift apart either.
 
+**`pc open` is on the in-process side for a stronger version of the same reason.** Opening a file in a
+third-party CAD application puts a window on a screen, and the only screen a command can put one on is the one
+in front of the user who ran it: a daemon can be remote, where that window would appear on somebody else's
+desk, on a machine that may have no display at all -- and the path on the command line names a file only the
+client has. It needs no package graph, no CAD runtime and no context either, so there is deliberately no RPC
+method for it and none may be added. The application, the container PartCAD keeps for one that is not
+installed, and the X forwarding into it are `partcad_client.external`, so the command never imports the heavy
+`partcad`. Taking a path rather than a `<package>:<part>` name follows from the same rule: resolving a name is
+a package-graph question, which is exactly the round trip this command does not make. The VS Code extension's
+"Open in..." context menu runs `pc open --json`, so the two cannot drift apart.
+
 A command stays **in-process** only when it operates on the client's own state, which does not cross the wire:
 `init` (creates the workspace, before any package or context exists, and adds the `Render` command to the
 repository's `.vscode/launch.json` — see `src/partcad/launch_config.py`; the daemon's `init` operation

--- a/src/partcad_cli/click/command.py
+++ b/src/partcad_cli/click/command.py
@@ -126,9 +126,10 @@ option_groups = [
 command_groups = [
     {
         # `version` and `upgrade` are about this installation of PartCAD;
-        # `config`, `system` and `daemon` about the host it runs on.
+        # `config`, `system`, `daemon` and `open` about the host it runs on --
+        # `open` starts an application on the screen of whoever ran it.
         "name": "Host commands",
-        "commands": ["version", "upgrade", "config", "system", "daemon"],
+        "commands": ["version", "upgrade", "config", "system", "daemon", "open"],
     },
     {
         "name": "Package commands",

--- a/src/partcad_cli/click/commands/open.py
+++ b/src/partcad_cli/click/commands/open.py
@@ -1,0 +1,91 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""`pc open` -- open a file in a third-party CAD application.
+
+Entirely in the client process, and deliberately so. Opening a file in FreeCAD
+is not work the daemon can do on anyone's behalf: a daemon can be remote, where
+the window would appear on somebody else's screen (or on a machine with no
+screen at all), and the path named on this command line means nothing on the
+other side of the wire. It needs no package graph, no CAD runtime and no
+context either -- the file is already on disk -- so there is no RPC method for
+it and none should be added. Same reasoning as `pc lint --file` and
+`pc upgrade`; see "Command boundary" in src/partcad_cli/AGENTS.md.
+
+That is also why it takes a path rather than a `<package>:<part>` name:
+resolving a name means loading the package graph, which is exactly the daemon
+round trip this command does not make. The VS Code extension's "Open in..."
+context menu passes the source file of the part or assembly the user clicked.
+
+The application is run from this machine when it is installed here, and
+otherwise -- with `--use-docker` -- from a container PartCAD keeps for it. The
+finding, the container and the X forwarding are `partcad_client.external`, so
+the extension and the CLI cannot drift apart.
+"""
+
+import json
+
+import rich_click as click
+
+
+@click.command(help="Open a file in a third-party CAD application, on this machine.")
+@click.option(
+    "--with",
+    "tool",
+    type=str,
+    default="freecad",
+    show_default=True,
+    metavar="APPLICATION",
+    help="Which application to open the file in.",
+)
+@click.option(
+    "--use-docker",
+    is_flag=True,
+    help="If the application is not installed here, run it in a container PartCAD keeps for it.",
+)
+@click.option(
+    "--docker-image",
+    type=str,
+    default=None,
+    metavar="IMAGE",
+    help="Create that container from this image instead of the application's default one.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Print what happened as JSON, including the reason on failure.",
+)
+@click.argument("path", type=str, required=True)
+@click.pass_context
+def cli(click_ctx, tool: str, use_docker: bool, docker_image: str, as_json: bool, path: str) -> None:
+    # Deferred: `pc --help` imports every command module to print its short
+    # help, and there is no reason for that to touch the tool tables.
+    from partcad_client import external
+
+    try:
+        result = external.open_file(
+            path,
+            tool=tool,
+            use_docker=use_docker,
+            image=docker_image,
+            # Silent under --json: the caller parses stdout, and progress lines
+            # would be in the way of the one thing it is there to read.
+            log=None if as_json else click.echo,
+        )
+    except external.ExternalToolError as e:
+        if as_json:
+            # Machine-readable and self-contained, so a caller needs neither the
+            # log stream nor the exit code to know what to show the user. The
+            # message is the whole point of the failure -- it says which X
+            # server to install, or how to let PartCAD use a container.
+            click.echo(json.dumps({"ok": False, "tool": tool, "path": path, "error": str(e)}))
+            click_ctx.exit(1)
+        raise click.ClickException(str(e))
+
+    if as_json:
+        click.echo(json.dumps(result.to_dict()))
+        return
+    click.echo(result.detail)

--- a/src/partcad_client/__init__.py
+++ b/src/partcad_client/__init__.py
@@ -17,6 +17,8 @@ machine and its own installation**, from the process running out of it.
   PartCAD, whether it is the Python wheels or the standalone bundle.
 * :mod:`~partcad_client.lint` -- checking the files this process was handed,
   including content an editor has not saved yet.
+* :mod:`~partcad_client.external` -- opening one of those files in a third-party
+  CAD application: the one installed here, or a container this machine can run.
 
 None of it belongs to a daemon. A daemon can be remote, where "update PartCAD"
 would mean updating somebody else's installation and "stop the local daemons"
@@ -25,7 +27,9 @@ neighbours would be racing every client on the machine. A client is one process,
 acting on the machine it runs on, which is what makes stopping every local daemon
 before an update a sane thing to do rather than a distributed algorithm. Checking
 a file joins them for the same reason: it is the client's file, sometimes not
-even on disk, and it needs nothing a daemon has.
+even on disk, and it needs nothing a daemon has. So does opening one in FreeCAD:
+the window belongs on the screen of whoever ran the command, and a remote daemon
+has neither that screen nor that file.
 
 `partcad-utils` holds what both ends share (logging, telemetry, user config, and
 the client/daemon rendezvous: framing and workspace addressing). The CLI is the

--- a/src/partcad_client/external.py
+++ b/src/partcad_client/external.py
@@ -1,0 +1,669 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Opening a file in a third-party application, on the machine the client runs on.
+
+This is a client's job by construction, and it is why the code sits here rather
+than behind an RPC method. A daemon can be remote: "open this in FreeCAD" sent to
+one would start a window on somebody else's desk, on a machine that may have no
+display at all -- and the file named on the command line is the client's own,
+found by a path that means nothing on the other side of the wire. So `pc open`
+never speaks to a daemon, the way `pc lint --file` and `pc upgrade` do not, and
+the VS Code extension reaches this code by running `pc open` rather than by
+reimplementing it in TypeScript.
+
+Two ways to run a tool, tried in this order:
+
+* **Natively**, when the machine has the application installed. Nothing is
+  containerised, nothing is downloaded, and the application sees the file at the
+  path the user typed.
+* **In a container**, when it does not, Docker is available, and the caller
+  passed ``use_docker``. One long-lived container per tool, named
+  ``partcad-<tool>`` -- a *container* name, not an image name, so a user can
+  create, inspect, customise or `docker rm` theirs, and the next `pc open` finds
+  and reuses whatever is there.
+
+The container mounts the workspace root **at the same absolute path** it has on
+the host, along with the directory holding the workspace's daemon socket. Same
+path on both sides is what keeps the arrangement honest: the file argument, an
+error message, and anything the application writes back all name one path that
+means the same thing inside the container, on the host, and to the daemon.
+
+A containerised GUI needs an X server on the host, which is the one place where
+this cannot paper over the difference between platforms. On Linux the display is
+usually a socket that can simply be shared, cookie and all, and nothing has to be
+set up; on macOS and Windows -- and on Linux over a forwarded display -- it is a
+TCP connection to an X server the user has to install and allow. There is no way
+to do that for them, so when it is missing they get told which one to install and
+what to run, rather than a container that starts and silently never shows a window.
+"""
+
+import contextlib
+import glob
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+from partcad_utils.workspace import determine_root_path, socket_path
+
+__all__ = [
+    "ExternalToolError",
+    "OpenResult",
+    "Tool",
+    "TOOLS",
+    "open_file",
+    "tool_names",
+]
+
+# How long to wait for the `docker` commands that only ask a question. Generous
+# enough for a busy daemon, short enough that a wedged one is reported rather
+# than hanging an editor's context menu.
+DOCKER_TIMEOUT = 60.0
+
+# The container's name is derived from the tool's, so `pc open --with freecad`
+# uses `partcad-freecad`. Deliberately a fixed name rather than a fresh
+# container each time: the user can prepare theirs (install add-ons, keep
+# preferences) and PartCAD will keep using it.
+CONTAINER_PREFIX = "partcad-"
+
+
+class ExternalToolError(Exception):
+    """No way to open the file, with a message saying what would fix that."""
+
+
+@dataclass(frozen=True)
+class Tool:
+    """A third-party application PartCAD knows how to launch.
+
+    Everything platform-specific about finding one is data, so that adding the
+    second tool is a table entry rather than another copy of the logic below.
+    """
+
+    name: str
+    display_name: str
+    # The image a container is created from when the machine has no local copy.
+    image: str
+    # Executable names to look for, both on this machine's PATH and inside the
+    # container. Ordered: the first one found wins.
+    binaries: Tuple[str, ...] = ()
+    # macOS application bundles, looked for under /Applications and ~/Applications.
+    macos_apps: Tuple[str, ...] = ()
+    # Windows install locations, as globs relative to the directories in
+    # `windows_roots`, so a versioned directory name still matches.
+    windows_globs: Tuple[str, ...] = ()
+    flatpak_id: Optional[str] = None
+    # Extra arguments the application needs before the file name, if any.
+    args: Tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def container_name(self) -> str:
+        return CONTAINER_PREFIX + self.name
+
+
+FREECAD = Tool(
+    name="freecad",
+    display_name="FreeCAD",
+    # `:latest`, not a pinned tag: a user asking for a container wants the
+    # current FreeCAD, and a pin here would quietly age into a version nobody
+    # chose. The image is a community one because the FreeCAD project publishes
+    # none -- the `freecad/freecad` repository on Docker Hub has never had an
+    # image pushed to it -- and it is this one because it carries a GUI FreeCAD
+    # on `PATH` and is still being rebuilt. `--docker-image` overrides it, which
+    # is also the answer for anyone who would rather run their own.
+    image="linuxserver/freecad:latest",
+    binaries=("freecad", "FreeCAD", "freecad-daily"),
+    macos_apps=("FreeCAD.app",),
+    windows_globs=("FreeCAD*/bin/FreeCAD.exe", "FreeCAD*/FreeCAD.exe"),
+    flatpak_id="org.freecad.FreeCAD",
+)
+
+# The tools `pc open --with` accepts. FreeCAD is the first; the second one is a
+# row here, not a branch anywhere below.
+TOOLS: Dict[str, Tool] = {FREECAD.name: FREECAD}
+
+
+def tool_names() -> List[str]:
+    """The tools that can be named, in the order they are offered."""
+    return list(TOOLS)
+
+
+@dataclass
+class OpenResult:
+    """What was opened, and how -- so a caller can say so rather than guess."""
+
+    tool: str
+    # "native" or "docker": which of the two routes below actually ran.
+    method: str
+    path: str
+    command: List[str]
+    detail: str
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": True,
+            "tool": self.tool,
+            "method": self.method,
+            "path": self.path,
+            "command": list(self.command),
+            "detail": self.detail,
+        }
+
+
+def open_file(
+    path: str,
+    tool: str = FREECAD.name,
+    use_docker: bool = False,
+    image: Optional[str] = None,
+    log: Optional[Callable[[str], None]] = None,
+) -> OpenResult:
+    """Open ``path`` in ``tool``, natively if it is installed, else in a container.
+
+    ``use_docker`` is the caller's permission to fall back to a container, not a
+    demand for one: a machine with the application installed uses it either way.
+    Without that permission, and without a local installation, this raises rather
+    than pulling an image nobody asked for.
+    """
+    say = log or (lambda _message: None)
+
+    spec = TOOLS.get(tool)
+    if spec is None:
+        raise ExternalToolError(
+            "Unknown application '%s'. PartCAD can open files in: %s." % (tool, ", ".join(tool_names()))
+        )
+
+    resolved = os.path.abspath(os.path.expanduser(path))
+    if not os.path.exists(resolved):
+        raise ExternalToolError("No such file: %s" % resolved)
+
+    native = native_command(spec)
+    if native is not None:
+        command = list(native) + list(spec.args) + [resolved]
+        say("Opening %s in %s..." % (resolved, spec.display_name))
+        _spawn(command)
+        return OpenResult(
+            tool=spec.name,
+            method="native",
+            path=resolved,
+            command=command,
+            detail="%s is installed on this machine." % spec.display_name,
+        )
+
+    if not use_docker:
+        raise ExternalToolError(
+            "%s was not found on this machine.\n"
+            "Install it, or let PartCAD run it in a container: pass --use-docker to `pc open` "
+            "(the 'partcad.open.useDocker' setting in the VS Code extension)." % spec.display_name
+        )
+
+    return _open_in_container(spec, resolved, image, say)
+
+
+# ---------------------------------------------------------------------------
+# A local installation
+# ---------------------------------------------------------------------------
+
+
+def native_command(spec: Tool) -> Optional[List[str]]:
+    """The command that runs a locally installed ``spec``, or None if there is none.
+
+    Every platform's usual answers, in the order a user would expect them: what
+    is on the PATH first, because that is what they chose to put there, then the
+    places an installer puts things.
+    """
+    for binary in spec.binaries:
+        found = shutil.which(binary)
+        if found:
+            return [found]
+
+    system = platform.system()
+    if system == "Darwin":
+        for app in spec.macos_apps:
+            for directory in ("/Applications", os.path.expanduser("~/Applications")):
+                bundle = os.path.join(directory, app)
+                if os.path.isdir(bundle):
+                    # Through `open`, not the executable inside the bundle: it is
+                    # how macOS launches an application, and it reuses a running
+                    # instance instead of starting a second one.
+                    return ["open", "-a", bundle]
+    elif system == "Windows":  # pragma: no cover - exercised only on Windows
+        for root in _windows_roots():
+            for pattern in spec.windows_globs:
+                matches = sorted(glob.glob(os.path.join(root, pattern.replace("/", os.sep))))
+                if matches:
+                    # Newest-looking last, so a machine with two versions gets
+                    # the later one.
+                    return [matches[-1]]
+    elif spec.flatpak_id is not None and shutil.which("flatpak"):
+        # Asked only once nothing else has matched: it costs a process, and a
+        # flatpak is rarely the only copy on a machine that has one.
+        if _run(["flatpak", "info", spec.flatpak_id]).returncode == 0:
+            return ["flatpak", "run", spec.flatpak_id]
+
+    return None
+
+
+def _windows_roots() -> List[str]:  # pragma: no cover - exercised only on Windows
+    """The directories Windows installers put applications in."""
+    roots = []
+    for variable in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"):
+        value = os.environ.get(variable)
+        if value:
+            roots.append(value)
+    local = os.environ.get("LOCALAPPDATA")
+    if local:
+        roots.append(os.path.join(local, "Programs"))
+    return roots
+
+
+# ---------------------------------------------------------------------------
+# A container
+# ---------------------------------------------------------------------------
+
+
+def _open_in_container(spec: Tool, path: str, image: Optional[str], say: Callable[[str], None]) -> OpenResult:
+    """Run ``spec`` in its container, creating and starting one as needed."""
+    if not _docker_available():
+        raise ExternalToolError(
+            "%s is not installed on this machine and Docker is not available to run it in a container.\n"
+            "Install %s, or install Docker and make sure `docker info` succeeds."
+            % (spec.display_name, spec.display_name)
+        )
+
+    # Worked out before anything is created or started: a container that cannot
+    # show a window is not worth starting, and the message below is the whole
+    # point of the check.
+    x11_env, x11_mounts, x11_advice = _x11_forwarding(spec)
+    display = x11_env["DISPLAY"]
+
+    root = _workspace_for(path)
+
+    state = _container_state(spec.container_name)
+    if state is None:
+        say("Creating the '%s' container from %s..." % (spec.container_name, image or spec.image))
+        _create_container(spec, image or spec.image, root, x11_mounts, x11_env)
+    else:
+        _check_container_mounts(spec, root)
+        if state != "running":
+            say("Starting the '%s' container..." % spec.container_name)
+            _start_container(spec.container_name)
+
+    binary = _container_binary(spec)
+    # The display travels on the exec rather than being left to what the
+    # container was created with: the container outlives the session, and the
+    # display the user is on now is the one the window has to come out on.
+    command = [
+        "docker",
+        "exec",
+        "--detach",
+        *_env_args(x11_env),
+        "--workdir",
+        root,
+        spec.container_name,
+        binary,
+        *spec.args,
+        path,
+    ]
+    say("Opening %s in %s (container '%s', DISPLAY=%s)..." % (path, spec.display_name, spec.container_name, display))
+    result = _run(command)
+    if result.returncode != 0:
+        raise ExternalToolError(
+            "Failed to start %s in the '%s' container: %s"
+            % (spec.display_name, spec.container_name, _message(result) or "docker exec failed")
+        )
+
+    detail = "%s runs in the '%s' container, displaying on %s." % (spec.display_name, spec.container_name, display)
+    if x11_advice:
+        detail += "\n" + x11_advice
+    return OpenResult(tool=spec.name, method="docker", path=path, command=command, detail=detail)
+
+
+def _env_args(env: Dict[str, str]) -> List[str]:
+    """``--env K=V`` for each entry, in a fixed order so a command line is stable."""
+    args = []
+    for key in sorted(env):
+        args += ["--env", "%s=%s" % (key, env[key])]
+    return args
+
+
+def _workspace_for(path: str) -> str:
+    """The workspace to mount into the container so that ``path`` is inside it.
+
+    The one this command runs in, when it holds the file: that is the workspace
+    whose daemon socket is worth mounting beside it, and the one the caller
+    means -- an editor runs `pc open` in the window's workspace folder. A file
+    somewhere else gets its own workspace mounted instead, which still contains
+    it; there is simply no daemon of this workspace's to offer it.
+    """
+    root = determine_root_path()
+    if _is_within(path, root):
+        return root
+    return determine_root_path(os.path.dirname(path))
+
+
+def _docker_available() -> bool:
+    """True when there is a `docker` that answers -- not merely one on the PATH.
+
+    A CLI with no daemon behind it is the common case (Docker Desktop not
+    started), and it fails several seconds later inside `docker run`, where the
+    error says nothing useful.
+    """
+    if shutil.which("docker") is None:
+        return False
+    return _run(["docker", "info"]).returncode == 0
+
+
+def _container_state(name: str) -> Optional[str]:
+    """The state of the container named ``name`` ("running", "exited", ...), or None.
+
+    The filter narrows the listing; the name is then compared exactly, because
+    `--filter name=` is a substring pattern -- a user's `partcad-freecad-test`
+    must not be mistaken for the container PartCAD manages.
+    """
+    result = _run(
+        [
+            "docker",
+            "ps",
+            "--all",
+            "--filter",
+            "name=" + name,
+            "--format",
+            "{{.Names}}\t{{.State}}",
+        ]
+    )
+    if result.returncode != 0:
+        raise ExternalToolError("Failed to look for the '%s' container: %s" % (name, _message(result)))
+    for line in (result.stdout or "").splitlines():
+        fields = line.strip().split("\t")
+        if len(fields) == 2 and fields[0] == name:
+            return fields[1]
+    return None
+
+
+def _create_container(spec: Tool, image: str, root: str, x11_mounts: List[str], x11_env: Dict[str, str]) -> None:
+    """Create the tool's container, mounting the workspace and the daemon socket.
+
+    The container is created idle (it sleeps) and the application is started in
+    it with `docker exec`, rather than being the container's own command. One
+    container then serves every `pc open`: the first one does not have to be
+    treated differently from the next, and closing the application's window does
+    not throw away a container the user may have customised.
+    """
+    mounts = ["--volume", "%s:%s" % (root, root)]
+
+    # The daemon's socket, so that a PartCAD running inside the container talks
+    # to the same daemon this workspace already has, instead of starting a
+    # second one against a directory only it can see. The directory is mounted
+    # rather than the socket file: a restarted daemon creates a new socket, and
+    # a bind mount of the old file would keep pointing at something that is gone.
+    #
+    # Created here if it does not exist yet, because the mounts are fixed when
+    # the container is created and this container outlives the daemon several
+    # times over. Waiting for a daemon that has not started would mean a
+    # container that can never see the one that eventually does -- and the
+    # directory is PartCAD's own, which the daemon would create the same way.
+    socket_dir = os.path.dirname(socket_path(root))
+    with contextlib.suppress(OSError):
+        os.makedirs(socket_dir, exist_ok=True)
+    if os.path.isdir(socket_dir):
+        mounts += ["--volume", "%s:%s" % (socket_dir, socket_dir)]
+
+    command = [
+        "docker",
+        "run",
+        "--detach",
+        "--name",
+        spec.container_name,
+        "--workdir",
+        root,
+        *_env_args(x11_env),
+        *mounts,
+        *x11_mounts,
+        # The image's own entrypoint is the application; it has to be replaced
+        # for the container to stay up and wait for `docker exec`.
+        "--entrypoint",
+        "sh",
+        image,
+        "-c",
+        "while true; do sleep 3600; done",
+    ]
+    result = _run(command, timeout=None)
+    if result.returncode != 0:
+        raise ExternalToolError(
+            "Failed to create the '%s' container from %s: %s" % (spec.container_name, image, _message(result))
+        )
+
+
+def _start_container(name: str) -> None:
+    result = _run(["docker", "start", name])
+    if result.returncode != 0:
+        raise ExternalToolError("Failed to start the '%s' container: %s" % (name, _message(result)))
+
+
+def _check_container_mounts(spec: Tool, root: str) -> None:
+    """Refuse an existing container that cannot see this workspace.
+
+    A container outlives the workspace it was created for, and the mounts are
+    fixed when it is created. Without this check the application starts, reports
+    that the file does not exist, and the user has no way to know why.
+    """
+    result = _run(
+        ["docker", "inspect", "--format", "{{range .Mounts}}{{println .Destination}}{{end}}", spec.container_name]
+    )
+    if result.returncode != 0:
+        # Not fatal: an old Docker that formats this differently must not stop
+        # a container that is very probably fine.
+        return
+    mounted = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+    if not mounted:
+        return
+    if any(_is_within(root, destination) for destination in mounted):
+        return
+    raise ExternalToolError(
+        "The '%s' container does not have this workspace (%s) mounted; it was created for a different one.\n"
+        "Remove it and PartCAD will create one for this workspace: docker rm -f %s"
+        % (spec.container_name, root, spec.container_name)
+    )
+
+
+def _container_binary(spec: Tool) -> str:
+    """The application's executable inside the container, or an error naming why not."""
+    for binary in spec.binaries:
+        result = _run(["docker", "exec", spec.container_name, "sh", "-c", "command -v " + binary])
+        if result.returncode == 0 and (result.stdout or "").strip():
+            return (result.stdout or "").strip().splitlines()[0]
+    raise ExternalToolError(
+        "The '%s' container has no %s executable (looked for: %s).\n"
+        "Remove it so that PartCAD recreates it from %s: docker rm -f %s"
+        % (
+            spec.container_name,
+            spec.display_name,
+            ", ".join(spec.binaries),
+            spec.image,
+            spec.container_name,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Getting the window onto the user's screen
+# ---------------------------------------------------------------------------
+
+_LINUX_NO_DISPLAY = (
+    "There is no X display to show {name} on (DISPLAY is not set).\n"
+    "Run `pc open` from a graphical session, or set DISPLAY to the X server to use.\n"
+    "Under Wayland, install XWayland so that X applications have a display."
+)
+
+_MACOS_NO_DISPLAY = (
+    "Running {name} in a container needs an X server on macOS, and none was found.\n"
+    "Install XQuartz (https://www.xquartz.org/ or `brew install --cask xquartz`), then:\n"
+    "  1. start XQuartz and turn on Preferences > Security > 'Allow connections from network clients';\n"
+    "  2. log out and back in, so XQuartz restarts with that setting;\n"
+    "  3. run `xhost + 127.0.0.1` to let the container connect.\n"
+    "Install {name} on this machine instead if you would rather not run an X server."
+)
+
+_WINDOWS_NO_DISPLAY = (
+    "Running {name} in a container needs an X server on Windows, and none was found.\n"
+    "Install one -- VcXsrv (https://sourceforge.net/projects/vcxsrv/), X410 or Xming -- start it with\n"
+    "access control disabled ('Disable access control' in the VcXsrv wizard), then set DISPLAY, e.g.\n"
+    "  set DISPLAY=host.docker.internal:0\n"
+    "Install {name} on this machine instead if you would rather not run an X server."
+)
+
+_MACOS_ADVICE = "If no window appears, run `xhost + 127.0.0.1` in a terminal and check that XQuartz is running."
+_WINDOWS_ADVICE = "If no window appears, check that the X server is running with access control disabled."
+_LINUX_ADVICE = "If the application reports 'Authorization required', run `xhost +local:` to let the container connect."
+_LINUX_TCP_ADVICE = (
+    "The display is reached over TCP, so the container connects to it as host.docker.internal; "
+    "run `xhost +` on the machine running the X server if it is refused."
+)
+
+
+def _x11_forwarding(spec: Tool) -> Tuple[Dict[str, str], List[str], str]:
+    """How the container reaches the user's screen: (environment, mounts, advice).
+
+    Raises with instructions when there is nothing to reach. That message is the
+    reason this runs before the container is created: an unusable container that
+    starts and shows nothing is worse than a command that says what to install.
+    """
+    system = platform.system()
+    display = os.environ.get("DISPLAY", "").strip()
+
+    if system == "Darwin":
+        if not (display or _xquartz_installed()):
+            raise ExternalToolError(_MACOS_NO_DISPLAY.format(name=spec.display_name))
+        # Always over TCP: the container has no access to the launchd socket
+        # macOS puts in DISPLAY, and host.docker.internal is how Docker Desktop
+        # exposes the host to it.
+        return {"DISPLAY": _host_display(display)}, [], _MACOS_ADVICE
+
+    if system == "Windows":  # pragma: no cover - exercised only on Windows
+        if not display:
+            raise ExternalToolError(_WINDOWS_NO_DISPLAY.format(name=spec.display_name))
+        return {"DISPLAY": _host_display(display)}, [], _WINDOWS_ADVICE
+
+    if not display:
+        raise ExternalToolError(_LINUX_NO_DISPLAY.format(name=spec.display_name))
+
+    host = display.rsplit(":", 1)[0] if ":" in display else ""
+    if host not in ("", "unix") and not host.startswith("/"):
+        # A display reached over TCP -- an SSH-forwarded one, or an X server on
+        # another machine. There is no socket to share, so the container is
+        # given the address instead; `host-gateway` is what makes "the host"
+        # resolvable from inside a container on Linux.
+        return (
+            {"DISPLAY": _host_display(display)},
+            ["--add-host", "host.docker.internal:host-gateway"],
+            _LINUX_TCP_ADVICE,
+        )
+
+    env = {"DISPLAY": display}
+    mounts = []
+    if os.path.isdir("/tmp/.X11-unix"):
+        # The display is a socket on this machine, so it can simply be shared --
+        # no TCP, no listening X server, nothing for the user to configure.
+        mounts += ["--volume", "/tmp/.X11-unix:/tmp/.X11-unix:rw"]
+    xauthority = os.environ.get("XAUTHORITY")
+    if xauthority and os.path.isfile(xauthority):
+        # Both the file and the variable naming it: an X client that cannot find
+        # the cookie is refused by the server, and the container's idea of a home
+        # directory is not the user's.
+        mounts += ["--volume", "%s:%s:ro" % (xauthority, xauthority)]
+        env["XAUTHORITY"] = xauthority
+    return env, mounts, _LINUX_ADVICE
+
+
+def _xquartz_installed() -> bool:
+    """True when macOS has an X server installed, even if it is not running."""
+    return any(
+        os.path.exists(candidate)
+        for candidate in ("/Applications/Utilities/XQuartz.app", "/opt/X11/bin/Xquartz", "/opt/X11/bin/xquartz")
+    )
+
+
+def _host_display(display: str) -> str:
+    """The host's display, addressed the way a container has to address it.
+
+    A local display is on the host, which a container on macOS or Windows
+    reaches as `host.docker.internal`. Local covers more than ":0": macOS puts
+    the path of XQuartz's launchd socket in DISPLAY, which names nothing at all
+    outside this machine. Anything that does name a machine is passed through
+    untouched.
+    """
+    screen = display.rsplit(":", 1)[-1] if ":" in display else "0"
+    host = display.rsplit(":", 1)[0] if ":" in display else ""
+    if host in ("", "localhost", "127.0.0.1", "unix") or host.startswith("/"):
+        return "host.docker.internal:" + screen
+    return display
+
+
+# ---------------------------------------------------------------------------
+# Running things
+# ---------------------------------------------------------------------------
+
+
+def _is_within(path: str, directory: str) -> bool:
+    """True when ``path`` is ``directory`` or below it."""
+    try:
+        relative = os.path.relpath(os.path.realpath(path), os.path.realpath(directory))
+    except ValueError:  # pragma: no cover - different drives on Windows
+        return False
+    if relative == os.curdir:
+        return True
+    return relative != os.pardir and not relative.startswith(os.pardir + os.sep)
+
+
+def _message(result: subprocess.CompletedProcess) -> str:
+    """The most useful line Docker printed, for a message a user has to act on."""
+    for stream in (result.stderr, result.stdout):
+        text = (stream or "").strip()
+        if text:
+            return text.splitlines()[-1]
+    return ""
+
+
+def _run(args: List[str], timeout: Optional[float] = DOCKER_TIMEOUT) -> subprocess.CompletedProcess:
+    """Run a command and capture what it said; a timeout is a failed command."""
+    try:
+        return subprocess.run(
+            args,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(args, 1, "", "timed out after %s seconds" % timeout)
+    except OSError as e:
+        return subprocess.CompletedProcess(args, 1, "", str(e))
+
+
+def _spawn(args: List[str]) -> None:
+    """Start a GUI application and leave it running once this process exits.
+
+    Detached on purpose: `pc open` is done the moment the window belongs to the
+    user, and an editor's context menu must not stay busy for as long as the
+    application is open.
+    """
+    kwargs = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+    if os.name == "nt":  # pragma: no cover - exercised only on Windows
+        kwargs["creationflags"] = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+    else:
+        kwargs["start_new_session"] = True
+    try:
+        subprocess.Popen(args, **kwargs)
+    except OSError as e:
+        raise ExternalToolError("Failed to run %s: %s" % (" ".join(args), e))

--- a/tests/partcad_cli/unit/test_command_boundary.py
+++ b/tests/partcad_cli/unit/test_command_boundary.py
@@ -62,6 +62,10 @@ IN_PROCESS = {
     # process running from it can do. Two commands, on opposite sides of the
     # boundary, which is why they are not one command with a flag.
     "upgrade.py": "replaces this machine's PartCAD installation, and stops the local daemons to do it",
+    # A GUI application opens on the screen of the machine that starts it, and
+    # the path it is handed only exists there. A daemon can be remote, so this
+    # cannot be its work -- and it needs no package graph or CAD runtime anyway.
+    "open.py": "launches a third-party application on the client's own machine, with the client's own file",
     "daemon/start.py": "manages the daemon process itself",
     "daemon/stop.py": "manages the daemon process itself",
     "system/telemetry/clear.py": "clears the client's own telemetry id under the client's state dir",

--- a/tests/partcad_cli/unit/test_open.py
+++ b/tests/partcad_cli/unit/test_open.py
@@ -1,0 +1,119 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Tests for `pc open`.
+
+The command is a thin wrapper over `partcad_client.external`, and what is pinned
+here is the wrapping: the options it hands over, and the two ways it reports
+back. The JSON shape matters most -- the VS Code extension's "Open in..." menu
+reads it, and on a failure the message it carries is the whole answer (which X
+server to install, or how to let PartCAD use a container), so it has to survive
+a non-zero exit rather than be replaced by one.
+
+Which side of the command boundary this command is on is checked by
+`test_command_boundary.py`; nothing here starts an application or a container.
+"""
+
+import json
+from collections.abc import Iterator
+
+import pytest
+from click.testing import CliRunner
+from partcad_cli.click.command import cli
+from partcad_client import external
+
+
+@pytest.fixture
+def opened(monkeypatch):
+    """Record the call `pc open` makes, and answer it however a test wants."""
+
+    class Recorder:
+        def __init__(self):
+            self.calls = []
+            self.error = None
+            self.result = external.OpenResult(
+                tool="freecad",
+                method="native",
+                path="/w/cube.step",
+                command=["/usr/bin/freecad", "/w/cube.step"],
+                detail="FreeCAD is installed on this machine.",
+            )
+
+        def open_file(self, path, tool="freecad", use_docker=False, image=None, log=None):
+            self.calls.append({"path": path, "tool": tool, "use_docker": use_docker, "image": image, "log": log})
+            if self.error:
+                raise self.error
+            return self.result
+
+    recorder = Recorder()
+    monkeypatch.setattr(external, "open_file", recorder.open_file)
+    return recorder
+
+
+def _invoke(click_runner, *args):
+    return click_runner.invoke(cli, ["--no-ansi", "open", *args])
+
+
+def test_the_options_reach_the_opener(click_runner: Iterator[CliRunner], opened) -> None:
+    result = _invoke(
+        click_runner, "--with", "freecad", "--use-docker", "--docker-image", "freecad/freecad:weekly", "x.step"
+    )
+    assert result.exit_code == 0, result.output
+    assert opened.calls == [
+        {
+            "path": "x.step",
+            "tool": "freecad",
+            "use_docker": True,
+            "image": "freecad/freecad:weekly",
+            "log": opened.calls[0]["log"],
+        }
+    ]
+
+
+def test_freecad_is_the_default_application(click_runner: Iterator[CliRunner], opened) -> None:
+    _invoke(click_runner, "x.step")
+    assert opened.calls[0]["tool"] == "freecad"
+    assert opened.calls[0]["use_docker"] is False
+
+
+def test_what_happened_is_reported(click_runner: Iterator[CliRunner], opened) -> None:
+    result = _invoke(click_runner, "x.step")
+    assert "FreeCAD is installed on this machine." in result.output
+
+
+def test_json_reports_what_happened_in_full(click_runner: Iterator[CliRunner], opened) -> None:
+    result = _invoke(click_runner, "--json", "x.step")
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "ok": True,
+        "tool": "freecad",
+        "method": "native",
+        "path": "/w/cube.step",
+        "command": ["/usr/bin/freecad", "/w/cube.step"],
+        "detail": "FreeCAD is installed on this machine.",
+    }
+
+
+def test_json_stays_silent_about_progress(click_runner: Iterator[CliRunner], opened) -> None:
+    # The caller parses stdout; progress lines would be in the way of the one
+    # thing it is there to read.
+    _invoke(click_runner, "--json", "x.step")
+    assert opened.calls[0]["log"] is None
+
+
+def test_a_failure_is_an_error_with_the_reason(click_runner: Iterator[CliRunner], opened) -> None:
+    opened.error = external.ExternalToolError("FreeCAD was not found on this machine.")
+    result = _invoke(click_runner, "x.step")
+    assert result.exit_code != 0
+    assert "FreeCAD was not found" in result.output
+
+
+def test_a_failure_keeps_its_message_under_json(click_runner: Iterator[CliRunner], opened) -> None:
+    opened.error = external.ExternalToolError("Install XQuartz (https://www.xquartz.org/)")
+    result = _invoke(click_runner, "--json", "x.step")
+    assert result.exit_code == 1
+    reported = json.loads(result.output)
+    assert reported["ok"] is False
+    assert "XQuartz" in reported["error"]

--- a/tests/partcad_client/test_external.py
+++ b/tests/partcad_client/test_external.py
@@ -1,0 +1,380 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Tests for opening a file in a third-party application (`partcad_client.external`).
+
+Two routes are pinned here, and the rule that decides between them: a locally
+installed application is used whenever there is one, and a container is only
+ever reached for when the caller has allowed it. Everything the container route
+does is a `docker` command line, so that is what these tests read -- the mounts
+that make the workspace and the daemon socket visible at the paths they have on
+the host, the display the window comes out on, and the refusals that carry the
+instructions a user has to follow.
+
+Nothing here runs Docker, and nothing starts an application: `_run` and `_spawn`
+are the two places where this module reaches out of the process, and both are
+replaced.
+"""
+
+import subprocess
+
+import pytest
+
+from partcad_client import external
+
+
+@pytest.fixture(autouse=True)
+def no_local_tools(monkeypatch):
+    """A machine with nothing installed on it, unless a test says otherwise.
+
+    `shutil.which` would otherwise answer from whatever the machine running the
+    tests happens to have, which is the one thing that decides the whole route.
+    """
+    monkeypatch.setattr(external.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(external.platform, "system", lambda: "Linux")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.delenv("XAUTHORITY", raising=False)
+
+
+@pytest.fixture
+def spawned(monkeypatch):
+    """Record what would have been started, instead of starting it."""
+    started = []
+    monkeypatch.setattr(external, "_spawn", lambda args: started.append(list(args)))
+    return started
+
+
+class FakeDocker:
+    """A `docker` that answers from state a test sets, and records every call."""
+
+    def __init__(self):
+        self.commands = []
+        # None means the container does not exist yet.
+        self.state = None
+        self.mounts = []
+        self.available = True
+        self.binaries = ["/usr/bin/freecad"]
+        self.exec_returncode = 0
+
+    def install(self, monkeypatch):
+        monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+        monkeypatch.setattr(external, "_run", self)
+        return self
+
+    def __call__(self, args, timeout=external.DOCKER_TIMEOUT):
+        self.commands.append(list(args))
+        return self._answer(list(args))
+
+    def _answer(self, args):
+        if args[:2] == ["docker", "info"]:
+            return self._result(0 if self.available else 1, stderr="Cannot connect to the Docker daemon")
+        if args[:2] == ["docker", "ps"]:
+            if self.state is None:
+                return self._result(0)
+            return self._result(0, stdout="partcad-freecad\t%s\n" % self.state)
+        if args[:2] == ["docker", "run"]:
+            self.state = "running"
+            self.mounts = [value.split(":")[1] for flag, value in zip(args, args[1:]) if flag == "--volume"]
+            return self._result(0)
+        if args[:2] == ["docker", "start"]:
+            self.state = "running"
+            return self._result(0)
+        if args[:2] == ["docker", "inspect"]:
+            return self._result(0, stdout="".join(destination + "\n" for destination in self.mounts))
+        if args[:2] == ["docker", "exec"]:
+            if args[-2:-1] == ["-c"] or "command -v" in args[-1]:
+                wanted = args[-1].rsplit(" ", 1)[-1]
+                found = [b for b in self.binaries if b.rsplit("/", 1)[-1] == wanted]
+                return self._result(0 if found else 1, stdout=(found[0] + "\n") if found else "")
+            return self._result(self.exec_returncode, stderr="" if not self.exec_returncode else "exec failed")
+        raise AssertionError("unexpected docker command: %s" % " ".join(args))
+
+    @staticmethod
+    def _result(returncode, stdout="", stderr=""):
+        return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+    def command(self, *prefix):
+        """The first recorded command starting with ``prefix``."""
+        for args in self.commands:
+            if args[: len(prefix)] == list(prefix):
+                return args
+        return None
+
+
+@pytest.fixture
+def docker(monkeypatch):
+    return FakeDocker().install(monkeypatch)
+
+
+@pytest.fixture
+def part(tmp_path):
+    """A file inside a workspace, which is what gets opened."""
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    path = tmp_path / "cube.step"
+    path.write_text("ISO-10303-21;\n")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def workspace_socket(monkeypatch, tmp_path):
+    """Put the workspace's daemon socket where a test can see it get mounted."""
+    socket_dir = tmp_path / ".partcad" / "workspaces" / "hash"
+    socket_dir.mkdir(parents=True)
+    monkeypatch.setattr(external, "socket_path", lambda _root: str(socket_dir / "socket"))
+    return socket_dir
+
+
+# ---------------------------------------------------------------------------
+# Choosing between a local installation and a container
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_installation_is_used_when_there_is_one(monkeypatch, spawned, part):
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/" + name if name == "freecad" else None)
+    result = external.open_file(str(part))
+    assert result.method == "native"
+    assert spawned == [["/usr/bin/freecad", str(part)]]
+
+
+def test_a_local_installation_wins_even_when_docker_is_allowed(monkeypatch, spawned, part, docker):
+    # `use_docker` is permission to fall back, not a demand for a container.
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/" + name)
+    result = external.open_file(str(part), use_docker=True)
+    assert result.method == "native"
+    assert docker.commands == []
+
+
+def test_without_docker_allowed_the_failure_says_how_to_allow_it(part):
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part))
+    assert "--use-docker" in str(caught.value)
+    assert "useDocker" in str(caught.value)
+
+
+def test_docker_that_does_not_answer_is_not_docker(part, docker):
+    docker.available = False
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), use_docker=True)
+    assert "Docker" in str(caught.value)
+
+
+def test_an_unknown_application_lists_the_known_ones(part):
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), tool="solidworks")
+    assert "freecad" in str(caught.value)
+
+
+def test_a_missing_file_is_reported_before_anything_is_started(tmp_path, spawned):
+    with pytest.raises(external.ExternalToolError):
+        external.open_file(str(tmp_path / "gone.step"))
+    assert spawned == []
+
+
+# ---------------------------------------------------------------------------
+# The container
+# ---------------------------------------------------------------------------
+
+
+def test_the_container_is_created_with_the_workspace_and_the_socket_mounted(part, docker, workspace_socket, tmp_path):
+    result = external.open_file(str(part), use_docker=True)
+    assert result.method == "docker"
+    created = docker.command("docker", "run")
+    # Mounted at the path they have on the host, so that one path means the same
+    # thing on both sides -- the file argument below is that same host path.
+    assert "%s:%s" % (tmp_path, tmp_path) in created
+    assert "%s:%s" % (workspace_socket, workspace_socket) in created
+    assert "--name" in created and "partcad-freecad" in created
+
+
+def test_the_socket_directory_is_made_so_a_later_daemon_is_visible(part, docker, monkeypatch, tmp_path):
+    # The mounts are fixed when the container is created, and this container
+    # outlives the daemon several times over: waiting for one to exist would
+    # mean a container that can never see the one that eventually starts.
+    socket_dir = tmp_path / "state" / "workspaces" / "hash"
+    monkeypatch.setattr(external, "socket_path", lambda _root: str(socket_dir / "socket"))
+    external.open_file(str(part), use_docker=True)
+    assert socket_dir.is_dir()
+    assert "%s:%s" % (socket_dir, socket_dir) in docker.command("docker", "run")
+
+
+def test_the_container_is_named_after_the_tool_not_the_image(part, docker):
+    external.open_file(str(part), use_docker=True)
+    created = docker.command("docker", "run")
+    assert created[created.index("--name") + 1] == "partcad-freecad"
+    assert created[-3] == external.FREECAD.image
+
+
+def test_a_custom_image_replaces_the_default_one(part, docker):
+    external.open_file(str(part), use_docker=True, image="freecad/freecad:weekly")
+    assert docker.command("docker", "run")[-3] == "freecad/freecad:weekly"
+
+
+def test_an_existing_container_is_reused_rather_than_recreated(part, docker, tmp_path):
+    docker.state = "running"
+    docker.mounts = [str(tmp_path)]
+    external.open_file(str(part), use_docker=True)
+    assert docker.command("docker", "run") is None
+    assert docker.command("docker", "start") is None
+
+
+def test_a_stopped_container_is_started(part, docker, tmp_path):
+    docker.state = "exited"
+    docker.mounts = [str(tmp_path)]
+    external.open_file(str(part), use_docker=True)
+    assert docker.command("docker", "start") == ["docker", "start", "partcad-freecad"]
+
+
+def test_a_container_from_another_workspace_is_refused_with_the_way_out(part, docker):
+    docker.state = "running"
+    docker.mounts = ["/somewhere/else"]
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), use_docker=True)
+    assert "docker rm -f partcad-freecad" in str(caught.value)
+
+
+def test_a_container_without_the_application_is_refused_with_the_way_out(part, docker):
+    docker.binaries = []
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), use_docker=True)
+    assert "docker rm -f partcad-freecad" in str(caught.value)
+
+
+def test_the_application_is_started_in_the_container_on_the_host_file(part, docker):
+    external.open_file(str(part), use_docker=True)
+    started = docker.command("docker", "exec", "--detach")
+    assert started[-2:] == ["/usr/bin/freecad", str(part)]
+    assert "DISPLAY=:0" in started
+
+
+def test_a_file_outside_this_workspace_still_gets_a_mount_that_holds_it(tmp_path, docker, monkeypatch):
+    # Whatever is mounted has to contain the file, or the application would be
+    # handed a name the container cannot resolve. The workspace `pc open` runs
+    # in is preferred -- it is the one with a daemon -- but it is not imposed.
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    outside = elsewhere / "cube.step"
+    outside.write_text("ISO-10303-21;\n")
+
+    external.open_file(str(outside), use_docker=True)
+    created = docker.command("docker", "run")
+    assert "%s:%s" % (elsewhere, elsewhere) in created
+    assert "%s:%s" % (workspace, workspace) not in created
+
+
+def test_the_workspace_the_command_runs_in_is_the_one_mounted(part, docker, monkeypatch, tmp_path):
+    # The file is under it, so this is the workspace whose daemon socket is
+    # worth mounting beside it -- which is what an editor's `pc open` means.
+    nested = tmp_path / "parts"
+    nested.mkdir()
+    monkeypatch.chdir(nested)
+    external.open_file(str(part), use_docker=True)
+    assert "%s:%s" % (tmp_path, tmp_path) in docker.command("docker", "run")
+
+
+def test_a_failed_exec_is_reported_with_what_docker_said(part, docker):
+    docker.exec_returncode = 1
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), use_docker=True)
+    assert "exec failed" in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# Getting the window onto the user's screen
+# ---------------------------------------------------------------------------
+
+
+def test_linux_shares_the_x_socket_and_the_display(part, docker, monkeypatch):
+    # The display is a socket on this machine, so the container gets the socket
+    # rather than instructions for setting up an X server.
+    real_isdir = external.os.path.isdir
+    monkeypatch.setattr(external.os.path, "isdir", lambda path: True if path == "/tmp/.X11-unix" else real_isdir(path))
+    external.open_file(str(part), use_docker=True)
+    created = docker.command("docker", "run")
+    assert "/tmp/.X11-unix:/tmp/.X11-unix:rw" in created
+    assert "DISPLAY=:0" in created
+
+
+def test_linux_passes_the_x_cookie_as_well_as_the_socket(part, docker, monkeypatch, tmp_path):
+    # The file *and* the variable naming it: an X client that cannot find the
+    # cookie is refused by the server, and the container's home directory is not
+    # the user's.
+    cookie = tmp_path / "Xauthority"
+    cookie.write_text("cookie")
+    monkeypatch.setenv("XAUTHORITY", str(cookie))
+    external.open_file(str(part), use_docker=True)
+    created = docker.command("docker", "run")
+    assert "%s:%s:ro" % (cookie, cookie) in created
+    assert "XAUTHORITY=%s" % cookie in created
+
+
+def test_a_forwarded_linux_display_is_reached_over_the_host_gateway(part, docker, monkeypatch):
+    # An SSH-forwarded display is TCP, not a socket: there is nothing to share,
+    # so the container is told where the host is instead.
+    monkeypatch.setenv("DISPLAY", "localhost:10.0")
+    external.open_file(str(part), use_docker=True)
+    created = docker.command("docker", "run")
+    assert "DISPLAY=host.docker.internal:10.0" in created
+    assert "host.docker.internal:host-gateway" in created
+
+
+def test_linux_without_a_display_says_so_before_creating_anything(part, docker, monkeypatch):
+    monkeypatch.delenv("DISPLAY", raising=False)
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), use_docker=True)
+    assert "DISPLAY" in str(caught.value)
+    assert docker.command("docker", "run") is None
+
+
+def test_macos_without_an_x_server_names_the_one_to_install(part, docker, monkeypatch):
+    monkeypatch.setattr(external.platform, "system", lambda: "Darwin")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.setattr(external, "_xquartz_installed", lambda: False)
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), use_docker=True)
+    assert "XQuartz" in str(caught.value)
+    assert docker.command("docker", "run") is None
+
+
+def test_macos_reaches_the_host_x_server_over_tcp(part, docker, monkeypatch):
+    # The launchd socket macOS puts in DISPLAY means nothing inside a container.
+    monkeypatch.setattr(external.platform, "system", lambda: "Darwin")
+    monkeypatch.setenv("DISPLAY", "/private/tmp/com.apple.launchd.7Uu/org.xquartz:0")
+    monkeypatch.setattr(external, "_xquartz_installed", lambda: True)
+    result = external.open_file(str(part), use_docker=True)
+    assert "DISPLAY=host.docker.internal:0" in docker.command("docker", "run")
+    assert "xhost" in result.detail
+
+
+def test_windows_without_a_display_names_the_x_servers_to_install(part, docker, monkeypatch):
+    monkeypatch.setattr(external.platform, "system", lambda: "Windows")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), use_docker=True)
+    assert "VcXsrv" in str(caught.value)
+    assert docker.command("docker", "run") is None
+
+
+@pytest.mark.parametrize(
+    "display, expected",
+    [
+        (":0", "host.docker.internal:0"),
+        ("localhost:0", "host.docker.internal:0"),
+        ("127.0.0.1:1", "host.docker.internal:1"),
+        ("/private/tmp/com.apple.launchd.7Uu/org.xquartz:0", "host.docker.internal:0"),
+        ("workstation.local:0", "workstation.local:0"),
+    ],
+)
+def test_a_local_display_is_readdressed_for_the_container(display, expected):
+    assert external._host_display(display) == expected
+
+
+def test_the_result_says_how_the_file_was_opened(part, docker):
+    result = external.open_file(str(part), use_docker=True)
+    assert result.to_dict()["ok"] is True
+    assert result.to_dict()["method"] == "docker"
+    assert result.to_dict()["path"] == str(part)


### PR DESCRIPTION
## Copilot Summary

Opening a part or an assembly in a third-party CAD application — from the CLI and from the VS Code Explorer's context menu — with the daemon involved at no point. FreeCAD is the first application supported.

### `pc open <path>` — client-side only

It runs entirely in the client process, for a stronger version of the reason `pc lint --file` and `pc upgrade` do: a daemon can be remote, where the window would open on somebody else's screen — on a machine that may have no display at all — and the path on the command line names a file only the client has. There is deliberately **no RPC method** for it, and it takes a path rather than a `<package>:<part>` name because resolving a name is a package-graph question, which is the round trip this command does not make. `open.py` is registered in `IN_PROCESS` in `tests/partcad_cli/unit/test_command_boundary.py`, which also keeps it from importing the heavy `partcad`.

Options: `--with APPLICATION` (default `freecad`), `--use-docker`, `--docker-image IMAGE`, `--json`.

### `partcad_client/external.py` — the mechanism, shared by both callers

* **A local installation wins whenever there is one**: the `PATH`, `/Applications` on macOS, `Program Files` on Windows, a flatpak on Linux. `--use-docker` is permission to fall back, not a demand for a container.
* **Otherwise a container**, one per application, keyed by **container name** `partcad-freecad` (not an image name): reused when it is running, started when it is stopped, created from the application's image when it does not exist — so a container a user has prepared keeps being the one that is used. It is created idle and the application is started in it with `docker exec`, so the first open is not a special case and closing the window does not throw the container away.
* **Mounts**: the workspace root and the directory holding this workspace's daemon socket, both **at the paths they have on the host**, so one path means the same thing on both sides. The socket directory is created if the daemon has not run yet, because the mounts are fixed when the container is created. A container created for a different workspace is refused, naming `docker rm -f partcad-freecad`.
* **X forwarding**: on Linux the socket and its `XAUTHORITY` cookie are shared and nothing needs configuring; a display reached over TCP — a forwarded one, or an X server on macOS or Windows — is addressed as `host.docker.internal` (with `--add-host …:host-gateway` on Linux). With no X server on macOS/Windows the command says which one to install (XQuartz, VcXsrv) and what to allow, **before** anything is created, rather than starting a container whose window never appears.
* Anything else is an error that says what would fix it.

Everything platform-specific about finding an application is data on a `Tool` row, so the second application is a table entry rather than another branch.

### VS Code extension

"Open in > FreeCAD" on a part or an assembly runs `pc open --json` through the backend's CLI path, never over the JSON-RPC connection. What it hands over is `config.item_path`, not the tree's `itemPath` — the latter is set only for the types the editor can *edit*, so a STEP or BREP part, exactly what another CAD application is for, has none. A failure comes back as JSON *and* a non-zero exit, so the message survives into the error dialog: it is the whole answer the user needs. Two settings: `partcad.open.useDocker` and `partcad.open.dockerImage`.

### Notes

* The default image is `linuxserver/freecad:latest`, not `freecad/freecad:latest`: the latter repository exists on Docker Hub but has never had an image pushed to it, so it cannot be pulled. `--docker-image` / `partcad.open.dockerImage` overrides it.
* `features/open.feature`'s entry in `dev-tools/behave_durations.json` is an estimate, by analogy with `features/upgrade.feature`, rather than a CI measurement — said so in that file's `_source`.

### Validation

* 31 unit tests for `partcad_client.external` (both routes, the mounts, the X forwarding and every refusal — nothing runs Docker or starts an application), 7 for `pc open`, 3 behave scenarios that cannot open a window on any machine.
* `pytest tests/partcad_client tests/partcad_cli/unit` passes here except three tests that need a working daemon (`test_version`, `test_status`); those fail identically on unmodified `devel` in this environment. The `pre-commit` pytest/behave hooks could not be run — the dev container needs a Docker daemon, which this environment does not have.
* Extension: `npm run lint`, `npx tsc --noEmit`, `npm run format-check` and the webpack build are clean. `black`/`flake8` clean on the new Python (the three `flake8` findings in `command.py` pre-date this branch).
* Documented in `docs/source/cli.rst`, `ide/vscode/README.md`, and the `AGENTS.md` files for the repository root, `partcad_cli` and `ide/vscode`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AMW7xH3meEzksz2unvpiC1)_