### PR TITLE
docs: catch the user-facing documentation up with the last month on devel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,10 @@ a CAD addon, or documentation.
   so that an older `pip install partcad-cli` keeps working. Do not give it modules or entry points — two
   distributions owning one import name or one console script break each other on uninstall, silently.
 
-* [README.md](./README.md) and [docs](./docs/README.md):
+* [README.md](./README.md) and [docs/source](./docs/source):
 
-  Human-friendly documentation.
+  Human-friendly documentation. `docs/source` is the Sphinx tree published to
+  [Read the Docs](https://partcad.readthedocs.io/); `docs/source/index.rst` has its table of contents.
 
 ## Development process
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,14 @@ Subscribe on [LinkedIn], [YouTube], [TikTok], [Facebook], [Instagram], [Threads]
 - Workflow acceleration by caching rendered models (including OpenSCAD, CadQuery, build123d and Chili3D)
   - [x] In memory
   - [x] On disk
-  - [ ] Local Server _(in progress)_
-  - [ ] Cloud _(in progress)_
+  - [x] A memcached server shared by a team or a CI fleet (`cacheRemote`)
+  - [x] An S3 bucket that outlives both (`cacheS3`)
 - Collaboration on designs
   - [x] Versioning of CAD designs using `Git` _(like it's 2025 for real)_
     - [x] Mechanical
     - [x] Electronics
-    - [ ] Software _(in progress)_
+    - [x] Software — firmware images, binaries and disk images shipped as objects of a package,
+          reproducible by vendor and SKU, by file, or by `fileHash`
   - [x] Automated generation of `Markdown` documentation
   - [x] Parametric (hardware and software) bill of materials
   - [x] Publish models online on PartCAD.org
@@ -141,13 +142,19 @@ Subscribe on [LinkedIn], [YouTube], [TikTok], [Facebook], [Instagram], [Threads]
 - Assembly models (3D)
   - [x] Using specialized `Assembly YAML` format
     - [x] Automatically maintaining the bill of materials
-    - [ ] Generating user-friendly visual assembly instructions _(in progress)_
+    - [x] Generating user-friendly visual assembly instructions (`PDF` and `HTML` instruction books)
+  - [x] Using `URDF`, with links, joints and physics
+  - [x] Using a `STEP` file that stays the source
+- Scenes (3D) — placed arrangements of objects: a workcell, a table, a simulation world
+  - [x] Stating where things are, rather than how they got there
+  - [x] Exporting to a `Gazebo` world (SDFormat), and opening it in Gazebo
 - Part models (3D)
   - Using scripting languages
     - [x] [CadQuery]
     - [x] [build123d]
     - [x] [Chili3D]
     - [x] [OpenSCAD]
+    - [x] [SDF]
   - Using legacy CAD files
     - [x] `STEP`
     - [x] `BREP`
@@ -156,6 +163,7 @@ Subscribe on [LinkedIn], [YouTube], [TikTok], [Facebook], [Instagram], [Threads]
     - [x] `OBJ`
   - Using file formats of third-party tools
     - [x] `KiCad EDA` (PCB)
+  - Using a part type the package defines itself (`partTypes`)
 - Part and interface blueprints (2D)
   - Using scripting languages
     - [x] [CadQuery]
@@ -175,11 +183,19 @@ Subscribe on [LinkedIn], [YouTube], [TikTok], [Facebook], [Instagram], [Threads]
   - [x] Free-form `comment:` context in `Assembly YAML`, written for whoever reads the assembly next
 - Other features
   - Object-Oriented Programming approach to maintaining part interfaces and mating information
-  - Live preview of 3D models while working in Visual Studio Code
-  - Render 2D and 3D to images
+  - Live preview of 3D models while working in Visual Studio Code, with the bill of materials, the assembly
+    instructions and supplier quotes on tabs beside the 3D view
+  - Open an object in the application that made it (`pc open`): `FreeCAD`, `Gazebo`, `KiCad` — installed
+    locally, or run in a container when it is not
+  - Render 2D projections, from any viewing angle (`--view`, or an arbitrary one), with the connection
+    ports and interfaces drawn on top if asked
     - [x] `SVG`
     - [x] `PNG`
     - [x] `JPEG`
+    - [x] `DXF`
+  - Generate documents
+    - [x] `Markdown` package and assembly documents
+    - [x] `PDF` and `HTML` assembly instruction books
   - Export 3D models to CAD files
     - [x] `STEP`
     - [x] `BREP`
@@ -189,6 +205,9 @@ Subscribe on [LinkedIn], [YouTube], [TikTok], [Facebook], [Instagram], [Threads]
     - [x] `OBJ`
     - [x] `IGES`
     - [x] `glTF`
+    - [x] `URDF`
+    - [x] `Gazebo` world (SDFormat)
+  - Output types a package implements itself, for both `render:` and `export:`
 
 ## Installation
 
@@ -214,6 +233,10 @@ Already using Visual Studio Code? Install the extension into it instead of the I
 
 This extension can be installed by searching for `PartCAD` in the VS Code extension search form, or by browsing
 [its VS Code marketplace page](https://marketplace.visualstudio.com/items?itemName=OpenVMP.partcad).
+
+Every [release](https://github.com/partcad/partcad/releases) also carries the packaged extension as
+`partcad-<version>.vsix`, to pin a version or to install where the marketplace is not reachable:
+`code --install-extension partcad-<version>.vsix`.
 
 Make sure to have Python configured and a [conda] environment set up in VS Code before using PartCAD.
 
@@ -292,6 +315,7 @@ Give us a star for our hard work!
 [build123d]: https://github.com/gumyr/build123d
 [Chili3D]: https://github.com/xiangechen/chili3d
 [OpenSCAD]: https://openscad.org/
+[SDF]: https://github.com/fogleman/sdf
 [STEP]: https://en.wikipedia.org/wiki/ISO_10303
 [BREP]: https://en.wikipedia.org/wiki/Boundary_representation
 [OpenCASCADE]: https://www.opencascade.com/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Browse [our documentation] and visit [our website]. Watch our 💥💥[demos](ht
 
 ## What is PartCAD?
 
-[PartCAD] is the standard for documenting manufacturable physical products. It comes with a set of tools to maintain
+[PartCAD] is the programming language for things.
+
+It is the standard for documenting manufacturable physical products. It comes with a set of tools to maintain
 product information and to facilitate efficient and effective workflows at all product lifecycle phases.
 
 PartCAD is more than just a traditional CAD tool for drawing. In fact, it’s **not for drawing at all**. The letters

--- a/ai-agents/README.md
+++ b/ai-agents/README.md
@@ -40,8 +40,8 @@ The plugin folder is named `claude`, but the command namespace comes from
   installs the standalone PyInstaller build from the latest GitHub release via
   the official `install.sh`; `python-module` installs the `partcad` wheel
   into the active Python environment (run as `python -m partcad_cli.click.command`).
-  Until a standalone release is published, `executable` reports that no published
-  installer is available and stops.
+  Releases publish bundles for Linux (x86_64, arm64), macOS (Apple silicon) and
+  Windows, and a `platforms.json` the installer reads to pick this machine's.
 - **`/pc:gen <description>`** — decides whether the request is a part, an
   assembly, or a 2D sketch and follows the matching flow below.
 - **`/pc:gen-part <description>`** — generates a single part: the agent picks a
@@ -89,6 +89,13 @@ The plugin folder is named `claude`, but the command namespace comes from
   `//pub/feature/render/draftwright` (through `pc render -e`) for a dimensioned
   technical drawing, so the numbers in the description are read off the drawing
   instead of estimated from pixels.
+- **`/pc:add-interfaces <part>`** — adds `interfaces`, ports and `implements:`
+  to an existing part so PartCAD can mate it by connection rather than by
+  hand-placed coordinates. The agent works the port positions out of the
+  geometry and then proves them twice: by drawing them on the part
+  (`pc render --with-all`) and by mating two instances in a throwaway assembly
+  and rendering that. The part has to pass `pc test` and the validation assembly
+  has to come out correctly connected.
 - **`/pc:search <query>`** — finds existing parts and assemblies in the catalog
   whose name, description, or source matches the query (`pc search parts` /
   `pc search assemblies`), lists the matches, and can inspect or render a chosen

--- a/ai-agents/common/skills/install/SKILL.md
+++ b/ai-agents/common/skills/install/SKILL.md
@@ -37,18 +37,29 @@ Options pass through the pipe with `sh -s --` (for example
 `... | sh -s -- --version 0.7.135`); the same knobs exist as environment
 variables (`PARTCAD_VERSION`, `PARTCAD_REPOSITORY`, `PARTCAD_BIN_DIR`, …).
 
-**There is no published standalone release yet.** Today the installer ends with a
-download 404:
+Every release publishes bundles for Linux (x86_64, arm64), macOS (Apple silicon)
+and Windows, along with a `platforms.json` manifest the installer reads to pick
+the right one for this machine. The download is around 57MB on Linux x86_64 and
+about half that on macOS and Linux arm64.
+
+Should the installer fail, report what it said and stop. Do not fall back to
+another install method and do not hand-roll one. The two failures worth
+recognizing:
 
 ```
 error: download failed.
        There may be no build of <version> for <platform>.
 ```
 
-(or *"could not determine the latest release"* if there is no release at all).
-When the standalone bundle is not published, report that **no published PartCAD
-installer is available** and stop. Do not fall back to another install method and
-do not hand-roll one.
+— no bundle for this platform in the release that was asked for. `--platform`
+names one explicitly; `--version` picks a different release.
+
+```
+error: could not determine the latest release
+```
+
+— the release list could not be reached at all, which is a network or rate-limit
+problem rather than a missing build.
 
 ## `python-module` — into the active Python environment
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -70,6 +70,30 @@ Host commands
 
   The "Update PartCAD" command in the VS Code extension runs exactly this, so the two never drift apart.
 
+``pc daemon``
+  Manage the background daemon described above. There is one per workspace, it is started on demand by the
+  first command that needs it, and it is not normally something to think about — these are here for when it
+  is:
+
+  - ``pc daemon start`` — Start this workspace's daemon if it is not already running, and print the socket
+    path it serves on. This is also how the VS Code extension finds the daemon, so that "where is it" has one
+    implementation rather than one per language.
+  - ``pc daemon stop`` — Stop the daemon serving this workspace, and say whether one was running.
+  - ``pc daemon status`` — Display the state of the internal data the daemon holds.
+  - ``pc daemon reset`` — Drop that state. ``--repo-only``, ``--sandbox-only`` and ``--cache-only`` narrow it
+    to the cached dependencies, the sandboxed runtime environments, or the filesystem cache respectively;
+    without them all of it goes.
+  - ``pc daemon set telemetry`` — Set the daemon's telemetry settings (``type``, ``env``, ``sentryDsn``),
+    the daemon-side counterpart of ``pc system set``.
+
+  There is no daemon to restart after changing a setting: every command hands the daemon its own resolved user
+  configuration, as explained above. Stopping one is for upgrades and for clearing a wedged state.
+
+  .. note::
+
+    The socket daemon is not available on Windows yet. ``pc`` there runs a per-invocation service instead, and
+    ``pc daemon start``/``stop`` say so rather than pretending otherwise.
+
 ``pc open``
   Open a file in a third-party application, on this machine::
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1277,12 +1277,65 @@ object it produces is the one it would have produced without it.
 Both are available for :ref:`sketches` and :ref:`assemblies` too, spelled the
 same way.
 
-Other Part Types
-----------------
+.. _part-types:
 
-Other methods to define parts are coming soon (e.g. `SDF <https://github.com/fogleman/sdf>`_).
-Please, express your interest in support for other formats by filing a corresponding issue on GitHub
-or sending an email to `support@partcad.org <mailto:support@partcad.org>`_.
+Part types the package defines itself
+-------------------------------------
+
+The types above are the ones PartCAD implements. A package can also declare a
+type of its own, in a ``partTypes`` section, and then build parts with it. This
+is worth doing when a family of parts is produced the same way every time --
+generated from a table, fetched from a catalogue, built by a modelling helper
+the package already has -- and the difference between them is a handful of
+parameters rather than a script each.
+
+.. code-block:: yaml
+
+  partTypes:
+    box:
+      kind: wrapper
+      path: box_wrapper.py
+
+  parts:
+    demo:
+      type: ":box"
+      parameters:
+        size:
+          type: float
+          default: 12
+
+``kind`` is ``wrapper``, which is the default and currently the only kind. Its
+``path`` (``<name>.py`` if left out) is a Python script that PartCAD runs in the
+sandbox once per part, with the part's ``request`` in its globals -- the
+resolved ``parameters`` among them -- and which leaves the geometry in a global
+``output``:
+
+.. code-block:: python
+
+  if __name__ == "__partcad_part__":
+      from build123d import Box
+
+      size = float(request["parameters"].get("size", 10))
+      output = {"shape": Box(size, size, size).wrapped}
+
+Because the script runs in a sandbox it may import OCP, build123d or CadQuery;
+``pythonRequirements`` on the ``partType`` says what that sandbox needs, exactly
+as it does for a package. This is the same mechanism as a custom output
+implementation (see :ref:`output-files`), pointed at building a shape rather
+than writing a file.
+
+A ``type`` beginning with ``:`` names a ``partType`` of the part's own package
+and is expanded to ``<package path>:<name>`` when the package is loaded. Write
+the package path out to use another package's type, which is what makes these
+shareable: a package that declares a ``partType`` is a package other people can
+import and build parts with. A ``partType`` is listed like any other object but
+is never a shape in its own right -- it is how parts are made, not one of them.
+
+See ``examples/produce_part_wrapper`` for the whole of the example above.
+
+Should PartCAD implement a type natively that you find yourself writing again
+and again, please file an issue on GitHub or write to
+`support@partcad.org <mailto:support@partcad.org>`_.
 
 .. _parameters:
 

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -167,7 +167,8 @@ Object IDs
 ==========
 
 PartCAD packages contain objects of different types: *sketches*, *parts*,
-*assemblies*, *scenes*, *interfaces*, *providers* and so on.
+*assemblies*, *scenes*, *interfaces*, *mates*, *providers*, *software* and
+*partTypes*.
 All of them need to get referenced.
 
 Single object
@@ -253,10 +254,19 @@ PartCAD CLI tools get installed using the PyPI package ``partcad``, which also
 carries the Python module and the JSON-RPC service. The main tool is called ``pc``.
 The CLI tools are supposed to provide the complete set of PartCAD features.
 
-Visual Studio Code extension
-============================
+Graphical interfaces
+====================
 
-The PartCAD extension for ``vscode`` is designed to be the primary tool.
+The PartCAD extension for ``vscode`` is designed to be the primary graphical
+tool. The **PartCAD IDE** is that extension, the editor and the command line
+tools in one application, for a machine with neither Python nor an editor set
+up. A **FreeCAD** add-on browses the same packages inside FreeCAD and imports
+objects into the open document.
+
+None of the three carries PartCAD itself. Each is a client of the
+``partcad-json-rpc`` service, which owns the warm context and the sandboxes, so
+they all see the same packages and the same cache as ``pc`` does on the same
+machine. See :doc:`installation` for all three.
 
 
 ========================

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -31,10 +31,30 @@ Objects
 - **Display** (inspect) a part, assembly, scene, sketch, or interface in the ``PartCAD Viewer``; parts can
   also be opened for display and editing together, or their source edited directly.
 - **Test** a part, assembly, or scene.
+- **Open in >** — Open the object's own source file in the application that made it: **FreeCAD** for a part
+  or an assembly, **Gazebo** for a scene of type ``world``, **KiCad** for a part of type ``kicad``. This runs
+  on your machine rather than on the daemon: the extension runs ``pc open`` (see :doc:`cli`), which starts an
+  application installed here, or runs one in a container when there is none and ``partcad.open.useDocker``
+  is on.
 
 The Explorer also lists the ``software`` a package ships. Selecting one shows its path and its ``fileHash``
 in the Inspector and leaves the ``PartCAD Viewer`` as it is: software is a file, not geometry, so there is
 nothing to render.
+
+The PartCAD Viewer
+------------------
+
+Displaying an object opens the ``PartCAD Viewer``, which is a strip of tabs over that one object rather than
+a bare canvas. Which tabs appear depends on what is being shown, and the 3D view is always the first:
+
+- **3D** — the shape itself, tessellated by PartCAD and drawn here. Always present.
+- **Bill of Materials** — for an assembly or a scene: every part it is made of, recursively, counted.
+- **Instructions** — for an assembly that declares its steps: the assembly guide, step by step.
+- **Supply** — what the objects in view can be bought from, and a quote per supplier.
+
+The 3D view arrives over the viewer protocol from whichever ``partcad`` asked for the shape to be shown; the
+other tabs are questions put to the PartCAD daemon, fetched the first time the tab is looked at and cached
+until the next object is shown. An object that belongs to no package gets the 3D view alone.
 
 Export
 ------
@@ -128,6 +148,47 @@ At the moment code-CAD caching is experimental and can be enabled by using the f
 
     # ~/.partcad/config.yaml
     cacheDependenciesIgnore: True
+
+Cache tiers
+-----------
+
+The cache is a hierarchy of tiers, each with its own switch, because what is
+worth keeping in memory is not what is worth a file, and neither is what is
+worth a network round trip:
+
+======================= ============================================================ ==========
+Tier                    Where it keeps things                                        Default
+======================= ============================================================ ==========
+``cacheMem``            This process's memory. Nearest, and lost on exit.            on
+``cacheFiles``          A directory under the internal state directory. Local.       on
+``cacheRemote``         A memcached server, shared by a team or a CI fleet.          off
+``cacheS3``             An S3 bucket, which outlives all of the above.               off
+======================= ============================================================ ==========
+
+A read walks them in that order and stops at the first hit; a write offers the
+entry to every tier whose size window accepts it. The two shared tiers are off
+by default because they need an address that only a deployment can supply:
+
+  .. code-block:: yaml
+
+    # ~/.partcad/config.yaml
+    cacheRemote: True
+    cacheRemoteServer: memcached.example.com:11211
+
+    cacheS3: True
+    cacheS3Bucket: my-partcad-cache
+    cacheS3Region: us-east-1
+
+Each tier also takes ``...MaxEntrySize`` and ``...MinEntrySize`` to set the
+window of object sizes it accepts, and the memcached tier takes
+``cacheRemoteNamespace`` and ``cacheRemoteExpiration``. ``cacheS3`` additionally
+accepts ``cacheS3Prefix`` and ``cacheS3EndpointUrl``, the latter for an
+S3-compatible store that is not AWS.
+
+``cacheRemote`` needs nothing installed. ``cacheS3`` needs the ``aws`` extra
+(``pip install -U 'partcad[aws]'``); enabling it without that reports an error
+naming the package to install and leaves the remaining tiers working. See
+:doc:`installation` for both.
 
 ========
 Security

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -64,8 +64,11 @@ The commands and options supported by PartCAD CLI:
 
   Host commands:
     version      Display the versions of the PartCAD Python Module and CLI, then exit
+    upgrade      Upgrade PartCAD itself to the latest version
     config       Show the current user configuration
     system       PartCAD system commands (reset, set, status, telemetry)
+    daemon       Manage the PartCAD background daemon (start, stop, status, reset, set)
+    open         Open a file in a third-party application, on this machine
 
   Package commands:
     init         Create a new PartCAD package in the current directory
@@ -74,13 +77,16 @@ The commands and options supported by PartCAD CLI:
     lint         Run linting checks on files within packages
 
   Object commands:
-    list         List components (parts, sketches, assemblies, interfaces, mates, packages)
-    add          Add a dependency, sketch, part, or assembly
+    list         List components (parts, sketches, assemblies, scenes, interfaces, mates,
+                 providers, software, packages)
+    search       Search for parts, sketches, assemblies, or scenes
+    add          Add a dependency, sketch, part, assembly, scene, or software
     import       Import a dependency, sketch, part, or assembly
     test         Run tests on a part, assembly, or scene
     inspect      View a part, assembly, or scene visually
     info         Show detailed information about a part, assembly, or scene
-    convert      Convert parts or sketches to another format and update their type
+    bom          Print the bill of materials of an assembly or a scene
+    convert      Convert parts, sketches or assemblies to another format and update their type
     export       Export a 3D view of parts, assemblies, or scenes
     render       Render a 2D projection of parts, assemblies, or scenes onto a plane
 
@@ -90,7 +96,6 @@ The commands and options supported by PartCAD CLI:
   Other commands:
     adhoc        Ad-hoc operations that do not require a package
     healthcheck  Check the host system for known issues
-    search       Search for parts, sketches, or assemblies
 
 Common options apply to every command, including ``-v``/``-q`` to raise or lower verbosity, ``--no-ansi`` for
 plain-text logs, and ``-p PATH`` to select the package (a ``partcad.yaml`` file or a directory that contains
@@ -287,9 +292,14 @@ missing.
 What is included, and what is not
 =================================
 
-The bundle carries everything the wheels would install, including the optional extras that the wheels leave
-to the user: the Python linter (``lint``). A frozen bundle cannot be extended afterwards, so it ships
-complete.
+The bundle carries the optional extras that the wheels leave to the user, because a frozen bundle cannot be
+extended afterwards: the Python linter (``lint``) is in it, ready to run.
+
+What it does **not** carry is a CAD kernel. The bundle is three console programs, not a library to import, and
+every shape those programs build, render, export or tessellate is produced in the conda sandbox PartCAD
+provisions and comes back as geometry the commands never open themselves. So ``conda`` (or ``mamba``) is as
+much a prerequisite here as it is for the wheels, and leaving OpenCASCADE out is most of why the bundle is
+around 180MB rather than around 1GB.
 
 On Linux x86_64 and on Windows it also carries **OpenSCAD**, which PartCAD runs as an external program to
 build ``.scad`` parts. The bundled copy is used in preference to any OpenSCAD installed on the machine, so that the
@@ -443,8 +453,9 @@ The installer is not signed, so SmartScreen shows a warning: choose "More info",
 ``partcad-ide-<version>-windows-x86_64.zip`` is published next to it, for unpacking somewhere and running
 ``partcad-ide.exe`` without installing anything.
 
-The download is around 1GB: an editor, a Python interpreter, the OpenCASCADE geometry kernel and the
-extensions, all in one archive.
+It unpacks to around 500MB: an editor, a Python interpreter, the command line tools and the extensions, all
+in one archive. Like the standalone bundle inside it, it carries no CAD kernel -- shapes are built in a conda
+sandbox, so ``conda`` (or ``mamba``) is still expected on the machine.
 
 What is inside
 ==============
@@ -569,6 +580,18 @@ see :ref:`the PartCAD IDE <partcad-ide>`.
 
 This extension is available through the VS Code marketplace.
 The corresponding marketplace page is `here <https://marketplace.visualstudio.com/items?itemName=OpenVMP.partcad>`_.
+
+Every `GitHub release <https://github.com/partcad/partcad/releases>`_ also carries the packaged extension as
+``partcad-<version>.vsix``, next to the wheels and the bundles. Install it from the command line, or with
+"Install from VSIX..." in the Extensions view:
+
+.. code-block:: shell
+
+  $ code --install-extension partcad-<version>.vsix
+
+Use it to pin a particular version, to install where the marketplace is not reachable, or to try a release
+before the marketplace has it. One package serves every platform: the extension is a JSON-RPC client with no
+Python and nothing compiled in it.
 
 .. _freecad-addon:
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -107,12 +107,19 @@ PartCAD Viewer
 ==============
 
 The ``PartCAD Viewer`` is a tab the extension opens when a part, assembly,
-sketch or interface is inspected. PartCAD tessellates the shape in a sandboxed
-runtime, and sends the result to the extension as compressed glTF over a socket
-on ``127.0.0.1:9137``. The Python side of that connection is the
+scene, sketch or interface is inspected. PartCAD tessellates the shape in a
+sandboxed runtime, and sends the result to the extension as compressed glTF over
+a socket on ``127.0.0.1:9137``. The Python side of that connection is the
 ``partcad_ide_client`` package, which ships inside ``partcad`` itself -- so
 ``pip install partcad`` is all that is needed, and there is nothing separate to
 install.
+
+Beside the 3D view the panel carries tabs for the questions that are about the
+object rather than its shape -- **Bill of Materials**, **Instructions** and
+**Supply**, each appearing where it applies. Those do not come over the socket
+above: they are answered by the PartCAD daemon and fetched the first time the
+tab is opened, so a failure in one of them is a daemon problem and says so in
+the tab, while the 3D view keeps working.
 
 Anything with a ``partcad`` that can reach that port can display into the same
 viewer -- including a ``pc`` run in a plain terminal, as long as a window with

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -18,13 +18,27 @@ Also, make sure to visit [our website](https://partcad.org/) and browse [the rep
 
 ## PartCAD Viewer
 
-Selecting a part, assembly, sketch or interface opens it in the **PartCAD Viewer** tab. PartCAD tessellates the
-shape in a sandboxed runtime and sends the result to this extension as compressed glTF over a socket on
-`127.0.0.1:9137`, so the viewer needs no CAD library of its own. The Python side of that connection is the
-`partcad_ide_client` package, which ships inside `partcad` itself.
+Selecting a part, assembly, scene, sketch or interface opens it in the **PartCAD Viewer** tab. PartCAD
+tessellates the shape in a sandboxed runtime and sends the result to this extension as compressed glTF over a
+socket on `127.0.0.1:9137`, so the viewer needs no CAD library of its own. The Python side of that connection
+is the `partcad_ide_client` package, which ships inside `partcad` itself.
 
 Anything that can reach that port displays into the same viewer, including a `pc inspect` run in a plain
 terminal. Set `PARTCAD_IDE_PORT` to move both ends off the default port.
+
+The panel is a strip of tabs over the one object, not just a canvas. The 3D view is always the first; the rest
+appear where they apply:
+
+| tab | what it shows |
+| --- | --- |
+| **3D** | The shape, drawn here from what arrived over the socket above. |
+| **Bill of Materials** | For an assembly or a scene: every part it is made of, recursively, counted. |
+| **Instructions** | For an assembly that declares its steps: the assembly guide, step by step. |
+| **Supply** | Where the objects in view can be bought, and a quote per supplier. |
+
+Only the 3D view comes over the viewer protocol. The others are questions about `<package>:<name>` that this
+extension puts to the PartCAD daemon, fetched the first time a tab is looked at and cached until the next
+object is shown — so an object belonging to no package gets the 3D view alone.
 
 ## The command line in the integrated terminal
 

--- a/tools/containers/kicad/README.md
+++ b/tools/containers/kicad/README.md
@@ -85,7 +85,7 @@ providers:
 The manufacturability test of the PCBs using a `manufacturer` and the manufacturing methods starting with `pcb` is not
 implemented yet.
 
-````yaml
+```yaml
 parts:
   my-pcb:
     type: kicad
@@ -100,9 +100,7 @@ providers:
   pcbManufacturingProvider1:
     type: manufacturer
     ...
-
 ```
-
 
 ## Build Instructions
 
@@ -110,4 +108,4 @@ To build the container, run the following command:
 
 ```bash
 docker build -t partcad-integration-kicad -f tools/containers/kicad/Dockerfile tools/containers
-````
+```


### PR DESCRIPTION
A review of every `README.md` in the tree and of `docs/` against everything that
merged to `devel` over the last 30 days — roughly 100 substantive commits, from
`#469` through `#576`. No behaviour changes here; the features are all already
in. This is the documentation of them catching up.

Most of it had kept up. `cli.rst` in particular is current down to `pc open`,
`pc adhoc render` and the `--with-ports` flags, and `#556` correctly revised the
bundle sizes in four places. Seventeen things had not.

### Contradicted the shipped code

- **`docs/source/installation.rst` pasted a `pc --help` that predates four
  commands.** Rebuilt from `command.py`: `upgrade` (#520), `daemon` (#465),
  `open` (#574) and `bom` (#510) were absent, `search` had moved from "Other" to
  "Object commands", and the summaries for `list`/`add` had not grown
  `scenes`/`software`/`providers`.
- **The standalone bundle was still described as carrying "everything the wheels
  would install".** Since #556 it deliberately carries no CAD kernel — most of
  the 1010MB → 183MB it lost — so `conda` is as much a prerequisite there as for
  the wheels. The IDE section was a release further behind still, advertising
  "around 1GB … the OpenCASCADE geometry kernel"; it is ~500MB and has no kernel
  either.
- **`ai-agents/README.md` and `install/SKILL.md` both said no standalone release
  is published.** `deploy.yml` has been attaching the bundles, the IDE, the
  `.vsix` and `platforms.json` to every release for weeks — so `/pc:install
  executable` was refusing an install that works. Replaced with what ships, and
  with the two failure modes worth recognizing.
- **`README.md` had four shipped things marked in progress:** the shared cache
  tiers (#521), software versioning (#569) and the visual assembly instructions
  (#509).

### Missing outright

- **`pc daemon` appeared in no reference at all** — five subcommands, one of
  which is how the VS Code extension locates the daemon. Added to `cli.rst`.
- **`partTypes` (#469) was undocumented**, while "Other Part Types" still said
  other ways to define a part were "coming soon (e.g. SDF)" — wrong about SDF
  too. Replaced with the real section: the wrapper kind, the `request`/`output`
  contract, the `:name` short form, `examples/produce_part_wrapper`. Note that
  "Custom implementations" already said "the same mechanism as a `partType`
  wrapper"; now there is something to point at.
- **The Viewer grew tabs in #568** — Bill of Materials, Instructions, Supply —
  and every user-facing description of it still said "a 3D view". Covered in
  `features.rst`, `troubleshooting.rst` and `ide/vscode/README.md`, including
  that only the 3D view comes over the viewer socket, so a failing tab is a
  daemon problem rather than a viewer one.
- **The "Open in…" menu (#574)** was in `cli.rst` and the extension README but
  not in the `features.rst` list of what the extension does.
- **The `.vsix` (#547)** ships on every release and was offered nowhere as an
  install path.
- **`features.rst` described caching without the shared tiers.** Added the tier
  table and settings, read off `user_config.py`.

### Smaller

- `design.rst` listed the object types without `mates`, `software` or
  `partTypes`, and still called the VS Code extension "the primary tool" with no
  mention of the IDE (#526) or the FreeCAD add-on (#512). That all three are
  JSON-RPC clients of one service seemed the point worth making.
- `README.md` feature lists gained SDF, `partTypes`, URDF and STEP assemblies,
  scenes and Gazebo worlds, `pc open`, DXF/PDF/HTML output, URDF and world
  export, and package-supplied output types.
- `AGENTS.md` linked `./docs/README.md`, which does not exist.
- `tools/containers/kicad/README.md` had a four-backtick fence swallowing its
  "Build Instructions" section, there since #375.

### Not changed

`#486` retired the built-in GenAI part generation and the README still listed
Gemini/ChatGPT/Ollama as delivered — but `#556` had already fixed that before
this branch, so nothing was needed.

### Checks

`python -m sphinx -b html -W --keep-going` builds clean, and `pre-commit` passes,
both in the dev container.

The second commit is a one-line README framing that was already in the working
tree; it is separate so it can be dropped independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
