### PR TITLE
Keep the release's downloads out of the source tree it is uploaded from

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,6 +154,14 @@ jobs:
       # Before the downloads: "actions/checkout" cleans the workspace, and the
       # artifacts are downloaded into it. This job needs the checkout only for
       # "dev-tools/release/platforms-manifest.sh".
+      #
+      # Which is why every download below lands under "release/", a directory
+      # this repository does not have: a download path that names one it *does*
+      # have merges the artifacts into the source tree instead of standing
+      # beside it. "path: ide" did exactly that in 0.8.25 -- the IDE archives
+      # unpacked next to "ide/standalone" and "ide/vscode", and the upload,
+      # which globbed the directory, tried to send the IDE's own source tree to
+      # the release and died on "is a directory" halfway through.
       - uses: actions/checkout@v7
 
       - name: Set up Python
@@ -181,14 +189,14 @@ jobs:
         with:
           pattern: partcad-standalone-*
           merge-multiple: true
-          path: standalone
+          path: release/standalone
 
       - name: Download the IDE
         uses: actions/download-artifact@v8
         with:
           pattern: partcad-ide-*
           merge-multiple: true
-          path: ide
+          path: release/ide
 
       # By name, not by pattern: there is exactly one of these, and the two
       # patterns above already claim every other "partcad-*" artifact this run
@@ -197,7 +205,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: partcad-vsix
-          path: vsix
+          path: release/vsix
 
       # "install.sh" derives an asset name from `uname` and fails for the user
       # if that asset is not on the release. Downloading artifacts does not fail
@@ -206,6 +214,17 @@ jobs:
       - name: Check the standalone bundles are complete
         run: |
           missing=0
+          # Nothing but the three download directories, and nothing but files in
+          # them. A "release/" that grew a directory would mean the checkout and
+          # the downloads had collided again, and every check below would be
+          # looking at source files -- so say so here, before the release
+          # exists, rather than by publishing the wrong assets.
+          stray="$(find release -mindepth 1 -type d \
+            ! -path release/standalone ! -path release/ide ! -path release/vsix)"
+          if [ -n "${stray}" ]; then
+            echo "::error::unexpected directories under release/: $(echo ${stray})"
+            missing=1
+          fi
           # The platforms built by "build-standalone.yml". Keep in sync with the
           # matrix there: a release missing one of these is a release some
           # machine cannot install, and the manifest generated below would
@@ -215,8 +234,8 @@ jobs:
             ubuntu-24.04-x86_64 ubuntu-24.04-arm64 \
             macos-15-arm64 macos-26-arm64 \
             windows-2022-x86_64; do
-            archive=$(find standalone -type f -name "partcad-*-${platform}.*" ! -name "*.sha256")
-            checksum=$(find standalone -type f -name "partcad-*-${platform}.*.sha256")
+            archive=$(find release/standalone -type f -name "partcad-*-${platform}.*" ! -name "*.sha256")
+            checksum=$(find release/standalone -type f -name "partcad-*-${platform}.*.sha256")
             if [ -z "${archive}" ] || [ -z "${checksum}" ]; then
               echo "::error::no standalone bundle for ${platform}"
               missing=1
@@ -233,19 +252,20 @@ jobs:
             windows-*) extension="zip" ;;
             *) extension="tar.gz" ;;
             esac
-            archive="$(find ide -type f -name "partcad-ide-*-${platform}.${extension}" | head -n 1)"
+            archive="$(find release/ide -type f -name "partcad-ide-*-${platform}.${extension}" | head -n 1)"
             if [ -z "${archive}" ] || [ ! -f "${archive}.sha256" ]; then
               echo "::error::no IDE archive for ${platform}"
               missing=1
             else
-              find ide -type f -name "partcad-ide-*-${platform}*" ! -name "*.sha256" \
+              find release/ide -type f -name "partcad-ide-*-${platform}*" ! -name "*.sha256" \
                 -printf "%p %s bytes\n"
             fi
           done
-          # And the extension. One file, no platform in its name -- but the
-          # upload below globs "vsix/**", and an empty glob would fail there,
-          # after the release has already been created.
-          vsix="$(find vsix -type f -name "partcad-*.vsix" | head -n 1)"
+          # And the extension. One file, no platform in its name -- and the
+          # upload below sends the files it finds, so an extension that was
+          # never built would not fail there: it would simply be absent from
+          # the release, for somebody to notice later.
+          vsix="$(find release/vsix -type f -name "partcad-*.vsix" | head -n 1)"
           if [ -z "${vsix}" ]; then
             echo "::error::no VS Code extension package"
             missing=1
@@ -264,9 +284,9 @@ jobs:
       - name: Build the release manifest
         run: |
           dev-tools/release/platforms-manifest.sh \
-            --bundles standalone --ide ide --output platforms.json
-          cat platforms.json
-          python3 -c 'import json; json.load(open("platforms.json"))'
+            --bundles release/standalone --ide release/ide --output release/platforms.json
+          cat release/platforms.json
+          python3 -c 'import json; json.load(open("release/platforms.json"))'
 
       - name: Determine the release tag
         if: github.ref == 'refs/heads/main'
@@ -279,13 +299,32 @@ jobs:
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ env.MERGED_TAG }}
         run: |
-          gh release create '${{ env.MERGED_TAG }}' --repo '${{ github.repository }}' --notes "";
-          gh release upload '${{ env.MERGED_TAG }}' dist/** --repo '${{ github.repository }}'
-          gh release upload '${{ env.MERGED_TAG }}' standalone/** --repo '${{ github.repository }}'
-          gh release upload '${{ env.MERGED_TAG }}' ide/** --repo '${{ github.repository }}'
-          gh release upload '${{ env.MERGED_TAG }}' vsix/** --repo '${{ github.repository }}'
-          gh release upload '${{ env.MERGED_TAG }}' platforms.json --repo '${{ github.repository }}'
+          # A draft until every asset is on it. "pc upgrade", the VS Code
+          # extension and the FreeCAD addon all resolve what to install through
+          # "/releases/latest", which skips drafts -- so a run that dies partway
+          # leaves the previous, complete release as the latest one, instead of
+          # one that is missing "platforms.json" and half its archives and that
+          # every client then fails on.
+          #
+          # And created only when it is not there already, because the run that
+          # is re-run is the one that failed after creating it: "a release with
+          # that tag already exists" used to stop the re-run before it could
+          # finish the uploads it was re-run for.
+          if ! gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+            gh release create "${TAG}" --repo "${REPO}" --draft --notes ""
+          fi
+          # Files, never a glob: "dist/**" and its siblings are `bash` globs
+          # that match directories as readily as files, and `gh` fails on a
+          # directory ("is a directory") -- after the release exists, with the
+          # assets it had already started uploading on it and the rest not.
+          # "--clobber" so that a re-run replaces what a failed run left behind
+          # rather than failing on it.
+          find dist release -type f -print0 |
+            xargs -0 gh release upload "${TAG}" --clobber --repo "${REPO}"
+          gh release edit "${TAG}" --repo "${REPO}" --draft=false
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -309,11 +309,20 @@ jobs:
           # one that is missing "platforms.json" and half its archives and that
           # every client then fails on.
           #
-          # And created only when it is not there already, because the run that
-          # is re-run is the one that failed after creating it: "a release with
-          # that tag already exists" used to stop the re-run before it could
-          # finish the uploads it was re-run for.
-          if ! gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+          # And a draft again if it is already there, rather than created:
+          # the run that gets re-run is the one that failed after creating the
+          # release, so "a release with that tag already exists" used to stop
+          # the re-run before it could finish the uploads it was re-run for.
+          # One that got as far as publishing has to go back to being a draft
+          # before its assets are replaced -- "--clobber" deletes each one
+          # before it sends it again, and on a published release that is a
+          # stretch of minutes in which clients resolve this release and find
+          # the archive they came for gone. Drafted first, they resolve the
+          # release before it instead, which is a complete one, and a re-run
+          # that fails again leaves them there rather than on this.
+          if gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+            gh release edit "${TAG}" --repo "${REPO}" --draft=true
+          else
             gh release create "${TAG}" --repo "${REPO}" --draft --notes ""
           fi
           # Files, never a glob: "dist/**" and its siblings are `bash` globs


### PR DESCRIPTION
## Copilot Summary

Fixes the `Publish to PyPI` failure in [Deployment #133](https://github.com/partcad/partcad/actions/runs/33359637284) (0.8.25):

```
Post ".../releases/379528905/assets?label=&name=standalone": read ide/standalone: is a directory
```

The job downloads the IDE archives into `ide`, and the workspace it downloads them into is a checkout of this
repository — which has an `ide` directory of its own. The archives unpacked beside `ide/standalone` and
`ide/vscode`, and `gh release upload ide/**` — a `bash` glob, which matches directories as readily as files —
handed `gh` the IDE's own source tree.

By then the release existed and was published, so what the failure left behind is a release every client
resolves and none can install: no `platforms.json`, no `.vsix`, and the macOS `.dmg` still in flight when the
command aborted. The wheels never reached PyPI (the publish step never ran), and the run cannot simply be
re-run either, because `gh release create` refuses a tag that already has a release.

Four changes to `.github/workflows/deploy.yml`, one per way this went wrong:

* Every download now lands under `release/`, a directory the checkout does not have, so the artifacts stand
  beside the source tree instead of merging into it.
* The upload passes files, found rather than globbed, in one call, with `--clobber` so a re-run replaces what
  a failed run left behind.
* The release is created as a draft and published once every asset is on it. `pc upgrade`, the VS Code
  extension and the FreeCAD addon all resolve what to install through `/releases/latest`, which skips drafts,
  so a run that dies partway leaves the previous release as the latest one rather than a broken one.
* A release that is already there is drafted again rather than created, so re-running a failed deployment
  finishes the uploads it was re-run for — and one that had got as far as being published spends the re-upload
  as a draft, since `--clobber` deletes each asset before it sends it again.

The completeness check, which already refuses to publish a release that is missing a platform, now also
refuses one whose staging directories hold directories — the shape a collision like this has, caught before
the release exists rather than halfway through its uploads.

### Validation

No CI check exercises these steps: `deploy.yml` runs on a push to `main` and on tags, never on a pull request,
and the changed steps are additionally gated on `github.ref == 'refs/heads/main'`. So this was validated by
hand instead:

* `check-yaml` and `check-github-workflows` (check-jsonschema) pass.
* Both changed `run:` blocks were extracted from the patched YAML and executed against a simulated workspace
  (the 29 files of the 0.8.25 run) with a stubbed `gh` that rejects directories the way the real one does and
  tracks the release's draft state:
  * a first run creates the draft, uploads all 29 files and publishes it;
  * a re-run over an already published release drafts it, re-uploads, and publishes it again;
  * a re-run whose upload fails leaves it a draft, so clients stay on the release before it;
  * an injected `release/ide/standalone` fails the completeness check before any release is touched.
* `dev-tools/release/platforms-manifest.sh` was run against the new paths and produced a valid manifest.

The first real exercise is the next release. 0.8.25 itself is not repaired by this — it needs a 0.8.26.