### PR TITLE
Serve the PartCAD daemon on Windows, and read stdin as UTF-8

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -15,12 +15,19 @@ on:
 jobs:
   build:
     strategy:
-      # Don't let one OS failing cancel the other: a green Linux run was being
+      # Don't let one OS failing cancel the others: a green Linux run was being
       # reported as failed only because it was canceled when the macOS job
-      # failed. Keep both statuses independent (matches build.yml).
+      # failed. Keep the statuses independent (matches build.yml).
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest] # windows-latest for some reason doesn't run test suite.
+        # Windows is here because the extension ships to it. It was dropped as
+        # "for some reason doesn't run test suite", and the reason was the modal
+        # "shall I download PartCAD?" dialog that activation puts up on a runner
+        # with no PartCAD installed: nothing headless can answer it, and the
+        # window never closed. `.vscode-test.js` now tells the extension not to
+        # ask (PARTCAD_EXTENSION_NO_PROMPTS), and the sample workspace the runner
+        # opens is a directory that actually exists.
+        os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -75,9 +75,10 @@ Host commands
   first command that needs it, and it is not normally something to think about — these are here for when it
   is:
 
-  - ``pc daemon start`` — Start this workspace's daemon if it is not already running, and print the socket
-    path it serves on. This is also how the VS Code extension finds the daemon, so that "where is it" has one
-    implementation rather than one per language.
+  - ``pc daemon start`` — Start this workspace's daemon if it is not already running, and print the endpoint
+    it serves on — a socket path, or a named pipe on Windows. This is also how the VS Code extension finds the
+    daemon, so that "where is it" has one implementation rather than one per language. The endpoint is printed
+    once the daemon answers on it, so whoever reads it can connect straight away.
   - ``pc daemon stop`` — Stop the daemon serving this workspace, and say whether one was running.
   - ``pc daemon status`` — Display the state of the internal data the daemon holds.
   - ``pc daemon reset`` — Drop that state. ``--repo-only``, ``--sandbox-only`` and ``--cache-only`` narrow it
@@ -91,8 +92,10 @@ Host commands
 
   .. note::
 
-    The socket daemon is not available on Windows yet. ``pc`` there runs a per-invocation service instead, and
-    ``pc daemon start``/``stop`` say so rather than pretending otherwise.
+    On Windows the daemon serves a named pipe rather than a Unix socket, and it is started as a detached
+    process rather than by forking; ``pc daemon start``/``stop`` work the same way and print the same kind of
+    answer. ``pc`` itself does not use it yet — each command there still runs a service of its own — so what a
+    daemon buys on Windows today is the editor extension's warm context.
 
 ``pc open``
   Open a file in a third-party application, on this machine::

--- a/ide/vscode/.vscode-test.js
+++ b/ide/vscode/.vscode-test.js
@@ -9,15 +9,19 @@ module.exports = defineConfig([
     launchArgs: ['--disable-gpu'],
     // version: 'insiders', // For some reason this doesn't work
     workspaceFolder: './sampleWorkspace',
+    // No PartCAD is installed on a CI runner, so activation reaches the "shall I
+    // download it?" dialog. Nothing in a headless run can answer a modal dialog,
+    // and on Windows an unanswered one is enough to keep the window from ever
+    // closing -- which is what "windows-latest doesn't run the test suite" was.
+    env: { PARTCAD_EXTENSION_NO_PROMPTS: '1' },
     mocha: {
       ui: 'tdd',
-      // Activation starts the Python language server, so this budget is really
-      // "how long a cold LSP start takes on a loaded runner" rather than
-      // anything about the assertion. It went 20s -> 30s once already for the
-      // same reason, and 30s started failing about two runs in three (the same
-      // commit passed and failed), so it is marginal rather than broken.
-      // Doubled to stop trimming it by 50% every time the runners get busier;
-      // if activation ever genuinely hangs, 60s still fails the run.
+      // This budget is "how long activation takes on a loaded runner" rather
+      // than anything about the assertions. It went 20s -> 30s once, and 30s
+      // then started failing about two runs in three (the same commit passing
+      // and failing), so it is marginal rather than broken. Doubled to stop
+      // trimming it by 50% every time the runners get busier; if activation
+      // ever genuinely hangs, 60s still fails the run.
       timeout: 60000,
     },
   },

--- a/ide/vscode/.vscodeignore
+++ b/ide/vscode/.vscodeignore
@@ -1,4 +1,5 @@
 .vscode-test/**
+sampleWorkspace/**
 coverage/**
 out/**
 **/node_modules/**

--- a/ide/vscode/AGENTS.md
+++ b/ide/vscode/AGENTS.md
@@ -11,14 +11,31 @@ executable, translating each `partcad.*` command the UI issues into the CLI-shap
 the service's notifications back under the `?/partcad/*` names the handlers listen on. See
 `src/common/backend.ts` and `src/common/provision.ts`.
 
-By default it connects over the per-workspace socket **daemon** (`partcad.serviceChannel: socket`): it runs
-`pc daemon start`, reads the printed socket path, and connects. `partcad.serviceChannel: stdio` runs a
-dedicated process over stdin/stdout instead. "Restart PartCAD"/reset runs `pc daemon stop` to tear down the
-warm context.
+By default it connects over the per-workspace **daemon** (`partcad.serviceChannel: socket`): it runs
+`pc daemon start`, reads the printed endpoint, and connects — a socket path on POSIX, a `\\.\pipe\...` name on
+Windows, which `net.connect` takes either way. `partcad.serviceChannel: stdio` runs a dedicated process over
+stdin/stdout instead. "Restart PartCAD"/reset runs `pc daemon stop` to tear down the warm context.
+
+**What `pc daemon start` prints is checked before it is connected to** (`daemonEndpointIn`). A `pc` with no
+daemon for its platform answers with a *sentence* saying so — on stdout, with a zero exit status, which is
+where the endpoint goes. Windows `pc` did exactly that until the daemon there was un-gated, and "the first
+non-empty line" handed that sentence to `net.connect`: ENOENT about a filename made of English, and a window
+with no backend at all. So an answer that is neither an absolute path nor a pipe name means "this installation
+has no daemon", and the backend falls back to `stdio` — one service for this window, cold rather than shared,
+which is a downgrade and not a failure. It says so in the terminal view, because a user who asked for `socket`
+did not get it.
+
+The connect itself retries for a few seconds (`connectEndpoint`). The endpoint `pc` prints is live by the time
+it prints it, on both platforms; the retry covers the difference in *how* — a POSIX daemon binds and listens
+before it forks, so an early client queues, while the Windows daemon is a separate process whose pipe does not
+exist until it is ready, and connecting to a pipe that is not there fails rather than waits.
 
 Where the executable comes from is `resolveServicePath`: the `partcad.servicePath` setting, then an existing
-standalone install, then the extension's own download directory, then `~/.local/bin`, then a plain `PATH`
-lookup. That last one is why a user with their own Python needs no download at all -- `pip install partcad`
+standalone install (`$XDG_DATA_HOME/partcad`, or `%LOCALAPPDATA%\PartCAD` on Windows — `install.sh` does not
+run there, so naming the POSIX locations in the report only sent Windows users looking somewhere nothing
+installs to), then the extension's own download directory, then `~/.local/bin` where there is one, then a
+plain `PATH` lookup (quoted entries and all: Windows quotes a `PATH` entry containing a space, and the quotes
+are not part of the directory's name). That last one is why a user with their own Python needs no download at all -- `pip install partcad`
 puts `partcad-json-rpc` on the `PATH`.
 
 **The dialog appears if and only if none of those five resolves.** Anything found is used, silently: an
@@ -127,6 +144,15 @@ Four things about it are load-bearing:
 - **Two webpack bundles, two tsconfigs.** The extension host is CommonJS; the webview is a browser context and
   three.js ships its addons as ES modules only, so `src/webview` compiles under `tsconfig.webview.json` (and is
   excluded from `tsconfig.json`). `npm run compile` builds both.
+- **The listen options are platform-specific, and getting that wrong is silent.** `SO_REUSEPORT` lets a second
+  window share the viewer port instead of losing it, and libuv implements it only where it also load-balances
+  — Linux and the BSDs — *rejecting the bind with ENOTSUP everywhere else*. Asking for it unconditionally
+  therefore took the whole viewer down on Windows and macOS, with one line in the output channel to show for
+  it, from the moment VS Code shipped a Node new enough to pass the option through (22.12). There is nothing
+  to ask for instead on Windows: `listen` has no `reuseAddr` (that is `dgram`, for UDP), and libuv sets
+  neither `SO_REUSEADDR` nor `SO_EXCLUSIVEADDRUSE` for a TCP server there on purpose, since `SO_REUSEADDR` on
+  Windows means "take a port another process is using". `listenOptions` decides, and the second window falls
+  back to the `EADDRINUSE` branch, which is what it always did.
 - **The panel's CSP forbids network access.** Geometry arrives over `postMessage` and is parsed from memory;
   three.js is bundled rather than loaded from a CDN. Do not add an asset that is fetched at runtime — that is
   what rules out drei's `environment` presets, and why the renderer uses `RoomEnvironment`.
@@ -288,7 +314,11 @@ reasoning as `pc daemon stop`: defer to the CLI rather than keep a second copy h
 An ASSY file a **scene** points at is checked against the same schema with `how` forbidden, and which of the
 two a given file is is not a property of the file. `PartcadLint.flavorOf` answers it from the package contents
 the Explorer has already loaded -- the declaration itself -- and leaves the question to `pc lint` for a file no
-loaded package mentions. Both lean the same way when they cannot tell: unknown means assembly, because reading
+loaded package mentions. Both sides go through `pathKey` (`common/paths.ts`) rather than comparing paths as
+strings: `Uri.fsPath` lower-cases a Windows drive letter and PartCAD does not, so the editor's spelling of a
+document and the daemon's spelling of the same file never matched there and every scene was checked as an
+assembly. The daemon answers the same question with `os.path.samefile`; this one has to work on a buffer that
+has never been saved, so it normalises instead of asking the filesystem. Both lean the same way when they cannot tell: unknown means assembly, because reading
 an assembly as a scene would put a false error on correct code.
 
 The checker is `partcad_utils.assy_lint` (schema: `src/partcad_utils/schema/assy.json`), shared
@@ -356,6 +386,18 @@ npm run lint                                # eslint on src/**/*.ts
 npm run format-check                        # prettier check
 npm test                                    # vscode-test extension tests (xvfb-run -a npm test on Linux)
 ```
+
+`npm test` downloads a VS Code and opens `sampleWorkspace/` in it -- a directory that has to exist and has to
+be free of PartCAD content, or the extension activates through `workspaceContains` before the test that
+activates it. `.vscode-test.js` sets `PARTCAD_EXTENSION_NO_PROMPTS=1`, because a runner has no PartCAD
+installed and activation would otherwise put up the modal "shall I download it?" dialog that nothing headless
+can answer. Both of those are why the suite now runs on `windows-latest` in `npm-test.yml`, where it had been
+disabled as "for some reason doesn't run test suite".
+
+**Windows and macOS behaviour is tested from the Linux runner where it can be.** A platform-specific decision
+belongs in a pure function that takes the platform (`pathKey`, `listenOptions`, `daemonEndpointIn`,
+`resolveServicePath`'s `searched` list) so a test can ask what it would do somewhere else. Everything in this
+file that starts "on Windows" was shipped broken at some point precisely because nothing asked.
 
 ## Build / package
 

--- a/ide/vscode/sampleWorkspace/README.md
+++ b/ide/vscode/sampleWorkspace/README.md
@@ -1,0 +1,10 @@
+# The extension test suite's workspace
+
+`.vscode-test.js` opens this directory as the workspace folder of the VS Code
+window the tests run in. It exists because the tests need *a* workspace: the
+extension reports "No workspace folders found" and stops before it starts a
+backend without one, so a window opened on nothing exercises almost none of it.
+
+It is deliberately empty of PartCAD content. There is no `partcad.yaml` here,
+because that would activate the extension through `workspaceContains` before a
+test has said to -- and what the first test asserts is that activating it works.

--- a/ide/vscode/src/PartcadExplorer.ts
+++ b/ide/vscode/src/PartcadExplorer.ts
@@ -8,6 +8,7 @@
 //
 
 import * as vscode from 'vscode';
+import { pathKey } from './common/paths';
 import {
     PartcadItem,
     PartConfig,
@@ -231,13 +232,19 @@ export class PartcadExplorer implements vscode.TreeDataProvider<PartcadItem> {
      * Absent from both sets means "unknown", not "assembly": a package that has
      * not loaded reports nothing, and a scene inside it must not be reported as
      * a broken assembly in the meantime.
+     *
+     * Both sets hold `pathKey`s, not paths: the caller looks a document up by
+     * the editor's spelling of its path, which is not PartCAD's on Windows.
      */
     public assyFlavors(): { scenes: Set<string>; assemblies: Set<string> } {
         const scenes = new Set<string>();
         const assemblies = new Set<string>();
         for (const items of Object.values(this.packages)) {
-            assyPaths(items.scenes).forEach((path) => scenes.add(path));
-            assyPaths(items.assemblies).forEach((path) => assemblies.add(path));
+            // Keyed rather than stored as they came: these are PartCAD's
+            // spelling of the path and the caller has the editor's, which are
+            // the same file spelled two ways on Windows (see `pathKey`).
+            assyPaths(items.scenes).forEach((path) => scenes.add(pathKey(path)));
+            assyPaths(items.assemblies).forEach((path) => assemblies.add(pathKey(path)));
         }
         return { scenes, assemblies };
     }

--- a/ide/vscode/src/PartcadLint.ts
+++ b/ide/vscode/src/PartcadLint.ts
@@ -44,6 +44,7 @@
 
 import * as vscode from 'vscode';
 import { traceVerbose } from './common/log/logging';
+import { pathKey } from './common/paths';
 import { PartcadExplorer } from './PartcadExplorer';
 
 // How long to wait after the last keystroke before re-checking. Long enough not
@@ -134,11 +135,14 @@ export class PartcadLint implements vscode.Disposable {
             traceVerbose(`Failed to read the package contents: ${e}`);
             return undefined;
         }
-        const path = document.uri.fsPath;
-        if (flavors.assemblies.has(path)) {
+        // By key, not by path: `Uri.fsPath` and the path PartCAD reports are
+        // the same file spelled differently on Windows, and comparing the two
+        // strings there answered "unknown" for every file (see `pathKey`).
+        const key = pathKey(document.uri.fsPath);
+        if (flavors.assemblies.has(key)) {
             return 'assembly';
         }
-        if (flavors.scenes.has(path)) {
+        if (flavors.scenes.has(key)) {
             return 'scene';
         }
         return undefined;

--- a/ide/vscode/src/common/backend.ts
+++ b/ide/vscode/src/common/backend.ts
@@ -22,6 +22,7 @@
 
 import * as cp from 'child_process';
 import * as net from 'net';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { Disposable } from 'vscode';
 import {
@@ -85,7 +86,10 @@ class JsonRpcBackend implements PartcadBackend {
 
     constructor(
         private readonly connection: MessageConnection,
-        private readonly cleanup: () => void,
+        // May be asynchronous: the stdio channel's cleanup terminates a process
+        // and waits for it to be gone, because the caller that stops a backend
+        // before an update is about to replace the files it runs from.
+        private readonly cleanup: () => void | Promise<void>,
         private readonly outputChannel: vscode.LogOutputChannel,
         cli: CliAccess = {},
     ) {
@@ -182,7 +186,7 @@ class JsonRpcBackend implements PartcadBackend {
         } catch {
             // ignore
         }
-        this.cleanup();
+        await this.cleanup();
     }
 
     async stopDaemon(): Promise<void> {
@@ -431,6 +435,30 @@ function serviceEnv(serverId: string): NodeJS.ProcessEnv {
 }
 
 /**
+ * The environment a `pc` invocation runs in: the caller's, with the child's
+ * text encoding pinned to UTF-8.
+ *
+ * What travels between the two processes is UTF-8 either way -- Node writes a
+ * string to a pipe as UTF-8 and decodes what comes back the same way -- but
+ * Python chooses the encoding of its own streams from the locale, which is
+ * UTF-8 on Linux and macOS and the ANSI code page on Windows. So a `pc lint
+ * --stdin` there was handed an editor buffer it decoded with cp1252: a
+ * description with an umlaut in it arrived as mojibake, and a byte the code
+ * page has no character for killed the decoder and took the findings with it.
+ * `pc` reads its own end as UTF-8 as well (see `_lint_files`); this is the
+ * other half of the same agreement, and covers every `pc` this runs.
+ */
+function utf8Env(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    return {
+        ...(env ?? process.env),
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        PYTHONUTF8: '1',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        PYTHONIOENCODING: 'utf-8',
+    };
+}
+
+/**
  * Run a `pc` subcommand and resolve with its stdout.
  *
  * `--no-ansi` because the progress renderer would otherwise interleave control
@@ -450,7 +478,7 @@ function runCli(
             reject(new Error('no `pc` executable beside the PartCAD service'));
             return;
         }
-        const proc = cp.execFile(cliPath, ['--no-ansi', ...args], { cwd, env }, (err, stdout, stderr) => {
+        const proc = cp.execFile(cliPath, ['--no-ansi', ...args], { cwd, env: utf8Env(env) }, (err, stdout, stderr) => {
             if (stderr) {
                 outputChannel.append(stderr);
             }
@@ -465,6 +493,37 @@ function runCli(
         // cannot tell "nothing yet" from "nothing at all".
         proc.stdin?.end(options?.stdin ?? '');
     });
+}
+
+/**
+ * This installation has no daemon to connect to, whatever the setting says.
+ *
+ * Not the same thing as a daemon that failed to start: it means `pc` answered
+ * the question and the answer was "not here". The caller runs a service of its
+ * own over stdio instead, which is what the user gets either way -- the daemon
+ * only makes it warm and shared.
+ */
+class NoDaemonChannel extends Error {}
+
+/**
+ * The endpoint in `pc daemon start`'s output, or undefined if it printed none.
+ *
+ * It prints one line: an absolute path to a Unix socket, or a `\\.\pipe\...`
+ * name on Windows. A `pc` with no daemon for this platform answers with a
+ * sentence saying so instead -- on stdout, with a zero exit status -- and
+ * "the first non-empty line" handed that sentence to `net.connect`, which
+ * reported ENOENT about a filename made of English and left the window with no
+ * backend at all. So what is printed has to look like an endpoint before it is
+ * treated as one; anything else means no daemon channel here.
+ *
+ * Exported for the test suite: this is the parse that decides whether a
+ * platform has a daemon, and it cannot be exercised from a machine that has one.
+ */
+export function daemonEndpointIn(stdout: string): string | undefined {
+    return stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => /^\\\\[.?]\\pipe\\./.test(line) || (line.length > 0 && path.isAbsolute(line)));
 }
 
 /**
@@ -484,11 +543,51 @@ async function daemonEndpoint(
     outputChannel: vscode.LogOutputChannel,
 ): Promise<string> {
     const stdout = await runCli(cliPath, [...args, 'daemon', 'start'], cwd, outputChannel, env);
-    const line = stdout.split(/\r?\n/).find((l) => l.trim().length > 0);
-    if (!line) {
-        throw new Error('`pc daemon start` did not print a socket path');
+    const endpoint = daemonEndpointIn(stdout);
+    if (!endpoint) {
+        const said = stdout.trim().split(/\r?\n/)[0];
+        throw new NoDaemonChannel(`\`pc daemon start\` printed no endpoint: ${said || '(nothing)'}`);
     }
-    return line.trim();
+    return endpoint;
+}
+
+/** How long to keep trying an endpoint `pc` has said is being served. */
+const CONNECT_TIMEOUT_MS = 10000;
+const CONNECT_RETRY_MS = 100;
+
+/** Connect failures worth trying again: the endpoint is not there *yet*. */
+const CONNECT_RETRY_CODES = ['ENOENT', 'ECONNREFUSED', 'EBUSY', 'EAGAIN'];
+
+/**
+ * Connect to the daemon's endpoint, retrying while it is not there yet.
+ *
+ * `pc daemon start` waits for the daemon to answer before printing where it is,
+ * so the first attempt normally succeeds and this costs nothing. It is for the
+ * moment either side of that -- and for the difference between the two
+ * transports: a POSIX daemon binds and listens before it prints, so a client
+ * that arrives early simply queues, while a Windows daemon is a separate
+ * process whose named pipe does not exist until it is ready, and connecting to
+ * a pipe that is not there fails outright rather than waiting.
+ */
+async function connectEndpoint(endpoint: string): Promise<net.Socket> {
+    const deadline = Date.now() + CONNECT_TIMEOUT_MS;
+    for (;;) {
+        try {
+            return await new Promise<net.Socket>((resolve, reject) => {
+                const socket = net.connect(endpoint);
+                socket.once('connect', () => resolve(socket));
+                socket.once('error', (e) => {
+                    socket.destroy();
+                    reject(e);
+                });
+            });
+        } catch (e: any) {
+            if (!CONNECT_RETRY_CODES.includes(e?.code) || Date.now() >= deadline) {
+                throw e;
+            }
+            await new Promise((resolve) => setTimeout(resolve, CONNECT_RETRY_MS));
+        }
+    }
 }
 
 async function connectSocket(
@@ -499,15 +598,70 @@ async function connectSocket(
     outputChannel: vscode.LogOutputChannel,
 ): Promise<JsonRpcBackend> {
     const cliPath = cliBeside(execPath);
+    if (!cliPath) {
+        // Where the daemon is, and whether one is running, is `pc`'s to answer
+        // -- the extension deliberately keeps no second copy of those rules. No
+        // `pc` is therefore not a broken daemon but no daemon channel at all,
+        // and the service beside it still serves this window perfectly well
+        // over stdio.
+        throw new NoDaemonChannel(`there is no \`pc\` beside ${execPath} to ask where the daemon is`);
+    }
     const socketPath = await daemonEndpoint(cliPath, args, cwd, env, outputChannel);
     traceInfo(`PartCAD service: connecting to daemon at ${socketPath}`);
-    const socket: net.Socket = await new Promise((resolve, reject) => {
-        const s = net.connect(socketPath);
-        s.once('connect', () => resolve(s));
-        s.once('error', reject);
-    });
+    const socket = await connectEndpoint(socketPath);
     const connection = createMessageConnection(new StreamMessageReader(socket), new StreamMessageWriter(socket));
-    return new JsonRpcBackend(connection, () => socket.destroy(), outputChannel, { cliPath, cwd, sharedDaemon: true });
+    return new JsonRpcBackend(
+        connection,
+        () => {
+            socket.destroy();
+        },
+        outputChannel,
+        { cliPath, cwd, sharedDaemon: true },
+    );
+}
+
+/** How long to wait for a terminated service process to actually be gone. */
+const TERMINATE_TIMEOUT_MS = 5000;
+
+/**
+ * Stop the private service process, and everything it started.
+ *
+ * `kill()` signals the process itself, which is the whole story on POSIX: the
+ * service and the sandboxed runtimes it launched share a process group and go
+ * down together. Windows has no such group -- the children of a terminated
+ * process keep running, and they keep the bundle directory open, which is the
+ * one thing that makes replacing it fail there -- so the tree is taken down by
+ * pid instead. `taskkill` is part of Windows; a machine without it, or a
+ * process that has already exited, falls through to `kill()`.
+ */
+async function terminate(proc: cp.ChildProcess): Promise<void> {
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+        return;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const exited = new Promise<void>((resolve) => {
+        proc.once('exit', () => resolve());
+        // Waiting is not the same as waiting forever: a service wedged in a
+        // signal handler must not hold up the window's shutdown.
+        timer = setTimeout(resolve, TERMINATE_TIMEOUT_MS);
+    });
+    let killed = false;
+    if (process.platform === 'win32' && proc.pid !== undefined) {
+        killed = await new Promise<boolean>((resolve) => {
+            cp.execFile('taskkill', ['/pid', String(proc.pid), '/t', '/f'], (err) => resolve(!err));
+        });
+    }
+    if (!killed) {
+        try {
+            proc.kill();
+        } catch {
+            // Already gone.
+        }
+    }
+    await exited;
+    if (timer !== undefined) {
+        clearTimeout(timer);
+    }
 }
 
 function connectStdio(
@@ -518,7 +672,10 @@ function connectStdio(
     outputChannel: vscode.LogOutputChannel,
 ): JsonRpcBackend {
     traceInfo(`PartCAD service: launching ${execPath} --stdio`);
-    const proc = cp.spawn(execPath, ['--stdio', ...args], { cwd, env }) as cp.ChildProcessWithoutNullStreams;
+    const proc = cp.spawn(execPath, ['--stdio', ...args], {
+        cwd,
+        env: utf8Env(env),
+    }) as cp.ChildProcessWithoutNullStreams;
     proc.stderr.on('data', (d: Buffer) => outputChannel.append(d.toString()));
     // Without an 'error' listener, a failed launch (ENOENT/EACCES) is emitted
     // asynchronously as an uncaught exception in the extension host rather than
@@ -536,13 +693,7 @@ function connectStdio(
     );
     return new JsonRpcBackend(
         connection,
-        () => {
-            try {
-                proc.kill();
-            } catch {
-                // ignore
-            }
-        },
+        () => terminate(proc),
         outputChannel,
         // A private service process, so `pc daemon stop` must not be used on it
         // -- but `pc lint --file` still is: it acts on a file, not on a daemon.
@@ -646,6 +797,20 @@ export async function restartBackend(
         }
         return await connectSocket(execPath, args, cwd, env, outputChannel);
     } catch (e) {
+        if (e instanceof NoDaemonChannel) {
+            // The installation has no daemon for this platform. That is a
+            // reason to run the service a different way, not a reason to leave
+            // the window with no PartCAD in it: everything works over stdio,
+            // just per-window and cold. Said out loud, because a user who set
+            // `partcad.serviceChannel` to "socket" is entitled to know they did
+            // not get it.
+            traceInfo(`PartCAD: ${e.message}; running a dedicated service over stdio instead`);
+            writeTerminal(
+                `WARNING: This PartCAD has no daemon to share, so this window runs a service of its own.\r\n` +
+                    `WARNING: ${e.message}\r\n`,
+            );
+            return connectStdio(execPath, args, cwd, env, outputChannel);
+        }
         // Invisible for the same reason as the case above: this leaves the
         // window with no backend, and the output channel is not open.
         traceError(`Failed to start the PartCAD service: ${e}`);

--- a/ide/vscode/src/common/paths.ts
+++ b/ide/vscode/src/common/paths.ts
@@ -1,0 +1,46 @@
+//
+// PartCAD, 2026
+//
+// Licensed under Apache License, Version 2.0.
+//
+// Comparing one file path against another.
+//
+
+import * as path from 'path';
+
+/**
+ * A key two spellings of the same file share.
+ *
+ * The extension holds paths from two sources and has to match them up: what
+ * VS Code says a document is (`Uri.fsPath`) and what PartCAD says an object is
+ * defined by (`item_path`, straight out of Python). On POSIX those are the same
+ * string and a `Set` of them works. On Windows they are routinely not:
+ * `Uri.fsPath` lower-cases the drive letter, so a document is `c:\...` while
+ * everything the daemon reports keeps whatever case the configuration and the
+ * working directory had, usually `C:\...`. The filesystem there does not
+ * distinguish them and neither may this; a plain string comparison did, which
+ * is why `PartcadLint` could never tell a scene from an assembly on Windows and
+ * checked every scene against the assembly schema.
+ *
+ * Case is folded on Windows only. macOS is case-insensitive by default too, but
+ * both sides spell a path there the same way, so folding would buy nothing and
+ * would be wrong on the case-sensitive volumes that platform also has.
+ *
+ * The daemon answers the same question with `os.path.samefile`, which is why
+ * looking a file up over the wire has always worked. This cannot: it compares
+ * paths that need not exist yet -- a buffer being typed into -- so it
+ * normalises instead of asking the filesystem.
+ *
+ * `platform` is a parameter so the test suite can check the platform it is not
+ * running on; callers pass nothing.
+ */
+export function pathKey(value: string, platform: NodeJS.Platform = process.platform): string {
+    // The named flavour rather than `path`: they are the same object in
+    // production -- `path` is `path.win32` on Windows and `path.posix`
+    // everywhere else -- and a test passing `win32` on a Linux runner means a
+    // Windows path, which the POSIX rules would take for a relative one and
+    // resolve against the runner's working directory.
+    const rules = platform === 'win32' ? path.win32 : path.posix;
+    const resolved = rules.resolve(value);
+    return platform === 'win32' ? resolved.toLowerCase() : resolved;
+}

--- a/ide/vscode/src/common/provision.ts
+++ b/ide/vscode/src/common/provision.ts
@@ -12,9 +12,12 @@
 import * as cp from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
+import * as http from 'http';
 import * as https from 'https';
+import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
+import * as tls from 'tls';
 import * as vscode from 'vscode';
 
 // HTTP header names are not camelCase; that is not a code-style choice.
@@ -28,6 +31,14 @@ const EXE = process.platform === 'win32' ? 'partcad-json-rpc.exe' : 'partcad-jso
 // What a release says it carries, published beside the archives by
 // `dev-tools/release/platforms-manifest.sh`.
 const MANIFEST_NAME = 'platforms.json';
+
+/**
+ * Set to "1" in a window that cannot answer a dialog -- the extension test run.
+ *
+ * There is one dialog in this extension that a window with no PartCAD always
+ * gets, and a test run is always such a window.
+ */
+const NO_PROMPTS_ENV = 'PARTCAD_EXTENSION_NO_PROMPTS';
 
 /**
  * The release manifest: `{version, bundle: {os: {arch: [platform, ...]}}, ide: ...}`,
@@ -208,6 +219,39 @@ export function selectPlatforms(
     return usable.length > 0 ? usable : [published[published.length - 1]];
 }
 
+/**
+ * Errors Windows raises while something else has a file open for a moment.
+ *
+ * Removing or renaming a directory fails there while any file in it is open,
+ * and something has one open more often than the code that wrote it expects:
+ * the virus scanner reading an executable that was just extracted, the search
+ * indexer, a file browser with the folder selected. It clears in milliseconds.
+ */
+const BUSY_CODES = ['EPERM', 'EACCES', 'EBUSY', 'ENOTEMPTY'];
+
+/** Retries: 100ms, 200ms, 400ms, 800ms -- about a second and a half in all. */
+const BUSY_RETRIES = 4;
+
+/**
+ * Run a filesystem operation, retrying briefly while Windows says it is busy.
+ *
+ * A refusal that outlives the retries is a real one -- a service still running
+ * out of the directory -- and is raised as it was: this turns a failed install
+ * into a slightly slower one, and must not turn a broken one into a hang.
+ */
+async function whenNotBusy<T>(operation: () => Promise<T>): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return await operation();
+        } catch (e: any) {
+            if (attempt >= BUSY_RETRIES || !BUSY_CODES.includes(e?.code)) {
+                throw e;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100 * 2 ** attempt));
+        }
+    }
+}
+
 function isFile(p: string): boolean {
     try {
         return !!p && fs.existsSync(p) && fs.statSync(p).isFile();
@@ -216,8 +260,26 @@ function isFile(p: string): boolean {
     }
 }
 
+/**
+ * The directories on PATH.
+ *
+ * Windows quotes an entry that contains a space -- `"C:\Program Files\..."` --
+ * and the quotes are part of what the variable holds rather than of the
+ * directory's name, so joining a filename onto one produces a path that cannot
+ * exist. Nothing on POSIX puts them there, and no directory is really named
+ * with a quote at each end, so stripping a matched pair is safe everywhere.
+ *
+ * Exported for the test suite.
+ */
+export function pathEntries(): string[] {
+    return (process.env.PATH ?? '')
+        .split(path.delimiter)
+        .map((entry) => entry.trim().replace(/^"(.*)"$/, '$1'))
+        .filter((entry) => entry.length > 0);
+}
+
 function whichOnPath(exe: string): string | undefined {
-    for (const dir of (process.env.PATH ?? '').split(path.delimiter)) {
+    for (const dir of pathEntries()) {
         const candidate = path.join(dir, exe);
         if (isFile(candidate)) {
             return candidate;
@@ -240,6 +302,28 @@ export function cliBeside(execPath: string): string | undefined {
 
 function cachedBundleRoot(context: vscode.ExtensionContext): string {
     return path.join(context.globalStorageUri.fsPath, 'partcad-bundle');
+}
+
+/**
+ * Where a standalone installation may already be, this platform's answers first.
+ *
+ * On POSIX these are `install.sh`'s: `$XDG_DATA_HOME/partcad`, defaulting to
+ * `~/.local/share/partcad`. `install.sh` does not run on Windows and nothing
+ * else writes there, so naming those on Windows only told a user the extension
+ * had searched somewhere nothing installs to -- `resolveServicePath` reports
+ * every place it looked, and a list of POSIX paths on Windows reads as noise.
+ * `%LOCALAPPDATA%\PartCAD` is where a per-user installation belongs there.
+ *
+ * The extension's own download directory is last either way: an installation
+ * the user chose outranks one this downloaded for them.
+ */
+function installRoots(context: vscode.ExtensionContext): string[] {
+    if (process.platform === 'win32') {
+        const localAppData = process.env.LOCALAPPDATA;
+        return [...(localAppData ? [path.join(localAppData, 'PartCAD')] : []), cachedBundleRoot(context)];
+    }
+    const xdgData = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+    return [path.join(xdgData, 'partcad'), cachedBundleRoot(context)];
 }
 
 /** Compare two version strings numerically, oldest first. */
@@ -285,9 +369,10 @@ function newestBundleIn(root: string): string | undefined {
 
 /**
  * Return the path to a usable `partcad-json-rpc`, or undefined if none is
- * present. Checked in order: the explicit setting, the newest bundle at the
- * install.sh location, the newest bundle previously downloaded into the
- * extension's storage, the launcher symlink in `~/.local/bin`, then PATH.
+ * present. Checked in order: the explicit setting, the newest bundle at this
+ * platform's installation location (see `installRoots`), the newest bundle
+ * previously downloaded into the extension's storage, the launcher symlink in
+ * `~/.local/bin` where there is one, then PATH.
  *
  * `searched` collects a description of each place as it is tried, so that the
  * "no service available" report can say where it looked without keeping a
@@ -309,10 +394,7 @@ export function resolveServicePath(
         return configured;
     }
 
-    const home = os.homedir();
-    const xdgData = process.env.XDG_DATA_HOME || path.join(home, '.local', 'share');
-    const roots = [path.join(xdgData, 'partcad'), cachedBundleRoot(context)];
-    for (const root of roots) {
+    for (const root of installRoots(context)) {
         searched?.push(root);
         const found = newestBundleIn(root);
         if (found) {
@@ -320,17 +402,21 @@ export function resolveServicePath(
         }
     }
 
-    const linked = path.join(home, '.local', 'bin', EXE);
-    searched?.push(linked);
-    if (isFile(linked)) {
-        return linked;
+    // The launcher symlink `install.sh` puts on PATH. POSIX only: it is a
+    // symlink, made by a script that does not run on Windows.
+    if (process.platform !== 'win32') {
+        const linked = path.join(os.homedir(), '.local', 'bin', EXE);
+        searched?.push(linked);
+        if (isFile(linked)) {
+            return linked;
+        }
     }
 
     // Worth spelling out in the report: this is the PATH of the process VS Code
     // was started from, which is not the PATH of an integrated terminal and does
     // not contain an activated Python virtual environment unless VS Code itself
     // was launched from one.
-    searched?.push(`PATH as VS Code inherited it (${(process.env.PATH ?? '').split(path.delimiter).length} entries)`);
+    searched?.push(`PATH as VS Code inherited it (${pathEntries().length} entries)`);
     return whichOnPath(EXE);
 }
 
@@ -436,6 +522,16 @@ export async function ensureServiceExecutable(
     if (existing) {
         traceInfo(`PartCAD: using service executable at ${existing}`);
         return { kind: 'ready', execPath: existing };
+    }
+
+    if (process.env[NO_PROMPTS_ENV] === '1') {
+        // Nobody is going to answer. The extension test suite activates the
+        // extension on a machine with no PartCAD installed -- exactly the case
+        // this dialog is for -- and a modal dialog in a headless run is a window
+        // that stays open until the run gives up on it. Set by the test runner
+        // and by nothing else; a user never reaches this.
+        traceInfo('PartCAD: no installation found, and this window cannot be asked about it.');
+        return { kind: 'none' };
     }
 
     const choice = await vscode.window.showInformationMessage(
@@ -647,9 +743,9 @@ async function downloadAndExtract(
         throw new Error('the service executable was not found in the downloaded bundle');
     }
     const target = path.join(root, version);
-    await fs.promises.rm(target, { recursive: true, force: true });
-    await fs.promises.rename(unpacked, target);
-    await fs.promises.rm(staging, { recursive: true, force: true });
+    await whenNotBusy(() => fs.promises.rm(target, { recursive: true, force: true }));
+    await whenNotBusy(() => fs.promises.rename(unpacked, target));
+    await fs.promises.rm(staging, { recursive: true, force: true }).catch(() => undefined);
 
     const exe = path.join(target, EXE);
     if (process.platform !== 'win32') {
@@ -665,9 +761,12 @@ async function downloadAndExtract(
  * so leaving the superseded ones behind is not an option; failing to remove one
  * (a file still open on Windows) is, and is only logged.
  *
- * Callers stop the daemon first: `root` is the extension's own storage, so the
- * only thing that runs from these bundles is a PartCAD daemon this extension
- * started. A daemon in another window is stopped by its own reconnect.
+ * Callers stop the backend first -- the shared daemon *and* the private stdio
+ * process, which is the one that matters here: `root` is the extension's own
+ * storage, so the only thing running from these bundles is a service this
+ * window started, and on Windows a directory holding a running executable
+ * cannot be removed at all. A service in another window is stopped by its own
+ * reconnect, and `whenNotBusy` covers the moment in between.
  */
 async function pruneBundles(root: string, keep: string): Promise<void> {
     let entries: string[];
@@ -682,7 +781,7 @@ async function pruneBundles(root: string, keep: string): Promise<void> {
             continue;
         }
         try {
-            await fs.promises.rm(entry, { recursive: true, force: true });
+            await whenNotBusy(() => fs.promises.rm(entry, { recursive: true, force: true }));
             traceInfo(`PartCAD: removed the previous bundle at ${entry}`);
         } catch (e) {
             traceInfo(`PartCAD: could not remove the previous bundle at ${entry}: ${e}`);
@@ -776,50 +875,145 @@ async function latestRelease(repo: string): Promise<string> {
     return tag;
 }
 
-function httpsGet(url: string, headers: Record<string, string> = {}): Promise<Buffer> {
+/**
+ * The proxy to reach GitHub through, if this machine has one.
+ *
+ * VS Code's own setting first: a user behind a corporate proxy has already told
+ * the editor about it, and should not have to tell the extension separately.
+ * Then the environment variable every other tool reads, for a machine
+ * configured at the shell rather than in the editor. `https.get` consults
+ * neither on its own, which is why downloading the bundle used to fail with a
+ * bare connection error on a network where `pc` itself installs fine.
+ */
+function proxyFor(): URL | undefined {
+    const configured = vscode.workspace.getConfiguration('http').get<string>('proxy')?.trim();
+    const proxy = configured || process.env.HTTPS_PROXY || process.env.https_proxy;
+    if (!proxy) {
+        return undefined;
+    }
+    try {
+        return new URL(proxy);
+    } catch {
+        // A proxy setting with no scheme in it ("proxy.corp:3128") is a
+        // configuration mistake, not a reason to fail the download: without a
+        // proxy this reaches GitHub directly on most networks, and with a
+        // broken one it reaches nothing at all.
+        traceError(`PartCAD: ignoring an unusable proxy setting: ${proxy}`);
+        return undefined;
+    }
+}
+
+/**
+ * A socket to `target`, tunnelled through `proxy` with HTTP CONNECT.
+ *
+ * The TLS is still end to end: the proxy is asked for a raw tunnel and the
+ * caller wraps its own TLS around it, so nothing is decrypted on the way and no
+ * certificate check is relaxed. Credentials in the proxy URL travel as Basic
+ * proxy authorization, which is what they are for.
+ */
+function tunnel(target: URL, proxy: URL): Promise<net.Socket> {
     return new Promise((resolve, reject) => {
-        https
-            .get(url, { headers: { 'User-Agent': 'partcad-vscode', ...headers } }, (res) => {
-                const status = res.statusCode ?? 0;
-                if (status >= 300 && status < 400 && res.headers.location) {
-                    res.resume();
-                    resolve(httpsGet(res.headers.location, headers));
-                    return;
-                }
-                if (status !== 200) {
-                    res.resume();
-                    reject(new HttpError(status, url));
-                    return;
-                }
-                const chunks: Buffer[] = [];
-                res.on('data', (c) => chunks.push(c));
-                res.on('end', () => resolve(Buffer.concat(chunks)));
-            })
-            .on('error', reject);
+        const authority = `${target.hostname}:${target.port || 443}`;
+        const headers: Record<string, string> = { host: authority };
+        if (proxy.username) {
+            const credentials = `${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`;
+            headers['Proxy-Authorization'] = `Basic ${Buffer.from(credentials).toString('base64')}`;
+        }
+        const request = http.request({
+            host: proxy.hostname,
+            port: Number(proxy.port || (proxy.protocol === 'https:' ? 443 : 80)),
+            method: 'CONNECT',
+            path: authority,
+            headers,
+        });
+        request.once('connect', (response: http.IncomingMessage, socket: net.Socket) => {
+            if (response.statusCode !== 200) {
+                socket.destroy();
+                reject(
+                    new Error(
+                        `the proxy at ${proxy.origin} refused a tunnel to ${authority} (HTTP ${response.statusCode})`,
+                    ),
+                );
+                return;
+            }
+            resolve(socket);
+        });
+        request.once('error', reject);
+        request.end();
     });
 }
 
-function downloadFile(url: string, dest: string): Promise<void> {
+/** Redirects to follow before deciding something is looping. */
+const MAX_REDIRECTS = 5;
+
+/**
+ * GET a URL, following redirects and honouring the configured proxy, and hand
+ * the caller the response to read however it wants to.
+ *
+ * One implementation for both readers below: they differ in what they do with
+ * the body -- buffer it, or write it to a file -- and in nothing else, and the
+ * redirect and proxy handling is what neither of them should be carrying twice.
+ */
+async function openUrl(
+    url: string,
+    headers: Record<string, string> = {},
+    redirects = 0,
+): Promise<http.IncomingMessage> {
+    if (redirects > MAX_REDIRECTS) {
+        throw new Error(`too many redirects for ${url}`);
+    }
+    const target = new URL(url);
+    const options: https.RequestOptions = {
+        host: target.hostname,
+        port: target.port || 443,
+        path: `${target.pathname}${target.search}`,
+        headers: { 'User-Agent': 'partcad-vscode', ...headers },
+    };
+    const proxy = proxyFor();
+    if (proxy) {
+        const socket = await tunnel(target, proxy);
+        // The TLS is put on the tunnelled socket here rather than by an agent
+        // that would open its own connection. `servername` has to be said out
+        // loud for the same reason: there is no hostname to infer it from once
+        // the socket is already open.
+        options.agent = false;
+        options.createConnection = () => tls.connect({ socket, servername: target.hostname });
+    }
+
+    const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        https.get(options, resolve).on('error', reject);
+    });
+    const status = response.statusCode ?? 0;
+    if (status >= 300 && status < 400 && response.headers.location) {
+        response.resume();
+        // Resolved against the URL it came from: a redirect may be relative.
+        return openUrl(new URL(response.headers.location, url).toString(), headers, redirects + 1);
+    }
+    if (status !== 200) {
+        response.resume();
+        throw new HttpError(status, url);
+    }
+    return response;
+}
+
+async function httpsGet(url: string, headers: Record<string, string> = {}): Promise<Buffer> {
+    const response = await openUrl(url, headers);
     return new Promise((resolve, reject) => {
-        https
-            .get(url, { headers: { 'User-Agent': 'partcad-vscode' } }, (res) => {
-                const status = res.statusCode ?? 0;
-                if (status >= 300 && status < 400 && res.headers.location) {
-                    res.resume();
-                    downloadFile(res.headers.location, dest).then(resolve, reject);
-                    return;
-                }
-                if (status !== 200) {
-                    res.resume();
-                    reject(new HttpError(status, url));
-                    return;
-                }
-                const file = fs.createWriteStream(dest);
-                res.pipe(file);
-                file.on('finish', () => file.close((err) => (err ? reject(err) : resolve())));
-                file.on('error', reject);
-            })
-            .on('error', reject);
+        const chunks: Buffer[] = [];
+        response.on('data', (c) => chunks.push(c));
+        response.on('end', () => resolve(Buffer.concat(chunks)));
+        response.on('error', reject);
+    });
+}
+
+async function downloadFile(url: string, dest: string): Promise<void> {
+    const response = await openUrl(url);
+    return new Promise((resolve, reject) => {
+        const file = fs.createWriteStream(dest);
+        response.on('error', reject);
+        response.pipe(file);
+        file.on('finish', () => file.close((err) => (err ? reject(err) : resolve())));
+        file.on('error', reject);
     });
 }
 
@@ -845,11 +1039,37 @@ function run(cmd: string, args: string[], cwd: string): Promise<void> {
     });
 }
 
+/** A string as a PowerShell single-quoted literal. */
+function powershellLiteral(value: string): string {
+    return `'${value.replace(/'/g, "''")}'`;
+}
+
 async function extract(archivePath: string, dest: string, ext: 'tar.xz' | 'zip'): Promise<void> {
     if (ext === 'zip') {
         if (process.platform === 'win32') {
-            // Windows 10+ ships bsdtar, which unpacks zip archives.
-            await run('tar', ['-xf', archivePath, '-C', dest], dest);
+            try {
+                // Windows 10 1803 and later ship bsdtar as `tar`, which unpacks
+                // zip archives.
+                await run('tar', ['-xf', archivePath, '-C', dest], dest);
+            } catch (e) {
+                // An older Windows, or one whose PATH has lost System32.
+                // PowerShell is on every Windows that runs VS Code and unpacks
+                // a zip on its own, so the download is not wasted over a
+                // missing archiver -- and the failure, if this fails too, names
+                // something the user has heard of.
+                traceInfo(`PartCAD: 'tar' did not unpack the bundle (${e}); using PowerShell`);
+                await run(
+                    'powershell',
+                    [
+                        '-NoProfile',
+                        '-NonInteractive',
+                        '-Command',
+                        `Expand-Archive -LiteralPath ${powershellLiteral(archivePath)} ` +
+                            `-DestinationPath ${powershellLiteral(dest)} -Force`,
+                    ],
+                    dest,
+                );
+            }
         } else {
             await run('unzip', ['-q', '-o', archivePath, '-d', dest], dest);
         }

--- a/ide/vscode/src/common/provision.ts
+++ b/ide/vscode/src/common/provision.ts
@@ -996,6 +996,7 @@ async function openUrl(
     return response;
 }
 
+/** GET a URL and return the whole body. For the small ones: manifests, tags. */
 async function httpsGet(url: string, headers: Record<string, string> = {}): Promise<Buffer> {
     const response = await openUrl(url, headers);
     return new Promise((resolve, reject) => {
@@ -1006,6 +1007,7 @@ async function httpsGet(url: string, headers: Record<string, string> = {}): Prom
     });
 }
 
+/** GET a URL straight to a file, without holding the body in memory. */
 async function downloadFile(url: string, dest: string): Promise<void> {
     const response = await openUrl(url);
     return new Promise((resolve, reject) => {

--- a/ide/vscode/src/extension.ts
+++ b/ide/vscode/src/extension.ts
@@ -503,6 +503,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 // fallback download path, which does not, and this connection
                 // has to go either way.
                 await lsClient?.stopDaemon?.();
+                // And the service process itself, before anything replaces the
+                // files it is running from. `stopDaemon` stops the *shared*
+                // daemon; the stdio channel owns a private process instead, and
+                // nothing stopped that until the reconnect at the end of this
+                // command -- long after the bundle it runs from had been
+                // deleted and replaced. On Windows that deletion simply fails
+                // (a directory with a running executable in it cannot be
+                // removed), so every update left another ~180MB behind.
+                const running = lsClient;
+                lsClient = undefined;
+                await running?.stop();
                 const result = await updateServiceBundle(context, serverId, outputChannel);
                 // `pc upgrade` installs beside the running bundle and deletes
                 // every superseded one, so the directory this put on the PATH

--- a/ide/vscode/src/test/suite/backend.test.ts
+++ b/ide/vscode/src/test/suite/backend.test.ts
@@ -1,0 +1,54 @@
+//
+// PartCAD, 2026
+//
+// Licensed under Apache License, Version 2.0.
+//
+// Reading `pc daemon start`'s answer.
+//
+
+import * as assert from 'assert';
+
+import { daemonEndpointIn } from '../../common/backend';
+
+suite('Where the daemon is', () => {
+    test('a socket path is the endpoint', () => {
+        assert.strictEqual(
+            daemonEndpointIn('/home/me/.partcad/workspaces/0123456789abcdef/socket\n'),
+            '/home/me/.partcad/workspaces/0123456789abcdef/socket',
+        );
+    });
+
+    test('a Windows named pipe is the endpoint', () => {
+        // Printed with CRLF by a Windows `pc`, and not an absolute path by any
+        // definition `path.isAbsolute` has on a POSIX machine -- which is where
+        // this test runs.
+        assert.strictEqual(
+            daemonEndpointIn('\\\\.\\pipe\\partcad-0123456789abcdef\r\n'),
+            '\\\\.\\pipe\\partcad-0123456789abcdef',
+        );
+    });
+
+    test('a sentence is not an endpoint', () => {
+        // What a `pc` without a daemon for this platform prints -- on stdout,
+        // with a zero exit status. Taking "the first non-empty line" handed it
+        // to `net.connect`, which failed with ENOENT about a filename made of
+        // English, and the window was left with no backend at all rather than
+        // with a service over stdio.
+        assert.strictEqual(
+            daemonEndpointIn(
+                'The PartCAD socket daemon is not available on Windows yet; ' +
+                    'commands run a per-invocation service instead.\n',
+            ),
+            undefined,
+        );
+    });
+
+    test('nothing at all is not an endpoint', () => {
+        assert.strictEqual(daemonEndpointIn(''), undefined);
+        assert.strictEqual(daemonEndpointIn('\n  \n'), undefined);
+    });
+
+    test('the endpoint is found past anything printed before it', () => {
+        assert.strictEqual(daemonEndpointIn('Starting the daemon...\n/tmp/pc/socket\n'), '/tmp/pc/socket');
+    });
+});

--- a/ide/vscode/src/test/suite/paths.test.ts
+++ b/ide/vscode/src/test/suite/paths.test.ts
@@ -1,0 +1,42 @@
+//
+// PartCAD, 2026
+//
+// Licensed under Apache License, Version 2.0.
+//
+// Matching a path the editor reports against one PartCAD reports.
+//
+
+import * as assert from 'assert';
+import * as path from 'path';
+
+import { pathKey } from '../../common/paths';
+
+suite('Comparing file paths', () => {
+    test('a Windows drive letter compares in either case', () => {
+        // The whole reason this exists: `Uri.fsPath` lower-cases the drive
+        // letter and PartCAD does not, so the editor's spelling of a document
+        // and the daemon's spelling of the same file are different strings.
+        // `PartcadLint` compared them directly and never once matched, which
+        // silently turned every scene into an assembly there.
+        assert.strictEqual(
+            pathKey('c:\\Users\\me\\pkg\\robot.assy', 'win32'),
+            pathKey('C:\\Users\\me\\pkg\\robot.assy', 'win32'),
+        );
+    });
+
+    test('case is folded on Windows and nowhere else', () => {
+        assert.strictEqual(pathKey('C:\\Pkg\\Robot.assy', 'win32'), 'c:\\pkg\\robot.assy');
+        // A case-sensitive filesystem has two different files here, and saying
+        // otherwise would report findings about the wrong one.
+        assert.notStrictEqual(pathKey('/pkg/Robot.assy', 'linux'), pathKey('/pkg/robot.assy', 'linux'));
+    });
+
+    test('a path is normalised before it is compared', () => {
+        const direct = path.resolve('pkg', 'robot.assy');
+        assert.strictEqual(pathKey(direct), pathKey(path.join('pkg', '.', 'sub', '..', 'robot.assy')));
+    });
+
+    test('different files still differ', () => {
+        assert.notStrictEqual(pathKey('/pkg/robot.assy'), pathKey('/pkg/robot2.assy'));
+    });
+});

--- a/ide/vscode/src/test/suite/provision.test.ts
+++ b/ide/vscode/src/test/suite/provision.test.ts
@@ -143,10 +143,20 @@ suite('Where the service was looked for', () => {
      * the two strings said the extension had not looked there. Which is the
      * very confusion `pathKey` exists for, arriving here by the same route it
      * arrives everywhere else.
+     *
+     * And not a substring match either: an entry has to *be* the directory or
+     * be *inside* it. The report names the bundle root inside the storage
+     * directory rather than the directory itself, so an exact comparison alone
+     * would not do -- but a plain `includes` would let `<tmp>/storage-backup`
+     * answer for `<tmp>/storage`, and a test that cannot tell those apart
+     * cannot tell whether the extension looked where it said it did.
      */
     function names(searched: string[], target: string): boolean {
         const needle = pathKey(target);
-        return searched.some((entry) => pathKey(entry).includes(needle));
+        return searched.some((entry) => {
+            const key = pathKey(entry);
+            return key === needle || key.startsWith(needle + path.sep);
+        });
     }
 
     // `resolveServicePath` looks at this platform's installation directory and

--- a/ide/vscode/src/test/suite/provision.test.ts
+++ b/ide/vscode/src/test/suite/provision.test.ts
@@ -19,7 +19,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { resolveServicePath, selectPlatforms, serviceUnder } from '../../common/provision';
+import { pathEntries, resolveServicePath, selectPlatforms, serviceUnder } from '../../common/provision';
 
 const MANIFEST = {
     version: '0.7.177',
@@ -132,20 +132,24 @@ suite('Where the service was looked for', () => {
             .update('servicePath', exe ?? '', vscode.ConfigurationTarget.Global);
     }
 
-    // `resolveServicePath` looks in `$XDG_DATA_HOME/partcad` and in the home
-    // directory before it reaches PATH, so on a machine with PartCAD installed
-    // by `install.sh` it would return early and the search report would be one
-    // entry long. Point both at the empty temporary directory for the duration:
-    // what is under test is the report, not this machine.
-    let savedXdg: string | undefined;
-    let savedHome: string | undefined;
+    // `resolveServicePath` looks at this platform's installation directory and
+    // in the home directory before it reaches PATH, so on a machine with PartCAD
+    // installed it would return early and the search report would be one entry
+    // long. Point every variable those are derived from at the empty temporary
+    // directory for the duration: what is under test is the report, not this
+    // machine. `HOME` alone is not enough -- `os.homedir()` reads `USERPROFILE`
+    // on Windows -- and neither is the home directory, since the Windows lookup
+    // starts at `%LOCALAPPDATA%`.
+    const SANDBOXED = ['XDG_DATA_HOME', 'HOME', 'USERPROFILE', 'LOCALAPPDATA'];
+    let saved: Map<string, string | undefined>;
 
     setup(() => {
         tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'partcad-provision-'));
-        savedXdg = process.env.XDG_DATA_HOME;
-        savedHome = process.env.HOME;
+        saved = new Map(SANDBOXED.map((name) => [name, process.env[name]]));
         process.env.XDG_DATA_HOME = path.join(tmp, 'data');
         process.env.HOME = path.join(tmp, 'home');
+        process.env.USERPROFILE = path.join(tmp, 'home');
+        process.env.LOCALAPPDATA = path.join(tmp, 'local');
     });
 
     function restore(name: string, value: string | undefined): void {
@@ -157,25 +161,45 @@ suite('Where the service was looked for', () => {
     }
 
     teardown(async () => {
-        restore('XDG_DATA_HOME', savedXdg);
-        restore('HOME', savedHome);
+        saved.forEach((value, name) => restore(name, value));
         await pointServicePathAt(undefined);
         fs.rmSync(tmp, { recursive: true, force: true });
     });
+
+    /**
+     * The report `resolveServicePath` would produce on `platform`.
+     *
+     * Which places are searched depends on the platform, and a CI leg only ever
+     * runs on one of them -- while the value of the report is precisely that it
+     * names what *this* platform looked at. `process.platform` is an own
+     * property of a plain object, so it can be made to say something else for
+     * the length of one synchronous call and put back afterwards.
+     */
+    function searchedOn(platform: NodeJS.Platform): string[] {
+        const original = process.platform;
+        Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+        try {
+            const searched: string[] = [];
+            resolveServicePath(fakeContext(), 'partcad', searched);
+            return searched;
+        } finally {
+            Object.defineProperty(process, 'platform', { value: original, configurable: true });
+        }
+    }
 
     test('every place tried is reported when nothing is found', async () => {
         await pointServicePathAt(undefined);
         const searched: string[] = [];
         resolveServicePath(fakeContext(), 'partcad', searched);
 
-        assert.ok(searched.length >= 5, `expected every lookup to be named, got ${searched.length}: ${searched}`);
+        assert.ok(searched.length >= 4, `expected every lookup to be named, got ${searched.length}: ${searched}`);
         assert.ok(
             searched.some((s) => s.includes('partcad.servicePath')),
             'the setting is the first thing checked and has to be named, set or not',
         );
         assert.ok(
-            searched.some((s) => s.includes(path.join('.local', 'bin'))),
-            'the ~/.local/bin launcher is checked and has to be named',
+            searched.some((s) => s.includes(path.join(tmp, 'storage'))),
+            "the extension's own download directory is checked and has to be named",
         );
         // The one that matters most: a user with PartCAD in a virtual
         // environment needs to be told which PATH was consulted, since it is not
@@ -183,6 +207,36 @@ suite('Where the service was looked for', () => {
         assert.ok(
             searched.some((s) => s.startsWith('PATH')),
             'PATH is the last resort and has to be named',
+        );
+    });
+
+    test("the POSIX lookup names install.sh's locations", async () => {
+        await pointServicePathAt(undefined);
+        const searched = searchedOn('linux');
+        assert.ok(
+            searched.some((s) => s.includes(path.join(tmp, 'data', 'partcad'))),
+            '$XDG_DATA_HOME/partcad is where install.sh puts a bundle and has to be named',
+        );
+        assert.ok(
+            searched.some((s) => s.includes(path.join('.local', 'bin'))),
+            'the ~/.local/bin launcher is checked and has to be named',
+        );
+    });
+
+    test('the Windows lookup names Windows locations and no others', async () => {
+        // Nothing installs to `~/.local/share` on Windows -- `install.sh` does
+        // not run there -- so reporting it as searched sends a user looking in a
+        // directory no installer of theirs has ever written to, which is the
+        // opposite of what this list is for.
+        await pointServicePathAt(undefined);
+        const searched = searchedOn('win32');
+        assert.ok(
+            searched.some((s) => s.includes(path.join(tmp, 'local', 'PartCAD'))),
+            '%LOCALAPPDATA%\\PartCAD is where a Windows installation goes and has to be named',
+        );
+        assert.ok(
+            !searched.some((s) => s.includes('.local')),
+            'the POSIX locations are not searched on Windows and must not be reported as searched',
         );
     });
 
@@ -252,5 +306,43 @@ suite('Finding the service in a directory the user picked', () => {
         // otherwise be handed to the spawn as if it were a program.
         fs.mkdirSync(path.join(tmp, 'trap', EXE), { recursive: true });
         assert.strictEqual(serviceUnder(path.join(tmp, 'trap')), undefined);
+    });
+});
+
+// A Windows PATH quotes an entry that contains a space, and the quotes belong to
+// the variable rather than to the directory. Joining `partcad-json-rpc.exe` onto
+// one produced a path that could not exist, so an installation in
+// `C:\Program Files\...` was invisible to the last-resort lookup.
+suite('Reading the PATH', () => {
+    let savedPath: string | undefined;
+
+    setup(() => {
+        savedPath = process.env.PATH;
+    });
+
+    teardown(() => {
+        if (savedPath === undefined) {
+            delete process.env.PATH;
+        } else {
+            process.env.PATH = savedPath;
+        }
+    });
+
+    test('a quoted entry is the directory inside the quotes', () => {
+        process.env.PATH = ['"/opt/with space"', '/usr/bin'].join(path.delimiter);
+        assert.deepStrictEqual(pathEntries(), ['/opt/with space', '/usr/bin']);
+    });
+
+    test('empty entries are not directories', () => {
+        // A trailing delimiter is normal on Windows, and an empty entry means
+        // the current directory to some shells -- never something to search
+        // for an executable to run.
+        process.env.PATH = ['/usr/bin', '', '  '].join(path.delimiter);
+        assert.deepStrictEqual(pathEntries(), ['/usr/bin']);
+    });
+
+    test('an unset PATH has no entries', () => {
+        delete process.env.PATH;
+        assert.deepStrictEqual(pathEntries(), []);
     });
 });

--- a/ide/vscode/src/test/suite/provision.test.ts
+++ b/ide/vscode/src/test/suite/provision.test.ts
@@ -19,6 +19,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
+import { pathKey } from '../../common/paths';
 import { pathEntries, resolveServicePath, selectPlatforms, serviceUnder } from '../../common/provision';
 
 const MANIFEST = {
@@ -132,6 +133,22 @@ suite('Where the service was looked for', () => {
             .update('servicePath', exe ?? '', vscode.ConfigurationTarget.Global);
     }
 
+    /**
+     * Whether the report names `target`, however this platform spells it.
+     *
+     * Not `String.includes` on the paths as they come: the storage directory
+     * reaches `resolveServicePath` as `globalStorageUri.fsPath`, and on Windows
+     * `Uri.fsPath` lower-cases the drive letter -- so the report says
+     * `c:\...\storage` where this test built `C:\...\storage`, and comparing
+     * the two strings said the extension had not looked there. Which is the
+     * very confusion `pathKey` exists for, arriving here by the same route it
+     * arrives everywhere else.
+     */
+    function names(searched: string[], target: string): boolean {
+        const needle = pathKey(target);
+        return searched.some((entry) => pathKey(entry).includes(needle));
+    }
+
     // `resolveServicePath` looks at this platform's installation directory and
     // in the home directory before it reaches PATH, so on a machine with PartCAD
     // installed it would return early and the search report would be one entry
@@ -198,7 +215,7 @@ suite('Where the service was looked for', () => {
             'the setting is the first thing checked and has to be named, set or not',
         );
         assert.ok(
-            searched.some((s) => s.includes(path.join(tmp, 'storage'))),
+            names(searched, path.join(tmp, 'storage')),
             "the extension's own download directory is checked and has to be named",
         );
         // The one that matters most: a user with PartCAD in a virtual
@@ -214,7 +231,7 @@ suite('Where the service was looked for', () => {
         await pointServicePathAt(undefined);
         const searched = searchedOn('linux');
         assert.ok(
-            searched.some((s) => s.includes(path.join(tmp, 'data', 'partcad'))),
+            names(searched, path.join(tmp, 'data', 'partcad')),
             '$XDG_DATA_HOME/partcad is where install.sh puts a bundle and has to be named',
         );
         assert.ok(
@@ -231,7 +248,7 @@ suite('Where the service was looked for', () => {
         await pointServicePathAt(undefined);
         const searched = searchedOn('win32');
         assert.ok(
-            searched.some((s) => s.includes(path.join(tmp, 'local', 'PartCAD'))),
+            names(searched, path.join(tmp, 'local', 'PartCAD')),
             '%LOCALAPPDATA%\\PartCAD is where a Windows installation goes and has to be named',
         );
         assert.ok(

--- a/ide/vscode/src/test/suite/viewerServer.test.ts
+++ b/ide/vscode/src/test/suite/viewerServer.test.ts
@@ -1,0 +1,51 @@
+//
+// PartCAD, 2026
+//
+// Licensed under Apache License, Version 2.0.
+//
+// How the viewer's port is bound.
+//
+
+import * as assert from 'assert';
+import * as net from 'net';
+
+import { listenOptions } from '../../viewer/PartcadViewerServer';
+import { PARTCAD_IDE_HOST, PARTCAD_IDE_PORT } from '../../viewer/protocol';
+
+type MaybeReusePort = net.ListenOptions & { reusePort?: boolean };
+
+suite('Binding the viewer port', () => {
+    test('the port and the loopback host are always asked for', () => {
+        const options = listenOptions(PARTCAD_IDE_PORT, PARTCAD_IDE_HOST);
+        assert.strictEqual(options.port, PARTCAD_IDE_PORT);
+        assert.strictEqual(options.host, PARTCAD_IDE_HOST);
+    });
+
+    test('SO_REUSEPORT is asked for only where libuv has it', () => {
+        // Where it does not -- Windows, macOS -- `listen` fails with ENOTSUP
+        // rather than ignoring the option, which took the viewer down entirely
+        // on both as soon as VS Code shipped a Node that passes the option
+        // through (22.12). There is nothing to ask for instead: Node's `listen`
+        // has no `reuseAddr`, and libuv sets neither SO_REUSEADDR nor
+        // SO_EXCLUSIVEADDRUSE for a TCP server on Windows.
+        const options = listenOptions(PARTCAD_IDE_PORT, PARTCAD_IDE_HOST) as MaybeReusePort;
+        assert.strictEqual(options.reusePort, process.platform === 'linux' ? true : undefined);
+    });
+
+    test('the options really bind', async () => {
+        // The assertion the two above cannot make: whatever this platform is,
+        // a server started with these options listens.
+        const server = net.createServer();
+        try {
+            await new Promise<void>((resolve, reject) => {
+                server.once('error', reject);
+                // Port 0: the constant one may be held by a viewer this very
+                // window is running.
+                server.listen({ ...listenOptions(0, PARTCAD_IDE_HOST) }, resolve);
+            });
+            assert.ok(server.listening);
+        } finally {
+            server.close();
+        }
+    });
+});

--- a/ide/vscode/src/viewer/PartcadViewerServer.ts
+++ b/ide/vscode/src/viewer/PartcadViewerServer.ts
@@ -20,6 +20,51 @@ import {
 } from './protocol';
 
 /**
+ * Where SO_REUSEPORT can be asked for.
+ *
+ * libuv implements the option only where it also load-balances the incoming
+ * connections -- Linux, FreeBSD, DragonFly, Solaris 11.4, AIX 7.2.5 -- and
+ * *rejects the bind* with ENOTSUP everywhere else, rather than ignoring it.
+ * Only the one this is exercised on is listed: an AIX or Solaris too old for it
+ * would fail the bind exactly as Windows does, and what is bought is an
+ * optimisation, not the viewer.
+ */
+const REUSEPORT_PLATFORMS: ReadonlySet<string> = new Set(['linux']);
+
+/**
+ * How to bind the viewer port on this platform.
+ *
+ * SO_REUSEPORT lets two windows each hold the port and have the kernel hand
+ * each connection to one of them, instead of the second window losing the race
+ * and having no viewer at all. It is asked for only where it exists: `listen`
+ * fails outright with ENOTSUP on a platform libuv does not support it on, and
+ * that is not a failure this can shrug off -- it is the whole viewer, silently,
+ * with only a line in the output channel to show for it. It went unnoticed
+ * because Node ignored the option until 22.12 and VS Code shipped an older one;
+ * a VS Code on Node 22.12 or later takes the viewer down on Windows and macOS.
+ *
+ * There is nothing to ask for instead on Windows. Node's `listen` has no
+ * `reuseAddr` option (`dgram` has one, for UDP sockets, and this is TCP), and
+ * libuv deliberately sets neither SO_REUSEADDR nor SO_EXCLUSIVEADDRUSE for a
+ * TCP server there -- on Windows SO_REUSEADDR does not mean "rebind a port in
+ * TIME_WAIT", it means "take a port another process is using". So the second
+ * window falls back to what it always did: the EADDRINUSE branch of the error
+ * handler, which says another window is serving the viewer.
+ *
+ * Exported for the test suite, which has to check the platforms it is not
+ * running on.
+ */
+export function listenOptions(port: number, host: string): net.ListenOptions {
+    const options: net.ListenOptions = { port, host };
+    if (REUSEPORT_PLATFORMS.has(process.platform)) {
+        // Not in the object literal above: `reusePort` reached Node's typings
+        // in 22.12, and this compiles against the older ones VS Code ships.
+        (options as net.ListenOptions & { reusePort?: boolean }).reusePort = true;
+    }
+    return options;
+}
+
+/**
  * Listens for PartCAD processes that want to display something.
  *
  * The IDE is the server half of the protocol: 'partcad' runs in a subprocess (or
@@ -74,14 +119,7 @@ export class PartcadViewerServer implements vscode.Disposable {
             });
             server.once('error', () => resolve());
 
-            // 'reusePort' asks for SO_REUSEPORT, and libuv already sets
-            // SO_REUSEADDR for every TCP server it binds on non-Windows. Node
-            // gained the option in 22.12; VS Code ships an older Node, where an
-            // unknown listen option is simply ignored and only SO_REUSEADDR
-            // applies. Passing it regardless is what makes the behaviour right
-            // on the runtimes that do support it, at no cost on the ones that
-            // do not.
-            server.listen({ port: this.port, host: this.host, reusePort: true } as net.ListenOptions);
+            server.listen(listenOptions(this.port, this.host));
         });
     }
 

--- a/src/partcad_cli/click/commands/daemon/start.py
+++ b/src/partcad_cli/click/commands/daemon/start.py
@@ -12,22 +12,20 @@ and connects. One implementation of "where is the daemon", in
 """
 
 import logging
-import os
 
 import rich_click as click
 from partcad_client import client
 
 
-@click.command(help="Start the PartCAD daemon for this workspace (if needed) and print its socket path")
+@click.command(help="Start the PartCAD daemon for this workspace (if needed) and print its endpoint")
 def cli() -> None:
-    if os.name == "nt":
-        click.echo(
-            "The PartCAD socket daemon is not available on Windows yet; "
-            "commands run a per-invocation service instead."
-        )
-        return
-    path = client.start_daemon(extra_args=daemon_args())
-    click.echo(path)
+    # Every platform, including Windows: the daemon is an AF_UNIX socket on
+    # POSIX and a named pipe there (`partcad_service_json_rpc.daemon`
+    # implements both), and the endpoint is printed the same way either way.
+    # This used to answer Windows with a sentence saying there was no daemon --
+    # on stdout, with a zero exit status, which is where the endpoint goes. The
+    # editor extension connected to the sentence.
+    click.echo(client.start_daemon(extra_args=daemon_args()))
 
 
 def daemon_args() -> list:

--- a/src/partcad_cli/click/commands/daemon/stop.py
+++ b/src/partcad_cli/click/commands/daemon/stop.py
@@ -4,17 +4,15 @@
 # Licensed under Apache License, Version 2.0.
 #
 
-import os
-
 import rich_click as click
 from partcad_client import daemon
 
 
 @click.command(help="Stop the PartCAD daemon serving this workspace")
 def cli() -> None:
-    if os.name == "nt":
-        click.echo("The PartCAD socket daemon is not available on Windows yet; nothing to stop.")
-        return
+    # `stop_daemon` knows both transports -- the AF_UNIX socket and the Windows
+    # named pipe -- so there is nothing to decide here. It answered Windows with
+    # "nothing to stop" while `pc daemon start` was starting one.
     if daemon.stop_daemon():
         click.echo("PartCAD daemon stopped")
     else:

--- a/src/partcad_cli/click/commands/lint.py
+++ b/src/partcad_cli/click/commands/lint.py
@@ -111,13 +111,42 @@ def cli(
     )
 
 
+def _read_stdin() -> str:
+    """The buffer on standard input, decoded as UTF-8.
+
+    Decoded here rather than by ``sys.stdin``, which uses the locale encoding:
+    UTF-8 on Linux and macOS, but the ANSI code page on Windows. What arrives is
+    an editor's unsaved file -- the VS Code extension writes the buffer as UTF-8
+    and reads this command's JSON back the same way -- so on Windows a
+    description with an umlaut in it came out as mojibake, and a byte the code
+    page has no character for killed the decoder and took the findings with it.
+    The extension pins ``PYTHONIOENCODING`` for the same reason; this makes the
+    command right on its own, whoever runs it.
+
+    ``utf-8-sig`` because a file piped in on Windows may still carry a byte
+    order mark, which is not part of the text and is not what column 1 of line 1
+    is. A ``sys.stdin`` a caller has replaced (a test, an embedding) has no
+    binary buffer, and its text is taken as it comes.
+    """
+    raw = getattr(sys.stdin, "buffer", None)
+    if raw is None:
+        return sys.stdin.read()
+    return raw.read().decode("utf-8-sig")
+
+
 def _lint_files(click_ctx, paths: list, stdin: bool, as_json: bool, flavor: str = "auto") -> None:
     """Check the named files in this process and report what came back."""
     text = None
     if stdin:
         if len(paths) != 1:
             raise click.UsageError("--stdin supplies the content of one file; name exactly one --file")
-        text = sys.stdin.read()
+        try:
+            text = _read_stdin()
+        except UnicodeDecodeError as e:
+            # A clean message rather than a traceback: the caller is usually an
+            # editor parsing this command's output, and a traceback is neither
+            # the JSON it expects nor something it can show a user.
+            raise click.UsageError("--stdin expects UTF-8 text: %s" % e)
 
     # Deferred: `pc --help` imports every command module to print its short help,
     # and this one pulls in jsonschema and jinja2.

--- a/src/partcad_client/client.py
+++ b/src/partcad_client/client.py
@@ -8,13 +8,16 @@
 Used by the CLI (a thin client), by the VS Code extension through
 `pc daemon start`/`pc daemon stop`, and available to any other Python caller.
 
-On POSIX, :func:`connect` uses the shared per-workspace **socket daemon** (a warm
-context): ``start_daemon`` runs the ``partcad-json-rpc`` launcher and returns its
-socket path. On Windows, where the socket daemon is not yet available, it falls
-back to launching a one-shot ``partcad-json-rpc --stdio`` service and talking to
-it over its pipes. Either way the caller stays a thin client that does not import
-``partcad``; :class:`DaemonClient` speaks framed JSON-RPC and delivers server
-notifications to an optional callback while waiting for the matching response.
+On POSIX, :func:`connect` uses the shared per-workspace **daemon** (a warm
+context): ``start_daemon`` runs the ``partcad-json-rpc`` launcher and returns the
+endpoint it printed. On Windows it falls back to launching a one-shot
+``partcad-json-rpc --stdio`` service and talking to it over its pipes -- not
+because there is no daemon there (the service serves a named pipe, and
+``start_daemon`` starts it for `pc daemon start` and the editor extension) but
+because the CLI has not been moved onto it yet. Either way the caller stays a
+thin client that does not import ``partcad``; :class:`DaemonClient` speaks framed
+JSON-RPC and delivers server notifications to an optional callback while waiting
+for the matching response.
 """
 
 import os
@@ -47,10 +50,16 @@ def launcher_argv() -> list:
 
 
 def start_daemon(cwd: Optional[str] = None, extra_args=()) -> str:
-    """Ensure a socket daemon serves the workspace at ``cwd``; return its path.
+    r"""Ensure a daemon serves the workspace at ``cwd``; return its endpoint.
 
-    POSIX only (the socket daemon uses AF_UNIX and fork). On Windows use the
-    stdio fallback via :func:`connect`.
+    An AF_UNIX socket path on POSIX, a ``\\.\pipe\...`` name on Windows: the
+    service implements both (``partcad_service_json_rpc.daemon``) and prints
+    whichever it served. The endpoint it prints is live -- the launcher waits
+    for the daemon to answer before naming it -- so a caller can connect to it
+    straight away.
+
+    :func:`connect` below still runs a one-shot stdio service on Windows; this
+    is what `pc daemon start` and the editor extension use.
     """
     result = subprocess.run(
         launcher_argv() + ["--socket", *extra_args],
@@ -149,7 +158,9 @@ def connect(cwd: Optional[str] = None, extra_args=()) -> DaemonClient:
 
     POSIX: the shared per-workspace socket daemon (warm context), falling back to
     a one-shot stdio service if it cannot be started. Windows: a one-shot stdio
-    service (the socket daemon is not available there yet).
+    service. The named-pipe daemon there works -- `pc daemon start` starts one
+    and the editor extension connects to it -- but this has not been moved onto
+    it, and the cost of trying and failing is paid by every `pc` invocation.
     """
     if os.name != "nt":
         try:

--- a/src/partcad_service_json_rpc/AGENTS.md
+++ b/src/partcad_service_json_rpc/AGENTS.md
@@ -55,6 +55,12 @@ directory.
   the daemon's transport), `http.py` (optional HTTP+SSE).
 - `daemon.py` — workspace root discovery, hashing, socket path, liveness (`rpc.discover` probe), stale recovery,
   double-fork/detach, `daemon.stop`. `win_pipe.py` — the Windows named-pipe counterpart (untested on POSIX/CI).
+  Two things differ on Windows and both are load-bearing. The daemon is a **detached new process**, not a fork,
+  so `_launcher_argv` has to name the frozen bundle as itself rather than as `python -m` — the bundle takes the
+  service's own options and rejects `-m`, so the daemon simply was not there. And `ensure_daemon` **waits for
+  the pipe to answer** before printing it: the POSIX branch binds and listens in this very process, so the
+  socket exists the moment it is named, while a pipe does not exist until the new process gets that far, and
+  connecting to a pipe that is not there fails instead of queueing.
 - `client.py` — `DaemonClient` and `start_daemon`, used by the CLI (and any Python caller) to reach the daemon.
 - `__main__.py` — the `partcad-json-rpc` entry point: channel selection (`--socket` default, `--stdio`,
   `--http`) and CLI-style flags mirroring `pc` globals.

--- a/src/partcad_service_json_rpc/daemon.py
+++ b/src/partcad_service_json_rpc/daemon.py
@@ -22,6 +22,7 @@ import os
 import signal
 import socket
 import sys
+import time
 from typing import Callable, Optional
 
 from partcad_utils.workspace import (
@@ -74,6 +75,15 @@ def ensure_daemon(
         pipe = pipe_name(root)
         if not is_pipe_alive(pipe, liveness_timeout):
             spawn_pipe_daemon(root)
+            # Wait for it to answer before saying where it is. The POSIX branch
+            # below binds and listens in *this* process, so the socket is there
+            # the moment it is printed and a client that arrives early simply
+            # queues; the Windows daemon is a separate process that creates its
+            # pipe once it is ready, and connecting to a pipe that does not
+            # exist yet fails outright rather than waiting. Printing first
+            # therefore handed every client a name it could not connect to.
+            if not _wait_for_pipe(pipe, liveness_timeout):
+                raise RuntimeError("the PartCAD daemon did not start serving %s in %ss" % (pipe, START_TIMEOUT))
         print(pipe, flush=True)
         return pipe
 
@@ -99,6 +109,25 @@ def ensure_daemon(
 
     _serve_detached(server_sock, sock, wdir, build_session)
     return sock
+
+
+# How long to wait for a freshly spawned Windows daemon to answer. Generous:
+# it has to start a process, import PartCAD and build the warm session before
+# it can serve, and the alternative to waiting is telling the client to connect
+# to a pipe that is not there.
+START_TIMEOUT = 120.0
+
+
+def _wait_for_pipe(pipe: str, liveness_timeout: float) -> bool:  # pragma: no cover - Windows only
+    """True once the named-pipe daemon answers, False if it never does."""
+    from .win_pipe import is_pipe_alive
+
+    deadline = time.monotonic() + START_TIMEOUT
+    while time.monotonic() < deadline:
+        if is_pipe_alive(pipe, liveness_timeout):
+            return True
+        time.sleep(0.1)
+    return False
 
 
 def _serve_detached(server_sock: socket.socket, sock: str, wdir: str, build_session: Callable) -> None:

--- a/src/partcad_service_json_rpc/win_pipe.py
+++ b/src/partcad_service_json_rpc/win_pipe.py
@@ -30,13 +30,32 @@ from .rpc.dispatcher import Dispatcher
 from .rpc.methods import build_registry
 
 
+def _launcher_argv() -> list:
+    """How to run this service again as a new process.
+
+    The standalone bundle is a single executable that takes the service's own
+    options, so `sys.executable -m partcad_service_json_rpc` -- right for a
+    source checkout -- is exactly what it rejects: `-m` is not one of its
+    arguments, argparse exits, and the daemon that was supposed to serve the
+    pipe was never there. That bundle is what the editor extension downloads and
+    runs, which is who asks for this daemon.
+
+    `partcad_client.launcher_argv` answers the same question for a client and is
+    deliberately not imported here: this package does not depend on the client
+    (see AGENTS.md). Two lines are the price of that.
+    """
+    if getattr(sys, "frozen", False):
+        return [sys.executable]
+    return [sys.executable, "-m", "partcad_service_json_rpc"]
+
+
 def spawn_pipe_daemon(root_path: str) -> None:
     """Start a detached server process serving the workspace's named pipe."""
     creationflags = 0
     creationflags |= getattr(subprocess, "DETACHED_PROCESS", 0)
     creationflags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
     subprocess.Popen(
-        [sys.executable, "-m", "partcad_service_json_rpc", "--serve-pipe", pipe_name(root_path)],
+        _launcher_argv() + ["--serve-pipe", pipe_name(root_path)],
         close_fds=True,
         creationflags=creationflags,
     )

--- a/tests/partcad_cli/unit/test_daemon_commands.py
+++ b/tests/partcad_cli/unit/test_daemon_commands.py
@@ -1,0 +1,57 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""`pc daemon start` and `pc daemon stop`, on every platform.
+
+Both commands used to answer Windows with a sentence instead of doing anything
+-- `daemon start` printing "not available on Windows yet" on *stdout*, where the
+endpoint goes, with a zero exit status. The VS Code extension reads that stdout
+to find the daemon, so it connected to the sentence and the window was left with
+no PartCAD in it at all.
+
+The daemon exists on Windows (a named pipe, served by
+`partcad_service_json_rpc.daemon`), so there is nothing here to branch on any
+more. These tests hold that: whatever `os.name` says, the command hands the
+question to `partcad_client` and prints what came back.
+"""
+
+import os
+
+import pytest
+from click.testing import CliRunner
+from partcad_cli.click.commands.daemon import start as start_command
+from partcad_cli.click.commands.daemon import stop as stop_command
+
+ENDPOINTS = {
+    "posix": "/home/me/.partcad/workspaces/0123456789abcdef/socket",
+    "nt": "\\\\.\\pipe\\partcad-0123456789abcdef",
+}
+
+
+@pytest.mark.parametrize("os_name", ["posix", "nt"])
+def test_start_prints_the_endpoint_it_was_given(monkeypatch, os_name):
+    monkeypatch.setattr(os, "name", os_name)
+    monkeypatch.setattr(start_command.client, "start_daemon", lambda **_: ENDPOINTS[os_name])
+
+    result = CliRunner().invoke(start_command.cli, [])
+
+    assert result.exit_code == 0
+    # Exactly the endpoint and nothing else: whoever reads this connects to it.
+    assert result.output.strip() == ENDPOINTS[os_name]
+
+
+@pytest.mark.parametrize("os_name", ["posix", "nt"])
+def test_stop_reports_whether_one_was_running(monkeypatch, os_name):
+    monkeypatch.setattr(os, "name", os_name)
+
+    monkeypatch.setattr(stop_command.daemon, "stop_daemon", lambda: True)
+    stopped = CliRunner().invoke(stop_command.cli, [])
+    assert stopped.exit_code == 0
+    assert "PartCAD daemon stopped" in stopped.output
+
+    monkeypatch.setattr(stop_command.daemon, "stop_daemon", lambda: False)
+    idle = CliRunner().invoke(stop_command.cli, [])
+    assert idle.exit_code == 0
+    assert "No PartCAD daemon was running" in idle.output

--- a/tests/partcad_cli/unit/test_lint_stdin.py
+++ b/tests/partcad_cli/unit/test_lint_stdin.py
@@ -1,0 +1,56 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""What `pc lint --file --stdin` reads.
+
+The buffer on standard input comes from an editor: the VS Code extension writes
+the document as UTF-8 and reads this command's JSON back the same way. Python
+does not agree with that on its own -- ``sys.stdin`` decodes with the locale
+encoding, which is UTF-8 on Linux and macOS and the ANSI code page on Windows --
+so a file with a non-ASCII character in it was checked as mojibake there, or
+died in the decoder and took the findings with it. Nothing about that is visible
+from a POSIX runner, which is why the encoding is pinned rather than inherited,
+and why these tests hand the reader a stream that is *not* UTF-8.
+"""
+
+import io
+import sys
+
+import pytest
+from partcad_cli.click.commands.lint import _read_stdin
+
+# A description someone would really write, in characters cp1252 does not have.
+TEXT = "desc: Läufer — ⌀30µm\n"
+
+
+def _stdin(raw: bytes, encoding: str = "cp1252"):
+    """A `sys.stdin`: text on top of bytes, decoding as the locale would."""
+    return io.TextIOWrapper(io.BytesIO(raw), encoding=encoding, errors="replace")
+
+
+def test_utf8_is_read_as_utf8_whatever_the_locale_says(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", _stdin(TEXT.encode("utf-8")))
+    assert _read_stdin() == TEXT
+
+
+def test_a_byte_order_mark_is_not_part_of_the_text(monkeypatch):
+    # A Windows editor may write one, and it is not what column 1 of line 1 is:
+    # left in, every finding on the first line would be off by one character.
+    monkeypatch.setattr(sys, "stdin", _stdin(b"\xef\xbb\xbf" + TEXT.encode("utf-8")))
+    assert _read_stdin() == TEXT
+
+
+def test_bytes_that_are_not_utf8_are_refused_rather_than_guessed(monkeypatch):
+    # Better than silently checking mojibake: the caller is told, and `pc lint`
+    # turns it into a usage error rather than a traceback.
+    monkeypatch.setattr(sys, "stdin", _stdin(TEXT.encode("cp1252", "replace")))
+    with pytest.raises(UnicodeDecodeError):
+        _read_stdin()
+
+
+def test_a_stdin_with_no_binary_buffer_is_read_as_text(monkeypatch):
+    # A replaced `sys.stdin` -- a test harness, an embedding -- has no `buffer`.
+    monkeypatch.setattr(sys, "stdin", io.StringIO(TEXT))
+    assert _read_stdin() == TEXT

--- a/tests/partcad_service_json_rpc/test_win_pipe.py
+++ b/tests/partcad_service_json_rpc/test_win_pipe.py
@@ -1,0 +1,35 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""How the Windows named-pipe daemon is started.
+
+Windows has no `fork`, so the daemon is a *new process* rather than a copy of
+this one -- which means the argv that starts it has to be right, and there is no
+Windows runner in CI to notice when it is not. It was not: the frozen bundle is
+a single executable that takes the service's own options, and it was being run
+as `sys.executable -m partcad_service_json_rpc`, which it rejects. That bundle is
+what the editor extension downloads and runs, so on Windows the daemon it asked
+for was never there.
+
+The spawn itself is Windows-only (detached process creation flags); what is
+pinned here is the argv, which is neither.
+"""
+
+import sys
+
+from partcad_service_json_rpc.win_pipe import _launcher_argv
+
+
+def test_a_source_checkout_runs_the_module(monkeypatch):
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    assert _launcher_argv() == [sys.executable, "-m", "partcad_service_json_rpc"]
+
+
+def test_a_frozen_bundle_runs_itself(monkeypatch):
+    # `partcad-json-rpc.exe --serve-pipe ...`, not `partcad-json-rpc.exe -m
+    # partcad_service_json_rpc --serve-pipe ...`: the bundle's argument parser
+    # has no `-m`, so the daemon exited before it served anything.
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    assert _launcher_argv() == [sys.executable]


### PR DESCRIPTION
`pc daemon start` answered Windows with a sentence -- "The PartCAD socket
daemon is not available on Windows yet" -- printed on stdout, where the
endpoint goes, with a zero exit status. The daemon it said was missing has
been implemented for a while: `ensure_daemon` serves a named pipe there.
Un-gate both commands and let `partcad_client` answer for every platform,
as it already can.

Two things behind that gate had never run:

* `spawn_pipe_daemon` started the daemon as `sys.executable -m
  partcad_service_json_rpc`, which is right for a source checkout and is
  exactly what the frozen bundle rejects -- `-m` is not one of its
  arguments, so argparse exited and the pipe was never served. The bundle
  is what the editor extension downloads and runs, so it was the one caller
  guaranteed to hit this. `_launcher_argv` names the bundle as itself.
  `partcad_client.launcher_argv` answers the same question for a client and
  is deliberately not imported: this package does not depend on the client.

* `ensure_daemon` printed the pipe name before anything served it. The
  POSIX branch binds and listens in the launcher process, so the socket
  exists the moment it is named and an early client queues; a pipe does not
  exist until the detached process gets that far, and connecting to one
  that is not there fails rather than waits. Wait for it to answer first,
  so the printed endpoint is live on both platforms.

`pc lint --file --stdin` read the editor's buffer through `sys.stdin`,
which decodes with the locale encoding: UTF-8 on Linux and macOS, the ANSI
code page on Windows. The buffer is UTF-8 -- the VS Code extension writes
it as UTF-8 and reads the JSON back the same way -- so a description with
an umlaut in it was checked as mojibake there, and a byte cp1252 has no
character for killed the decoder and took the findings with it, silently:
the extension logs a failed check at verbose level and leaves the previous
squiggles alone. Read the bytes and decode them here, and turn a decode
failure into a usage error rather than a traceback.

`pc` itself still runs a one-shot service per invocation on Windows; what
this makes work is `pc daemon start`/`stop` and the editor extension that
uses them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01986o8o9QetMkeLSxpUhobB