### PR TITLE
Install OpenSCAD on macOS from the cask Homebrew still has

### DIFF
--- a/.github/actions/setup-test/action.yml
+++ b/.github/actions/setup-test/action.yml
@@ -28,14 +28,45 @@ runs:
       if: runner.os == 'macOS'
       shell: bash -el {0}
       run: |
-        # The below "rm" command does not have "-f" on purpose:
-        # the second "brew install" command is only needed when the dmg file is psesent but corrupted
-        which openscad \
-          || HOMEBREW_NO_AUTO_UPDATE=1 brew install -f openscad \
-          || ( \
-            rm /Users/$USER/Library/Caches/Homebrew/downloads/*--OpenSCAD-*.dmg \
-            && HOMEBREW_NO_AUTO_UPDATE=1 brew install -f openscad \
-          )
+        # Homebrew disabled the "openscad" cask on 2026-09-01: the pinned
+        # 2021.01 release does not pass the macOS Gatekeeper check. That makes
+        # `brew install openscad` fail outright, and the retry beneath it --
+        # which existed for a *corrupted cached* .dmg -- fail with it, so the
+        # step could not succeed on any macOS runner.
+        #
+        # The snapshot cask is the maintained one, and on these runners it is
+        # the only candidate: they are arm64, and 2021.01 ships an x86_64-only
+        # .dmg. "dev-tools/pyinstaller/build.sh" says so, and declines to
+        # bundle OpenSCAD on macOS for exactly that reason -- so fetching that
+        # release directly would quietly require Rosetta 2 rather than fix
+        # anything.
+        set -euo pipefail
+
+        if ! command -v openscad >/dev/null 2>&1; then
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask openscad@snapshot
+        fi
+
+        # A cask need not put a binary on PATH, and the .app it installs is not
+        # named identically across versions, so look for the executable rather
+        # than assuming either. `-iname`, because the binary inside the bundle
+        # is "OpenSCAD" while what the tests invoke is "openscad".
+        if ! command -v openscad >/dev/null 2>&1; then
+          binary="$(find /Applications -maxdepth 4 -path '*/Contents/MacOS/*' \
+            -type f -perm -111 -iname 'openscad' 2>/dev/null | head -n 1)"
+          if [ -z "${binary}" ]; then
+            echo "::error::openscad@snapshot installed but no OpenSCAD executable was found under /Applications"
+            exit 1
+          fi
+          mkdir -p "${HOME}/.local/bin"
+          ln -sf "${binary}" "${HOME}/.local/bin/openscad"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          export PATH="${HOME}/.local/bin:${PATH}"
+        fi
+
+        # Proves the thing runs on this architecture, rather than that a file
+        # of the right name exists. An x86_64 build on an arm64 runner with no
+        # Rosetta fails here, which is the failure worth seeing.
+        openscad --version
 
     - name: Install OpenSCAD (Windows)
       if: runner.os == 'Windows'

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -566,12 +566,45 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash -el {0}
         run: |
-          which openscad \
-            || HOMEBREW_NO_AUTO_UPDATE=1 brew install -f openscad \
-            || ( \
-              rm /Users/"$USER"/Library/Caches/Homebrew/downloads/*--OpenSCAD-*.dmg \
-              && HOMEBREW_NO_AUTO_UPDATE=1 brew install -f openscad \
-            )
+          # Homebrew disabled the "openscad" cask on 2026-09-01: the pinned
+          # 2021.01 release does not pass the macOS Gatekeeper check. That makes
+          # `brew install openscad` fail outright, and the retry beneath it --
+          # which existed for a *corrupted cached* .dmg -- fail with it, so the
+          # step could not succeed on any macOS runner.
+          #
+          # The snapshot cask is the maintained one, and on these runners it is
+          # the only candidate: they are arm64, and 2021.01 ships an x86_64-only
+          # .dmg. "dev-tools/pyinstaller/build.sh" says so, and declines to
+          # bundle OpenSCAD on macOS for exactly that reason -- so fetching that
+          # release directly would quietly require Rosetta 2 rather than fix
+          # anything.
+          set -euo pipefail
+
+          if ! command -v openscad >/dev/null 2>&1; then
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask openscad@snapshot
+          fi
+
+          # A cask need not put a binary on PATH, and the .app it installs is not
+          # named identically across versions, so look for the executable rather
+          # than assuming either. `-iname`, because the binary inside the bundle
+          # is "OpenSCAD" while what the tests invoke is "openscad".
+          if ! command -v openscad >/dev/null 2>&1; then
+            binary="$(find /Applications -maxdepth 4 -path '*/Contents/MacOS/*' \
+              -type f -perm -111 -iname 'openscad' 2>/dev/null | head -n 1)"
+            if [ -z "${binary}" ]; then
+              echo "::error::openscad@snapshot installed but no OpenSCAD executable was found under /Applications"
+              exit 1
+            fi
+            mkdir -p "${HOME}/.local/bin"
+            ln -sf "${binary}" "${HOME}/.local/bin/openscad"
+            echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+            export PATH="${HOME}/.local/bin:${PATH}"
+          fi
+
+          # Proves the thing runs on this architecture, rather than that a file
+          # of the right name exists. An x86_64 build on an arm64 runner with no
+          # Rosetta fails here, which is the failure worth seeing.
+          openscad --version
 
       - name: Download the bundle
         uses: actions/download-artifact@v8

--- a/src/partcad/healthcheck/openscad.py
+++ b/src/partcad/healthcheck/openscad.py
@@ -154,11 +154,20 @@ class MacOpenSCADCheck(OpenSCADCheck):
         return platform.system().lower() == "darwin"
 
     def fix(self) -> bool:
-        """Attempt to install OpenSCAD using Homebrew."""
+        """Attempt to install OpenSCAD using Homebrew.
+
+        The snapshot cask rather than the release one: Homebrew disabled
+        ``openscad`` on 2026-09-01 because the pinned 2021.01 release does not
+        pass the macOS Gatekeeper check, so ``brew install openscad`` cannot
+        succeed on any machine any more. 2021.01 is also x86_64 only -- the
+        reason ``dev-tools/pyinstaller/build.sh`` does not bundle OpenSCAD on
+        macOS -- so on Apple Silicon it was the wrong build to reach for even
+        while it installed.
+        """
         env = os.environ.copy()
         env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
 
-        install_cmd = ["brew", "install", "-f", "openscad"]
+        install_cmd = ["brew", "install", "--cask", "openscad@snapshot"]
         cache_dir = Path.home() / "Library" / "Caches" / "Homebrew" / "downloads"
 
         try:

--- a/tests/partcad/unit/test_openscad.py
+++ b/tests/partcad/unit/test_openscad.py
@@ -95,3 +95,49 @@ def test_ignore_bundled_returns_none_when_the_host_has_none(bundle, monkeypatch)
     _make_payload(bundle)
     monkeypatch.setattr(pc_openscad.shutil, "which", lambda _name: None)
     assert pc_openscad.find_executable(ignore_bundled=True) is None
+
+
+# The macOS installer. Homebrew disabled the "openscad" cask on 2026-09-01 for
+# failing the Gatekeeper check, and until then this ran `brew install openscad`
+# -- so the auto-fix could not install OpenSCAD on any Mac, and CI, which ran
+# the same command, could not either. None of that is visible from a Linux test
+# run, and the command is a list of strings nothing here executes, so the cask
+# it names is pinned rather than left to be rediscovered the next time the one
+# it names goes away.
+
+
+@pytest.fixture
+def homebrew(tmp_path, monkeypatch):
+    """Capture the command ``MacOpenSCADCheck.fix`` runs, and run nothing.
+
+    ``Path.home`` is redirected too, and not for isolation alone: before
+    installing, ``fix`` deletes cached ``*openscad*.dmg`` files out of the real
+    Homebrew download directory, which is not something a unit test may do to
+    the machine running it.
+    """
+    calls = []
+
+    class _Completed:
+        returncode = 0
+        stderr = b""
+
+    def _run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _Completed()
+
+    monkeypatch.setattr(pc_openscad.subprocess, "run", _run)
+    monkeypatch.setattr(pc_openscad.Path, "home", staticmethod(lambda: tmp_path))
+    return calls
+
+
+def test_macos_installs_the_cask_homebrew_still_has(homebrew):
+    """`openscad` is disabled for good; `openscad@snapshot` is the maintained one."""
+    assert pc_openscad.MacOpenSCADCheck().fix() is True
+    assert [command for command, _ in homebrew] == [["brew", "install", "--cask", "openscad@snapshot"]]
+
+
+def test_macos_install_does_not_let_homebrew_update_itself(homebrew):
+    """One install stays one install rather than becoming a full `brew update`."""
+    pc_openscad.MacOpenSCADCheck().fix()
+    _, kwargs = homebrew[0]
+    assert kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"] == "1"


### PR DESCRIPTION
## Copilot Summary

Homebrew disabled the `openscad` cask on **2026-09-01** — the pinned 2021.01 release does not pass the macOS Gatekeeper check. Every macOS job in `test.yml` now dies in `Install OpenSCAD (macOS)` before a test body runs:

```
==> Fetching downloads for: openscad
Error: Cask 'openscad' has been disabled because it does not pass the macOS Gatekeeper check!
rm: /Users/runner/Library/Caches/Homebrew/downloads/*--OpenSCAD-*.dmg: No such file or directory
Error: Process completed with exit code 1.
```

The retry underneath it fails too. It exists for a *corrupted cached* `.dmg`, and its `rm` deliberately has no `-f` (there's a comment saying so), so with nothing cached the `||` chain exits 1 rather than reaching the second `brew install`. Nothing about the step could succeed once the cask went away.

This is not specific to any one branch: `devel` itself is red this way. Run [33457431296](https://github.com/partcad/partcad/actions/runs/33457431296), the `0.8.26 → 0.8.27` bump, failed 6 of 30 jobs and **all six are macOS**, with this exact error.

### Three places ran that command

| Site | Effect |
| --- | --- |
| `.github/actions/setup-test/action.yml` | the one breaking CI now |
| `.github/workflows/build-standalone.yml` | a copy its own comment calls *"Same install as the wheel-based jobs' setup-test action"* — would break the macOS bundles identically |
| `MacOpenSCADCheck.fix()` in `src/partcad/healthcheck/openscad.py` | **shipped code**, so `pc healthcheck --fix` cannot install OpenSCAD for a macOS user either |

All three move to `openscad@snapshot`.

### Why the snapshot cask, and not a direct download of the release

Because the runners are arm64 and **2021.01 ships an x86_64-only `.dmg`**. This repository already worked that out — `dev-tools/pyinstaller/build.sh` declines to bundle OpenSCAD on macOS for precisely that reason:

> macOS is deliberately excluded for the same shape of reason. The 2021.01 release predates Apple Silicon and ships an x86_64-only .dmg, which on the arm64 bundle would require Rosetta 2 […] The current development snapshots may well be universal binaries, but they are snapshots, and their architecture has not been confirmed.

Fetching 2021.01 directly would quietly require Rosetta 2 rather than fix anything.

### The architecture is confirmed, not assumed

Since *"their architecture has not been confirmed"* is exactly the open question, the CI steps confirm it rather than assume it. They locate the executable inside whatever the cask named its `.app` — a cask need not put a binary on `PATH`, and the bundle's name has moved before — link it onto `PATH` as `openscad`, and then run:

```
openscad --version
```

An x86_64 build on an arm64 runner with no Rosetta fails there, which is the failure worth seeing. A step that only checked for a file of the right name would not.

### What is verified, and what isn't

Verified here: both files parse; `check-jsonschema` passes on the workflow **and** on the composite action; the new step's shell passes `shellcheck`; the Python compiles.

**Not verifiable from my environment:** that `openscad@snapshot` exists and is arm64. Egress is blocked here — neither `formulae.brew.sh` nor `files.openscad.org` is reachable — so I could not check the cask or the published artifacts. **CI on this pull request is what answers that**, and the `--version` call is what makes the answer unambiguous either way. If the snapshot cask turns out not to exist or not to be arm64, this run says so plainly instead of failing later and vaguely.

Pre-existing `black` findings in `healthcheck/openscad.py` (import spacing, a long log line in the Windows class) are left alone — the file fails `black` at `HEAD` too, and none of it is code this touches.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYDzecziwHsXmzUFn86CEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYDzecziwHsXmzUFn86CEe)_