### PR TITLE
A PartCAD welcome window, and a package to start in

### DIFF
--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -72,6 +72,16 @@ jobs:
       - name: Run the tests
         run: python -m pytest ide/standalone/tests -o addopts= -v
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+
+      # The IDE bootstrap extension: what it does on the first start, against a
+      # stubbed editor. No dependencies -- `node --test` is in Node itself.
+      - name: Run the bootstrap extension's tests
+        run: node --test ide/standalone/bootstrap/test/*.test.js
+
   # Where the command line bundles that go inside the IDE come from.
   #
   # They are the same bundles `install.sh` installs, frozen by the "Standalone"
@@ -530,7 +540,9 @@ jobs:
           - os: macos-latest
             platform: macos-arm64
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # The first start below runs the editor and waits for a PyInstaller bundle
+    # to unpack itself, which the rest of this job does not.
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -583,6 +595,84 @@ jobs:
           }
           test -x "${resources}/partcad-cli/partcad-json-rpc"
 
+      # A display for the editor. Nothing here looks at what it draws; it does
+      # not start at all without one.
+      - name: Install Xvfb
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes xvfb
+
+      # What the IDE does for someone who has just installed it: `pc init` a
+      # package in ~/.partcad/projects/start and open it as the workspace.
+      # Started the way a user starts it, with no arguments -- and with a user
+      # data directory of its own, so that this is a first start however many
+      # times the job is re-run, and so that the state the editor writes is
+      # somewhere this job can read it.
+      - name: Start it once
+        shell: bash
+        run: |
+          export PATH="${HOME}/partcad-bin:${PATH}"
+          user_data="${RUNNER_TEMP}/ide-user-data"
+          starter="${HOME}/.partcad/projects/start"
+          rm -rf "${user_data}" "${starter}"
+
+          # Killed however this ends: on the way out this job uninstalls the
+          # application the editor is running from. Matched loosely and without
+          # regard to case, because on macOS the process is the executable
+          # inside "PartCAD IDE.app" rather than the launcher's name.
+          #
+          # The launcher spawns the editor and returns, so its own output says
+          # nothing; what the editor has to say is in its log directory.
+          diagnose() {
+            pkill -if "partcad.ide" || true
+            echo "--- what the editor logged:"
+            find "${user_data}/logs" -name "*.log" -exec sh -c 'echo "== $1"; tail -n 40 "$1"' _ {} \; 2>/dev/null || true
+          }
+          trap diagnose EXIT
+
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            # Started here rather than through `xvfb-run`: the launcher returns
+            # as soon as it has spawned the editor, and `xvfb-run` takes the
+            # display down with the command it was given.
+            Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &
+            export DISPLAY=:99
+            # The runner image restricts unprivileged user namespaces, which is
+            # what Chromium's sandbox is built on. A property of this machine
+            # rather than of the IDE.
+            partcad-ide --no-sandbox --user-data-dir "${user_data}"
+          else
+            partcad-ide --user-data-dir "${user_data}"
+          fi
+
+          # Five minutes: `pc init` writes a template, but it runs out of a
+          # PyInstaller bundle that unpacks itself first, on a machine that has
+          # just written a gigabyte to disk.
+          package="${starter}/partcad.yaml"
+          for _ in $(seq 60); do
+            [ -f "${package}" ] && break
+            sleep 5
+          done
+          if [ ! -f "${package}" ]; then
+            echo "::error::the IDE did not create ${package} on its first start"
+            exit 1
+          fi
+          head -n 5 "${package}"
+
+          # And opened it: the editor writes the folder a window belongs to
+          # beside that window's storage, as it opens it. The path is a URI in
+          # there, so it is spelled with forward slashes.
+          opened=""
+          for _ in $(seq 36); do
+            if grep -rls "\.partcad/projects/start" "${user_data}/User/workspaceStorage" 2>/dev/null | grep -q .; then
+              opened="yes"
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "${opened}" ]; then
+            echo "::error::the IDE did not open the starter package as its workspace"
+            exit 1
+          fi
+
       - name: Uninstall with install.sh
         shell: bash
         run: |
@@ -601,7 +691,9 @@ jobs:
     name: "Install (windows-x86_64)"
     needs: build
     runs-on: windows-latest
-    timeout-minutes: 30
+    # The first start below runs the editor and waits for a PyInstaller bundle
+    # to unpack itself, which the rest of this job does not.
+    timeout-minutes: 40
 
     steps:
       - name: Download the IDE
@@ -642,6 +734,56 @@ jobs:
           # The PATH entries the installer adds for a new terminal.
           $path = (Get-ItemProperty -Path "HKCU:\Environment" -Name Path).Path
           if ($path -notlike "*PartCAD IDE\bin*") { throw "the installer did not add bin to PATH" }
+
+      # The same first start as the job above, on the platform where the setup
+      # program is the installer: `pc init` in %USERPROFILE%\.partcad\projects\start,
+      # and that folder opened as the workspace.
+      - name: Start it once
+        shell: pwsh
+        run: |
+          $app = Join-Path $env:LOCALAPPDATA "Programs\PartCAD IDE"
+          $userData = Join-Path $env:RUNNER_TEMP "ide-user-data"
+          $starter = Join-Path $env:USERPROFILE ".partcad/projects/start"
+          $log = Join-Path $env:RUNNER_TEMP "ide.log"
+          Remove-Item -Recurse -Force $userData, $starter -ErrorAction SilentlyContinue
+
+          Start-Process -FilePath (Join-Path $app "partcad-ide.exe") `
+            -ArgumentList "--user-data-dir", $userData `
+            -RedirectStandardOutput $log -RedirectStandardError "$log.err" | Out-Null
+          try {
+            # Five minutes: `pc init` writes a template, but it runs out of a
+            # PyInstaller bundle that unpacks itself first, on a machine that
+            # has just written a gigabyte to disk.
+            $package = Join-Path $starter "partcad.yaml"
+            $deadline = (Get-Date).AddMinutes(5)
+            while (-not (Test-Path $package) -and (Get-Date) -lt $deadline) { Start-Sleep -Seconds 5 }
+            if (-not (Test-Path $package)) {
+              throw "the IDE did not create $package on its first start"
+            }
+            Get-Content $package -TotalCount 5
+
+            # And opened it: the editor writes the folder a window belongs to
+            # beside that window's storage, as it opens it. The path is a URI
+            # in there, so it is spelled with forward slashes.
+            $storage = Join-Path $userData "User\workspaceStorage"
+            $deadline = (Get-Date).AddMinutes(3)
+            $opened = $false
+            while (-not $opened -and (Get-Date) -lt $deadline) {
+              $opened = $null -ne (Get-ChildItem $storage -Recurse -Filter workspace.json -ErrorAction SilentlyContinue |
+                Select-String -SimpleMatch -Pattern ".partcad/projects/start")
+              if (-not $opened) { Start-Sleep -Seconds 5 }
+            }
+            if (-not $opened) {
+              throw "the IDE did not open the starter package as its workspace"
+            }
+          } finally {
+            # Stopped however this ends: the uninstaller below cannot remove an
+            # application that is running.
+            Stop-Process -Name partcad-ide -Force -ErrorAction SilentlyContinue
+            Write-Host "--- the editor said:"
+            Get-Content $log -Tail 40 -ErrorAction SilentlyContinue
+            Get-Content "$log.err" -Tail 40 -ErrorAction SilentlyContinue
+          }
 
       - name: Uninstall
         shell: pwsh

--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -594,6 +594,14 @@ jobs:
             exit 1
           }
           test -x "${resources}/partcad-cli/partcad-json-rpc"
+          # The examples the welcome window offers to open, packaged into the
+          # bootstrap extension by the build.
+          bootstrap=$(find "${resources}/app/extensions" -maxdepth 1 -iname "partcad.partcad-ide-bootstrap-*" | head -n 1)
+          test -n "${bootstrap}" || {
+            echo "::error::the installed IDE has no PartCAD IDE bootstrap extension"
+            exit 1
+          }
+          test -f "${bootstrap}/examples/produce_part_cadquery_primitive/partcad.yaml"
 
       # A display for the editor. Nothing here looks at what it draws; it does
       # not start at all without one.
@@ -731,6 +739,12 @@ jobs:
           if (-not (Get-ChildItem $extensions -Directory | Where-Object { $_.Name -match "^partcad\.partcad-\d" })) {
             throw "the installed IDE has no PartCAD extension"
           }
+          # The examples the welcome window offers to open, packaged into the
+          # bootstrap extension by the build.
+          $bootstrap = Get-ChildItem $extensions -Filter "partcad.partcad-ide-bootstrap-*" | Select-Object -First 1
+          if (-not $bootstrap) { throw "the installed IDE has no PartCAD IDE bootstrap extension" }
+          $example = Join-Path $bootstrap.FullName "examples\produce_part_cadquery_primitive\partcad.yaml"
+          if (-not (Test-Path $example)) { throw "the welcome window's examples were not installed" }
           # The PATH entries the installer adds for a new terminal.
           $path = (Get-ItemProperty -Path "HKCU:\Environment" -Name Path).Path
           if ($path -notlike "*PartCAD IDE\bin*") { throw "the installer did not add bin to PATH" }

--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ installing or using any PartCAD tool, then make sure to install [conda].
 ### PartCAD IDE
 
 The whole thing in one application: the editor, the PartCAD extension, and the command line tools. No Python,
-no extensions to pick, no environment to set up. It opens in the PartCAD workbench.
+no extensions to pick, no environment to set up. It opens in the PartCAD workbench, and the first time it
+starts it creates a package for you and opens that -- so there is something to render before there is anything
+to read.
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/partcad/partcad/main/install.sh | sh -s -- --ide

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -457,6 +457,33 @@ It unpacks to around 500MB: an editor, a Python interpreter, the command line to
 in one archive. Like the standalone bundle inside it, it carries no CAD kernel -- shapes are built in a conda
 sandbox, so ``conda`` (or ``mamba``) is still expected on the machine.
 
+The first start
+===============
+
+There is nothing to set up after installing. The first time the IDE starts, it runs ``pc init`` in
+``~/.partcad/projects/start`` -- ``%USERPROFILE%\.partcad\projects\start`` on Windows -- and opens that
+folder as the workspace, so the window you get has a package in it rather than an empty editor. A welcome
+window opens beside it with the six things worth doing first: add a part, look at it in 3D, render the
+package, use ``pc`` in the terminal.
+
+The package is an ordinary one in an ordinary folder. It is under ``~/.partcad`` rather than inside the
+application, so ``pc`` in any terminal works with the same package, and uninstalling the IDE does not take
+it with it. Move it, put it in git, or leave it and make your own with ``pc init`` somewhere else.
+
+The editor asks whether you trust the authors of a folder before it runs anything from it, and this folder
+is no exception -- the answer for the one it just made for you is yes.
+
+This happens once. Afterwards the IDE opens where you left it, like any editor:
+
+* ``PartCAD IDE: Open the starter package`` in the Command Palette opens the package again, and creates it
+  if it is not there.
+* ``PartCAD IDE: Welcome`` opens the welcome window again.
+* ``partcadIde.createStarterPackage``, in the settings, turns the whole thing off for a fresh installation:
+  the IDE then starts in an empty window.
+
+Opening the IDE on a folder of your own -- from "Open with PartCAD IDE", or by starting it with a path --
+skips it too. It never takes over a window that already has something in it.
+
 What is inside
 ==============
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -463,8 +463,9 @@ The first start
 There is nothing to set up after installing. The first time the IDE starts, it runs ``pc init`` in
 ``~/.partcad/projects/start`` -- ``%USERPROFILE%\.partcad\projects\start`` on Windows -- and opens that
 folder as the workspace, so the window you get has a package in it rather than an empty editor. A welcome
-window opens beside it with the six things worth doing first: add a part, look at it in 3D, render the
-package, use ``pc`` in the terminal.
+window opens beside it with the things worth doing first: open an example that already works, add a part of
+your own, look at it in 3D, render the package, use ``pc`` in the terminal -- each with a link to the page
+here that explains it.
 
 The package is an ordinary one in an ordinary folder. It is under ``~/.partcad`` rather than inside the
 application, so ``pc`` in any terminal works with the same package, and uninstalling the IDE does not take
@@ -473,10 +474,33 @@ it with it. Move it, put it in git, or leave it and make your own with ``pc init
 The editor asks whether you trust the authors of a folder before it runs anything from it, and this folder
 is no exception -- the answer for the one it just made for you is yes.
 
+Start from an example
+---------------------
+
+The welcome window's second step, and ``PartCAD IDE: Open an example`` in the Command Palette, offer
+packages that already work:
+
+* **A part in CadQuery** -- a cube and a cylinder as scripts, and the same cube declared again at other
+  dimensions, which is how a package reuses a shape instead of copying it.
+* **A part in build123d** -- the smallest package there is: one script, one entry under ``parts:``.
+* **A part in OpenSCAD** -- a ``.scad`` file used as it is, and a parameterized module PartCAD instantiates
+  with arguments from ``partcad.yaml``.
+* **An assembly** -- parts placed relative to each other in an ``.assy`` file, taken from *other* packages,
+  which come with it.
+
+They are the examples this project publishes -- the packages under
+`examples/ <https://github.com/partcad/partcad/tree/main/examples>`_ -- copied into
+``~/.partcad/projects/start`` next to your own package, where they show up in the PartCAD Explorer and are
+yours to change. A copy you have already edited is never overwritten.
+
+Every step of the welcome window also links to the page of this documentation that explains it, and the last
+one lists them all.
+
 This happens once. Afterwards the IDE opens where you left it, like any editor:
 
 * ``PartCAD IDE: Open the starter package`` in the Command Palette opens the package again, and creates it
   if it is not there.
+* ``PartCAD IDE: Open an example`` copies another example in beside it.
 * ``PartCAD IDE: Welcome`` opens the welcome window again.
 * ``partcadIde.createStarterPackage``, in the settings, turns the whole thing off for a fresh installation:
   the IDE then starts in an empty window.

--- a/ide/standalone/AGENTS.md
+++ b/ide/standalone/AGENTS.md
@@ -55,12 +55,19 @@ does not contain the switch -- each of which leaves an IDE that either has no so
 ## Test
 
 ```bash
-python -m pytest ide/standalone/tests -o addopts=       # the build tooling
+python -m pytest ide/standalone/tests -o addopts=              # the build tooling
+node --test ide/standalone/bootstrap/test/*.test.js           # the IDE bootstrap extension
 ```
 
 `-o addopts=` because the repository-wide `pyproject.toml` options pull in coverage and reporting plugins these
 tests have no use for. They are not part of the `pytest tests` run or of the `pre-commit` hook;
 `.github/workflows/build-ide-standalone.yml` runs them, before it spends an hour building.
+
+The bootstrap tests need nothing installed -- `node --test` is in Node, and `test/vscode-stub.js` is as much of
+the `vscode` module as the extension touches. They cover the first start (the package it creates, the workspace
+it opens, the welcome window that follows the window reopening), which is otherwise only visible in a built and
+installed IDE. Pass the files rather than the directory: `node --test <dir>` is not the same thing in every
+Node release.
 
 There is no unit test for `build.sh` itself. What checks it is `tools/verify_bundle.py`, which the build runs on
 its own result, and the `install` job in that workflow, which installs the archive and runs what comes out.
@@ -71,8 +78,14 @@ its own result, and the `install` job in that workflow, which installs the archi
   installed from Open VSX or cannot be redistributed, and say which in the `reason`.
 - **Branding, or a default setting**: `product.overlay.json`. A `null` removes a key; `${VERSION}` is the
   PartCAD version.
-- **What the IDE does on startup**: `bootstrap/extension.js`. It is plain JavaScript, packaged as it is -- no
-  compile step, so keep it that way.
+- **What the IDE does on startup**: `bootstrap/extension.js` -- including the package it creates in
+  `~/.partcad/projects/start` and opens as the first workspace. It is plain JavaScript, packaged as it is --
+  no compile step, so keep it that way.
+- **The welcome window**: the walkthrough in `bootstrap/package.json`, with the text of its steps in
+  `bootstrap/media/`. `tests/test_bootstrap.py` checks that its buttons run commands that exist and that its
+  steps point at files that are there; moving the starter package means moving it in the install jobs of
+  `.github/workflows/build-ide-standalone.yml` and in `docs/source/installation.rst` too, which that test
+  also enforces.
 - **What the Windows installer sets up**: `installer/partcad-ide.iss`. Never change its `AppId`: Windows
   recognizes an upgrade, and an uninstall, by that and nothing else.
 - **The VSCodium release**: `build.sh --vscodium-version <tag> --record`, then restore the comments `--record`

--- a/ide/standalone/AGENTS.md
+++ b/ide/standalone/AGENTS.md
@@ -82,7 +82,11 @@ its own result, and the `install` job in that workflow, which installs the archi
   `~/.partcad/projects/start` and opens as the first workspace. It is plain JavaScript, packaged as it is --
   no compile step, so keep it that way.
 - **The welcome window**: the walkthrough in `bootstrap/package.json`, with the text of its steps in
-  `bootstrap/media/`. `tests/test_bootstrap.py` checks that its buttons run commands that exist and that its
+  `bootstrap/media/`. Every step links to the page of `partcad.readthedocs.io` that explains it, and the test
+  below fails on a link to a page that is not in `docs/source`.
+- **Which examples it offers**: `bootstrap/examples.json`. The packages themselves stay in `examples/` --
+  `tools/copy_examples.py` copies the ones it names, and whatever they reference, into the extension at build
+  time, and fails the build when the two disagree. `tests/test_bootstrap.py` checks that its buttons run commands that exist and that its
   steps point at files that are there; moving the starter package means moving it in the install jobs of
   `.github/workflows/build-ide-standalone.yml` and in `docs/source/installation.rst` too, which that test
   also enforces.

--- a/ide/standalone/README.md
+++ b/ide/standalone/README.md
@@ -42,8 +42,9 @@ than dropping it quietly.
   `../.vscode/extensions.json`.
 - `product.overlay.json` - the branding, merged into the editor's `product.json`.
 - `installer/partcad-ide.iss` - the Windows installer, compiled by Inno Setup.
-- `bootstrap/` - a small extension that ships only in this IDE: it opens the PartCAD workbench on startup and
-  points the PartCAD extension at the tools in the same application.
+- `bootstrap/` - a small extension that ships only in this IDE: it opens the PartCAD workbench on startup,
+  points the PartCAD extension at the tools in the same application, and creates and opens the package the
+  IDE starts in. `bootstrap/media/` is the text of the welcome window's steps.
 - `tools/` - the parts of the build that are more than a shell one-liner, each with its own tests.
 - `tests/` - `pytest` tests for `tools/`.
 
@@ -160,6 +161,47 @@ It is a separate extension rather than a few lines in `ide/vscode` on purpose. T
 activates when a workspace looks like a PartCAD project; making it activate on startup, everywhere, to check
 whether it is running inside this IDE would slow down every other Visual Studio Code that has it installed.
 
+## The first start, and the welcome window
+
+An editor that opens on an empty window asks the user to go and find something to open. This one has just
+been installed by somebody who has, by assumption, no PartCAD package to find -- so on its first start
+`bootstrap/` makes one: `pc init` in `~/.partcad/projects/start`, opened as the workspace, with the welcome
+window beside it.
+
+**The package goes under `~/.partcad`, not under `~/.partcad-ide`.** It is the user's first design, not
+editor state: `pc` in a terminal works with the same package, and uninstalling the IDE leaves it alone.
+
+**It runs the bundled `pc`, not the JSON-RPC service.** `pc init` writes a template and adds the "Render"
+command to `.vscode/launch.json`; going through the service would mean starting a daemon to write two files.
+The exit code is not what says whether it worked -- `pc init` reports a refusal by logging it and exiting 0 --
+so the check is that `partcad.yaml` is there afterwards.
+
+**It happens in the editor rather than in the installers.** There are three of those (`install.sh`, the
+Windows setup program, and a .dmg the user drags to Applications, which is no installer at all), and the
+folder has to be opened by the editor in any case. One implementation, in the one place that runs on every
+platform and every way of installing.
+
+**It happens once**, and it never takes over a window that has something in it: an IDE started on a folder --
+"Open with PartCAD IDE", or a path on the command line -- records that the first start has happened and
+leaves the user where they are. The record is in `globalState`, which is why the welcome window survives
+`vscode.openFolder` reopening the workbench: the walkthrough cannot be opened before the reload, because an
+editor belongs to the window it was opened in, so it is left as a note for the activation that follows.
+
+The welcome window itself is a walkthrough (`bootstrap/package.json`, with the text of its steps in
+`bootstrap/media/`), and `workbench.startupEditor` is `welcomePageInEmptyWorkbench` rather than `none`: with a
+package open the workbench is what the user came for, and with no folder open there is nothing else to show.
+It is what the editor calls "Welcome", so `Help > Welcome` and `PartCAD IDE: Welcome` reach it afterwards.
+
+`partcadIde.createStarterPackage` turns the whole thing off. Without the command line tools -- a developer
+build -- there is no `pc` to run, so the IDE says so in its output channel, shows the welcome window and
+starts in an empty window.
+
+One thing the IDE cannot do for the user: the folder it just created is still a folder the editor has not
+been told to trust, so the trust prompt appears on it. `bootstrap` supports untrusted workspaces (it reads
+nothing from the workspace), so the welcome window is there to explain what is asking. Turning workspace
+trust off in `product.overlay.json` would remove the prompt for every package the user ever opens, including
+the ones they download, and PartCAD runs the code in those.
+
 ## Where things end up on the user's machine
 
 | | Linux | macOS | Windows |
@@ -167,6 +209,7 @@ whether it is running inside this IDE would slow down every other Visual Studio 
 | The application | `~/.local/share/partcad/<version>-ide` | `/Applications/PartCAD IDE.app` | wherever the .zip was unpacked |
 | Settings, state, extensions the user installs | `~/.partcad-ide` | `~/.partcad-ide` | `%USERPROFILE%\.partcad-ide` |
 | PartCAD's own cache and configuration | `~/.partcad` | `~/.partcad` | `%USERPROFILE%\.partcad` |
+| The package the IDE starts in | `~/.partcad/projects/start` | `~/.partcad/projects/start` | `%USERPROFILE%\.partcad\projects\start` |
 
 `~/.partcad-ide` is what keeps this IDE from sharing anything with a Visual Studio Code or VSCodium on the same
 machine. `~/.partcad` is deliberately shared: it is PartCAD's, not the editor's, and a package installed from

--- a/ide/standalone/README.md
+++ b/ide/standalone/README.md
@@ -44,7 +44,8 @@ than dropping it quietly.
 - `installer/partcad-ide.iss` - the Windows installer, compiled by Inno Setup.
 - `bootstrap/` - a small extension that ships only in this IDE: it opens the PartCAD workbench on startup,
   points the PartCAD extension at the tools in the same application, and creates and opens the package the
-  IDE starts in. `bootstrap/media/` is the text of the welcome window's steps.
+  IDE starts in. `bootstrap/media/` is the text of the welcome window's steps, and `bootstrap/examples.json`
+  is the examples it offers to open.
 - `tools/` - the parts of the build that are more than a shell one-liner, each with its own tests.
 - `tests/` - `pytest` tests for `tools/`.
 
@@ -191,6 +192,36 @@ The welcome window itself is a walkthrough (`bootstrap/package.json`, with the t
 `bootstrap/media/`), and `workbench.startupEditor` is `welcomePageInEmptyWorkbench` rather than `none`: with a
 package open the workbench is what the user came for, and with no folder open there is nothing else to show.
 It is what the editor calls "Welcome", so `Help > Welcome` and `PartCAD IDE: Welcome` reach it afterwards.
+Every step carries the page of https://partcad.readthedocs.io that explains it; `tests/test_bootstrap.py`
+fails on a link to a page that is not in `docs/source`.
+
+## The examples the welcome window offers
+
+"Start from an example" (`PartCAD IDE: Open an example`) is a list of packages that already work: parts in
+CadQuery, build123d and OpenSCAD, and an assembly. The one the user picks is copied into their starter package
+and the file worth reading first is opened.
+
+**They are the packages under `examples/` in this repository, not a copy of them.** `tools/copy_examples.py`
+copies the ones `bootstrap/examples.json` names into the extension when the IDE is built. Those packages are
+rendered by the `Examples (PartCAD)` job and their output is checked in, so what the IDE hands a user is what
+the project publishes and keeps working; a second copy would be a second thing to keep current, and would not
+be.
+
+**An example brings what it references.** A package may name a sibling (`../produce_part_cadquery_primitive`,
+in an assembly that places parts from it), which is a reference that means nothing once the directory is
+copied out of `examples/` on its own. So the manifest declares what each entry needs, `copy_examples.py`
+checks that declaration against what the `partcad.yaml` and `.assy` files actually reference -- transitively,
+because the package an assembly's parts come from may name a third -- and both the copy into the extension and
+the copy onto the user's disk take the whole set. The build fails on a manifest that does not match; a user
+would otherwise find a package in the Explorer that cannot load.
+
+**They land in the starter package**, as subdirectories, because PartCAD imports every subdirectory that holds
+a `partcad.yaml`: the example appears in the Explorer under the package the user is in, with no edit to any
+`partcad.yaml` and nothing for the daemon to do. A copy that is already there is left alone -- it is the
+user's by then, and may have been changed.
+
+`verify_bundle.py` checks that a built IDE carries every package its manifest offers, and the file each one
+opens.
 
 `partcadIde.createStarterPackage` turns the whole thing off. Without the command line tools -- a developer
 build -- there is no `pc` to run, so the IDE says so in its output channel, shows the welcome window and

--- a/ide/standalone/bootstrap/.vscodeignore
+++ b/ide/standalone/bootstrap/.vscodeignore
@@ -1,1 +1,5 @@
+# What `vsce package` leaves out of the extension the IDE ships. Everything else
+# here goes in as it is -- there is no compile step, so what is in this
+# directory is what runs.
+test/**
 .vscodeignore

--- a/ide/standalone/bootstrap/README.md
+++ b/ide/standalone/bootstrap/README.md
@@ -5,16 +5,18 @@ extension in it: it opens the PartCAD workbench, connects the IDE to the PartCAD
 the same application, and -- the first time it starts -- creates a package for the user and opens it, with the
 welcome window beside it.
 
-The welcome window is the walkthrough contributed by `package.json`; the text of its steps is in `media/`.
-"The first start, and the welcome window" in `../README.md` explains what happens in which order, and why the
-package is created here rather than by the installers.
+The welcome window is the walkthrough contributed by `package.json`; the text of its steps is in `media/`, and
+the examples it offers to open are named in `examples.json` -- the packages themselves are copied in from the
+repository's `examples/` when the IDE is built, so `examples/` does not exist in this directory. "The first
+start, and the welcome window" in `../README.md` explains what happens in which order, why the package is
+created here rather than by the installers, and what an example brings with it.
 
 It is built and installed by `../build.sh` and ships only inside that IDE. It is not published to any registry:
 in a plain VS Code there are no bundled tools beside the application and no reason to override the user's
 layout, and this extension does nothing there.
 
 Three settings turn its three behaviors off: `partcadIde.openWorkbenchOnStartup`, `partcadIde.useBundledTools`
-and `partcadIde.createStarterPackage`. Two commands reach the first start afterwards:
-`PartCAD IDE: Open the starter package` and `PartCAD IDE: Welcome`.
+and `partcadIde.createStarterPackage`. Three commands reach afterwards what the first start does:
+`PartCAD IDE: Open the starter package`, `PartCAD IDE: Open an example` and `PartCAD IDE: Welcome`.
 
 Plain JavaScript, packaged as it is -- there is no compile step, so keep it that way.

--- a/ide/standalone/bootstrap/README.md
+++ b/ide/standalone/bootstrap/README.md
@@ -1,10 +1,20 @@
 # PartCAD IDE bootstrap
 
-The extension that makes the [PartCAD IDE](../README.md) open into the PartCAD workbench, and that connects it
-to the PartCAD command line tools shipped in the same application.
+The extension that makes the [PartCAD IDE](../README.md) an IDE for PartCAD rather than an editor with an
+extension in it: it opens the PartCAD workbench, connects the IDE to the PartCAD command line tools shipped in
+the same application, and -- the first time it starts -- creates a package for the user and opens it, with the
+welcome window beside it.
+
+The welcome window is the walkthrough contributed by `package.json`; the text of its steps is in `media/`.
+"The first start, and the welcome window" in `../README.md` explains what happens in which order, and why the
+package is created here rather than by the installers.
 
 It is built and installed by `../build.sh` and ships only inside that IDE. It is not published to any registry:
 in a plain VS Code there are no bundled tools beside the application and no reason to override the user's
 layout, and this extension does nothing there.
 
-Two settings turn its two behaviors off: `partcadIde.openWorkbenchOnStartup` and `partcadIde.useBundledTools`.
+Three settings turn its three behaviors off: `partcadIde.openWorkbenchOnStartup`, `partcadIde.useBundledTools`
+and `partcadIde.createStarterPackage`. Two commands reach the first start afterwards:
+`PartCAD IDE: Open the starter package` and `PartCAD IDE: Welcome`.
+
+Plain JavaScript, packaged as it is -- there is no compile step, so keep it that way.

--- a/ide/standalone/bootstrap/examples.json
+++ b/ide/standalone/bootstrap/examples.json
@@ -1,0 +1,33 @@
+{
+  "examples": [
+    {
+      "package": "produce_part_cadquery_primitive",
+      "label": "A part in CadQuery",
+      "detail": "A cube and a cylinder, and the same cube declared again with other dimensions",
+      "open": "cube.py",
+      "documentation": "https://partcad.readthedocs.io/en/latest/configuration.html"
+    },
+    {
+      "package": "produce_part_build123d_primitive",
+      "label": "A part in build123d",
+      "detail": "The smallest package there is: one script, one declaration",
+      "open": "cube.py",
+      "documentation": "https://partcad.readthedocs.io/en/latest/configuration.html"
+    },
+    {
+      "package": "produce_part_openscad",
+      "label": "A part in OpenSCAD",
+      "detail": "A .scad file, and a module PartCAD instantiates with parameters of its own",
+      "open": "parametric_box.scad",
+      "documentation": "https://partcad.readthedocs.io/en/latest/configuration.html"
+    },
+    {
+      "package": "produce_assembly_assy",
+      "label": "An assembly",
+      "detail": "Parts from other packages, placed and parameterized -- those packages come with it",
+      "open": "primitive.assy",
+      "requires": ["produce_part_cadquery_primitive", "produce_part_cadquery_logo", "produce_part_step"],
+      "documentation": "https://partcad.readthedocs.io/en/latest/assy.html"
+    }
+  ]
+}

--- a/ide/standalone/bootstrap/extension.js
+++ b/ide/standalone/bootstrap/extension.js
@@ -12,7 +12,9 @@
 //
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { execFile } = require('child_process');
 const vscode = require('vscode');
 
 // The view container the PartCAD extension contributes to the activity bar. VS
@@ -20,6 +22,37 @@ const vscode = require('vscode');
 const WORKBENCH_COMMAND = 'workbench.view.extension.partcad-container';
 
 const SERVICE_EXECUTABLE = process.platform === 'win32' ? 'partcad-json-rpc.exe' : 'partcad-json-rpc';
+const CLI_EXECUTABLE = process.platform === 'win32' ? 'pc.exe' : 'pc';
+
+// The welcome window: the walkthrough this extension contributes (see
+// `package.json`), addressed the way the editor addresses one --
+// `<publisher>.<name>#<walkthrough id>`.
+const WALKTHROUGH = 'PartCAD.partcad-ide-bootstrap#partcadStart';
+
+// The package the IDE creates for someone who has just installed it, and the
+// workspace it opens the first time it starts.
+//
+// It goes under `~/.partcad`, not under the IDE's own `~/.partcad-ide`, because
+// it is a package like any other: `pc` in a terminal and a second editor on the
+// same machine see the one the IDE made, and uninstalling the IDE does not take
+// the user's first design with it.
+const STARTER_PACKAGE_PATH = ['.partcad', 'projects', 'start'];
+const PACKAGE_CONFIGURATION = 'partcad.yaml';
+const STARTER_DESCRIPTION = 'A PartCAD package to start from';
+
+// Whether the first start has happened, and whether the welcome window is still
+// owed to the user. Both are in `globalState`, which is per installation of the
+// IDE rather than per workspace -- and which survives the window reopening on
+// the starter package, the reason the second one exists at all.
+const STARTER_DONE_KEY = 'partcadIde.starterPackage.done';
+const WELCOME_PENDING_KEY = 'partcadIde.welcome.pending';
+
+// `pc init` writes a template to disk: no network, no CAD kernel, no sandbox.
+// It is slow anyway the first time, because it runs out of a PyInstaller bundle
+// that unpacks itself before `main` -- on the cold filesystem of a machine that
+// has just installed the IDE, which is precisely when this runs, that has taken
+// tens of seconds.
+const INIT_TIMEOUT_MS = 5 * 60 * 1000;
 
 let output;
 
@@ -86,8 +119,184 @@ async function showWorkbench() {
     await vscode.commands.executeCommand(WORKBENCH_COMMAND);
 }
 
+/** The PartCAD walkthrough, in the editor area, as the welcome window. */
+async function showWelcome() {
+    try {
+        await vscode.commands.executeCommand('workbench.action.openWalkthrough', WALKTHROUGH, false);
+    } catch (error) {
+        // A welcome window that will not open is not a reason to stop: the IDE
+        // behind it works.
+        log(`Could not open the PartCAD welcome window: ${error}`);
+    }
+}
+
+function starterPackageDirectory() {
+    return path.join(os.homedir(), ...STARTER_PACKAGE_PATH);
+}
+
+/**
+ * `pc init` in `directory`.
+ *
+ * The path it writes to is its working directory rather than an argument: `pc`
+ * takes a package path globally (`-p`), but `init` creates `partcad.yaml`
+ * beside wherever it was run. `--no-ansi` because nobody is watching this
+ * terminal -- it turns the progress bars into plain text on stderr, which is
+ * what the output channel below is for.
+ */
+function runInit(cli, directory) {
+    return new Promise((resolve) => {
+        execFile(
+            cli,
+            ['--no-ansi', 'init', '--desc', STARTER_DESCRIPTION],
+            { cwd: directory, timeout: INIT_TIMEOUT_MS, windowsHide: true },
+            (error, stdout, stderr) => {
+                for (const stream of [stdout, stderr]) {
+                    const text = (stream || '').trim();
+                    if (text) {
+                        log(text);
+                    }
+                }
+                if (error) {
+                    log(`Running '${cli} init' failed: ${error}`);
+                }
+                resolve();
+            },
+        );
+    });
+}
+
+/**
+ * The starter package, created if it is not there yet.
+ *
+ * Returns its directory when there is a package in it to open, and undefined
+ * when there is not: an IDE built without the command line tools has no `pc` to
+ * run, and a `pc init` that failed leaves nothing worth opening. Neither is an
+ * error dialog -- the IDE still works, and the welcome window says how to make
+ * a package by hand.
+ */
+async function createStarterPackage(tools) {
+    const directory = starterPackageDirectory();
+    const configuration = path.join(directory, PACKAGE_CONFIGURATION);
+
+    if (fs.existsSync(configuration)) {
+        return directory;
+    }
+    if (!tools) {
+        log('No bundled PartCAD tools next to this application; not creating a starter package.');
+        return undefined;
+    }
+
+    log(`Creating a PartCAD package in ${directory}`);
+    await fs.promises.mkdir(directory, { recursive: true });
+    await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Window, title: 'Creating your first PartCAD package...' },
+        () => runInit(path.join(tools, CLI_EXECUTABLE), directory),
+    );
+
+    // `pc init` reports a refusal -- a configuration file that is already there,
+    // a directory it cannot write -- by logging it and exiting 0, so the file is
+    // what says whether this worked.
+    if (!fs.existsSync(configuration)) {
+        log(`No ${PACKAGE_CONFIGURATION} in ${directory} after 'pc init'; leaving the workspace empty.`);
+        // Nothing was created, so nothing is left behind: an empty directory in
+        // the user's home is worse than none, because the next attempt cannot
+        // tell it from a package that was emptied on purpose.
+        await fs.promises.rmdir(directory).catch(() => {});
+        return undefined;
+    }
+    return directory;
+}
+
+function isOpenWorkspace(directory) {
+    const folders = vscode.workspace.workspaceFolders || [];
+    return folders.some((folder) => path.resolve(folder.uri.fsPath) === path.resolve(directory));
+}
+
+/**
+ * Open the starter package as the workspace, and arrange for the welcome window
+ * to appear once it has.
+ *
+ * `vscode.openFolder` reopens the workbench on the new folder, and an editor
+ * opened before it goes with the window it was opened in -- so the welcome
+ * window is left as a note in `globalState` for the activation that follows,
+ * rather than opened here.
+ */
+async function openStarterWorkspace(context, directory) {
+    await context.globalState.update(WELCOME_PENDING_KEY, true);
+    try {
+        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(directory), {
+            forceNewWindow: false,
+        });
+    } catch (error) {
+        await context.globalState.update(WELCOME_PENDING_KEY, false);
+        throw error;
+    }
+}
+
+/**
+ * What the IDE does the first time it is started after being installed: make a
+ * package for the user and open it, so that the PartCAD Explorer has something
+ * in it and the welcome window has something to point at.
+ *
+ * It happens here rather than in the installers because there are three of them
+ * -- `install.sh`, the Windows setup program, and a .dmg the user drags to
+ * Applications, which is no installer at all -- and because the editor is what
+ * has to open the folder in any case.
+ */
+async function setUpStarterPackage(context, tools) {
+    if (context.globalState.get(STARTER_DONE_KEY)) {
+        return;
+    }
+
+    if ((vscode.workspace.workspaceFolders || []).length > 0 || vscode.workspace.workspaceFile) {
+        // Started on a folder of the user's own -- "Open with PartCAD IDE" on a
+        // directory, or a window restored from a previous session. There is
+        // nothing to set up, and recording it keeps the IDE from taking over
+        // some later empty window instead.
+        await context.globalState.update(STARTER_DONE_KEY, true);
+        return;
+    }
+
+    const directory = await createStarterPackage(tools);
+    await context.globalState.update(STARTER_DONE_KEY, true);
+
+    if (!directory) {
+        await showWelcome();
+        return;
+    }
+    await openStarterWorkspace(context, directory);
+}
+
+/**
+ * "PartCAD IDE: Open the starter package", and the button the welcome window's
+ * first step carries. Creates the package if it is not there -- the first start
+ * can have run without the command line tools, or before the user had a home
+ * directory to write to.
+ */
+async function openStarterPackage() {
+    const directory = await createStarterPackage(bundledToolsDirectory());
+    if (!directory) {
+        vscode.window.showErrorMessage(
+            `PartCAD could not create a package in ${starterPackageDirectory()}. ` +
+                'The "PartCAD IDE" output channel has the details.',
+        );
+        return;
+    }
+    if (isOpenWorkspace(directory)) {
+        // It is already the workspace: opening the folder again would reload
+        // the window for nothing, so show the package configuration instead.
+        const document = await vscode.workspace.openTextDocument(path.join(directory, PACKAGE_CONFIGURATION));
+        await vscode.window.showTextDocument(document);
+        return;
+    }
+    await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(directory), { forceNewWindow: false });
+}
+
 async function activate(context) {
     const configuration = vscode.workspace.getConfiguration('partcadIde');
+
+    context.subscriptions.push(vscode.commands.registerCommand('partcadIde.openStarterPackage', openStarterPackage));
+    context.subscriptions.push(vscode.commands.registerCommand('partcadIde.showWelcome', showWelcome));
 
     if (configuration.get('useBundledTools', true)) {
         const tools = bundledToolsDirectory();
@@ -111,6 +320,22 @@ async function activate(context) {
             await showWorkbench();
         } catch (error) {
             log(`Could not open the PartCAD workbench: ${error}`);
+        }
+    }
+
+    // The other half of the first start, running in the window that
+    // `vscode.openFolder` reopened. Cleared first: a welcome window that fails
+    // to open is not owed forever.
+    if (context.globalState.get(WELCOME_PENDING_KEY)) {
+        await context.globalState.update(WELCOME_PENDING_KEY, false);
+        await showWelcome();
+    }
+
+    if (configuration.get('createStarterPackage', true)) {
+        try {
+            await setUpStarterPackage(context, bundledToolsDirectory());
+        } catch (error) {
+            log(`Could not set up the starter package: ${error}`);
         }
     }
 }

--- a/ide/standalone/bootstrap/extension.js
+++ b/ide/standalone/bootstrap/extension.js
@@ -47,6 +47,18 @@ const STARTER_DESCRIPTION = 'A PartCAD package to start from';
 const STARTER_DONE_KEY = 'partcadIde.starterPackage.done';
 const WELCOME_PENDING_KEY = 'partcadIde.welcome.pending';
 
+// The examples the welcome window offers. `examples.json` is checked in beside
+// this file; `examples/` is filled by `tools/copy_examples.py` when the IDE is
+// built, out of the packages under `examples/` in the repository. An IDE built
+// without them -- a developer build -- has the manifest and no packages, which
+// is why what is on disk decides what is offered.
+const EXAMPLES_MANIFEST = 'examples.json';
+const EXAMPLES_DIRECTORY = 'examples';
+
+// The command the PartCAD extension registers for "Reload the package". An
+// example copied into the open workspace is a package the Explorer has not seen.
+const REFRESH_COMMAND = 'partcad.refresh';
+
 // `pc init` writes a template to disk: no network, no CAD kernel, no sandbox.
 // It is slow anyway the first time, because it runs out of a PyInstaller bundle
 // that unpacks itself before `main` -- on the cold filesystem of a machine that
@@ -268,6 +280,131 @@ async function setUpStarterPackage(context, tools) {
 }
 
 /**
+ * The examples this IDE carries, in the order the manifest lists them.
+ *
+ * Only those that are actually there: the manifest ships with the extension and
+ * the packages are put beside it by the build, so an IDE built without them has
+ * a list of things it cannot open. Reporting that once here beats four entries
+ * in a menu that fail when they are chosen.
+ */
+function shippedExamples(context) {
+    let manifest;
+    try {
+        manifest = JSON.parse(fs.readFileSync(path.join(context.extensionPath, EXAMPLES_MANIFEST), 'utf-8'));
+    } catch (error) {
+        log(`Could not read ${EXAMPLES_MANIFEST}: ${error}`);
+        return [];
+    }
+    const examples = (manifest.examples || []).filter((example) =>
+        fs.existsSync(path.join(context.extensionPath, EXAMPLES_DIRECTORY, example.package, PACKAGE_CONFIGURATION)),
+    );
+    if (!examples.length) {
+        log('This PartCAD IDE was built without the example packages.');
+    }
+    return examples;
+}
+
+/** Copy a directory, as `fs.cp` would in a Node this extension cannot count on. */
+async function copyDirectory(source, destination) {
+    await fs.promises.mkdir(destination, { recursive: true });
+    for (const entry of await fs.promises.readdir(source, { withFileTypes: true })) {
+        const from = path.join(source, entry.name);
+        const to = path.join(destination, entry.name);
+        if (entry.isDirectory()) {
+            await copyDirectory(from, to);
+        } else if (entry.isFile()) {
+            await fs.promises.copyFile(from, to);
+        }
+    }
+}
+
+/**
+ * Put an example, and the packages it uses, inside `destination`.
+ *
+ * They go in as sibling directories of each other, which is what makes an
+ * assembly's `../<package>` references resolve after the copy -- and, because
+ * PartCAD imports every subdirectory that holds a `partcad.yaml`, what makes
+ * them appear in the PartCAD Explorer under the package they were copied into.
+ *
+ * A copy that is already there is left alone: it is the user's now, and they may
+ * have changed it.
+ */
+async function copyExample(context, example, destination) {
+    const shipped = path.join(context.extensionPath, EXAMPLES_DIRECTORY);
+    for (const name of [example.package, ...(example.requires || [])]) {
+        const target = path.join(destination, name);
+        if (fs.existsSync(target)) {
+            log(`${target} is already there; leaving it as it is.`);
+            continue;
+        }
+        log(`Copying the ${name} example into ${destination}`);
+        await copyDirectory(path.join(shipped, name), target);
+    }
+    return path.join(destination, example.package);
+}
+
+/**
+ * "PartCAD IDE: Open an example", and the button the welcome window's example
+ * step carries: pick one of the packages this IDE ships, copy it into the
+ * starter package, and open the file worth reading first.
+ */
+async function openExample(context) {
+    const examples = shippedExamples(context);
+    if (!examples.length) {
+        vscode.window.showErrorMessage(
+            'This PartCAD IDE was built without the example packages. ' +
+                'The examples are at https://github.com/partcad/partcad/tree/main/examples.',
+        );
+        return;
+    }
+
+    const picked = await vscode.window.showQuickPick(
+        examples.map((example) => ({ label: example.label, detail: example.detail, example })),
+        { title: 'Which example would you like to open?', matchOnDetail: true },
+    );
+    if (!picked) {
+        return;
+    }
+
+    const starter = await createStarterPackage(bundledToolsDirectory());
+    if (!starter) {
+        vscode.window.showErrorMessage(
+            `PartCAD could not create a package in ${starterPackageDirectory()} to copy the example into. ` +
+                'The "PartCAD IDE" output channel has the details.',
+        );
+        return;
+    }
+
+    const directory = await copyExample(context, picked.example, starter);
+    const document = await vscode.workspace.openTextDocument(path.join(directory, picked.example.open));
+    await vscode.window.showTextDocument(document);
+
+    // The Explorer reads the package when the workspace is opened, so a
+    // subdirectory that appeared afterwards is one it does not know about. Done
+    // before the notification below, which stays on screen until it is
+    // answered.
+    if (isOpenWorkspace(starter)) {
+        const commands = await vscode.commands.getCommands(true);
+        if (commands.includes(REFRESH_COMMAND)) {
+            await vscode.commands.executeCommand(REFRESH_COMMAND);
+        }
+    }
+
+    // Where it went, and what explains it. The file is open in front of the
+    // user, but the package it belongs to is not necessarily the workspace they
+    // are in, and the manifest is where the documentation for each example is
+    // recorded.
+    const documentation = picked.example.documentation;
+    const chosen = await vscode.window.showInformationMessage(
+        `The ${picked.example.label} example is in ${directory}.`,
+        ...(documentation ? ['Documentation'] : []),
+    );
+    if (chosen === 'Documentation') {
+        await vscode.env.openExternal(vscode.Uri.parse(documentation));
+    }
+}
+
+/**
  * "PartCAD IDE: Open the starter package", and the button the welcome window's
  * first step carries. Creates the package if it is not there -- the first start
  * can have run without the command line tools, or before the user had a home
@@ -296,6 +433,7 @@ async function activate(context) {
     const configuration = vscode.workspace.getConfiguration('partcadIde');
 
     context.subscriptions.push(vscode.commands.registerCommand('partcadIde.openStarterPackage', openStarterPackage));
+    context.subscriptions.push(vscode.commands.registerCommand('partcadIde.openExample', () => openExample(context)));
     context.subscriptions.push(vscode.commands.registerCommand('partcadIde.showWelcome', showWelcome));
 
     if (configuration.get('useBundledTools', true)) {

--- a/ide/standalone/bootstrap/media/documentation.md
+++ b/ide/standalone/bootstrap/media/documentation.md
@@ -1,13 +1,33 @@
-## Where to go next
+## The documentation
+
+Everything below is at
+[partcad.readthedocs.io](https://partcad.readthedocs.io/en/latest/).
 
 * [Tutorial](https://partcad.readthedocs.io/en/latest/tutorial.html) --
   a package from nothing, one command at a time.
 * [Configuration](https://partcad.readthedocs.io/en/latest/configuration.html) --
-  everything `partcad.yaml` can say.
+  everything `partcad.yaml` can say: packages, dependencies, parts, sketches,
+  interfaces, parameters.
+* [Assemblies](https://partcad.readthedocs.io/en/latest/assy.html) --
+  the `.assy` format, and how parts from other packages are placed.
+* [CLI reference](https://partcad.readthedocs.io/en/latest/cli.html) --
+  every `pc` command and its options.
+* [Additional features](https://partcad.readthedocs.io/en/latest/features.html) --
+  what the workbench, the Explorer and the Inspector do.
+* [Simulation](https://partcad.readthedocs.io/en/latest/simulation.html) and
+  [use cases](https://partcad.readthedocs.io/en/latest/use_cases.html) --
+  where a design goes after it is drawn.
+* [Installation](https://partcad.readthedocs.io/en/latest/installation.html) --
+  PartCAD on another machine, in a terminal, or in an editor you already have.
+* [Troubleshooting](https://partcad.readthedocs.io/en/latest/troubleshooting.html) --
+  when something does not work.
+
+And beyond the documentation:
+
 * [Public packages](https://partcad.org/repository) --
   parts and assemblies to depend on rather than draw.
 * [GitHub](https://github.com/partcad/partcad) --
-  the source, the issues, and where to ask.
+  the source, the examples, the issues, and where to ask.
 
 PartCAD is a package manager for CAD: packages depend on packages, parts are
 built from source, and a design is a repository rather than a folder of files

--- a/ide/standalone/bootstrap/media/documentation.md
+++ b/ide/standalone/bootstrap/media/documentation.md
@@ -1,0 +1,14 @@
+## Where to go next
+
+* [Tutorial](https://partcad.readthedocs.io/en/latest/tutorial.html) --
+  a package from nothing, one command at a time.
+* [Configuration](https://partcad.readthedocs.io/en/latest/configuration.html) --
+  everything `partcad.yaml` can say.
+* [Public packages](https://partcad.org/repository) --
+  parts and assemblies to depend on rather than draw.
+* [GitHub](https://github.com/partcad/partcad) --
+  the source, the issues, and where to ask.
+
+PartCAD is a package manager for CAD: packages depend on packages, parts are
+built from source, and a design is a repository rather than a folder of files
+somebody emailed you.

--- a/ide/standalone/bootstrap/media/example.md
+++ b/ide/standalone/bootstrap/media/example.md
@@ -1,0 +1,23 @@
+## The examples this IDE carries
+
+| | What it shows |
+| --- | --- |
+| **A part in CadQuery** | A cube and a cylinder as CadQuery scripts, and the same cube declared again at other dimensions -- `enrich` and `alias`, which is how a package reuses a shape without copying it |
+| **A part in build123d** | The smallest package there is: one script, one entry under `parts:` |
+| **A part in OpenSCAD** | A `.scad` file used as it is, and a parameterized module PartCAD instantiates with arguments from `partcad.yaml` |
+| **An assembly** | Parts placed relative to each other in an `.assy` file, taken from *other* packages -- which is what a package manager for CAD is for |
+
+They are the examples this project publishes, unchanged. The one you pick is
+copied into `~/.partcad/projects/start`, next to your own package, with whatever
+packages it uses beside it -- an assembly brings the packages its parts come
+from. A copy you have already edited is left alone.
+
+Everything in them is yours to change: they are files in your home directory,
+not something inside the application.
+
+### Documentation
+
+* [Tutorial](https://partcad.readthedocs.io/en/latest/tutorial.html)
+* [Assemblies](https://partcad.readthedocs.io/en/latest/assy.html)
+* [Configuration reference](https://partcad.readthedocs.io/en/latest/configuration.html)
+* [All the examples, on GitHub](https://github.com/partcad/partcad/tree/main/examples)

--- a/ide/standalone/bootstrap/media/package.md
+++ b/ide/standalone/bootstrap/media/package.md
@@ -1,0 +1,22 @@
+## The starter package
+
+```
+~/.partcad/projects/start
+├── partcad.yaml      the package: what is in it, and what it depends on
+└── .vscode
+    └── launch.json   the "Render" command, in the Run and Debug view
+```
+
+`partcad.yaml` is the whole package. Parts, assemblies and sketches are listed
+in it, and so are the packages this one depends on -- including `pub`, the
+public PartCAD index, which every new package starts with.
+
+The PartCAD Explorer, on the left, shows the same file as a tree: the packages
+it can reach, and the objects in them.
+
+The editor asks whether you trust the authors of a folder before it runs
+anything from it. This one it made for you, so the answer is yes -- and
+PartCAD stays quiet until you give it.
+
+Nothing here is special to the IDE. Copy the folder somewhere else, put it in
+git, or make another one with `pc init` -- it is a package either way.

--- a/ide/standalone/bootstrap/media/package.md
+++ b/ide/standalone/bootstrap/media/package.md
@@ -20,3 +20,9 @@ PartCAD stays quiet until you give it.
 
 Nothing here is special to the IDE. Copy the folder somewhere else, put it in
 git, or make another one with `pc init` -- it is a package either way.
+
+### Documentation
+
+* [Packages and dependencies](https://partcad.readthedocs.io/en/latest/configuration.html)
+* [Tutorial: create a package](https://partcad.readthedocs.io/en/latest/tutorial.html)
+* [What `pc init` writes](https://partcad.readthedocs.io/en/latest/cli.html)

--- a/ide/standalone/bootstrap/media/part.md
+++ b/ide/standalone/bootstrap/media/part.md
@@ -1,0 +1,25 @@
+## Parts
+
+A part is one shape, produced by one script:
+
+```python
+# a CadQuery part
+import cadquery as cq
+
+result = cq.Workplane("XY").box(10, 10, 10)
+```
+
+...and one entry in `partcad.yaml`:
+
+```yaml
+parts:
+  box:
+    type: cadquery
+```
+
+"Add a part" writes both. It asks for a name and a type -- CadQuery, build123d
+and OpenSCAD are scripts; STEP, STL, 3MF and DXF are files PartCAD imports as
+they are.
+
+Parts take parameters, so one script can be a family of parts. Assemblies put
+parts together, and are added the same way.

--- a/ide/standalone/bootstrap/media/part.md
+++ b/ide/standalone/bootstrap/media/part.md
@@ -23,3 +23,9 @@ they are.
 
 Parts take parameters, so one script can be a family of parts. Assemblies put
 parts together, and are added the same way.
+
+### Documentation
+
+* [Parts, and every type of them](https://partcad.readthedocs.io/en/latest/configuration.html)
+* [Tutorial: add a part](https://partcad.readthedocs.io/en/latest/tutorial.html)
+* [Parameters and interfaces](https://partcad.readthedocs.io/en/latest/configuration.html)

--- a/ide/standalone/bootstrap/media/render.md
+++ b/ide/standalone/bootstrap/media/render.md
@@ -15,3 +15,9 @@ the Explorer's context menu has the same formats under "Export".
 
 The "Render" entry in the Run and Debug view runs `pc render` in this
 workspace. `pc init` put it there when it created the package.
+
+### Documentation
+
+* [`pc render`, `pc export` and their options](https://partcad.readthedocs.io/en/latest/cli.html)
+* [What a package declares to render](https://partcad.readthedocs.io/en/latest/configuration.html)
+* [Tutorial: export the part](https://partcad.readthedocs.io/en/latest/tutorial.html)

--- a/ide/standalone/bootstrap/media/render.md
+++ b/ide/standalone/bootstrap/media/render.md
@@ -1,0 +1,17 @@
+## Rendering
+
+```shell
+pc render          # every projection and document the package declares
+pc export -t stl   # the 3D file another tool wants
+```
+
+`pc render` draws the package: SVG and PNG projections, a PDF or an HTML
+document, a DXF for a laser cutter, and the `README.md` an assembly's
+instruction book goes into. What each object renders to is declared in
+`partcad.yaml`, so everyone who has the package gets the same files.
+
+`pc export` is the other direction -- STEP, STL, 3MF, OBJ, glTF, IGES -- and
+the Explorer's context menu has the same formats under "Export".
+
+The "Render" entry in the Run and Debug view runs `pc render` in this
+workspace. `pc init` put it there when it created the package.

--- a/ide/standalone/bootstrap/media/terminal.md
+++ b/ide/standalone/bootstrap/media/terminal.md
@@ -13,3 +13,9 @@ environment, no Python at all.
 
 `pc --help` lists the commands. They are the same ones the extension runs for
 you, and both talk to the same PartCAD service.
+
+### Documentation
+
+* [CLI command reference](https://partcad.readthedocs.io/en/latest/cli.html)
+* [Installing PartCAD elsewhere](https://partcad.readthedocs.io/en/latest/installation.html)
+* [When something does not work](https://partcad.readthedocs.io/en/latest/troubleshooting.html)

--- a/ide/standalone/bootstrap/media/terminal.md
+++ b/ide/standalone/bootstrap/media/terminal.md
@@ -1,0 +1,15 @@
+## The command line
+
+```shell
+pc list parts      # what is in this package
+pc render          # draw it
+pc export -t step  # hand it to another tool
+pc healthcheck     # what PartCAD needs on this machine, and what is missing
+```
+
+The IDE ships `pc` and points the PartCAD extension at it, so the terminal in
+this window has it on the PATH already -- no `pip install`, no virtual
+environment, no Python at all.
+
+`pc --help` lists the commands. They are the same ones the extension runs for
+you, and both talk to the same PartCAD service.

--- a/ide/standalone/bootstrap/media/viewer.md
+++ b/ide/standalone/bootstrap/media/viewer.md
@@ -1,0 +1,14 @@
+## The PartCAD Viewer
+
+Select a part in the PartCAD Explorer and it appears in the viewer: the shape
+the script produced, not a preview of the text.
+
+The shape is built by PartCAD rather than by the editor, in a sandbox it makes
+for the CAD kernel the part needs. The first build of a part downloads that
+sandbox, so it takes a while; the ones after it do not.
+
+Save the script and the viewer follows.
+
+The 3D view needs WebGL. This IDE turns on the software renderer, so it works
+on a machine with no usable GPU driver -- a virtual machine, a remote desktop,
+a container -- rather than showing an empty canvas.

--- a/ide/standalone/bootstrap/media/viewer.md
+++ b/ide/standalone/bootstrap/media/viewer.md
@@ -12,3 +12,9 @@ Save the script and the viewer follows.
 The 3D view needs WebGL. This IDE turns on the software renderer, so it works
 on a machine with no usable GPU driver -- a virtual machine, a remote desktop,
 a container -- rather than showing an empty canvas.
+
+### Documentation
+
+* [The workbench, view by view](https://partcad.readthedocs.io/en/latest/features.html)
+* [Tutorial: inspect the part](https://partcad.readthedocs.io/en/latest/tutorial.html)
+* [When the 3D view stays empty](https://partcad.readthedocs.io/en/latest/troubleshooting.html)

--- a/ide/standalone/bootstrap/package.json
+++ b/ide/standalone/bootstrap/package.json
@@ -17,10 +17,28 @@
   },
   "homepage": "https://partcad.org/",
   "main": "./extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true,
+      "description": "This extension does not read or run anything from the workspace: it points the PartCAD extension at the tools shipped beside the editor, and creates the package the IDE starts in. It is supported in a restricted window so that the welcome window is there to explain the one asking to be trusted."
+    }
+  },
   "activationEvents": [
     "onStartupFinished"
   ],
   "contributes": {
+    "commands": [
+      {
+        "command": "partcadIde.openStarterPackage",
+        "title": "Open the starter package",
+        "category": "PartCAD IDE"
+      },
+      {
+        "command": "partcadIde.showWelcome",
+        "title": "Welcome",
+        "category": "PartCAD IDE"
+      }
+    ],
     "configuration": {
       "title": "PartCAD IDE",
       "properties": {
@@ -33,8 +51,92 @@
           "type": "boolean",
           "default": true,
           "description": "Use the PartCAD command line tools that ship with this IDE: point the PartCAD extension at the bundled service, and put `pc` on the PATH of the integrated terminal. Turn this off to use a PartCAD installation of your own."
+        },
+        "partcadIde.createStarterPackage": {
+          "type": "boolean",
+          "default": true,
+          "description": "The first time the IDE starts, create a PartCAD package in `~/.partcad/projects/start` and open it as the workspace. Turn this off to start in an empty window instead; the package can still be created from `PartCAD IDE: Open the starter package`."
         }
       }
-    }
+    },
+    "walkthroughs": [
+      {
+        "id": "partcadStart",
+        "title": "Start with PartCAD",
+        "description": "Design manufacturable products in code. Your first package is open already -- add a part to it, look at it in 3D, and render the whole package.",
+        "featuredFor": [
+          "**/partcad.yaml"
+        ],
+        "steps": [
+          {
+            "id": "package",
+            "title": "Your first package",
+            "description": "The first time it starts, the IDE creates a PartCAD package in `~/.partcad/projects/start` and opens it as the workspace. It is an ordinary folder with a `partcad.yaml` in it, so `pc` in a terminal works with the same package.\n[Open the starter package](command:partcadIde.openStarterPackage)",
+            "media": {
+              "markdown": "media/package.md"
+            },
+            "completionEvents": [
+              "onCommand:partcadIde.openStarterPackage",
+              "onContext:partcad.packageLoaded"
+            ]
+          },
+          {
+            "id": "part",
+            "title": "Add a part",
+            "description": "A part is a CAD script -- CadQuery, build123d or OpenSCAD -- or a file PartCAD imports. Adding one writes the script and registers it in `partcad.yaml`.\n[Add a part](command:partcad.addPart)",
+            "media": {
+              "markdown": "media/part.md"
+            },
+            "completionEvents": [
+              "onCommand:partcad.addPart"
+            ]
+          },
+          {
+            "id": "viewer",
+            "title": "See it in 3D",
+            "description": "The PartCAD Viewer shows the shape the script produces, and reloads it when you save. Select a part in the PartCAD Explorer to display it.\n[Open the PartCAD Viewer](command:partcad.viewer)",
+            "media": {
+              "markdown": "media/viewer.md"
+            },
+            "completionEvents": [
+              "onCommand:partcad.viewer"
+            ]
+          },
+          {
+            "id": "render",
+            "title": "Render the package",
+            "description": "Rendering turns the package into the files other tools want: STEP, STL, 3MF, SVG, PNG. \"Render\" is in the Run and Debug view, put there when the package was created.\n[Open Run and Debug](command:workbench.view.debug)",
+            "media": {
+              "markdown": "media/render.md"
+            },
+            "completionEvents": [
+              "onCommand:workbench.view.debug"
+            ]
+          },
+          {
+            "id": "terminal",
+            "title": "The same thing from a terminal",
+            "description": "`pc` is the PartCAD command line, and this IDE carries it: no installation, no Python environment, already on the PATH of the terminal below.\n[Open a terminal](command:workbench.action.terminal.new)",
+            "media": {
+              "markdown": "media/terminal.md"
+            },
+            "completionEvents": [
+              "onCommand:workbench.action.terminal.new"
+            ]
+          },
+          {
+            "id": "documentation",
+            "title": "Where to go next",
+            "description": "The tutorial builds a package from nothing, and the documentation covers the file formats, the part types and the public package index.\n[Read the documentation](https://partcad.readthedocs.io/)",
+            "media": {
+              "markdown": "media/documentation.md"
+            },
+            "completionEvents": [
+              "onLink:https://partcad.readthedocs.io/"
+            ]
+          }
+        ]
+      }
+    ]
   }
 }

--- a/ide/standalone/bootstrap/package.json
+++ b/ide/standalone/bootstrap/package.json
@@ -34,6 +34,11 @@
         "category": "PartCAD IDE"
       },
       {
+        "command": "partcadIde.openExample",
+        "title": "Open an example",
+        "category": "PartCAD IDE"
+      },
+      {
         "command": "partcadIde.showWelcome",
         "title": "Welcome",
         "category": "PartCAD IDE"
@@ -71,7 +76,7 @@
           {
             "id": "package",
             "title": "Your first package",
-            "description": "The first time it starts, the IDE creates a PartCAD package in `~/.partcad/projects/start` and opens it as the workspace. It is an ordinary folder with a `partcad.yaml` in it, so `pc` in a terminal works with the same package.\n[Open the starter package](command:partcadIde.openStarterPackage)",
+            "description": "The first time it starts, the IDE creates a PartCAD package in `~/.partcad/projects/start` and opens it as the workspace. It is an ordinary folder with a `partcad.yaml` in it, so `pc` in a terminal works with the same package.\n[Open the starter package](command:partcadIde.openStarterPackage)\n[What a package declares](https://partcad.readthedocs.io/en/latest/configuration.html)",
             "media": {
               "markdown": "media/package.md"
             },
@@ -81,9 +86,20 @@
             ]
           },
           {
+            "id": "example",
+            "title": "Start from an example",
+            "description": "Packages that already work, to read and change: parts in CadQuery, build123d and OpenSCAD, and an assembly built out of other packages. The one you pick is copied into your package -- with whatever it uses -- and opened.\n[Open an example](command:partcadIde.openExample)\n[The tutorial](https://partcad.readthedocs.io/en/latest/tutorial.html)",
+            "media": {
+              "markdown": "media/example.md"
+            },
+            "completionEvents": [
+              "onCommand:partcadIde.openExample"
+            ]
+          },
+          {
             "id": "part",
             "title": "Add a part",
-            "description": "A part is a CAD script -- CadQuery, build123d or OpenSCAD -- or a file PartCAD imports. Adding one writes the script and registers it in `partcad.yaml`.\n[Add a part](command:partcad.addPart)",
+            "description": "A part is a CAD script -- CadQuery, build123d or OpenSCAD -- or a file PartCAD imports. Adding one writes the script and registers it in `partcad.yaml`.\n[Add a part](command:partcad.addPart)\n[How parts are declared](https://partcad.readthedocs.io/en/latest/configuration.html)",
             "media": {
               "markdown": "media/part.md"
             },
@@ -94,7 +110,7 @@
           {
             "id": "viewer",
             "title": "See it in 3D",
-            "description": "The PartCAD Viewer shows the shape the script produces, and reloads it when you save. Select a part in the PartCAD Explorer to display it.\n[Open the PartCAD Viewer](command:partcad.viewer)",
+            "description": "The PartCAD Viewer shows the shape the script produces, and reloads it when you save. Select a part in the PartCAD Explorer to display it.\n[Open the PartCAD Viewer](command:partcad.viewer)\n[What the workbench does](https://partcad.readthedocs.io/en/latest/features.html)",
             "media": {
               "markdown": "media/viewer.md"
             },
@@ -105,7 +121,7 @@
           {
             "id": "render",
             "title": "Render the package",
-            "description": "Rendering turns the package into the files other tools want: STEP, STL, 3MF, SVG, PNG. \"Render\" is in the Run and Debug view, put there when the package was created.\n[Open Run and Debug](command:workbench.view.debug)",
+            "description": "Rendering turns the package into the files other tools want: SVG and PNG projections, a PDF or an HTML document, STEP and STL through `pc export`. \"Render\" is in the Run and Debug view, put there when the package was created.\n[Open Run and Debug](command:workbench.view.debug)\n[pc render and pc export](https://partcad.readthedocs.io/en/latest/cli.html)",
             "media": {
               "markdown": "media/render.md"
             },
@@ -116,7 +132,7 @@
           {
             "id": "terminal",
             "title": "The same thing from a terminal",
-            "description": "`pc` is the PartCAD command line, and this IDE carries it: no installation, no Python environment, already on the PATH of the terminal below.\n[Open a terminal](command:workbench.action.terminal.new)",
+            "description": "`pc` is the PartCAD command line, and this IDE carries it: no installation, no Python environment, already on the PATH of the terminal below.\n[Open a terminal](command:workbench.action.terminal.new)\n[Every command there is](https://partcad.readthedocs.io/en/latest/cli.html)",
             "media": {
               "markdown": "media/terminal.md"
             },
@@ -127,7 +143,7 @@
           {
             "id": "documentation",
             "title": "Where to go next",
-            "description": "The tutorial builds a package from nothing, and the documentation covers the file formats, the part types and the public package index.\n[Read the documentation](https://partcad.readthedocs.io/)",
+            "description": "The tutorial builds a package from nothing, and the documentation covers the file formats, the part types and the public package index.\n[Read the documentation](https://partcad.readthedocs.io/)\n[Installing PartCAD elsewhere](https://partcad.readthedocs.io/en/latest/installation.html)",
             "media": {
               "markdown": "media/documentation.md"
             },

--- a/ide/standalone/bootstrap/test/extension.test.js
+++ b/ide/standalone/bootstrap/test/extension.test.js
@@ -1,0 +1,240 @@
+//
+// PartCAD, 2026
+//
+// Author: PartCAD (support@partcad.org)
+//
+// Licensed under Apache License, Version 2.0.
+//
+// The first start: the package the IDE creates for a new user and the workspace
+// it opens, which happens once, in an order that survives the window being
+// reopened on the new folder. All of it is invisible until an IDE is built,
+// installed and started -- `.github/workflows/build-ide-standalone.yml` does
+// exactly that, in about an hour -- so it is worth having the parts that are
+// only JavaScript checked in a second.
+//
+// Run with:  node --test ide/standalone/bootstrap/test
+//
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test, beforeEach, afterEach } = require('node:test');
+
+const { makeVscode, makeContext, loadExtension } = require('./vscode-stub');
+
+// The fake `pc` below is a shell script.
+const posix = { skip: process.platform === 'win32' ? 'POSIX only' : false };
+
+const STARTER = path.join('.partcad', 'projects', 'start');
+
+let home;
+let application;
+let previousHome;
+
+/** A home directory, and an application directory with tools beside it. */
+beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'partcad-ide-home-'));
+    application = fs.mkdtempSync(path.join(os.tmpdir(), 'partcad-ide-app-'));
+    previousHome = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+});
+
+afterEach(() => {
+    for (const [name, value] of Object.entries(previousHome)) {
+        if (value === undefined) {
+            delete process.env[name];
+        } else {
+            process.env[name] = value;
+        }
+    }
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(application, { recursive: true, force: true });
+});
+
+/**
+ * The command line tools, as the extension looks for them: `<resources>/app` is
+ * `appRoot`, and they sit in `<resources>/partcad-cli`.
+ *
+ * The `pc` written here records how it was run and writes the file `pc init`
+ * writes, so that a test can tell "it ran the tools" from "it found a package
+ * that was already there".
+ */
+function bundleTools({ writesPackage = true } = {}) {
+    const tools = path.join(application, 'resources', 'partcad-cli');
+    fs.mkdirSync(tools, { recursive: true });
+    fs.writeFileSync(path.join(tools, 'partcad-json-rpc'), '#!/bin/sh\n', { mode: 0o755 });
+    fs.writeFileSync(
+        path.join(tools, 'pc'),
+        '#!/bin/sh\n' +
+            `echo "$@" >> "${path.join(application, 'pc-was-run')}"\n` +
+            'pwd >> ' + `"${path.join(application, 'pc-was-run')}"\n` +
+            (writesPackage ? 'printf "dependencies:\\n" > partcad.yaml\n' : '') +
+            'exit 0\n',
+        { mode: 0o755 },
+    );
+    return path.join(application, 'resources', 'app');
+}
+
+function howPcWasRun() {
+    const record = path.join(application, 'pc-was-run');
+    return fs.existsSync(record) ? fs.readFileSync(record, 'utf-8').trim().split('\n') : [];
+}
+
+function commandsRun(vscode) {
+    return vscode.calls.filter((call) => call[0] === 'command').map((call) => call.slice(1));
+}
+
+function openedFolders(vscode) {
+    return commandsRun(vscode)
+        .filter((call) => call[0] === 'vscode.openFolder')
+        .map((call) => call[1].fsPath);
+}
+
+test('the first start creates a package and opens it as the workspace', posix, async () => {
+    const appRoot = bundleTools();
+    const vscode = makeVscode({ appRoot });
+    const context = makeContext();
+
+    await loadExtension(vscode).activate(context);
+
+    const [arguments_, workingDirectory] = howPcWasRun();
+    assert.match(arguments_, /^--no-ansi init --desc /, 'it runs `pc init`, with the logging a script wants');
+    assert.strictEqual(fs.realpathSync(workingDirectory), fs.realpathSync(path.join(home, STARTER)));
+    assert.deepStrictEqual(openedFolders(vscode), [path.join(home, STARTER)]);
+
+    // Not yet: the walkthrough is an editor, and `vscode.openFolder` takes the
+    // window it would be opened in with it.
+    assert.deepStrictEqual(
+        commandsRun(vscode).filter((call) => call[0] === 'workbench.action.openWalkthrough'),
+        [],
+    );
+    assert.strictEqual(context.globalState.get('partcadIde.welcome.pending'), true);
+});
+
+test('the welcome window opens in the window that the folder was opened in', posix, async () => {
+    const appRoot = bundleTools();
+    const context = makeContext();
+
+    const first = makeVscode({ appRoot });
+    await loadExtension(first).activate(context);
+
+    // What the editor does next: the same extension, activated again, in the
+    // window that now has the starter package open.
+    const second = makeVscode({ appRoot, workspaceFolders: [path.join(home, STARTER)] });
+    await loadExtension(second).activate(context);
+
+    assert.deepStrictEqual(
+        commandsRun(second).filter((call) => call[0] === 'workbench.action.openWalkthrough'),
+        [['workbench.action.openWalkthrough', 'PartCAD.partcad-ide-bootstrap#partcadStart', false]],
+    );
+    assert.deepStrictEqual(openedFolders(second), [], 'the first start does not happen twice');
+    assert.strictEqual(context.globalState.get('partcadIde.welcome.pending'), false);
+
+    // And a start after that is an ordinary one.
+    const third = makeVscode({ appRoot, workspaceFolders: [path.join(home, STARTER)] });
+    await loadExtension(third).activate(context);
+    assert.deepStrictEqual(commandsRun(third), [['workbench.view.extension.partcad-container']]);
+});
+
+test('an IDE started on a folder of the user\'s own is left alone', posix, async () => {
+    const appRoot = bundleTools();
+    const project = path.join(home, 'projects', 'something-of-my-own');
+    fs.mkdirSync(project, { recursive: true });
+
+    const vscode = makeVscode({ appRoot, workspaceFolders: [project] });
+    const context = makeContext();
+    await loadExtension(vscode).activate(context);
+
+    assert.deepStrictEqual(howPcWasRun(), [], 'nothing was created');
+    assert.deepStrictEqual(openedFolders(vscode), [], 'and nothing was opened over their workspace');
+
+    // And it does not happen to the next empty window either: the first start
+    // has been had.
+    const later = makeVscode({ appRoot });
+    await loadExtension(later).activate(context);
+    assert.deepStrictEqual(openedFolders(later), []);
+});
+
+test('a package that is already there is opened rather than created again', posix, async () => {
+    const appRoot = bundleTools();
+    const starter = path.join(home, STARTER);
+    fs.mkdirSync(starter, { recursive: true });
+    fs.writeFileSync(path.join(starter, 'partcad.yaml'), 'dependencies:\n');
+
+    const vscode = makeVscode({ appRoot });
+    await loadExtension(vscode).activate(makeContext());
+
+    assert.deepStrictEqual(howPcWasRun(), [], '`pc init` would have refused, and said so to nobody');
+    assert.deepStrictEqual(openedFolders(vscode), [starter]);
+});
+
+test('an IDE without the command line tools shows the welcome window and nothing else', posix, async () => {
+    // A developer build, or this extension in an editor of the user's own:
+    // there is no `pc` to run, so there is no package to open.
+    const vscode = makeVscode({ appRoot: path.join(application, 'resources', 'app') });
+    const context = makeContext();
+    await loadExtension(vscode).activate(context);
+
+    assert.deepStrictEqual(openedFolders(vscode), []);
+    assert.ok(!fs.existsSync(path.join(home, '.partcad')), 'it did not leave an empty directory behind');
+    assert.deepStrictEqual(
+        commandsRun(vscode).filter((call) => call[0] === 'workbench.action.openWalkthrough'),
+        [['workbench.action.openWalkthrough', 'PartCAD.partcad-ide-bootstrap#partcadStart', false]],
+    );
+});
+
+test('a `pc init` that wrote nothing is not reported as a workspace', posix, async () => {
+    // `pc init` reports a refusal by logging it and exiting 0, so the file it
+    // was supposed to write is what says whether it worked.
+    const appRoot = bundleTools({ writesPackage: false });
+    const vscode = makeVscode({ appRoot });
+    await loadExtension(vscode).activate(makeContext());
+
+    assert.strictEqual(howPcWasRun().length, 2, 'it tried');
+    assert.deepStrictEqual(openedFolders(vscode), [], 'and opened nothing');
+    assert.ok(!fs.existsSync(path.join(home, STARTER)), 'and left no empty directory behind');
+});
+
+test('the starter package can be turned off', posix, async () => {
+    const appRoot = bundleTools();
+    const vscode = makeVscode({ appRoot });
+    vscode.settings.set('partcadIde.createStarterPackage', false);
+
+    await loadExtension(vscode).activate(makeContext());
+
+    assert.deepStrictEqual(howPcWasRun(), []);
+    assert.deepStrictEqual(openedFolders(vscode), []);
+});
+
+test('the command opens the package, and shows its configuration when it is open already', posix, async () => {
+    const appRoot = bundleTools();
+    const starter = path.join(home, STARTER);
+
+    const vscode = makeVscode({ appRoot });
+    const context = makeContext();
+    const extension = loadExtension(vscode);
+    await extension.activate(context);
+    vscode.calls.length = 0;
+
+    // In a window that has something else open, it opens the folder...
+    const elsewhere = makeVscode({ appRoot, workspaceFolders: [path.join(home, 'elsewhere')] });
+    const elsewhereContext = makeContext();
+    await loadExtension(elsewhere).activate(elsewhereContext);
+    elsewhere.calls.length = 0;
+    await elsewhere.commands.registered.get('partcadIde.openStarterPackage')();
+    assert.deepStrictEqual(openedFolders(elsewhere), [starter]);
+
+    // ...and in the one that has the starter package open, it shows the file,
+    // rather than reloading the window onto the folder it is already on.
+    const opened = makeVscode({ appRoot, workspaceFolders: [starter] });
+    await loadExtension(opened).activate(makeContext());
+    opened.calls.length = 0;
+    await opened.commands.registered.get('partcadIde.openStarterPackage')();
+    assert.deepStrictEqual(openedFolders(opened), []);
+    assert.deepStrictEqual(
+        opened.calls.filter((call) => call[0] === 'showTextDocument'),
+        [['showTextDocument', path.join(starter, 'partcad.yaml')]],
+    );
+});

--- a/ide/standalone/bootstrap/test/extension.test.js
+++ b/ide/standalone/bootstrap/test/extension.test.js
@@ -238,3 +238,109 @@ test('the command opens the package, and shows its configuration when it is open
         [['showTextDocument', path.join(starter, 'partcad.yaml')]],
     );
 });
+
+// ---------------------------------------------------------------------------
+// The examples the welcome window offers. They are packages copied into the
+// extension when the IDE is built (`tools/copy_examples.py`), and copied again
+// -- with whatever they reference -- into the user's own package when one is
+// chosen.
+// ---------------------------------------------------------------------------
+
+/** An extension directory carrying two examples, one of which needs the other. */
+function bundleExamples({ withPackages = true } = {}) {
+    const extension = fs.mkdtempSync(path.join(os.tmpdir(), 'partcad-ide-ext-'));
+    fs.writeFileSync(
+        path.join(extension, 'examples.json'),
+        JSON.stringify({
+            examples: [
+                { package: 'a_part', label: 'A part', detail: 'one script', open: 'cube.py' },
+                {
+                    package: 'an_assembly',
+                    label: 'An assembly',
+                    detail: 'parts from another package',
+                    open: 'it.assy',
+                    requires: ['a_part'],
+                    documentation: 'https://partcad.readthedocs.io/en/latest/assy.html',
+                },
+            ],
+        }),
+    );
+    if (withPackages) {
+        for (const [name, file] of [
+            ['a_part', 'cube.py'],
+            ['an_assembly', 'it.assy'],
+        ]) {
+            const directory = path.join(extension, 'examples', name);
+            fs.mkdirSync(directory, { recursive: true });
+            fs.writeFileSync(path.join(directory, 'partcad.yaml'), 'parts:\n');
+            fs.writeFileSync(path.join(directory, file), '# from the IDE\n');
+        }
+    }
+    return extension;
+}
+
+test('an example is copied into the starter package, with what it needs', posix, async () => {
+    const appRoot = bundleTools();
+    const extension = bundleExamples();
+    const vscode = makeVscode({ appRoot, workspaceFolders: [path.join(home, STARTER)] });
+    vscode.window.picked = 'An assembly';
+    vscode.window.pressed = 'Documentation';
+
+    const context = makeContext(extension);
+    await loadExtension(vscode).activate(context);
+    await vscode.commands.registered.get('partcadIde.openExample')();
+
+    const starter = path.join(home, STARTER);
+    assert.ok(fs.existsSync(path.join(starter, 'an_assembly', 'it.assy')));
+    assert.ok(fs.existsSync(path.join(starter, 'a_part', 'partcad.yaml')), 'the package its parts come from too');
+
+    assert.deepStrictEqual(
+        vscode.calls.filter((call) => call[0] === 'showTextDocument'),
+        [['showTextDocument', path.join(starter, 'an_assembly', 'it.assy')]],
+    );
+    // The Explorer read the package when the workspace was opened, so a
+    // subdirectory that appeared afterwards is one it has not seen.
+    assert.ok(commandsRun(vscode).some((call) => call[0] === 'partcad.refresh'));
+    assert.deepStrictEqual(
+        vscode.calls.filter((call) => call[0] === 'openExternal'),
+        [['openExternal', 'https://partcad.readthedocs.io/en/latest/assy.html']],
+    );
+
+    fs.rmSync(extension, { recursive: true, force: true });
+});
+
+test('a copy the user has already edited is left alone', posix, async () => {
+    const appRoot = bundleTools();
+    const extension = bundleExamples();
+    const starter = path.join(home, STARTER);
+    fs.mkdirSync(path.join(starter, 'a_part'), { recursive: true });
+    fs.writeFileSync(path.join(starter, 'a_part', 'partcad.yaml'), '# mine now\n');
+    fs.writeFileSync(path.join(starter, 'a_part', 'cube.py'), '# mine now\n');
+
+    const vscode = makeVscode({ appRoot, workspaceFolders: [starter] });
+    vscode.window.picked = 'A part';
+    await loadExtension(vscode).activate(makeContext(extension));
+    await vscode.commands.registered.get('partcadIde.openExample')();
+
+    assert.strictEqual(fs.readFileSync(path.join(starter, 'a_part', 'cube.py'), 'utf-8'), '# mine now\n');
+
+    fs.rmSync(extension, { recursive: true, force: true });
+});
+
+test('an IDE built without the examples says so rather than offering them', posix, async () => {
+    const appRoot = bundleTools();
+    const extension = bundleExamples({ withPackages: false });
+    const vscode = makeVscode({ appRoot, workspaceFolders: [path.join(home, STARTER)] });
+
+    await loadExtension(vscode).activate(makeContext(extension));
+    await vscode.commands.registered.get('partcadIde.openExample')();
+
+    assert.deepStrictEqual(
+        vscode.calls.filter((call) => call[0] === 'quickPick'),
+        [],
+        'nothing was offered',
+    );
+    assert.match(vscode.calls.find((call) => call[0] === 'error')[1], /built without the example packages/);
+
+    fs.rmSync(extension, { recursive: true, force: true });
+});

--- a/ide/standalone/bootstrap/test/vscode-stub.js
+++ b/ide/standalone/bootstrap/test/vscode-stub.js
@@ -1,0 +1,114 @@
+//
+// PartCAD, 2026
+//
+// Author: PartCAD (support@partcad.org)
+//
+// Licensed under Apache License, Version 2.0.
+//
+// As much of the `vscode` module as `../extension.js` touches, and the
+// extension host state it is handed. Node resolves `require('vscode')` to
+// nothing -- the real one is injected by the editor at run time -- so the tests
+// beside this file intercept the load and hand back `makeVscode()`.
+//
+
+const Module = require('node:module');
+const path = require('node:path');
+
+// What the editor reports as registered by default: the PartCAD extension's
+// view container is there, because in this IDE it always is.
+const REGISTERED_COMMANDS = ['workbench.view.extension.partcad-container'];
+
+/** A `vscode` module, plus a record of everything the extension did to it. */
+function makeVscode({ appRoot, workspaceFolders = [], commands = REGISTERED_COMMANDS } = {}) {
+    const calls = [];
+    const settings = new Map();
+
+    const uri = (fsPath) => ({ scheme: 'file', fsPath, toString: () => `file://${fsPath}` });
+
+    const api = {
+        // What the extension did, in order, for a test to assert on.
+        calls,
+        settings,
+        version: '1.82.0',
+
+        env: { appRoot },
+
+        Uri: { file: uri },
+
+        ConfigurationTarget: { Global: 1, Workspace: 2, WorkspaceFolder: 3 },
+        ProgressLocation: { Notification: 15, Window: 10 },
+
+        workspace: {
+            // Undefined rather than empty when there is none: that is what the
+            // editor hands an empty window, and what the extension tests for.
+            workspaceFolders: workspaceFolders.length
+                ? workspaceFolders.map((folder) => ({ uri: uri(folder) }))
+                : undefined,
+            workspaceFile: undefined,
+            getConfiguration: (section) => ({
+                get: (key, fallback) => (settings.has(`${section}.${key}`) ? settings.get(`${section}.${key}`) : fallback),
+                inspect: (key) => ({ globalValue: settings.get(`${section}.${key}`) }),
+                update: async (key, value) => settings.set(`${section}.${key}`, value),
+            }),
+            openTextDocument: async (fsPath) => {
+                calls.push(['openTextDocument', fsPath]);
+                return { fsPath };
+            },
+        },
+
+        window: {
+            createOutputChannel: () => ({ appendLine: (line) => calls.push(['log', line]) }),
+            showErrorMessage: (message) => calls.push(['error', message]),
+            showTextDocument: (document) => calls.push(['showTextDocument', document.fsPath]),
+            withProgress: (options, task) => task(),
+        },
+
+        commands: {
+            registered: new Map(),
+            getCommands: async () => commands,
+            registerCommand: (command, handler) => {
+                api.commands.registered.set(command, handler);
+                return { dispose() {} };
+            },
+            executeCommand: async (command, ...args) => {
+                calls.push(['command', command, ...args]);
+            },
+        },
+    };
+
+    return api;
+}
+
+/** The `ExtensionContext` the editor passes to `activate`. */
+function makeContext() {
+    const state = new Map();
+    return {
+        subscriptions: [],
+        environmentVariableCollection: { prepend: () => {}, description: undefined },
+        globalState: {
+            get: (key) => state.get(key),
+            update: async (key, value) => state.set(key, value),
+            keys: () => [...state.keys()],
+        },
+    };
+}
+
+/**
+ * Load `../extension.js` against `vscode`, freshly, so that the module state it
+ * keeps (the output channel) does not leak from one test into the next.
+ */
+function loadExtension(vscode) {
+    const load = Module._load;
+    Module._load = function (request, ...rest) {
+        return request === 'vscode' ? vscode : load.call(this, request, ...rest);
+    };
+    try {
+        const entry = path.join(__dirname, '..', 'extension.js');
+        delete require.cache[require.resolve(entry)];
+        return require(entry);
+    } finally {
+        Module._load = load;
+    }
+}
+
+module.exports = { makeVscode, makeContext, loadExtension };

--- a/ide/standalone/bootstrap/test/vscode-stub.js
+++ b/ide/standalone/bootstrap/test/vscode-stub.js
@@ -14,9 +14,9 @@
 const Module = require('node:module');
 const path = require('node:path');
 
-// What the editor reports as registered by default: the PartCAD extension's
-// view container is there, because in this IDE it always is.
-const REGISTERED_COMMANDS = ['workbench.view.extension.partcad-container'];
+// What the editor reports as registered by default: the commands the PartCAD
+// extension contributes, because in this IDE it is always installed.
+const REGISTERED_COMMANDS = ['workbench.view.extension.partcad-container', 'partcad.refresh'];
 
 /** A `vscode` module, plus a record of everything the extension did to it. */
 function makeVscode({ appRoot, workspaceFolders = [], commands = REGISTERED_COMMANDS } = {}) {
@@ -31,9 +31,12 @@ function makeVscode({ appRoot, workspaceFolders = [], commands = REGISTERED_COMM
         settings,
         version: '1.82.0',
 
-        env: { appRoot },
+        env: {
+            appRoot,
+            openExternal: async (target) => calls.push(['openExternal', target.toString()]),
+        },
 
-        Uri: { file: uri },
+        Uri: { file: uri, parse: (value) => ({ scheme: 'https', toString: () => value }) },
 
         ConfigurationTarget: { Global: 1, Workspace: 2, WorkspaceFolder: 3 },
         ProgressLocation: { Notification: 15, Window: 10 },
@@ -59,6 +62,18 @@ function makeVscode({ appRoot, workspaceFolders = [], commands = REGISTERED_COMM
         window: {
             createOutputChannel: () => ({ appendLine: (line) => calls.push(['log', line]) }),
             showErrorMessage: (message) => calls.push(['error', message]),
+            // What the test said the user would press, or nothing.
+            showInformationMessage: async (message, ...items) => {
+                calls.push(['information', message, ...items]);
+                return items.find((item) => item === api.window.pressed);
+            },
+            // The item a test wants chosen from the next quick pick.
+            showQuickPick: async (items) => {
+                calls.push(['quickPick', items.map((item) => item.label)]);
+                return items.find((item) => item.label === api.window.picked);
+            },
+            picked: undefined,
+            pressed: undefined,
             showTextDocument: (document) => calls.push(['showTextDocument', document.fsPath]),
             withProgress: (options, task) => task(),
         },
@@ -80,9 +95,10 @@ function makeVscode({ appRoot, workspaceFolders = [], commands = REGISTERED_COMM
 }
 
 /** The `ExtensionContext` the editor passes to `activate`. */
-function makeContext() {
+function makeContext(extensionPath) {
     const state = new Map();
     return {
+        extensionPath,
         subscriptions: [],
         environmentVariableCollection: { prepend: () => {}, description: undefined },
         globalState: {

--- a/ide/standalone/build.sh
+++ b/ide/standalone/build.sh
@@ -404,6 +404,16 @@ build_bootstrap_vsix() {
   rm -rf "${staging}"
   cp -R "${SCRIPT_DIR}/bootstrap" "${staging}"
   cp "${REPO_ROOT}/LICENSE.txt" "${staging}/LICENSE.txt"
+  # The examples the welcome window offers, taken from `examples/` in this
+  # repository rather than kept as a second copy of them: those are rendered and
+  # compared byte for byte by CI, so what the IDE hands a user is what the
+  # project publishes. Which ones, and what each brings with it, is
+  # `bootstrap/examples.json`; a manifest that does not match what is in
+  # `examples/` fails here rather than in a user's Explorer.
+  "${PYTHON}" "${SCRIPT_DIR}/tools/copy_examples.py" \
+    --repo-root "${REPO_ROOT}" \
+    --manifest "${staging}/examples.json" \
+    --output "${staging}/examples"
   # The bootstrap extension has no version of its own: it is part of the IDE,
   # and saying so makes an installed IDE self-describing in the Extensions view.
   "${PYTHON}" -c "

--- a/ide/standalone/product.overlay.json
+++ b/ide/standalone/product.overlay.json
@@ -54,10 +54,14 @@
   "configurationDefaults": {
     "update.mode": "none",
     "telemetry.telemetryLevel": "off",
-    // The PartCAD workbench is what this IDE opens into (see
-    // `bootstrap/extension.js`), so an editor tab covering it on every start is
-    // in the way.
-    "workbench.startupEditor": "none",
+    // The welcome window, when there is no folder open to show instead. It is
+    // PartCAD's own: `bootstrap/` contributes the walkthrough on it, and opens
+    // it on the first start (see "The first start" in README.md). "none" was
+    // right while the welcome page was the editor's generic one -- an editor
+    // tab covering the PartCAD workbench for no reason -- and
+    // "welcomePageInEmptyWorkbench" rather than "welcomePage" for the same
+    // reason: with a package open, the workbench is what the user came for.
+    "workbench.startupEditor": "welcomePageInEmptyWorkbench",
     // The backend that needs no Python environment on the user's machine. The
     // IDE ships the executable it runs, and the bootstrap extension points the
     // setting below at it.

--- a/ide/standalone/tests/test_bootstrap.py
+++ b/ide/standalone/tests/test_bootstrap.py
@@ -1,0 +1,128 @@
+#
+# PartCAD, 2026
+#
+# Author: PartCAD (support@partcad.org)
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""
+The bootstrap extension: the welcome window, and the package the IDE starts in.
+
+Everything here is a link between two files that nothing else keeps together --
+a walkthrough addressed by a string in JavaScript, a button that runs a command
+another extension contributes, a starter package whose path the installer tests
+and the documentation both spell out. Each of them breaks into an IDE that
+starts and looks right, with a welcome window whose buttons do nothing.
+"""
+
+import json
+import re
+
+import pytest
+from conftest import COMPONENT_ROOT, REPO_ROOT
+
+BOOTSTRAP = COMPONENT_ROOT / "bootstrap"
+EXTENSION_JS = (BOOTSTRAP / "extension.js").read_text(encoding="utf-8")
+
+# The commands a walkthrough may use without any extension contributing them:
+# the editor's own. Prefixes rather than a list -- what this is really checking
+# is that a `partcad.*` command in a button is one that exists.
+BUILT_IN_COMMAND_PREFIXES = ("workbench.", "vscode.", "editor.")
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    return json.loads((BOOTSTRAP / "package.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def walkthrough(manifest):
+    (only,) = manifest["contributes"]["walkthroughs"]
+    return only
+
+
+def javascript_constant(name):
+    """The string a `const NAME = '...'` in extension.js is set to."""
+    match = re.search(rf"^const {name} = '([^']*)';$", EXTENSION_JS, re.MULTILINE)
+    assert match, f"extension.js no longer declares {name}"
+    return match.group(1)
+
+
+def command_links(text):
+    return re.findall(r"\(command:([^)]+)\)", text)
+
+
+def test_the_walkthrough_is_the_one_the_extension_opens(manifest, walkthrough):
+    # `workbench.action.openWalkthrough` takes the id the editor gives a
+    # walkthrough, which is assembled from three fields in three places. An id
+    # that is not registered opens an empty editor and reports nothing.
+    identifier = f"{manifest['publisher']}.{manifest['name']}#{walkthrough['id']}"
+    assert javascript_constant("WALKTHROUGH") == identifier
+
+
+def test_every_step_has_the_media_it_names(walkthrough):
+    for step in walkthrough["steps"]:
+        (kind, value), *rest = step["media"].items()
+        assert not rest, f"step {step['id']} declares more than one kind of media"
+        assert kind in ("markdown", "image", "svg"), f"step {step['id']} has media the editor does not render"
+        assert (BOOTSTRAP / value).is_file(), f"step {step['id']} points at {value}, which is not there"
+
+
+def test_every_button_runs_a_command_that_exists(manifest, walkthrough):
+    ours = {command["command"] for command in manifest["contributes"]["commands"]}
+    extension = json.loads((REPO_ROOT / "ide" / "vscode" / "package.json").read_text(encoding="utf-8"))
+    theirs = {command["command"] for command in extension["contributes"]["commands"]}
+
+    for step in walkthrough["steps"]:
+        for command in command_links(step["description"]):
+            if command.startswith(BUILT_IN_COMMAND_PREFIXES):
+                continue
+            assert command in ours or command in theirs, f"step {step['id']} runs {command}, which nothing contributes"
+
+
+def test_every_completion_event_names_something_that_happens(manifest, walkthrough):
+    ours = {command["command"] for command in manifest["contributes"]["commands"]}
+    extension = json.loads((REPO_ROOT / "ide" / "vscode" / "package.json").read_text(encoding="utf-8"))
+    theirs = {command["command"] for command in extension["contributes"]["commands"]}
+
+    for step in walkthrough["steps"]:
+        for event in step.get("completionEvents", []):
+            if not event.startswith("onCommand:"):
+                continue
+            command = event[len("onCommand:") :]
+            if command.startswith(BUILT_IN_COMMAND_PREFIXES):
+                continue
+            # A step that waits for a command nobody can run never completes.
+            assert command in ours or command in theirs, f"step {step['id']} waits for {command}, which does not exist"
+
+
+def test_the_extension_registers_the_commands_it_contributes(manifest):
+    contributed = {command["command"] for command in manifest["contributes"]["commands"]}
+    registered = set(re.findall(r"registerCommand\('([^']+)'", EXTENSION_JS))
+    # One without the other is either a palette entry that fails when it is
+    # chosen, or a command that only the code knows about.
+    assert contributed == registered
+
+
+def test_the_settings_the_extension_reads_are_declared(manifest):
+    declared = set(manifest["contributes"]["configuration"]["properties"])
+    read = {f"partcadIde.{name}" for name in re.findall(r"configuration\.get\('([^']+)'", EXTENSION_JS)}
+    assert read <= declared, "extension.js reads a setting that is in no settings UI and has no default"
+
+
+def test_the_starter_package_is_where_everything_else_expects_it():
+    # The path is spelled out in four places that cannot import each other: the
+    # extension, the settings description, the documentation, and the workflow
+    # that starts an installed IDE and waits for the package to appear. The
+    # workflow is the one that matters -- moving the package without it silently
+    # stops testing anything.
+    path = re.search(r"const STARTER_PACKAGE_PATH = \[([^\]]+)\];", EXTENSION_JS)
+    assert path, "extension.js no longer declares STARTER_PACKAGE_PATH"
+    directory = "/".join(re.findall(r"'([^']+)'", path.group(1)))
+    assert directory == ".partcad/projects/start"
+
+    workflow = (REPO_ROOT / ".github" / "workflows" / "build-ide-standalone.yml").read_text(encoding="utf-8")
+    assert directory in workflow, "the install jobs no longer check the directory the IDE creates"
+    documentation = (REPO_ROOT / "docs" / "source" / "installation.rst").read_text(encoding="utf-8")
+    assert directory in documentation, "the documentation no longer tells the user where the package is"

--- a/ide/standalone/tests/test_bootstrap.py
+++ b/ide/standalone/tests/test_bootstrap.py
@@ -25,6 +25,10 @@ from conftest import COMPONENT_ROOT, REPO_ROOT
 BOOTSTRAP = COMPONENT_ROOT / "bootstrap"
 EXTENSION_JS = (BOOTSTRAP / "extension.js").read_text(encoding="utf-8")
 
+# The documentation the welcome window sends people to. Every page it names is a
+# page in `docs/source`, which is what this repository publishes there.
+DOCUMENTATION = re.compile(r"https://partcad\.readthedocs\.io/en/latest/([a-z_]+)\.html")
+
 # The commands a walkthrough may use without any extension contributing them:
 # the editor's own. Prefixes rather than a list -- what this is really checking
 # is that a `partcad.*` command in a button is one that exists.
@@ -40,6 +44,11 @@ def manifest():
 def walkthrough(manifest):
     (only,) = manifest["contributes"]["walkthroughs"]
     return only
+
+
+@pytest.fixture(scope="module")
+def examples():
+    return json.loads((BOOTSTRAP / "examples.json").read_text(encoding="utf-8"))["examples"]
 
 
 def javascript_constant(name):
@@ -126,3 +135,46 @@ def test_the_starter_package_is_where_everything_else_expects_it():
     assert directory in workflow, "the install jobs no longer check the directory the IDE creates"
     documentation = (REPO_ROOT / "docs" / "source" / "installation.rst").read_text(encoding="utf-8")
     assert directory in documentation, "the documentation no longer tells the user where the package is"
+
+
+def test_the_welcome_window_offers_the_examples(walkthrough):
+    # The step that hands a new user something that already works.
+    steps = {step["id"]: step for step in walkthrough["steps"]}
+    assert "example" in steps, "the welcome window no longer offers an example to open"
+    assert "partcadIde.openExample" in command_links(steps["example"]["description"])
+
+
+def test_every_step_points_at_the_documentation(walkthrough):
+    # Every step is somebody's first encounter with what it describes, so each
+    # one carries the page that explains it rather than leaving the reader to
+    # find the documentation from the last step.
+    for step in walkthrough["steps"]:
+        assert "partcad.readthedocs.io" in step["description"], f"step {step['id']} links to no documentation"
+
+
+def test_every_example_points_at_the_documentation(examples):
+    for example in examples:
+        assert "partcad.readthedocs.io" in example.get("documentation", ""), f"{example['package']} has no docs link"
+
+
+def test_the_documentation_links_are_pages_that_exist(manifest, examples):
+    # A link to a page that was renamed or never existed is a 404 in front of
+    # somebody who has just installed the IDE. The pages are the sources of
+    # https://partcad.readthedocs.io, in this repository.
+    text = json.dumps(manifest) + json.dumps(examples)
+    for media in sorted((BOOTSTRAP / "media").glob("*.md")):
+        text += media.read_text(encoding="utf-8")
+
+    pages = set(DOCUMENTATION.findall(text))
+    assert pages, "nothing links to the documentation any more"
+    for page in sorted(pages):
+        assert (REPO_ROOT / "docs" / "source" / f"{page}.rst").is_file(), f"there is no {page} page to link to"
+
+
+def test_the_examples_are_the_ones_the_build_ships(examples):
+    # `copy_examples.py` reads the same manifest and copies what it names into
+    # the extension; the extension offers what it finds there. Two readers, one
+    # list, and `test_copy_examples.py` checks it against `examples/`.
+    assert re.search(r"const EXAMPLES_MANIFEST = 'examples\.json';", EXTENSION_JS)
+    assert javascript_constant("EXAMPLES_DIRECTORY") == "examples"
+    assert examples, "the manifest offers nothing"

--- a/ide/standalone/tests/test_copy_examples.py
+++ b/ide/standalone/tests/test_copy_examples.py
@@ -1,0 +1,144 @@
+#
+# PartCAD, 2026
+#
+# Author: PartCAD (support@partcad.org)
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""
+The examples the IDE's welcome window offers, and what has to travel with them.
+"""
+
+import json
+
+import copy_examples
+import pytest
+from conftest import COMPONENT_ROOT, REPO_ROOT
+from copy_examples import ManifestError
+
+MANIFEST = COMPONENT_ROOT / "bootstrap" / "examples.json"
+
+
+def write_manifest(tmp_path, examples):
+    path = tmp_path / "examples.json"
+    path.write_text(json.dumps({"examples": examples}), encoding="utf-8")
+    return path
+
+
+def make_example(root, name, configuration="parts:\n", files=("cube.py",)):
+    directory = root / name
+    directory.mkdir(parents=True)
+    (directory / "partcad.yaml").write_text(configuration, encoding="utf-8")
+    for file in files:
+        (directory / file).write_text("# example\n", encoding="utf-8")
+    return directory
+
+
+def entry(name, **overrides):
+    return {"package": name, "label": name, "detail": "...", "open": "cube.py", **overrides}
+
+
+def test_an_entry_has_to_say_what_it_is(tmp_path):
+    with pytest.raises(ManifestError, match="label"):
+        copy_examples.load_manifest(write_manifest(tmp_path, [{"package": "a", "detail": "...", "open": "a.py"}]))
+
+
+def test_an_unknown_key_is_an_error(tmp_path):
+    # A misspelled `requires` would silently ship an example without its parts.
+    with pytest.raises(ManifestError, match="unknown key"):
+        copy_examples.load_manifest(write_manifest(tmp_path, [entry("a", require=["b"])]))
+
+
+def test_an_example_listed_twice_is_an_error(tmp_path):
+    with pytest.raises(ManifestError, match="listed twice"):
+        copy_examples.load_manifest(write_manifest(tmp_path, [entry("a"), entry("a")]))
+
+
+def test_an_example_that_is_not_in_the_repository_is_an_error(tmp_path):
+    with pytest.raises(ManifestError, match="not a PartCAD package"):
+        copy_examples.validate([entry("gone")], tmp_path)
+
+
+def test_the_file_the_welcome_window_opens_has_to_be_there(tmp_path):
+    make_example(tmp_path, "a", files=())
+    with pytest.raises(ManifestError, match="has no cube.py to open"):
+        copy_examples.validate([entry("a")], tmp_path)
+
+
+def test_a_sibling_an_example_references_has_to_travel_with_it(tmp_path):
+    # The failure this exists to prevent: an assembly copied out of `examples/`
+    # on its own, placing parts from a package that is not beside it any more.
+    make_example(tmp_path, "assembly")
+    (tmp_path / "assembly" / "it.assy").write_text("links:\n  - package: ../parts\n", encoding="utf-8")
+    make_example(tmp_path, "parts")
+
+    with pytest.raises(ManifestError, match="would be copied without parts"):
+        copy_examples.validate([entry("assembly")], tmp_path)
+
+    copy_examples.validate([entry("assembly", requires=["parts"])], tmp_path)
+
+
+def test_what_a_required_package_references_travels_too(tmp_path):
+    # One level is not enough: the package an assembly's parts come from may
+    # itself name a third.
+    make_example(tmp_path, "assembly")
+    (tmp_path / "assembly" / "it.assy").write_text("links:\n  - package: ../parts\n", encoding="utf-8")
+    make_example(tmp_path, "parts", configuration="parts:\n  x:\n    source: ../shapes:y\n")
+    make_example(tmp_path, "shapes")
+
+    with pytest.raises(ManifestError, match="would be copied without shapes"):
+        copy_examples.validate([entry("assembly", requires=["parts"])], tmp_path)
+
+    copy_examples.validate([entry("assembly", requires=["parts", "shapes"])], tmp_path)
+
+
+def test_a_package_that_names_itself_is_self_contained(tmp_path):
+    # `../<its own name>:part` is what an alias or an enrich writes, and it is
+    # still a reference to itself wherever the directory is copied to.
+    make_example(tmp_path, "a", configuration="parts:\n  b:\n    source: ../a:cube\n")
+    copy_examples.validate([entry("a")], tmp_path)
+
+
+def test_a_reference_in_a_source_file_is_not_a_package_reference(tmp_path):
+    # `../` in a script or a README is a path in somebody's code or a link in a
+    # document, and neither says anything about packages.
+    make_example(tmp_path, "a")
+    (tmp_path / "a" / "cube.py").write_text("open('../elsewhere/data.json')\n", encoding="utf-8")
+    (tmp_path / "a" / "README.md").write_text("[up](../index.md)\n", encoding="utf-8")
+    copy_examples.validate([entry("a")], tmp_path)
+
+
+def test_copying_takes_an_example_and_what_it_needs(tmp_path):
+    examples_root = tmp_path / "examples"
+    make_example(examples_root, "assembly")
+    make_example(examples_root, "parts")
+    make_example(examples_root, "unused")
+    output = tmp_path / "out"
+
+    copied = copy_examples.copy([entry("assembly", requires=["parts"])], examples_root, output)
+
+    assert copied == ["assembly", "parts"]
+    assert (output / "parts" / "partcad.yaml").is_file()
+    assert not (output / "unused").exists()
+
+
+def test_copying_replaces_what_was_there(tmp_path):
+    # The build runs into a staging directory it may have used before; an
+    # example that was removed from the manifest must not survive in it.
+    examples_root = tmp_path / "examples"
+    make_example(examples_root, "a")
+    output = tmp_path / "out"
+    (output / "gone").mkdir(parents=True)
+
+    copy_examples.copy([entry("a")], examples_root, output)
+    assert not (output / "gone").exists()
+
+
+def test_the_shipped_manifest_matches_the_repositorys_examples():
+    # The check that catches an example renamed or removed under `examples/`,
+    # and one whose configuration grew a reference to a package the welcome
+    # window would not copy with it. The build runs exactly this.
+    examples = copy_examples.load_manifest(MANIFEST)
+    copy_examples.validate(examples, REPO_ROOT / "examples")
+    assert examples, "the welcome window offers no examples"

--- a/ide/standalone/tests/test_verify_bundle.py
+++ b/ide/standalone/tests/test_verify_bundle.py
@@ -224,3 +224,63 @@ def test_a_wrapper_that_does_not_enable_it_is_a_problem(tmp_path, capsys):
 
     assert run(resources, tmp_path) != 0
     assert "does not enable software WebGL" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# The welcome window. It is a walkthrough contributed by the bootstrap
+# extension: a manifest entry pointing at files packaged beside it, which fails
+# by rendering nothing rather than by failing.
+# ---------------------------------------------------------------------------
+
+
+def add_bootstrap(extensions_dir, steps):
+    directory = extensions_dir / "PartCAD.partcad-ide-bootstrap-1.0.0"
+    directory.mkdir(parents=True)
+    (directory / "package.json").write_text(
+        json.dumps(
+            {
+                "publisher": "PartCAD",
+                "name": "partcad-ide-bootstrap",
+                "version": "1.0.0",
+                "contributes": {
+                    "walkthroughs": [{"id": "partcadStart", "title": "Start with PartCAD", "steps": steps}]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return directory
+
+
+def test_the_welcome_window_is_reported(tmp_path, capsys):
+    resources = make_bundle(tmp_path)
+    directory = add_bootstrap(
+        resources / "app" / "extensions", [{"id": "package", "media": {"markdown": "media/package.md"}}]
+    )
+    (directory / "media").mkdir()
+    (directory / "media" / "package.md").write_text("# hello\n", encoding="utf-8")
+
+    assert run(resources, tmp_path) == 0
+    assert "welcome window: Start with PartCAD (1 steps" in capsys.readouterr().out
+
+
+def test_a_walkthrough_step_whose_media_was_not_packaged_fails(tmp_path, capsys):
+    # What a `.vscodeignore`, or a build that copies the manifest and not the
+    # directory beside it, produces: a welcome window of empty pages.
+    resources = make_bundle(tmp_path)
+    add_bootstrap(resources / "app" / "extensions", [{"id": "package", "media": {"markdown": "media/package.md"}}])
+
+    assert run(resources, tmp_path) == 1
+    assert "step package shows media/package.md, which is not in the extension" in capsys.readouterr().out
+
+
+def test_a_bootstrap_extension_with_no_walkthrough_fails(tmp_path, capsys):
+    resources = make_bundle(tmp_path)
+    add_bootstrap(resources / "app" / "extensions", [])
+    manifest = resources / "app" / "extensions" / "PartCAD.partcad-ide-bootstrap-1.0.0" / "package.json"
+    package = json.loads(manifest.read_text(encoding="utf-8"))
+    package["contributes"] = {}
+    manifest.write_text(json.dumps(package), encoding="utf-8")
+
+    assert run(resources, tmp_path) == 1
+    assert "contributes no walkthrough" in capsys.readouterr().out

--- a/ide/standalone/tests/test_verify_bundle.py
+++ b/ide/standalone/tests/test_verify_bundle.py
@@ -8,6 +8,7 @@
 
 import json
 import os
+import shutil
 import stat
 
 import brand
@@ -233,7 +234,21 @@ def test_a_wrapper_that_does_not_enable_it_is_a_problem(tmp_path, capsys):
 # ---------------------------------------------------------------------------
 
 
-def add_bootstrap(extensions_dir, steps):
+EXAMPLES = [
+    {"package": "a_part", "label": "A part", "detail": "...", "open": "cube.py"},
+    {"package": "an_assembly", "label": "An assembly", "detail": "...", "open": "it.assy", "requires": ["a_part"]},
+]
+
+
+def add_example(directory, name, files):
+    package = directory / "examples" / name
+    package.mkdir(parents=True)
+    (package / "partcad.yaml").write_text("parts:\n", encoding="utf-8")
+    for name in files:
+        (package / name).write_text("# example\n", encoding="utf-8")
+
+
+def add_bootstrap(extensions_dir, steps, examples=EXAMPLES, with_examples=True):
     directory = extensions_dir / "PartCAD.partcad-ide-bootstrap-1.0.0"
     directory.mkdir(parents=True)
     (directory / "package.json").write_text(
@@ -249,6 +264,11 @@ def add_bootstrap(extensions_dir, steps):
         ),
         encoding="utf-8",
     )
+    if examples is not None:
+        (directory / "examples.json").write_text(json.dumps({"examples": examples}), encoding="utf-8")
+    if with_examples:
+        add_example(directory, "a_part", ["cube.py"])
+        add_example(directory, "an_assembly", ["it.assy"])
     return directory
 
 
@@ -284,3 +304,52 @@ def test_a_bootstrap_extension_with_no_walkthrough_fails(tmp_path, capsys):
 
     assert run(resources, tmp_path) == 1
     assert "contributes no walkthrough" in capsys.readouterr().out
+
+
+def test_the_examples_are_reported(tmp_path, capsys):
+    resources = make_bundle(tmp_path)
+    directory = add_bootstrap(
+        resources / "app" / "extensions", [{"id": "package", "media": {"markdown": "media/package.md"}}]
+    )
+    (directory / "media").mkdir()
+    (directory / "media" / "package.md").write_text("# hello\n", encoding="utf-8")
+
+    assert run(resources, tmp_path) == 0
+    assert "welcome window: 2 example package(s) to open" in capsys.readouterr().out
+
+
+def test_an_example_whose_packages_were_not_copied_fails(tmp_path, capsys):
+    # The welcome window would offer it and opening it would find nothing.
+    resources = make_bundle(tmp_path)
+    add_bootstrap(resources / "app" / "extensions", [], with_examples=False)
+
+    assert run(resources, tmp_path) == 1
+    assert "the a_part example is offered, but a_part was not packaged with it" in capsys.readouterr().out
+
+
+def test_an_assembly_example_without_its_parts_fails(tmp_path, capsys):
+    # An example that names other packages is only shipped if they are too:
+    # an assembly whose parts were left behind loads no better than a missing one.
+    resources = make_bundle(tmp_path)
+    directory = add_bootstrap(resources / "app" / "extensions", [])
+    shutil.rmtree(directory / "examples" / "a_part")
+
+    assert run(resources, tmp_path) == 1
+    assert "the an_assembly example is offered, but a_part was not packaged with it" in capsys.readouterr().out
+
+
+def test_an_example_missing_the_file_it_opens_fails(tmp_path, capsys):
+    resources = make_bundle(tmp_path)
+    directory = add_bootstrap(resources / "app" / "extensions", [])
+    (directory / "examples" / "a_part" / "cube.py").unlink()
+
+    assert run(resources, tmp_path) == 1
+    assert "the a_part example has no cube.py to open" in capsys.readouterr().out
+
+
+def test_a_bootstrap_extension_with_no_examples_manifest_fails(tmp_path, capsys):
+    resources = make_bundle(tmp_path)
+    add_bootstrap(resources / "app" / "extensions", [], examples=None)
+
+    assert run(resources, tmp_path) == 1
+    assert "no examples.json" in capsys.readouterr().out

--- a/ide/standalone/tools/copy_examples.py
+++ b/ide/standalone/tools/copy_examples.py
@@ -1,0 +1,165 @@
+#
+# PartCAD, 2026
+#
+# Author: PartCAD (support@partcad.org)
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""
+Put the examples the IDE's welcome window offers inside the bootstrap extension.
+
+They are not a second copy of anything: they are the packages under `examples/`
+in this repository, which CI renders and compares byte for byte, so what the IDE
+hands a user is what the project publishes. `../bootstrap/examples.json` says
+which of them, what to call each one in the list the user picks from, and which
+file to open.
+
+An example is a package, and a package may reference a sibling of its own --
+`../produce_part_cadquery_primitive`, in an assembly that places parts from it.
+Copied out of `examples/` on its own, that reference points at nothing, and the
+Explorer shows a package that will not load. So the manifest declares what each
+example brings with it, this checks that the declaration is what the files
+actually reference, and the extension copies a whole entry and its `requires`
+together into one directory.
+
+Run by `../build.sh` into the staging copy of the extension; the repository's own
+`bootstrap/` never has an `examples/` directory in it.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import sys
+
+# Where a package names another one relative to itself. Read from the files that
+# hold package references -- the package configuration and the assemblies -- and
+# not from sources or documents, where `../` is a path in somebody's script or a
+# link in a README.
+REFERENCE_FILES = ("partcad.yaml", "*.assy")
+SIBLING_REFERENCE = re.compile(r"\.\./([A-Za-z0-9._-]+)")
+
+PACKAGE_CONFIGURATION = "partcad.yaml"
+
+REQUIRED_KEYS = ("package", "label", "detail", "open")
+OPTIONAL_KEYS = ("requires", "documentation")
+
+
+class ManifestError(Exception):
+    """The manifest and the examples in the repository do not agree."""
+
+
+def load_manifest(path: pathlib.Path) -> list[dict]:
+    """The examples the welcome window offers, in the order it offers them."""
+    document = json.loads(path.read_text(encoding="utf-8"))
+    examples = document.get("examples")
+    if not examples:
+        raise ManifestError(f"{path} lists no examples")
+
+    seen = set()
+    for example in examples:
+        missing = [key for key in REQUIRED_KEYS if not example.get(key)]
+        if missing:
+            raise ManifestError(f"{path}: an entry is missing {', '.join(missing)}")
+        unknown = set(example) - set(REQUIRED_KEYS) - set(OPTIONAL_KEYS)
+        if unknown:
+            raise ManifestError(f"{path}: {example['package']} has unknown key(s): {', '.join(sorted(unknown))}")
+        if example["package"] in seen:
+            raise ManifestError(f"{path}: {example['package']} is listed twice")
+        seen.add(example["package"])
+    return examples
+
+
+def sibling_references(directory: pathlib.Path) -> set[str]:
+    """The packages beside this one that its configuration and assemblies name."""
+    found = set()
+    for pattern in REFERENCE_FILES:
+        for path in sorted(directory.glob(pattern)):
+            found.update(SIBLING_REFERENCE.findall(path.read_text(encoding="utf-8")))
+    # A package that refers to itself by path (`../<its own name>:part`, which
+    # an alias or an enrich does) is asking for a sibling that is itself, and
+    # still is one after the copy.
+    return found - {directory.name}
+
+
+def packages_to_copy(examples: list[dict]) -> dict[str, list[str]]:
+    """Map each example to the packages that go with it, itself first."""
+    return {example["package"]: [example["package"], *example.get("requires", [])] for example in examples}
+
+
+def validate(examples: list[dict], examples_root: pathlib.Path) -> None:
+    """Fail on anything that produces a welcome window offering a broken package."""
+    for example in examples:
+        directory = examples_root / example["package"]
+        if not (directory / PACKAGE_CONFIGURATION).is_file():
+            raise ManifestError(f"{directory} is not a PartCAD package (no {PACKAGE_CONFIGURATION})")
+        if not (directory / example["open"]).is_file():
+            raise ManifestError(f"{example['package']} has no {example['open']} to open")
+
+    for example in examples:
+        directory = examples_root / example["package"]
+        required = list(example.get("requires", []))
+        for name in required:
+            if not (examples_root / name / PACKAGE_CONFIGURATION).is_file():
+                raise ManifestError(f"{example['package']} requires {name}, which is not a package in {examples_root}")
+
+        # Every sibling an example names has to travel with it, and the ones it
+        # brings have to be complete themselves -- an assembly's parts are in a
+        # package that may reference a third.
+        pending = [example["package"], *required]
+        declared = set(required)
+        while pending:
+            name = pending.pop()
+            for reference in sibling_references(examples_root / name):
+                if reference not in declared:
+                    raise ManifestError(
+                        f"{example['package']} would be copied without {reference}, which {name} references: "
+                        f"add it to 'requires' in the manifest"
+                    )
+    return None
+
+
+def copy(examples: list[dict], examples_root: pathlib.Path, output: pathlib.Path) -> list[str]:
+    """Copy every package the manifest needs into `output`. Returns their names."""
+    needed = sorted({name for names in packages_to_copy(examples).values() for name in names})
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+    for name in needed:
+        shutil.copytree(examples_root / name, output / name)
+    return needed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo-root", type=pathlib.Path, required=True, help="the repository holding 'examples/'")
+    parser.add_argument("--manifest", type=pathlib.Path, required=True, help="the extension's examples.json")
+    parser.add_argument("--output", type=pathlib.Path, required=True, help="where to put the copies")
+    parser.add_argument("--check", action="store_true", help="validate the manifest and copy nothing")
+    args = parser.parse_args(argv)
+
+    examples_root = args.repo_root / "examples"
+    try:
+        examples = load_manifest(args.manifest)
+        validate(examples, examples_root)
+    except (ManifestError, OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        print(f"{len(examples)} example(s) in {args.manifest}, all present in {examples_root}")
+        return 0
+
+    copied = copy(examples, examples_root, args.output)
+    for example in examples:
+        extra = [name for name in example.get("requires", [])]
+        with_them = f" (with {', '.join(extra)})" if extra else ""
+        print(f"  example  {example['label']}: {example['package']}{with_them}")
+    print(f"Copied {len(copied)} package(s) into {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ide/standalone/tools/verify_bundle.py
+++ b/ide/standalone/tools/verify_bundle.py
@@ -32,10 +32,13 @@ import jsonc  # noqa: E402  (the path has to be set up first)
 
 SERVICE_EXECUTABLES = ("partcad-json-rpc", "partcad-json-rpc.exe")
 
+# The extension that carries the welcome window (`../bootstrap`).
+BOOTSTRAP_EXTENSION = "partcad.partcad-ide-bootstrap"
 
-def installed_extensions(extensions_dir: pathlib.Path) -> dict[str, dict]:
-    """Map `publisher.name` (lowercased) to its manifest, for every extension found."""
-    found: dict[str, dict] = {}
+
+def installed_extension_entries(extensions_dir: pathlib.Path) -> dict[str, tuple[pathlib.Path, dict]]:
+    """Map `publisher.name` (lowercased) to (directory, manifest), for every extension found."""
+    found: dict[str, tuple[pathlib.Path, dict]] = {}
     if not extensions_dir.is_dir():
         return found
     for entry in sorted(extensions_dir.iterdir()):
@@ -49,8 +52,63 @@ def installed_extensions(extensions_dir: pathlib.Path) -> dict[str, dict]:
         publisher = package.get("publisher")
         name = package.get("name")
         if publisher and name:
-            found[f"{publisher}.{name}".lower()] = package
+            found[f"{publisher}.{name}".lower()] = (entry, package)
     return found
+
+
+def installed_extensions(extensions_dir: pathlib.Path) -> dict[str, dict]:
+    """Map `publisher.name` (lowercased) to its manifest, for every extension found."""
+    return {identifier: package for identifier, (_, package) in installed_extension_entries(extensions_dir).items()}
+
+
+def media_files(step: dict) -> list[str]:
+    """The files a walkthrough step's media points at.
+
+    `image` may be one path or one per theme, `svg` and `markdown` are a path,
+    and `altText` is text rather than a file.
+    """
+    files = []
+    for kind, value in (step.get("media") or {}).items():
+        if kind == "altText":
+            continue
+        if isinstance(value, dict):
+            files.extend(str(path) for path in value.values())
+        else:
+            files.append(str(value))
+    return files
+
+
+def check_welcome(extensions_dir: pathlib.Path, problems: list[str], notes: list[str]) -> None:
+    """The welcome window: the walkthrough the IDE opens the first time it starts.
+
+    A walkthrough is data in a manifest pointing at files beside it, so it fails
+    the way data fails -- the editor renders an empty step and says nothing. The
+    check is that the extension carrying it shipped both halves: a packaging
+    rule that took the manifest and left the media behind produces an IDE whose
+    welcome window is a list of empty pages.
+    """
+    entry = installed_extension_entries(extensions_dir).get(BOOTSTRAP_EXTENSION)
+    if entry is None:
+        # Absent altogether is reported against the plan, with the reason.
+        return
+    directory, manifest = entry
+
+    walkthroughs = manifest.get("contributes", {}).get("walkthroughs", [])
+    if not walkthroughs:
+        problems.append(f"{BOOTSTRAP_EXTENSION} contributes no walkthrough; the IDE has no welcome window")
+        return
+
+    for walkthrough in walkthroughs:
+        for step in walkthrough.get("steps", []):
+            for name in media_files(step):
+                if not (directory / name).is_file():
+                    problems.append(
+                        f"welcome window: step {step.get('id')} shows {name}, which is not in the extension"
+                    )
+        notes.append(
+            f"welcome window: {walkthrough.get('title')} ({len(walkthrough.get('steps', []))} steps, "
+            f"from {BOOTSTRAP_EXTENSION})"
+        )
 
 
 def activity_bar_containers(extensions: dict[str, dict]) -> list[tuple[str, str, str]]:
@@ -188,6 +246,8 @@ def main(argv: list[str] | None = None) -> int:
     for entry in plan["skip"]:
         if entry["id"].lower() in present:
             problems.append(f"extension {entry['id']} was installed although the policy skips it: {entry['reason']}")
+
+    check_welcome(extensions_dir, problems, notes)
 
     if args.expect_tools:
         tools = args.resources / "partcad-cli"

--- a/ide/standalone/tools/verify_bundle.py
+++ b/ide/standalone/tools/verify_bundle.py
@@ -32,8 +32,12 @@ import jsonc  # noqa: E402  (the path has to be set up first)
 
 SERVICE_EXECUTABLES = ("partcad-json-rpc", "partcad-json-rpc.exe")
 
-# The extension that carries the welcome window (`../bootstrap`).
+# The extension that carries the welcome window (`../bootstrap`), and the
+# examples it offers to open (`copy_examples.py` puts them there).
 BOOTSTRAP_EXTENSION = "partcad.partcad-ide-bootstrap"
+EXAMPLES_MANIFEST = "examples.json"
+EXAMPLES_DIRECTORY = "examples"
+PACKAGE_CONFIGURATION = "partcad.yaml"
 
 
 def installed_extension_entries(extensions_dir: pathlib.Path) -> dict[str, tuple[pathlib.Path, dict]]:
@@ -78,6 +82,42 @@ def media_files(step: dict) -> list[str]:
     return files
 
 
+def check_examples(directory: pathlib.Path, problems: list[str], notes: list[str]) -> None:
+    """The example packages the welcome window offers to open.
+
+    The manifest ships with the extension and the packages are copied in beside
+    it when the IDE is built, so the two part company silently: the welcome
+    window offers four examples and opening one finds nothing. An example that
+    names other packages is checked with them -- an assembly whose parts were
+    left behind loads no better than one that is missing itself.
+    """
+    manifest_path = directory / EXAMPLES_MANIFEST
+    if not manifest_path.is_file():
+        problems.append(f"welcome window: no {EXAMPLES_MANIFEST} in {directory}")
+        return
+    try:
+        examples = json.loads(manifest_path.read_text(encoding="utf-8")).get("examples") or []
+    except (ValueError, UnicodeDecodeError) as error:
+        problems.append(f"welcome window: {manifest_path} is not readable: {error}")
+        return
+    if not examples:
+        problems.append(f"welcome window: {manifest_path} offers no examples")
+        return
+
+    for example in examples:
+        package = example.get("package")
+        for name in [package, *example.get("requires", [])]:
+            if not (directory / EXAMPLES_DIRECTORY / name / PACKAGE_CONFIGURATION).is_file():
+                problems.append(
+                    f"welcome window: the {package} example is offered, but {name} was not packaged with it"
+                )
+        source = directory / EXAMPLES_DIRECTORY / package / example.get("open", "")
+        if not source.is_file():
+            problems.append(f"welcome window: the {package} example has no {example.get('open')} to open")
+
+    notes.append(f"welcome window: {len(examples)} example package(s) to open")
+
+
 def check_welcome(extensions_dir: pathlib.Path, problems: list[str], notes: list[str]) -> None:
     """The welcome window: the walkthrough the IDE opens the first time it starts.
 
@@ -109,6 +149,8 @@ def check_welcome(extensions_dir: pathlib.Path, problems: list[str], notes: list
             f"welcome window: {walkthrough.get('title')} ({len(walkthrough.get('steps', []))} steps, "
             f"from {BOOTSTRAP_EXTENSION})"
         )
+
+    check_examples(directory, problems, notes)
 
 
 def activity_bar_containers(extensions: dict[str, dict]) -> list[tuple[str, str, str]]:


### PR DESCRIPTION
## Copilot Summary

The PartCAD IDE opened on an empty window and a welcome page belonging to the editor it is built from. Somebody who has just installed it has, by assumption, no PartCAD package to open — so the first thing the IDE asked them for was the thing they came here to make.

**On its first start** the bootstrap extension now runs the bundled `pc init` in `~/.partcad/projects/start`, opens that folder as the workspace, and opens a PartCAD walkthrough beside it: the package, an example to start from, adding a part, the 3D view, rendering, `pc` in the terminal, and where the documentation is. It happens once, it never takes over a window that already has something in it, and `partcadIde.createStarterPackage` turns it off. `PartCAD IDE: Open the starter package`, `PartCAD IDE: Open an example` and `PartCAD IDE: Welcome` reach all of it afterwards.

**"Start from an example"** offers four packages that already work — parts in CadQuery, build123d and OpenSCAD, and an assembly — copies the one that is picked into the starter package, and opens the file worth reading first.

**Every step links to the page of partcad.readthedocs.io that explains it**, each media page ends with the relevant pages, and the last step is the documentation itself.

### Decisions worth reviewing

- **The package is created by the editor, not by the installers.** There are three of those (`install.sh`, the Windows setup program, and a `.dmg` dragged to Applications, which is no installer at all), and the folder has to be opened by the editor in any case.
- **It goes under `~/.partcad`, not the IDE's own `~/.partcad-ide`:** it is the user's first design, not editor state, so `pc` in a terminal works with the same package and uninstalling the IDE leaves it alone.
- **The welcome window is opened after `vscode.openFolder`, not before:** that reopens the workbench, and an editor goes with the window it was opened in. The note that one is owed lives in `globalState`, which survives the reload.
- **`workbench.startupEditor` moves from `none` to `welcomePageInEmptyWorkbench`** — with a package open the workbench is what the user came for; with no folder open there is now something of PartCAD's own to show.
- **Workspace trust is left on.** The folder the IDE creates still gets the trust prompt; disabling trust would remove it for every package a user ever downloads, and PartCAD runs the code in those. Instead `bootstrap` declares untrusted-workspace support (it reads nothing from the workspace) so the welcome window is on screen to explain what is asking.
- **The examples are the packages under `examples/`, not a copy of them.** `tools/copy_examples.py` copies the ones `bootstrap/examples.json` names into the extension at build time; those packages are rendered by the `Examples (PartCAD)` job with their output checked in, so what the IDE hands a user is what the project publishes and keeps working.
- **An example brings what it references.** `../produce_part_cadquery_primitive` in an assembly means nothing once the folder is copied out of `examples/` alone, so the manifest declares what each entry needs, `copy_examples.py` checks that against what the `partcad.yaml` and `.assy` files actually reference (transitively), and both copies take the whole set. They land in the starter package as subdirectories, where PartCAD imports them as sub-packages — no edit to any `partcad.yaml`, nothing for the daemon to do. A copy the user has already edited is left alone.

### Tests

- `node --test ide/standalone/bootstrap/test/*.test.js` — new: the first start against a stubbed editor (the package created and opened, the welcome window arriving in the window `vscode.openFolder` reopened, a user's own folder left alone, a `pc init` that wrote nothing, picking an example and the packages that come with it). Run by the `Build tooling` job; no dependencies, `node --test` is in Node.
- `ide/standalone/tests/test_bootstrap.py` — the walkthrough's wiring: a button that runs a command nothing contributes, a step with no documentation link, a link to a docs page that is not in `docs/source`, a starter path the install jobs and the documentation no longer mention.
- `ide/standalone/tests/test_copy_examples.py` — the manifest rules, and the shipped manifest validated against `examples/`, which is exactly what the build runs.
- `verify_bundle.py` — fails a build whose bootstrap extension carries a walkthrough step whose media was not packaged, or an example it offers without the packages that go with it.
- Both install jobs now **start the installed IDE** and wait for the package to appear and for the editor to record the workspace it opened — on Windows through the setup program, on Linux and macOS through `install.sh` — and check that the examples survived packaging and installation.

83 pytest and 11 node tests pass locally; `vsce package` and the bundle checks were run against the real staged extension. The IDE build and the install jobs themselves have not run yet — this PR is what fires them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz5EdsiuRzHr7zxrkeGQbv


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz5EdsiuRzHr7zxrkeGQbv)_