### PR TITLE
fix(release): name the release after what it is releasing, not after `devel`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,6 +228,51 @@ jobs:
         with:
           name: partcad-plugin
           path: release/plugin
+      # The version this run is releasing, read from the tree it checked out.
+      # `bump-my-version` keeps it in "dev-tools/bumpversion.toml" and names the
+      # tag after exactly that value (`tag_name = "{new_version}"` there), so the
+      # tree and the tag cannot disagree unless somebody moved one by hand.
+      #
+      # This used to be `git describe --abbrev=0` in a clone made further down,
+      # after the manifest. `git clone` checks out the *default* branch --
+      # `devel` -- so what it described was the newest tag on `devel`, not the
+      # commit being released. Every release so far was named correctly only
+      # because `main` was fast-forwarded to `devel`'s tip in the same minute;
+      # promoting `main` to anything older would have published that commit's
+      # archives, and its wheel, under `devel`'s version.
+      #
+      # Not gated on `main`: a tag build is the rehearsal of a release, so it
+      # checks the naming too, and the checks below pin their globs to this.
+      #
+      # The distributions are checked against it because `skip-existing` on the
+      # PyPI upload below would quietly do nothing, rather than fail, if "dist"
+      # held a version that is already published.
+      - name: Determine the release version
+        run: |
+          set -euo pipefail
+          version="$(sed -n 's/^current_version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+            dev-tools/bumpversion.toml)"
+          if [ -z "${version}" ]; then
+            echo "::error::no current_version in dev-tools/bumpversion.toml"
+            exit 1
+          fi
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ] && [ "${GITHUB_REF_NAME:-}" != "${version}" ]; then
+            echo "::error::this run is tagged ${GITHUB_REF_NAME:-} but its tree is ${version}"
+            exit 1
+          fi
+          # The four files "dist" holds: the wheel and sdist of each of the two
+          # distributions, all four named after the version that built them.
+          for name in \
+            "partcad-${version}-py3-none-any.whl" "partcad-${version}.tar.gz" \
+            "partcad_cli-${version}-py3-none-any.whl" "partcad_cli-${version}.tar.gz"; do
+            if [ ! -f "dist/${name}" ]; then
+              echo "::error::dist/${name} is missing -- this run mixed the artifacts of two builds"
+              ls -l dist
+              exit 1
+            fi
+          done
+          echo "RELEASE_VERSION=${version}" >> "${GITHUB_ENV}"
+          echo "Releasing ${version}."
 
       # "install.sh" derives an asset name from `uname` and fails for the user
       # if that asset is not on the release. Downloading artifacts does not fail
@@ -252,13 +297,20 @@ jobs:
           # matrix there: a release missing one of these is a release some
           # machine cannot install, and the manifest generated below would
           # faithfully describe the gap rather than close it.
+          #
+          # By version, not by "partcad-*": an archive left over from another
+          # build satisfies the loose glob, and the release would then carry two
+          # versions -- which only "platforms-manifest.sh" would notice, after
+          # the assets were already checked.
           for platform in \
             ubuntu-22.04-x86_64 ubuntu-22.04-arm64 \
             ubuntu-24.04-x86_64 ubuntu-24.04-arm64 \
             macos-15-arm64 macos-26-arm64 \
             windows-2022-x86_64; do
-            archive=$(find release/standalone -type f -name "partcad-*-${platform}.*" ! -name "*.sha256")
-            checksum=$(find release/standalone -type f -name "partcad-*-${platform}.*.sha256")
+            archive=$(find release/standalone -type f \
+              -name "partcad-${RELEASE_VERSION}-${platform}.*" ! -name "*.sha256")
+            checksum=$(find release/standalone -type f \
+              -name "partcad-${RELEASE_VERSION}-${platform}.*.sha256")
             if [ -z "${archive}" ] || [ -z "${checksum}" ]; then
               echo "::error::no standalone bundle for ${platform}"
               missing=1
@@ -275,12 +327,14 @@ jobs:
             windows-*) extension="zip" ;;
             *) extension="tar.gz" ;;
             esac
-            archive="$(find release/ide -type f -name "partcad-ide-*-${platform}.${extension}" | head -n 1)"
+            archive="$(find release/ide -type f \
+              -name "partcad-ide-${RELEASE_VERSION}-${platform}.${extension}" | head -n 1)"
             if [ -z "${archive}" ] || [ ! -f "${archive}.sha256" ]; then
               echo "::error::no IDE archive for ${platform}"
               missing=1
             else
-              find release/ide -type f -name "partcad-ide-*-${platform}*" ! -name "*.sha256" \
+              find release/ide -type f -name "partcad-ide-${RELEASE_VERSION}-${platform}*" \
+                ! -name "*.sha256" \
                 -printf "%p %s bytes\n"
             fi
           done
@@ -292,8 +346,13 @@ jobs:
           # notice later. Each is checked by its own name rather than by one
           # "partcad-*.vsix" glob, which the shim also matches: that would
           # report a release carrying only the shim as complete.
+          #
+          # By version, like the archives above. "vsix.yml" names both packages
+          # after the version in "ide/vscode/package.json", so this is also what
+          # now catches that file lagging behind the bump -- the drift the shim
+          # stopped stating a version of its own to avoid.
           for package in "partcad" "partcad-shim"; do
-            vsix="$(find release/vsix -type f -name "${package}-[0-9]*.vsix" | head -n 1)"
+            vsix="$(find release/vsix -type f -name "${package}-${RELEASE_VERSION}.vsix" | head -n 1)"
             if [ -z "${vsix}" ]; then
               echo "::error::no ${package} VS Code extension package"
               missing=1
@@ -302,8 +361,10 @@ jobs:
             fi
           done
           # And the plugin. Named after the version like everything else here,
-          # so the documented `--plugin-url .../pc-<version>.zip` resolves.
-          plugin="$(find release/plugin -type f -name "pc-*.zip" | head -n 1)"
+          # so the documented `--plugin-url .../pc-<version>.zip` resolves -- by
+          # that version rather than "pc-*.zip", which is what would catch
+          # "plugin.json" lagging behind the bump the way it sat at 0.1.0.
+          plugin="$(find release/plugin -type f -name "pc-${RELEASE_VERSION}.zip" | head -n 1)"
           if [ -z "${plugin}" ]; then
             echo "::error::no Claude Code plugin archive"
             missing=1
@@ -324,22 +385,41 @@ jobs:
           dev-tools/release/platforms-manifest.sh \
             --bundles release/standalone --ide release/ide --output release/platforms.json
           cat release/platforms.json
-          python3 -c 'import json; json.load(open("release/platforms.json"))'
-
-      - name: Determine the release tag
-        if: github.ref == 'refs/heads/main'
-        run: |
-          git clone https://github.com/partcad/partcad partcad-git;
-          cd partcad-git;
-          echo "MERGED_TAG=$(git describe --abbrev=0)" >> "${GITHUB_ENV}"
+          # Valid JSON, and the version the archives carry -- which the script
+          # takes from the archive names and refuses to write if they disagree
+          # with each other. This is the other half of that: they have to agree
+          # with the tree this job checked out, and so with the wheel.
+          python3 -c '
+          import json, os, sys
+          manifest = json.load(open("release/platforms.json"))
+          want = os.environ["RELEASE_VERSION"]
+          if manifest["version"] != want:
+              sys.exit("::error::platforms.json says %s, but this run is releasing %s" % (manifest["version"], want))
+          '
 
       - name: Create GitHub Release
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          TAG: ${{ env.MERGED_TAG }}
+          TAG: ${{ env.RELEASE_VERSION }}
         run: |
+          # The tag has to be the one on the commit this run built. `gh release
+          # create` does not check: given a tag that does not exist it makes
+          # one, on the repository's default branch -- `devel` -- and publishes
+          # these archives against a tree nobody built. So resolve it first and
+          # refuse if it names anything else. "/commits/<ref>" resolves a tag,
+          # annotated ones included, to the commit it points at.
+          tagged="$(gh api "repos/${REPO}/commits/${TAG}" --jq .sha || true)"
+          if [ -z "${tagged}" ]; then
+            echo "::error::cannot resolve tag ${TAG} -- see the error above; a 404 means the"
+            echo "::error::version bump that creates the tag never landed on this commit"
+            exit 1
+          fi
+          if [ "${tagged}" != "${GITHUB_SHA}" ]; then
+            echo "::error::tag ${TAG} is on ${tagged}, not on ${GITHUB_SHA}, which is what this run built"
+            exit 1
+          fi
           # A draft until every asset is on it. "pc upgrade", the VS Code
           # extension and the FreeCAD addon all resolve what to install through
           # "/releases/latest", which skips drafts -- so a run that dies partway


### PR DESCRIPTION
## Copilot Summary

`deploy.yml` decided what to call a release by cloning the repository and running `git describe --abbrev=0` in it:

```yaml
      - name: Determine the release tag
        if: github.ref == 'refs/heads/main'
        run: |
          git clone https://github.com/partcad/partcad partcad-git;
          cd partcad-git;
          echo "MERGED_TAG=$(git describe --abbrev=0)" >> "${GITHUB_ENV}"
```

`git clone` checks out the **default branch — `devel`** — so what it described was the newest tag on `devel`, which has nothing to do with the commit pushed to `main` that the run was building.

Every release so far was named correctly by coincidence: `main` was fast-forwarded to `devel`'s tip and the deployment ran in the same minute, so the two agreed. Promote `main` to anything older — a hotfix, a re-run after a failed release, `main` simply lagging as it does right now at 0.8.25 while `devel` is at 0.8.30 — and the run uploads that commit's archives, and its wheel, to a release named after `devel`'s version. PyPI included, where it cannot be taken back.

### What changes

The version is read from **the tree the job checked out**: `current_version` in `dev-tools/bumpversion.toml`, which is the value `bump-my-version` tags with (`tag_name = "{new_version}"`). Everything the release carries then has to agree with it, and nothing did before:

* **the four files in `dist/`** — so a mixed run fails here rather than being waved through by `skip-existing` on the PyPI upload;
* **the standalone and IDE archives**, by pinning the completeness check's globs to the version. `partcad-*-PLATFORM.*` accepted an archive from any build, and only `platforms-manifest.sh` would have noticed, after the assets were already checked;
* **both `.vsix` packages**, which `vsix.yml` names after the version in `ide/vscode/package.json` — so this is now also what catches that file lagging behind a bump, the drift the shim stopped stating a version of its own to avoid (#581);
* **the plugin archive**, named after the version in `plugin.json` — the same file that sat at 0.1.0 while everything around it moved (#582);
* **`platforms.json`**, which `platforms-manifest.sh` derives from the archives, so the manifest clients read cannot describe a different release than the one being made.

And, before the release is created, that **the tag exists and is on this commit**. `gh release create` does not check: given a tag that does not exist it creates one, on the default branch, and publishes the archives against a tree nobody built.

The version step is not gated on `main`, so a tag build — the rehearsal of a release — checks the naming too, including that the tag it ran for matches its own tree.

This also removes the `git clone` from the release path, which was writing a new directory into the checked-out workspace mid-release: the same family of mistake as the `path: ide` collision that broke 0.8.25.

### Validation

The workflow is not reachable from a pull request, so the three `run:` blocks were extracted from this branch's file and executed against simulated release trees:

| scenario | result |
| --- | --- |
| everything consistent at 0.8.30 | passes, exports `RELEASE_VERSION=0.8.30` |
| completeness check, complete release (both `.vsix`, plugin) | passes |
| manifest step, versions agree | passes |
| `plugin.json` left at 0.1.0 | fails: `no Claude Code plugin archive` |
| shim `.vsix` lagging behind the bump | fails: `no partcad-shim VS Code extension package` |
| only the shim `.vsix` was built | fails: `no partcad VS Code extension package` |
| every artifact from an older build | fails: `no standalone bundle for ...` |
| `dist/` from another build | fails: `dist/partcad-VERSION-py3-none-any.whl is missing -- this run mixed the artifacts of two builds` |
| tagged 0.8.25, tree is 0.8.30 | fails: `this run is tagged 0.8.25 but its tree is 0.8.30` |
| one archive from another build | fails: `the archives carry more than one version` |
| archives uniformly older than the tree | fails: `platforms.json says X, but this run is releasing Y` |

Also: `check-jsonschema 0.37.4 --builtin-schema vendor.github-workflows` (the `check-github-workflows` hook) passes, `bash -n` parses every `run:` in the workflow, and `shellcheck` reports nothing on the new shell — the one finding in that job, `$(echo ${stray})`, is pre-existing and deliberate.

The `Create GitHub Release` half only executes on a push to `main`, so it stays unexercised until `main` is promoted — 0.8.26 through 0.8.30 have not been.

Rebased onto `devel` (0.8.30). #581 and #582 both rewrote blocks this touches; the resolution keeps their content — the two-package `.vsix` loop and the plugin check — and pins each to the version.