### PR TITLE
Catch the plugin manifest up to 0.8.30, which #582 landed behind

### DIFF
--- a/ai-agents/claude/.claude-plugin/plugin.json
+++ b/ai-agents/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pc",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "description": "Mechanical and robotics engineering with PartCAD",
   "author": {
     "name": "Roman Kuzmenko",


### PR DESCRIPTION
## Copilot Summary

One line: `ai-agents/claude/.claude-plugin/plugin.json` goes from `0.8.29` to `0.8.30`.

### What happened

#582 was branched from `0.8.29`. While it was open, `aa6c7105` ("Version updated from 0.8.29 to 0.8.30") landed on `devel`. #582 then merged, bringing a manifest stating `0.8.29` onto a tree stating `0.8.30`.

That is precisely the drift the test #582 added exists to catch, and it catches it — `test_the_claude_plugin_states_the_release_version` **fails on `devel` as it stands**:

```
plugin.json = 0.8.29
bumpversion current_version = 0.8.30
```

### Why the next bump would not fix it by itself

`dev-tools/bumpversion.toml` rewrites the manifest by searching for `"version": "{current_version}"`. `current_version` is `0.8.30` and the file says `0.8.29`, so the search matches nothing: the next release either publishes a plugin one version behind the release that published it, or the bump fails outright. Either way the drift does not heal on its own.

### Why this cannot recur

This was the transition, not a standing hazard. The `bumpversion.toml` entry that moves the manifest is on `devel` now, so from the next bump onward the manifest moves with the wheel, the extension and everything else — and a pull request can no longer land behind the version it was branched from.

### Validation

- `test_the_claude_plugin_states_the_release_version` and `test_the_claude_plugin_is_declared_in_bumpversion` pass
- the full `tests/partcad_cli/unit/test_ai_agent_skills.py` suite passes (38 cases)
- `ai-agents/scripts/materialize.sh` builds `pc-0.8.30.zip`; `claude plugin validate` passes on both the marketplace and the plugin manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYDzecziwHsXmzUFn86CEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYDzecziwHsXmzUFn86CEe)_