### PR TITLE
Give PartCAD a sandbox of its own when there is no conda

### DIFF
--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -122,6 +122,44 @@ based on the location and preferences of the requester, while leaving the
 possibility to enforce the use of a specific provider for corresponding parts
 (for example, for parts that are using a patented design).
 
+.. _python-sandbox:
+
+==================
+The Python sandbox
+==================
+
+Every CAD script PartCAD runs -- a ``cadquery`` or ``build123d`` part, the
+importer that reads a ``STEP`` file, a ``render:`` or ``cam:`` implementation --
+runs in a sandbox rather than in the interpreter PartCAD itself is running on.
+That is what lets one package render against build123d 0.11 while another wants
+0.9, and what keeps a CAD stack out of the environment you work in.
+
+``pythonSandbox`` chooses how that sandbox is built:
+
+==================== =========================================================================
+``conda``            An environment conda provisions, **interpreter included**. The only one
+                     that can give a package the Python version it asks for, so it is the
+                     default wherever conda or mamba is installed.
+``venv``             A plain virtual environment of PartCAD's own, one per interpreter
+                     version, under the internal state directory. The default when conda is
+                     not installed. Built from whichever Python the host has, so a package
+                     asking for a version the host does not have is rendered on the host's
+                     and told so.
+``none``             No environment at all: scripts run on the host's own interpreter and
+                     their dependencies are installed **into it**. Fast and shares whatever
+                     is already there, at the price of writing the CAD stack into the Python
+                     you work with -- and unusable where that Python is not writable.
+``pypy``             A conda environment built around PyPy.
+==================== =========================================================================
+
+  .. code-block:: yaml
+
+    # ~/.partcad/config.yaml
+    pythonSandbox: venv
+
+The equivalents everywhere else are ``PC_PYTHON_SANDBOX`` in the environment and
+``--python-sandbox`` on the command line, in the usual order of precedence.
+
 .. _caching:
 
 =======

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -369,7 +369,9 @@ Two other things are deliberately not in the bundle, because PartCAD runs them a
 than importing them, exactly as the wheels do:
 
 * **git**, used to fetch package repositories.
-* **conda** (or **mamba**), used to build the sandbox in which PartCAD runs CAD scripts.
+* **conda** (or **mamba**), used to build the sandbox in which PartCAD runs CAD scripts. Optional: without it
+  PartCAD builds a plain virtual environment instead (see :ref:`python-sandbox`); conda is what lets a package
+  ask for a Python version the host does not have.
 
 Run ``pc healthcheck`` to see what is missing on the current machine.
 
@@ -435,8 +437,8 @@ conda and git
 
 A snap does not carry your shell environment, so a conda installed under your home directory -- the usual
 place -- is not visible to it, and neither is a git outside the standard system prefixes. This is expected
-and accepted rather than worked around: PartCAD notices, falls back to running Python scripts without a
-sandbox (``pythonSandbox: none``), and reports both as missing. Packages imported from git repositories are
+and accepted rather than worked around: PartCAD notices, falls back to a virtual environment of its own
+(``pythonSandbox: venv`` -- see :ref:`python-sandbox`), and reports both as missing. Packages imported from git repositories are
 still cloned, through ``libgit2`` as everywhere else; what the snap cannot see is your git *configuration*
 (see :ref:`git-configuration`).
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -181,8 +181,10 @@ Nothing else on the system is touched, and no ``sudo`` is asked for. If ``~/.loc
 
 The bundle is around 180MB unpacked and 57MB to download on Linux x86_64, and about half that on macOS and
 on Linux arm64, which carry no bundled OpenSCAD. It carries no CAD kernel: PartCAD builds every shape in a
-conda sandbox it provisions itself, so ``conda`` (or ``mamba``) is a prerequisite here exactly as it is for
-the wheels. ``pc healthcheck`` reports what this machine is missing.
+sandbox it provisions itself, so what is said about ``conda`` for the wheels applies here too: it is not
+required -- PartCAD falls back to a virtual environment of its own -- but it is what lets a package be built
+on a Python version this machine does not have (see :ref:`python-sandbox`). ``pc healthcheck`` reports what
+this machine is missing.
 
 Supported platforms are Linux on x86_64 and arm64, and macOS on Apple silicon. Windows is covered by the
 ``.zip`` archives under :ref:`manual installation <standalone-manual>`.
@@ -341,10 +343,10 @@ The bundle carries the optional extras that the wheels leave to the user, becaus
 extended afterwards: the Python linter (``lint``) is in it, ready to run.
 
 What it does **not** carry is a CAD kernel. The bundle is three console programs, not a library to import, and
-every shape those programs build, render, export or tessellate is produced in the conda sandbox PartCAD
-provisions and comes back as geometry the commands never open themselves. So ``conda`` (or ``mamba``) is as
-much a prerequisite here as it is for the wheels, and leaving OpenCASCADE out is most of why the bundle is
-around 180MB rather than around 1GB.
+every shape those programs build, render, export or tessellate is produced in the sandbox PartCAD provisions
+and comes back as geometry the commands never open themselves. That sandbox is a conda environment where the
+machine has conda and a plain virtual environment otherwise (see :ref:`python-sandbox`); either way, leaving
+OpenCASCADE out of the bundle is most of why it is around 180MB rather than around 1GB.
 
 On Linux x86_64 and on Windows it also carries **OpenSCAD**, which PartCAD runs as an external program to
 build ``.scad`` parts. The bundled copy is used in preference to any OpenSCAD installed on the machine, so that the
@@ -408,7 +410,7 @@ is the packaging: snapd installs it, keeps it up to date, and removes it cleanly
 Two flags need explaining:
 
 * ``--classic`` is the confinement. PartCAD works on your own files -- it reads and writes CAD projects
-  anywhere on disk, clones git repositories, builds conda sandboxes and runs CAD scripts in them, and serves
+  anywhere on disk, clones git repositories, builds sandboxes and runs CAD scripts in them, and serves
   a daemon over a socket that the Visual Studio Code extension connects to. A strictly confined snap could do
   none of that.
 * ``--dangerous`` says the package is not signed by the Snap Store, which a downloaded file is not. It stops
@@ -420,7 +422,7 @@ itself. Without it, the commands are ``partcad``, ``partcad.pc`` and ``partcad.j
 Where it keeps its state
 ========================
 
-Everywhere else, PartCAD keeps its cache, its conda sandboxes and its git clones in ``~/.partcad``. The snap
+Everywhere else, PartCAD keeps its cache, its sandboxes and its git clones in ``~/.partcad``. The snap
 does not write them there. It sets ``PC_INTERNAL_STATE_DIR`` to the per-user directory snapd gives it, so all
 of that lives in ``~/snap/partcad/common`` instead, and ``sudo snap remove --purge partcad`` takes it away
 with the snap.
@@ -501,8 +503,9 @@ The installer is not signed, so SmartScreen shows a warning: choose "More info",
 ``partcad-ide.exe`` without installing anything.
 
 It unpacks to around 500MB: an editor, a Python interpreter, the command line tools and the extensions, all
-in one archive. Like the standalone bundle inside it, it carries no CAD kernel -- shapes are built in a conda
-sandbox, so ``conda`` (or ``mamba``) is still expected on the machine.
+in one archive. Like the standalone bundle inside it, it carries no CAD kernel -- shapes are built in a
+sandbox PartCAD provisions on the machine, using conda where there is conda and a virtual environment of its
+own otherwise (see :ref:`python-sandbox`).
 
 The first start
 ===============

--- a/src/partcad/runtime_python.py
+++ b/src/partcad/runtime_python.py
@@ -993,12 +993,25 @@ class PythonRuntime(runtime.Runtime):
             else:
                 path = session["path"]
                 use_venv = True
+        elif str(os.path.basename(path)).startswith(VENV_PREFIX):
+            use_venv = True
+        elif self.exec_path is not None and os.path.normpath(path) == os.path.normpath(self.path):
+            # The runtime's own directory, for a sandbox whose interpreter does
+            # not live inside it.
+            #
+            # 'none' is that sandbox: it runs whatever Python the host has, and
+            # its directory holds guard files and a constraints file rather than
+            # an environment. Every install defaults to that directory
+            # ('ensure_*' fills 'path' in with 'self.path'), so without this the
+            # interpreter that installs a package is '<sandbox>/bin/python' -- a
+            # file that never existed -- while the interpreter that then runs
+            # the wrapper is 'exec_path'. Nothing was installed where anything
+            # was looked for, and on a clean machine the install could not even
+            # start.
+            return self.exec_path
         else:
-            # This can be either a venv path or a conda path.
-            if str(os.path.basename(path)).startswith(VENV_PREFIX):
-                use_venv = True
-            else:
-                use_venv = False
+            # A conda prefix: its interpreter really is inside it.
+            use_venv = False
 
         if os.name == "nt":
             if use_venv:

--- a/src/partcad/runtime_python_all.py
+++ b/src/partcad/runtime_python_all.py
@@ -9,6 +9,7 @@
 from . import runtime_python_none
 from . import runtime_python_pypy
 from . import runtime_python_conda
+from . import runtime_python_venv
 
 
 def create(ctx, version, python_runtime=None):
@@ -16,6 +17,8 @@ def create(ctx, version, python_runtime=None):
         python_runtime = ctx.user_config.python_sandbox
     if python_runtime == "none":
         return runtime_python_none.NonePythonRuntime(ctx, version)
+    elif python_runtime == "venv":
+        return runtime_python_venv.VenvPythonRuntime(ctx, version)
     elif python_runtime == "pypy":
         return runtime_python_pypy.PyPyPythonRuntime(ctx, version)
     elif python_runtime == "conda":

--- a/src/partcad/runtime_python_venv.py
+++ b/src/partcad/runtime_python_venv.py
@@ -113,6 +113,24 @@ class VenvPythonRuntime(runtime_python.PythonRuntime):
         self.exec_path = self.host_exec_path
         return ["-m", "venv", "--upgrade-deps", self.path]
 
+    def _created(self, exitcode, stderr) -> None:
+        """Accept the environment, or fail with what actually went wrong.
+
+        'run_onced_locked' reports an exit code rather than raising, so a failed
+        '-m venv' -- no ensurepip, a full disk, a directory that cannot be
+        written -- would otherwise be stepped straight past. 'exec_path' would
+        then name an interpreter that was never created, and the first thing the
+        base does with it is install a package: the error the user sees would be
+        that install failing on a missing file, with the creation failure that
+        caused it nowhere in sight.
+        """
+        if exitcode != 0 or not os.path.exists(self.venv_exec_path):
+            raise Exception(
+                "Failed to create the '%s' sandbox at %s: %s"
+                % (self.sandbox, self.path, (stderr or "").strip() or "'-m venv' exited with %s" % exitcode)
+            )
+        self.exec_path = self.venv_exec_path
+
     def once(self):
         if self.provisioned:
             return
@@ -120,8 +138,8 @@ class VenvPythonRuntime(runtime_python.PythonRuntime):
             command = self._create_locked()
             if command:
                 with pc_logging.Action("Venv", self.version, self.path):
-                    self.run_onced_locked(command)
-                self.exec_path = self.venv_exec_path
+                    exitcode, _, stderr = self.run_onced_locked(command)
+                self._created(exitcode, stderr)
         # Outside the lock above rather than inside it: the base takes the same
         # lock, and it is a file lock rather than a re-entrant one.
         super().once()
@@ -133,6 +151,6 @@ class VenvPythonRuntime(runtime_python.PythonRuntime):
             command = self._create_locked()
             if command:
                 with pc_logging.Action("Venv", self.version, self.path):
-                    await self.run_async_onced_locked(command)
-                self.exec_path = self.venv_exec_path
+                    exitcode, _, stderr = await self.run_async_onced_locked(command)
+                self._created(exitcode, stderr)
         await super().once_async()

--- a/src/partcad/runtime_python_venv.py
+++ b/src/partcad/runtime_python_venv.py
@@ -1,0 +1,138 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""A sandbox that is a real virtual environment of its own.
+
+The middle ground between the two sandboxes that existed before it, and the
+reason it is the fallback rather than either of them:
+
+  * 'conda' provisions the interpreter as well as the packages, so it can give a
+    package the Python version it asked for. It has to be installed first, and
+    on a host without it there was nothing to fall back to but:
+  * 'none', which is not an environment at all. It runs whatever Python the host
+    has and installs into it -- so rendering a part writes packages into the
+    interpreter the user runs everything else with, and a machine whose Python
+    is not writable (a system package manager's, a read-only image) cannot
+    render at all.
+
+This one creates a virtual environment at the sandbox's own path and both
+installs into it and runs from it, which is what a sandbox is for. It cannot
+choose an interpreter version -- a venv is made *from* an interpreter, so what
+the host has is what a package gets -- and it says so when the host's version is
+not the one asked for, rather than quietly rendering on the wrong one.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+
+from . import logging as pc_logging
+from . import runtime_python
+from . import telemetry
+
+
+@telemetry.instrument()
+class VenvPythonRuntime(runtime_python.PythonRuntime):
+    def __init__(self, ctx, version=None):
+        super().__init__(ctx, "venv", version)
+
+        # The interpreter the environment is made *from*. Held separately
+        # because 'exec_path' has to be this one while the environment is being
+        # created and the environment's own one for everything afterwards, and
+        # the machinery that runs a command reads 'exec_path'.
+        self.host_exec_path = self._host_interpreter()
+        self.exec_path = self.venv_exec_path if os.path.exists(self.venv_exec_path) else self.host_exec_path
+
+    @property
+    def venv_exec_path(self) -> str:
+        """The interpreter inside the environment, once it exists."""
+        if os.name == "nt":
+            return os.path.join(self.path, "Scripts", self.exec_name)
+        return os.path.join(self.path, "bin", self.exec_name)
+
+    def _host_interpreter(self) -> str:
+        """The host interpreter to build this environment from.
+
+        The one named for the version asked for where the host has it, so a
+        package that asks for 3.11 gets 3.11 on a host that has several. Failing
+        that, whatever 'python3' is, and failing that the interpreter PartCAD
+        itself is running on -- which always exists, and is the answer that needs
+        no PATH at all.
+        """
+        if os.name != "nt":
+            for name in ("python%s" % self.version, "python3", "python"):
+                found = shutil.which(name)
+                if found is not None:
+                    return found
+        else:
+            found = shutil.which(self.exec_name)
+            if found is not None:
+                return found
+        return sys.executable
+
+    def _report_version(self) -> None:
+        """Say so when the host cannot give the version that was asked for.
+
+        Once per sandbox, and a warning rather than a refusal: rendering on
+        3.12 when a package asked for 3.11 usually works, and refusing to render
+        at all is worse than saying which interpreter did it.
+        """
+        try:
+            actual = subprocess.run(
+                [self.host_exec_path, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            ).stdout.strip()
+        except Exception as e:
+            pc_logging.debug("Could not ask %s its version: %s" % (self.host_exec_path, e))
+            return
+        if actual and actual != self.version:
+            pc_logging.warning(
+                "Python %s was asked for and this host has %s; the '%s' sandbox is built from the host's"
+                " interpreter, so %s is what this renders on. Install conda for a sandbox that can provision"
+                " an interpreter of its own." % (self.version, actual, self.sandbox, actual)
+            )
+
+    def _create_locked(self) -> list:
+        """The command that builds the environment, or an empty list.
+
+        Empty when it is already there, which is the common case: an environment
+        is built once and used by every render afterwards.
+        """
+        if os.path.exists(self.venv_exec_path):
+            self.exec_path = self.venv_exec_path
+            return []
+        os.makedirs(os.path.dirname(os.path.abspath(self.path)), exist_ok=True)
+        self._report_version()
+        # Built by the host's interpreter, so 'exec_path' has to be that one for
+        # the length of this command and the environment's own one afterwards.
+        self.exec_path = self.host_exec_path
+        return ["-m", "venv", "--upgrade-deps", self.path]
+
+    def once(self):
+        if self.provisioned:
+            return
+        with self.sync_lock(write=True):
+            command = self._create_locked()
+            if command:
+                with pc_logging.Action("Venv", self.version, self.path):
+                    self.run_onced_locked(command)
+                self.exec_path = self.venv_exec_path
+        # Outside the lock above rather than inside it: the base takes the same
+        # lock, and it is a file lock rather than a re-entrant one.
+        super().once()
+
+    async def once_async(self):
+        if self.provisioned:
+            return
+        async with self.async_lock(write=True):
+            command = self._create_locked()
+            if command:
+                with pc_logging.Action("Venv", self.version, self.path):
+                    await self.run_async_onced_locked(command)
+                self.exec_path = self.venv_exec_path
+        await super().once_async()

--- a/src/partcad_cli/click/command.py
+++ b/src/partcad_cli/click/command.py
@@ -301,8 +301,8 @@ click.rich_click.COMMAND_GROUPS = {
     "--python-sandbox",
     default=None,
     show_envvar=True,
-    type=click.Choice(["none", "pypy", "conda"]),
-    help="Sandboxing environment for invoking python scripts(defaults to conda)",
+    type=click.Choice(["none", "venv", "pypy", "conda"]),
+    help="Sandboxing environment for invoking python scripts (defaults to conda, else venv)",
 )
 @click.option(
     "--javascript-sandbox",

--- a/src/partcad_utils/user_config.py
+++ b/src/partcad_utils/user_config.py
@@ -498,10 +498,21 @@ class UserConfig(vyper.Vyper):
         self.set_default("cacheS3MinEntrySize", 100)
         self.set_default("cacheDependenciesIgnore", False)
 
+        # conda first, because it is the only sandbox that can provision an
+        # *interpreter*: a package asking for a Python the host does not have
+        # gets it. Failing that, a virtual environment of PartCAD's own, which
+        # is still a sandbox -- it installs where it runs, and nothing it
+        # installs reaches the interpreter the user works with.
+        #
+        # Not 'none'. That one has no environment at all: it renders with the
+        # host's interpreter and installs the CAD stack into it, which is a
+        # surprising thing to do to somebody's Python and impossible on a host
+        # whose Python is not writable. It stays available for a host that wants
+        # exactly that, and is chosen rather than fallen back to.
         if shutil.which("conda") is not None or importlib.util.find_spec("conda") is not None:
             self.set_default("pythonSandbox", "conda")
         else:
-            self.set_default("pythonSandbox", "none")
+            self.set_default("pythonSandbox", "venv")
 
         # Unlike Python, whose sandbox has to be provisioned because PartCAD's
         # own interpreter is the wrong one to render in, a host Node.js is
@@ -710,8 +721,8 @@ class UserConfig(vyper.Vyper):
 
         # option: pythonSandbox
         # description: sandboxing environment for invoking python scripts
-        # values: [none | pypy | conda]
-        # default: conda
+        # values: [none | venv | pypy | conda]
+        # default: conda where the host has it, else venv
         self.bind_env("pythonSandbox", "PC_PYTHON_SANDBOX")
         self.python_sandbox = self.get_string("pythonSandbox")
 

--- a/tests/partcad/unit/test_runtime_python.py
+++ b/tests/partcad/unit/test_runtime_python.py
@@ -9,19 +9,42 @@
 #
 
 import asyncio
+import importlib.util
+import shutil
+
 import pytest
 import sys
 
 import partcad as pc
 from partcad.user_config import UserConfig
 
+
+def _conda_is_installed():
+    return shutil.which("conda") is not None or importlib.util.find_spec("conda") is not None
+
+
 @pytest.fixture
 def config_for():
+    """A user configuration that really selects the named sandbox.
+
+    Assigned to the attribute rather than passed to 'set()'. 'UserConfig' reads
+    every option into an attribute of its own in '__init__' -- 'python_sandbox'
+    from 'pythonSandbox' -- and 'set()' is vyper's, which writes the underlying
+    config key. So 'set("python_sandbox", ...)' wrote a key nothing reads and
+    left the attribute at the host's default: every test below ran on whatever
+    sandbox the host happened to choose, and the conda ones passed on a host
+    with no conda by testing something else entirely.
+    """
+
     def _config_for(runtime):
+        if runtime == "conda" and not _conda_is_installed():
+            pytest.skip("conda is not installed on this host")
         user_config = UserConfig()
-        user_config.set("python_sandbox", runtime)
+        user_config.python_sandbox = runtime
         return user_config
+
     return _config_for
+
 
 def test_runtime_python_version_3_9_none(config_for):
     if sys.version_info[0] != 3 or sys.version_info[1] != 9:

--- a/tests/partcad/unit/test_runtime_python_venv.py
+++ b/tests/partcad/unit/test_runtime_python_venv.py
@@ -1,0 +1,184 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The 'venv' sandbox, and where an ambient-interpreter sandbox installs to.
+
+Two things are covered here and they are two halves of one problem: a sandbox
+has to install packages with the same interpreter it later runs them with. The
+'none' sandbox did not -- it ran the host's Python and installed with an
+interpreter path inside its own directory, which is not an environment and holds
+no interpreter at all -- and 'venv' exists so that the fallback is a real
+environment rather than the user's own Python.
+
+Nothing here provisions a CAD stack. Building an environment and filling it with
+build123d takes minutes and is what the gated end-to-end test at the bottom is
+for; the rest asks the runtime objects what they would do.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+import partcad as pc
+from partcad import runtime_python_all
+from partcad.runtime_python_none import NonePythonRuntime
+from partcad.runtime_python_venv import VenvPythonRuntime
+from partcad.user_config import UserConfig
+
+VERSION = "%d.%d" % (sys.version_info[0], sys.version_info[1])
+
+
+@pytest.fixture
+def config_for():
+    def _config_for(runtime):
+        user_config = UserConfig()
+        # The attribute, not 'set()': see the same fixture in
+        # 'test_runtime_python.py' for why that one selects nothing.
+        user_config.python_sandbox = runtime
+        return user_config
+
+    return _config_for
+
+
+@pytest.fixture
+def ctx(config_for):
+    return pc.Context("tests/partcad", user_config=config_for("venv"))
+
+
+# --------------------------------------------------------------------------- #
+# 'none': install where you run                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_the_none_sandbox_installs_with_the_interpreter_it_runs(config_for):
+    """Its directory is not an environment, so nothing lives in '<it>/bin'.
+
+    'ensure_*' fills the install path in with the runtime's own directory, and
+    resolving that to '<sandbox>/bin/python' named a file that never existed --
+    so on a clean machine the install could not start, and on a dirty one it
+    installed somewhere the wrapper would not look.
+    """
+    context = pc.Context("tests/partcad", user_config=config_for("none"))
+    runtime = context.get_python_runtime(VERSION)
+    assert isinstance(runtime, NonePythonRuntime)
+    assert runtime.exec_path is not None
+
+    # What a run uses, and what an install uses, are the same interpreter.
+    assert runtime.get_venv_python_path() == runtime.exec_path
+    assert runtime.get_venv_python_path(path=runtime.path) == runtime.exec_path
+    assert not runtime.get_venv_python_path(path=runtime.path).startswith(runtime.path)
+
+
+def test_a_conda_prefix_still_resolves_inside_itself(config_for):
+    """The rule is about *this* runtime's directory, not about any path given.
+
+    A conda prefix and a v-env both really do hold their interpreter, and the
+    fix above must not redirect those to the host's.
+    """
+    context = pc.Context("tests/partcad", user_config=config_for("none"))
+    runtime = context.get_python_runtime(VERSION)
+    elsewhere = os.path.join(os.path.dirname(runtime.path), "some-conda-prefix")
+    assert runtime.get_venv_python_path(path=elsewhere).startswith(elsewhere)
+
+
+# --------------------------------------------------------------------------- #
+# 'venv': a real environment of PartCAD's own                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_the_venv_sandbox_is_selectable(ctx):
+    runtime = ctx.get_python_runtime(VERSION)
+    assert isinstance(runtime, VenvPythonRuntime)
+    assert runtime.sandbox == "venv"
+    # Named after the sandbox and the version, like every other one, so two
+    # versions are two environments.
+    assert runtime.path.endswith("pc-py-venv-" + VERSION)
+
+
+def test_the_factory_knows_the_name():
+    assert runtime_python_all.create.__module__ == "partcad.runtime_python_all"
+    with pytest.raises(Exception, match="invalid python runtime"):
+        runtime_python_all.create(None, VERSION, "not-a-sandbox")
+
+
+def test_the_venv_interpreter_is_inside_the_sandbox(ctx):
+    """Which is the whole point: it installs and runs in its own directory."""
+    runtime = ctx.get_python_runtime(VERSION)
+    assert os.path.dirname(os.path.dirname(runtime.venv_exec_path)) == runtime.path
+    assert os.path.basename(runtime.venv_exec_path) == runtime.exec_name
+
+
+def test_the_host_interpreter_is_a_real_file(ctx):
+    """The environment is built *from* it, so it has to exist before anything."""
+    runtime = ctx.get_python_runtime(VERSION)
+    assert os.path.exists(runtime.host_exec_path)
+
+
+def test_an_unbuilt_sandbox_runs_the_host_interpreter(ctx, tmp_path):
+    """Until the environment exists, the host's is what creates it.
+
+    'exec_path' is what the command machinery reads, so it has to be the host's
+    for the length of the '-m venv' that builds the environment and the
+    environment's own for everything after it.
+    """
+    runtime = ctx.get_python_runtime(VERSION)
+    runtime.path = str(tmp_path / ("pc-py-venv-" + VERSION))
+    runtime.exec_path = runtime.host_exec_path
+
+    command = runtime._create_locked()
+    assert command == ["-m", "venv", "--upgrade-deps", runtime.path]
+    assert runtime.exec_path == runtime.host_exec_path
+
+
+def test_an_existing_environment_is_not_rebuilt(ctx, tmp_path):
+    """A sandbox is built once; every render afterwards just uses it."""
+    runtime = ctx.get_python_runtime(VERSION)
+    runtime.path = str(tmp_path / ("pc-py-venv-" + VERSION))
+    os.makedirs(os.path.dirname(runtime.venv_exec_path), exist_ok=True)
+    with open(runtime.venv_exec_path, "w") as f:
+        f.write("")
+
+    assert runtime._create_locked() == []
+    assert runtime.exec_path == runtime.venv_exec_path
+
+
+# --------------------------------------------------------------------------- #
+# What the fallback is                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_venv_is_the_fallback_when_conda_is_absent(monkeypatch):
+    """'none' was, and it is not a sandbox: it installs into the user's Python."""
+    import partcad_utils.user_config as user_config_module
+
+    monkeypatch.setattr(user_config_module.shutil, "which", lambda name: None)
+    monkeypatch.setattr(user_config_module.importlib.util, "find_spec", lambda name: None)
+    assert UserConfig().python_sandbox == "venv"
+
+
+def test_conda_is_still_preferred_when_it_is_there(monkeypatch):
+    """It is the only sandbox that can provision an interpreter version."""
+    import partcad_utils.user_config as user_config_module
+
+    monkeypatch.setattr(user_config_module.shutil, "which", lambda name: "/usr/bin/" + name)
+    assert UserConfig().python_sandbox == "conda"
+
+
+# --------------------------------------------------------------------------- #
+# End to end, which really builds an environment                              #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.slow
+def test_the_venv_sandbox_runs_the_interpreter_it_built(ctx):
+    """And it is the one inside the sandbox, not the host's."""
+    runtime = ctx.get_python_runtime(VERSION)
+    exitcode, version_string, errors = asyncio.run(runtime.run_async(["--version"]))
+    assert exitcode == 0, errors
+    assert version_string.startswith("Python " + VERSION)
+    assert os.path.exists(runtime.venv_exec_path)
+    assert runtime.exec_path == runtime.venv_exec_path

--- a/tests/partcad/unit/test_runtime_python_venv.py
+++ b/tests/partcad/unit/test_runtime_python_venv.py
@@ -146,6 +146,51 @@ def test_an_existing_environment_is_not_rebuilt(ctx, tmp_path):
     assert runtime.exec_path == runtime.venv_exec_path
 
 
+def test_a_failed_creation_is_raised_rather_than_stepped_past(ctx, tmp_path):
+    """'run_onced_locked' reports an exit code; it does not raise.
+
+    Without checking it, 'exec_path' would name an interpreter that was never
+    created and the base's first install would fail on the missing file -- so
+    what the user saw would be a pip error, with the ensurepip failure that
+    caused it nowhere in sight.
+    """
+    runtime = ctx.get_python_runtime(VERSION)
+    runtime.path = str(tmp_path / ("pc-py-venv-" + VERSION))
+    runtime.run_onced_locked = lambda *a, **k: (1, "", "ensurepip is not available")
+
+    with pytest.raises(Exception, match="ensurepip is not available"):
+        runtime.once()
+    assert not runtime.provisioned
+    # And it did not leave the interpreter pointing at a file that is not there.
+    assert runtime.exec_path == runtime.host_exec_path
+
+
+def test_the_asynchronous_path_fails_the_same_way(ctx, tmp_path):
+    """'once_async' is the path every render actually takes, so it matters more."""
+    runtime = ctx.get_python_runtime(VERSION)
+    runtime.path = str(tmp_path / ("pc-py-venv-" + VERSION))
+
+    async def failed(*args, **kwargs):
+        return 1, "", "Permission denied"
+
+    runtime.run_async_onced_locked = failed
+
+    with pytest.raises(Exception, match="Permission denied"):
+        asyncio.run(runtime.once_async())
+    assert not runtime.provisioned
+    assert runtime.exec_path == runtime.host_exec_path
+
+
+def test_a_creation_that_writes_no_interpreter_is_a_failure_too(ctx, tmp_path):
+    """A zero exit code is not the same as an environment that exists."""
+    runtime = ctx.get_python_runtime(VERSION)
+    runtime.path = str(tmp_path / ("pc-py-venv-" + VERSION))
+    runtime.run_onced_locked = lambda *a, **k: (0, "", "")
+
+    with pytest.raises(Exception, match="exited with 0|Failed to create"):
+        runtime.once()
+
+
 # --------------------------------------------------------------------------- #
 # What the fallback is                                                        #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Copilot Summary

A sandbox has to install packages with the same interpreter it later runs them with. Without conda, neither thing that happened did that.

### `none` installed somewhere it never ran

`none` is not an environment: it runs whatever Python the host has, and its directory under the state directory holds guard files and a constraints file — no interpreter. But every install defaults to that directory (`ensure_*` fills `path` in with `self.path`), and resolving it produced `<sandbox>/bin/python`, which has never existed there.

So the interpreter that installed a package and the interpreter that ran the wrapper were two different things. On a machine that happened to have the package already it worked by accident; on a clean one the install could not start at all:

```
[Errno 2] No such file or directory: '.../sandbox/pc-py-none-3.11/bin/python'
```

`get_venv_python_path()` now answers with `exec_path` for the runtime's *own* directory, so install and run agree. A conda prefix and a v-env are untouched — their interpreter really is inside them, and the rule is about this runtime's directory rather than about any path it is handed.

### …which leaves `none` correct, and still not a fallback

What it now correctly does is install the CAD stack into the Python the user works with, and a host whose Python is not writable cannot render at all.

So `venv`: a plain virtual environment at the sandbox's own path, built from the host's interpreter, installed into and run from. It cannot choose a version — a venv is made *from* an interpreter, which is what conda is still for and still preferred for — and it says which one it used rather than quietly rendering on the wrong one.

`pythonSandbox` now falls back to `venv` instead of `none`. `none` stays available for a host that wants exactly that, chosen rather than fallen back to.

### A test fixture that selected nothing

Fixed here because the default moving is what makes it dangerous. `UserConfig` reads each option into an attribute in `__init__`, and `set()` is vyper's, which writes the underlying key — so `set("python_sandbox", ...)` wrote a key nothing reads and left the attribute at the host's default.

Every test in `test_runtime_python.py` ran on whatever sandbox the host chose rather than the one it names. The four `_conda` ones passed on a host with no conda by testing something else entirely. They now select conda and skip when it is absent.

## Verification

- `192 passed, 7 skipped` across `test_runtime_python{,_venv,_conda,_deps}`, `test_sandbox_{lock,lock_conda,python_version,versions}` and `test_runtime_javascript`.
- A gated end-to-end test builds a real environment and runs the interpreter it built (`1 passed in 143s`). Checked by hand afterwards: `sys.prefix` is the sandbox, `sys.base_prefix` is `/usr`, and `import build123d, cadquery` succeeds inside it — the stack was installed by `/root/.partcad/sandbox/pc-py-venv-3.11/bin/python -m pip install`, which is the point of the change.
- Sphinx builds clean; `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016b6jUWyMqxwNfyXBQe7Jz8

---
_Generated by [Claude Code](https://claude.ai/code/session_016b6jUWyMqxwNfyXBQe7Jz8)_