### PR TITLE
Lint `partcad.yaml` in the editor, with the checker ASSY files use

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -291,6 +291,6 @@
     "devel"
   ],
   "yaml.schemas": {
-    "src/partcad/schema/partcad.json": "*/partcad.yaml"
+    "src/partcad_utils/schema/partcad.json": "*/partcad.yaml"
   }
 }

--- a/dev-tools/pyinstaller/partcad.spec
+++ b/dev-tools/pyinstaller/partcad.spec
@@ -141,10 +141,10 @@ datas += [
     (str(SRC / "partcad" / "builtin"), "partcad/builtin"),
     # Copied into new packages by `pc init`.
     (str(SRC / "partcad" / "template"), "partcad/template"),
-    # Read through `importlib.resources` by `pc lint`. The ASSY schema is in
-    # `partcad_utils` because both ends check ASSY files -- the daemon over a
-    # package, `pc lint --file` in the client over one file.
-    (str(SRC / "partcad" / "schema"), "partcad/schema"),
+    # Read through `importlib.resources` by `pc lint`. Both schemas -- the ASSY
+    # one and the `partcad.yaml` one -- are in `partcad_utils` because both ends
+    # check both kinds of file: the daemon over a package, `pc lint --file` in
+    # the client over one file.
     (str(SRC / "partcad_utils" / "schema"), "partcad_utils/schema"),
     # The loader lists this directory to enumerate the available subcommands.
     (str(SRC / "partcad_cli" / "click" / "commands"), "partcad_cli/click/commands"),

--- a/docs/source/assy.rst
+++ b/docs/source/assy.rst
@@ -487,3 +487,15 @@ Problems view. It answers the same question from the package contents it has
 already loaded, which is the declaration itself rather than a guess at it, and
 falls back to the command's own answer for a file no loaded package mentions.
 Set ``partcad.lint.enabled`` to ``false`` to turn that off.
+
+``partcad.yaml`` is checked the same way, by the same checker, against the
+configuration schema (``src/partcad_utils/schema/partcad.json``) -- see
+:doc:`configuration`. It is a Jinja2 template too, so it is masked before
+parsing exactly as an ASSY file is, and it has no assembly/scene flavor:
+nothing points at a package configuration, so ``--schema`` does not apply to
+one.
+
+  .. code-block:: shell
+
+    pc lint --file partcad.yaml
+    pc lint -f PartcadSchema     # the same check over a whole package

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -115,6 +115,34 @@ instance. This is intentional -- referencing two copies of the same package at
 once is almost always a mistake, and the alternative would be an implicit,
 easily-missed dependency on the upstream package.
 
+==========
+Validation
+==========
+
+``partcad.yaml`` is checked against a JSON schema
+(``src/partcad_utils/schema/partcad.json``) that describes everything below:
+which sections exist, which fields each kind of declaration takes, and which of
+them exclude or require one another.
+
+Run the check over a package, or over the file alone:
+
+  .. code-block:: shell
+
+    pc lint                          # every check, over the package
+    pc lint -f PartcadSchema         # this one only
+    pc lint --file partcad.yaml      # no package, no daemon - just the file
+
+Every finding names the line and column it came from. ``partcad.yaml`` is a
+Jinja2 template rendered to YAML before it is parsed (see ``includePaths``
+below), so the checker masks each template construct before parsing rather than
+rendering the file, which would need the values the template is waiting for. It
+is the same checker :doc:`ASSY files <assy>` go through, and the `PartCAD
+extension for VS Code
+<https://marketplace.visualstudio.com/items?itemName=PartCAD.partcad>`_ runs it
+on the open document -- so a mistyped section is underlined as it is typed,
+including in the file that is stopping the package from loading at all. Set
+``partcad.lint.enabled`` to ``false`` to turn that off.
+
 ============
 Dependencies
 ============

--- a/features/lint.feature
+++ b/features/lint.feature
@@ -21,6 +21,44 @@ Feature: `pc lint` command
     When I run "pc lint"
     Then the command should exit with a status code of "0"
 
+  @success
+  Scenario: What `pc init` writes is clean
+    # 'pc init' leaves each section empty, and 'pc add part' fills one in. An
+    # empty section parses as null, which is how the loader reads it too - so a
+    # brand new package must not be four findings the moment it is checked.
+    Given a file named "partcad.yaml" with content:
+      """
+      desc: A brand new package
+      dependencies:
+      sketches:
+      parts:
+      assemblies:
+      """
+    When I run "pc lint"
+    Then the command should exit with a status code of "0"
+    And STDOUT should not contain "is not of type 'object'"
+
+  @success
+  Scenario: Jinja2 in `partcad.yaml` is not mistaken for broken YAML
+    # A package configuration is a Jinja2 template as much as an ASSY file is -
+    # it even has an 'includePaths' of its own to pull fragments in.
+    Given a file named "partcad.yaml" with content:
+      """
+      desc: A package whose parts are generated
+      parts:
+      {% for size in [10, 20] %}
+        cube_{{ size }}:
+          type: cadquery
+          path: cube.py
+      {% endfor %}
+      """
+    And a file named "cube.py" with content:
+      """
+      # This is a py file for cube.py
+      """
+    When I run "pc lint"
+    Then the command should exit with a status code of "0"
+
   @failure
   Scenario: Unexpected top-level key should raise an error
     Given a file named "partcad.yaml" with content:
@@ -31,7 +69,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "0"
-    And STDOUT should contain "$: Additional properties are not allowed ('foo' was unexpected)"
+    And STDOUT should contain "partcad.yaml:2:1: unexpected property 'foo'"
 
   @failure
   Scenario: Unexpected subkey give warning
@@ -45,7 +83,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "0"
-    And STDOUT should contain "$.dependencies.core: Additional properties are not allowed ('foo' was unexpected)"
+    And STDOUT should contain "partcad.yaml:5:5: unexpected property 'foo'"
 
   @failure
   Scenario: Invalid enum value in part type
@@ -61,7 +99,7 @@ Feature: `pc lint` command
     Then the command should exit with a status code of "1"
     # A part 'type' is now anyOf {built-in enum, a '<package>:<partType>' reference},
     # so an unknown type fails the whole part schema rather than just the enum.
-    And STDOUT should contain "$.parts.part1: {'type': 'unknown_type'} is not valid under any of the given schemas"
+    And STDOUT should contain "partcad.yaml:5:5: {'type': 'unknown_type'} is not valid under any of the given schemas"
 
   @failure
   Scenario: Invalid enum in shape parameters
@@ -84,7 +122,7 @@ Feature: `pc lint` command
     Then the command should exit with a status code of "1"
     # Same anyOf part schema: a bad parameter 'type' surfaces as the parameter
     # object failing its schemas, not as a bare enum error.
-    And STDOUT should contain "{'type': 'nonsense'} is not valid under any of the given schemas"
+    And STDOUT should contain "partcad.yaml:4:5: {'type': 'cadquery', 'parameters': {'length': {'type': 'nonsense'}}} is not valid under any of the given schemas"
 
   @success
   Scenario: Fully valid configuration with deeply nested parameters
@@ -171,7 +209,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.parts.bolt: 'fileFrom' is a dependency of 'fileUrl'"
+    And STDOUT should contain "partcad.yaml:4:5: 'fileFrom' is a dependency of 'fileUrl'"
 
   @failure
   Scenario: Invalid provider type
@@ -185,7 +223,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.providers.localstore.type: 's3' is not one of ['store', 'manufacturer', 'enrich']"
+    And STDOUT should contain "partcad.yaml:4:11: 's3' is not one of ['store', 'manufacturer', 'enrich']"
 
   @failure
   Scenario: Invalid value for pythonRequirements
@@ -196,7 +234,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.pythonRequirements: 'should-be-a-list' is not of type 'array'"
+    And STDOUT should contain "partcad.yaml:2:21: 'should-be-a-list' is not of type 'array'"
 
   @success
   Scenario: Valid sketch with rectangle, square, and circle
@@ -244,7 +282,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.sketches.shape.rectangle: 'side-y' is a required property"
+    And STDOUT should contain "partcad.yaml:5:7: 'side-y' is a required property"
 
   @failure
   Scenario: Part with invalid axis format
@@ -259,7 +297,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.parts.extruder.axis[0]: [1, 2] is too short"
+    And STDOUT should contain "partcad.yaml:5:10: [1, 2] is too short"
 
   @success
   Scenario: Interface with valid parameters and ports
@@ -303,7 +341,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.providers.buildTool.parameters.configMode.enum[0]: 1 is not of type 'string'"
+    And STDOUT should contain "partcad.yaml:7:16: 1 is not of type 'string'"
 
   @failure
   Scenario: Part with invalid offset array
@@ -320,7 +358,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "'bad' is not of type 'number'"
+    And STDOUT should contain "partcad.yaml:6:16: 'bad' is not of type 'number'"
 
   @success
   Scenario: Valid OCCTLocation in part offset
@@ -359,7 +397,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.parts.block.offset[0]: [1.0, 2.0] is too short"
+    And STDOUT should contain "partcad.yaml:5:10: [1.0, 2.0] is too short"
 
   @success
   Scenario: Valid interface-parameter with directional parameters
@@ -393,7 +431,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.interfaces.mech.parameters.custom_axis: 'dir' is a required property"
+    And STDOUT should contain "partcad.yaml:6:9: 'dir' is a required property"
 
   @success
   Scenario: Valid assembly with parameters
@@ -475,7 +513,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.render.png.exclude[0]: 'nonsense' is not one of"
+    And STDOUT should contain "partcad.yaml:5:15: 'nonsense' is not one of"
 
   @success
   Scenario: Valid suppliers configuration
@@ -500,7 +538,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.suppliers[0]: 123 is not of type 'string'"
+    And STDOUT should contain "partcad.yaml:3:5: 123 is not of type 'string'"
 
   @success
   Scenario: Valid part with implements and ports
@@ -547,7 +585,7 @@ Feature: `pc lint` command
       """
     When I run "pc lint"
     Then the command should exit with a status code of "1"
-    And STDOUT should contain "$.parts.component.implements.iface1: {'invalid_field': True} is not valid under any of the given schemas"
+    And STDOUT should contain "partcad.yaml:6:9: {'invalid_field': True} is not valid under any of the given schemas"
 
   @success
   Scenario: Valid ASSY file passes lint check
@@ -737,6 +775,21 @@ Feature: `pc lint` command
     When I run "pc lint --file bench.assy --schema scene"
     Then the command should exit with a status code of "1"
     And STDOUT should contain "bench.assy:7:7: 'how' is not allowed in a scene"
+
+  @failure
+  Scenario: `pc lint --file` checks a `partcad.yaml` the same way
+    # The file that decides whether the package loads at all, checked without
+    # loading it - which is the only way to check it while it is broken.
+    Given a file named "partcad.yaml" with content:
+      """
+      desc: A package with a misspelled section
+      prts:
+        cube:
+          type: cadquery
+      """
+    When I run "pc lint --file partcad.yaml"
+    Then the command should exit with a status code of "0"
+    And STDOUT should contain "partcad.yaml:2:1: unexpected property 'prts'"
 
   @failure
   Scenario: `pc lint --file` rejects being mixed with the package options

--- a/ide/vscode/AGENTS.md
+++ b/ide/vscode/AGENTS.md
@@ -296,14 +296,21 @@ effect is that it appears on `PATH` twice.
 This has nothing to do with `src/terminal.ts`, which creates the `PartCAD` output pseudoterminal: that is a log
 surface with a no-op `handleInput`, not a shell, and has no environment to inherit.
 
-## ASSY diagnostics
+## YAML diagnostics
 
-`.assy` files are registered as YAML for highlighting but are not YAML: they are Jinja2 templates that render
-to YAML and then have to match the ASSY schema. (`.world` files are registered the same way, against `xml`:
-a Gazebo world *is* XML, so the editor's own XML support is the whole of what it needs -- there is no PartCAD
-check for one, and none is wanted.) `src/PartcadLint.ts` checks the open document (debounced on
-edit, immediately on open/save) through the `partcad.lintFile` command and publishes the answer into a
-`partcad` diagnostic collection.
+Two documents are checked: `.assy` files and a package's `partcad.yaml`. Both are registered as YAML for
+highlighting and neither is YAML -- each is a Jinja2 template that renders to YAML and then has to match a
+schema. (`.world` files are registered the same way, against `xml`: a Gazebo world *is* XML, so the editor's
+own XML support is the whole of what it needs -- there is no PartCAD check for one, and none is wanted.)
+`src/PartcadLint.ts` checks the open document (debounced on edit, immediately on open/save) through the
+`partcad.lintFile` command and publishes the answer into a `partcad` diagnostic collection.
+
+**Keeping the `yaml` language id is what keeps the highlighting.** The id is how the editor picks a grammar, so
+a PartCAD id of its own would have to bring a grammar of its own; the `languages` contribution in
+`package.json` claims `partcad.yaml` by filename and `.assy` by extension, and gives each the PartCAD icon,
+without taking either away from `yaml`. Diagnostics need none of that -- they are published per document URI,
+beside whatever else has an opinion about the file. `isPackageConfigDocument` matches the basename rather than
+the extension, because a `parts.yaml` next door is somebody's own file and not a package configuration.
 
 **The check never reaches the daemon**, and there is no RPC method for it. It is the client's own file --
 usually one the editor has not saved -- and it needs no package graph, no CAD runtime and no loaded context, so
@@ -312,8 +319,9 @@ exactly when the package fails to load *because* of the file being typed into. `
 answers it by running `pc --no-ansi lint --file <path> --stdin --json`, feeding the buffer on stdin. Same
 reasoning as `pc daemon stop`: defer to the CLI rather than keep a second copy here.
 
-An ASSY file a **scene** points at is checked against the same schema with `how` forbidden, and which of the
-two a given file is is not a property of the file. `PartcadLint.flavorOf` answers it from the package contents
+An **ASSY** file a **scene** points at is checked against the same schema with `how` forbidden, and which of the
+two a given file is is not a property of the file. (A `partcad.yaml` has no flavor -- nothing points at a
+package configuration -- so `flavorOf` returns nothing for one and none is sent.) `PartcadLint.flavorOf` answers it from the package contents
 the Explorer has already loaded -- the declaration itself -- and leaves the question to `pc lint` for a file no
 loaded package mentions. Both sides go through `pathKey` (`common/paths.ts`) rather than comparing paths as
 strings: `Uri.fsPath` lower-cases a Windows drive letter and PartCAD does not, so the editor's spelling of a
@@ -322,11 +330,12 @@ assembly. The daemon answers the same question with `os.path.samefile`; this one
 has never been saved, so it normalises instead of asking the filesystem. Both lean the same way when they cannot tell: unknown means assembly, because reading
 an assembly as a scene would put a false error on correct code.
 
-The checker is `partcad_utils.assy_lint` (schema: `src/partcad_utils/schema/assy.json`), shared
-with the daemon-side package lint so an editor and CI cannot disagree about a file. It masks each Jinja2
-construct with equally sized filler before parsing, which is what keeps every finding on its source line and
-column; findings that depend on what the mask hid are dropped rather than guessed. Change the schema or the
-message wording there, not here.
+The checker is `partcad_utils.assy_lint` (schemas: `src/partcad_utils/schema/assy.json` and
+`partcad.json`), shared with the daemon-side package lint so an editor and CI cannot disagree about a file. It
+masks each Jinja2 construct with equally sized filler before parsing, which is what keeps every finding on its
+source line and column; findings that depend on what the mask hid are dropped rather than guessed. Change the
+schema or the message wording there, not here -- and remember that a gap in the configuration schema is now a
+squiggle on a working file, so anything PartCAD's own tooling writes has to validate.
 
 ## Opening a file in a third-party application
 

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -200,7 +200,7 @@
         "properties": {
           "partcad.lint.enabled": {
             "default": true,
-            "description": "Check ASSY files for Jinja2, YAML and schema errors while editing, and report them in the Problems view.",
+            "description": "Check ASSY files and `partcad.yaml` for Jinja2, YAML and schema errors while editing, and report them in the Problems view.",
             "scope": "resource",
             "type": "boolean"
           },

--- a/ide/vscode/src/PartcadLint.ts
+++ b/ide/vscode/src/PartcadLint.ts
@@ -3,19 +3,26 @@
 //
 // Licensed under Apache License, Version 2.0.
 //
-// Syntax and schema checking for ASSY files.
+// Syntax and schema checking for the two YAML documents PartCAD writes: an
+// `.assy` file and a package's `partcad.yaml`.
 //
-// An `.assy` file is registered as YAML so it gets syntax highlighting, but it
-// is not YAML: it is a Jinja2 template that renders to YAML and then has to
-// match the ASSY schema. A plain YAML checker therefore both misses the errors
-// that matter (a mistyped `locaton:`, a location that is not an OCCT location)
+// Both are registered as YAML so they get the editor's YAML syntax
+// highlighting, and neither is YAML: each is a Jinja2 template that renders to
+// YAML and then has to match a schema. A plain YAML checker therefore both
+// misses the errors that matter (a mistyped `locaton:`, a location that is not
+// an OCCT location, a `part` declared with a `type` PartCAD has no factory for)
 // and invents errors that are not there (every `{% for %}` line).
+//
+// Registering them as `yaml` is also what keeps that highlighting: the language
+// id is what the editor picks a grammar by, so these stay `yaml` documents and
+// the diagnostics are published into a `partcad` collection beside whatever
+// else has an opinion about the file. Giving them a PartCAD language id of
+// their own would have bought nothing and lost the grammar.
 //
 // The check runs locally, never on the daemon: it is the client's own file --
 // usually one this editor has not saved -- and it needs no package graph, no CAD
-// runtime and no loaded context. `partcad.lintFile` is answered by whichever
-// local PartCAD the active backend has (`pc lint --file` for the service
-// backend, the bundled language server for the Python one), so it keeps
+// runtime and no loaded context. `partcad.lintFile` is answered by running this
+// machine's own `pc lint --file` (see `JsonRpcBackend.lintFile`), so it keeps
 // answering when the daemon is down or the package will not load because of the
 // very file being typed into.
 //
@@ -24,8 +31,8 @@
 // Jinja2 template before parsing so each finding still carries the line and
 // column of the source file.
 //
-// One thing has to be settled before the check can run: whether the file is an
-// **assembly** or a **scene**. The two are the same format read for two
+// One thing has to be settled before an **ASSY** file can be checked: whether
+// it is an **assembly** or a **scene**. The two are the same format read for two
 // purposes, and a scene is checked against the same schema with `how`
 // forbidden -- a scene states where things are, not how they got there (see
 // `partcad.scene`). Nothing in the file says which it is; what points at it
@@ -40,6 +47,10 @@
 // package this workspace has not opened -- is left to the CLI, which makes the
 // same call from the `partcad.yaml` files around the file
 // (`partcad_client.lint.detect_flavor`) and leans the same way.
+//
+// A `partcad.yaml` has no flavor -- nothing points at a package configuration
+// the way a declaration points at an ASSY file -- so nothing is settled for one
+// and none is sent.
 //
 
 import * as vscode from 'vscode';
@@ -74,8 +85,31 @@ type LintResult = {
 /** Which schema an ASSY file is checked against. `undefined` means "let the CLI decide". */
 type LintFlavor = 'assembly' | 'scene' | undefined;
 
+/** An ASSY file: checked against the ASSY schema, and the only kind with a flavor. */
 function isAssyDocument(document: vscode.TextDocument): boolean {
     return document.uri.scheme === 'file' && document.uri.fsPath.toLowerCase().endsWith('.assy');
+}
+
+/**
+ * A package configuration: `partcad.yaml`, by name.
+ *
+ * By name and not by extension, because that is what makes it one -- PartCAD
+ * looks for `partcad.yaml`, and a `parts.yaml` beside it is somebody's own file
+ * that nothing here should have an opinion about. Lower-cased for the same
+ * reason `pathKey` exists: on a case-insensitive filesystem the file the user
+ * opened as `PartCAD.yaml` is the one PartCAD is reading.
+ */
+function isPackageConfigDocument(document: vscode.TextDocument): boolean {
+    if (document.uri.scheme !== 'file') {
+        return false;
+    }
+    const path = document.uri.fsPath.replace(/\\/g, '/');
+    return path.slice(path.lastIndexOf('/') + 1).toLowerCase() === 'partcad.yaml';
+}
+
+/** Every document PartCAD checks. Anything else is left to whoever owns it. */
+function isCheckedDocument(document: vscode.TextDocument): boolean {
+    return isAssyDocument(document) || isPackageConfigDocument(document);
 }
 
 function isEnabled(): boolean {
@@ -124,6 +158,12 @@ export class PartcadLint implements vscode.Disposable {
      * so the CLI can make its own.
      */
     private flavorOf(document: vscode.TextDocument): LintFlavor {
+        if (!isAssyDocument(document)) {
+            // A `partcad.yaml` has one schema and no flavor. Sending one anyway
+            // would be asking for a scene-flavored configuration schema, which
+            // is a schema forbidding a `how` no configuration has.
+            return undefined;
+        }
         const explorer = this.explorer?.();
         if (explorer === undefined) {
             return undefined;
@@ -149,8 +189,9 @@ export class PartcadLint implements vscode.Disposable {
     }
 
     /**
-     * Re-check every open ASSY file. Called once the backend is up: documents
-     * opened before that were checked against a command that did not exist yet.
+     * Re-check every open file PartCAD checks. Called once the backend is up:
+     * documents opened before that were checked against a command that did not
+     * exist yet.
      */
     public refresh(): void {
         if (!isEnabled()) {
@@ -182,7 +223,7 @@ export class PartcadLint implements vscode.Disposable {
     }
 
     private schedule(document: vscode.TextDocument, delay: number): void {
-        if (!isAssyDocument(document)) {
+        if (!isCheckedDocument(document)) {
             return;
         }
         if (!isEnabled()) {

--- a/ide/vscode/src/extension.ts
+++ b/ide/vscode/src/extension.ts
@@ -161,12 +161,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     traceLog(`Module: ${serverInfo.module}`);
     traceVerbose(`Full Server Info: ${JSON.stringify(serverInfo)}`);
 
-    // ASSY files are checked through the backend; the checker is created here so
-    // the documents already open when the window came up get checked as soon as
-    // the backend registers `partcad.lintFile`. The Explorer is handed over as a
-    // getter rather than a value: it does not exist yet, and what the checker
-    // wants from it - which ASSY files the packages declare as scenes - only
-    // arrives once a package has loaded.
+    // ASSY files and `partcad.yaml` are checked through the backend; the checker
+    // is created here so the documents already open when the window came up get
+    // checked as soon as the backend registers `partcad.lintFile`. The Explorer
+    // is handed over as a getter rather than a value: it does not exist yet, and
+    // what the checker wants from it - which ASSY files the packages declare as
+    // scenes - only arrives once a package has loaded.
     partcadLint = new PartcadLint(() => partcadExplorer);
     context.subscriptions.push(partcadLint);
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,10 @@ aws = {file = ["requirements-aws.txt"]}
 "partcad.builtin.export" = ["*.py", "*.yaml"]
 "partcad.builtin.render" = ["*.py", "*.yaml"]
 "partcad.template" = ["*.yaml"]
-"partcad.schema" = ["**/partcad.json"]
-# The ASSY schema, which `partcad_utils.assy_lint` validates against.
+# The schemas `partcad_utils.assy_lint` validates against: the ASSY one and the
+# `partcad.yaml` one. Both live in `partcad_utils` because both ends check both
+# kinds of file -- the daemon over a package, every client over the one file
+# somebody is editing.
 "partcad_utils.schema" = ["**/*.json"]
 
 [tool.pytest.ini_options]

--- a/src/partcad/AGENTS.md
+++ b/src/partcad/AGENTS.md
@@ -149,16 +149,29 @@ isort --check src/partcad tests/partcad
 
 ## Schemas and linting
 
-`./src/partcad/schema/partcad.json` is the schema `lint/schema.py` validates `partcad.yaml` against, and
-`lint/all.py` registers the checks — the names it gives them are what `pc lint -f` filters on. Anything added to
-`schema/` ships through `[tool.setuptools.package-data]` in `pyproject.toml` and through the PyInstaller spec's
-copy of the whole directory.
+**Neither schema is here.** Both `partcad_utils/schema/partcad.json` (the `partcad.yaml` schema) and
+`partcad_utils/schema/assy.json` (the ASSY one) live beside `partcad_utils.assy_lint`, the checker that reads
+both, and ship through `[tool.setuptools.package-data]` in `pyproject.toml` and the PyInstaller spec's copy of
+that directory. They are there because a client checks the file it is editing without a daemon and without a
+CAD kernel: a schema under `partcad` would mean importing one to read a JSON file. `lint/all.py` registers the
+checks — the names it gives them are what `pc lint -f` filters on — and `get_partcad_schema()` is the one way
+in for anything that wants the configuration schema itself.
 
-The ASSY schema and its checker are **not** here: they are `partcad_utils.assy_lint` and
-`partcad_utils/schema/assy.json`. `AssySchemaLinting` is the *package* half — walking a package's `.assy` files
-needs the package graph, which is daemon work — while each client checks the one file being edited in its own
-process (`partcad_client.lint`, reached by `pc lint --file`). Two implementations of that check would let an
-editor and CI disagree about a file, so there is one, in the package both ends already depend on.
+`lint/schema.py` is the *package* half of both checks: `SchemaLinting` walks a package's `partcad.yaml`,
+`AssySchemaLinting` its `.assy` files, and `YamlLinting` under them is the shared body — reading the file and
+handing it to `assy_lint.validate_source`. Walking a package needs the package graph, which is daemon work,
+while each client checks the one file being edited in its own process (`partcad_client.lint`, reached by
+`pc lint --file`). Two implementations of that check would let an editor and CI disagree about a file, so there
+is one, in the package both ends already depend on. That is also why `AssySchemaLinting.get_targets` asks
+`assy_lint.is_assy_file` rather than "does this file have a schema": both kinds have one now, and the looser
+question would have it walk `partcad.yaml` too and report every finding twice.
+
+A `partcad.yaml` is a Jinja2 template exactly as an ASSY file is — `ProjectLocal` renders it, `includePaths`
+and all — so it goes through the same masking rather than straight to `yaml.safe_load`, and every finding
+carries the line and column it came from. **A gap in the configuration schema is now a squiggle on a working
+file**, not a message in a CI log nobody reads: whatever PartCAD's own tooling writes has to validate. `pc init`
+writes empty (null) sections, so every section accepts null; every registered part type has to be in the
+`parts` enum (`sdf` was not, and two shipped examples failed their own check because of it).
 
 The **scene** schema is that same schema with `how` forbidden, derived from it by
 `assy_lint.scene_schema()` rather than kept beside it as a second file — a copy is a copy that stops matching.

--- a/src/partcad/interface.py
+++ b/src/partcad/interface.py
@@ -292,7 +292,7 @@ class Interface:
         # 'physics' what moving it costs (effort and velocity limits, damping,
         # friction, spring and solver parameters). Both are closed sets of named
         # properties in PartCAD's own units - degrees and millimetres, SI for
-        # the rest - defined in schema/partcad.json; a format that states
+        # the rest - defined in partcad_utils/schema/partcad.json; a format that states
         # something outside them fails the import rather than being carried
         # under a name of its own.
         #

--- a/src/partcad/lint/all.py
+++ b/src/partcad/lint/all.py
@@ -1,21 +1,25 @@
 import os
-import json
-import importlib
+
+from partcad_utils.assy_lint import PARTCAD_SCHEMA, get_schema
 
 from .lint import Linting
 from .python import PythonLinting
 from .schema import AssySchemaLinting, SchemaLinting
 from .software import SoftwareLinting
 
-PARTCAD_SCHEMA = None
 _global_lint_checks = []
 
+
 def get_partcad_schema():
-    global PARTCAD_SCHEMA
-    if PARTCAD_SCHEMA is None:
-        with importlib.resources.files("partcad.schema").joinpath("partcad.json").open("r") as file:
-            PARTCAD_SCHEMA = json.load(file)
-    return PARTCAD_SCHEMA
+    """The schema every `partcad.yaml` is checked against.
+
+    Packaged with `partcad_utils` rather than here, beside the ASSY schema and
+    the checker that reads both: a client checks the `partcad.yaml` it is
+    editing without a daemon and without a CAD kernel, and reaching a schema
+    under `partcad` would import one to read a JSON file.
+    """
+    return get_schema(PARTCAD_SCHEMA)
+
 
 def get_linting_checks(concurrency_cap: int) -> list[Linting]:
     global _global_lint_checks
@@ -23,10 +27,12 @@ def get_linting_checks(concurrency_cap: int) -> list[Linting]:
         concurrency_cap = max(os.cpu_count(), 8)
     Linting.MAX_CONCURRENT_CHECKS = concurrency_cap
     if len(_global_lint_checks) == 0:
-        _global_lint_checks.extend([
-            SchemaLinting("PartcadSchema", get_partcad_schema()),
-            AssySchemaLinting("AssySchema"),
-            PythonLinting("Python"),
-            SoftwareLinting("Software")
-        ])
+        _global_lint_checks.extend(
+            [
+                SchemaLinting("PartcadSchema"),
+                AssySchemaLinting("AssySchema"),
+                PythonLinting("Python"),
+                SoftwareLinting("Software"),
+            ]
+        )
     return _global_lint_checks

--- a/src/partcad/lint/schema.py
+++ b/src/partcad/lint/schema.py
@@ -1,9 +1,6 @@
 import json
 import os
-import yaml
 import aiofiles
-import jsonschema
-import jsonschema.exceptions
 
 from ..project import Project
 from ..context import Context
@@ -12,87 +9,102 @@ from partcad.cache_hash import CacheHash
 from .lint import Linting, Severity, LintingReport
 
 # Shared with every client's `pc lint --file`, which is why it is not in this
-# package: the daemon checks a package's ASSY files while walking the package
-# graph, and a client checks the one file being edited in its own process. Two
-# copies of that check would let an editor and CI disagree about a file.
+# package: the daemon checks a package's files when it walks the package graph,
+# and a client checks the one file being edited in its own process. Two copies
+# of that check would let an editor and CI disagree about a file.
 from partcad_utils.assy_lint import (
-    ASSY_SCHEMA,
     FLAVOR_ASSEMBLY,
     FLAVOR_SCENE,
     SEVERITY_WARNING,
-    get_schema,
+    is_assy_file,
     schema_for_file,
-    schema_name_for_file,
     validate_source,
 )
 
 
-class SchemaLinting(Linting):
-    def __init__(self, name: str, schema: dict) -> None:
-        super().__init__(name)
-        self.schema = schema
+class YamlLinting(Linting):
+    """Check the YAML documents of a package against the schemas that govern them.
+
+    A `partcad.yaml` and an `.assy` are the same kind of document -- a Jinja2
+    template that renders to YAML and then has to match a schema -- so they are
+    checked by the same code, `partcad_utils.assy_lint.validate_source`, which
+    masks the template before parsing and reports each finding at the source
+    line and column it came from. What the two subclasses below differ in is
+    only which files they walk and which schema each file gets.
+
+    That sharing is the point rather than a convenience. `validate_source` is
+    also what every client runs over the single file somebody is editing
+    (`partcad_client.lint`, reached by `pc lint --file`), so a finding reads the
+    same, at the same position, in the editor and in CI. A second implementation
+    here -- handing the raw file to `yaml.safe_load` and reporting whatever
+    `jsonschema` raised first -- is what that used to be, and it disagreed with
+    the editor twice over: it stopped at one finding per file, and it called a
+    templated `partcad.yaml` broken YAML.
+    """
+
+    def flavor(self, name: str, target: str) -> str:
+        """What ``target`` is read as. Only an ASSY file has an answer."""
+        return None
+
+    def schema(self, name: str, target: str) -> dict:
+        return schema_for_file(target, self.flavor(name, target))
 
     def get_hash(self, name: str, target: str) -> CacheHash:
         # The schema is half of what produced a finding: a cached result for an
         # unchanged file is only valid while the schema it was checked against
-        # is the same one.
+        # is the same one. The flavor is in here for the same reason and is not
+        # implied by anything else in the hash: moving a file's declaration from
+        # 'assemblies:' to 'scenes:' changes which schema it is checked against
+        # without touching the file.
         hash = super().get_hash(name, target)
-        hash.add_string(json.dumps(self.schema, sort_keys=True))
+        hash.add_string(json.dumps(self.schema(name, target), sort_keys=True))
+        hash.add_string(str(self.flavor(name, target)))
         return hash
-
-    def get_targets(self, ctx: Context, package: Project) -> list[str]:
-        return [os.path.join(package.config_dir, "partcad.yaml")]
 
     async def validate(self, ctx: Context, package: Project, target: str, lint_ctx: dict = {}) -> LintingReport:
         lint_result = LintingReport(package.name)
-        async with aiofiles.open(target, mode="r") as file:
-            # Handle file access and decoding errors
-            try:
-                raw = await file.read()
-            except (OSError, IOError, UnicodeDecodeError) as err:
-                lint_result.add(
-                    Severity.FAILED,
-                    f"Failed to read configuration file: {err}"
-                )
-                return lint_result
 
-            # Handle YAML parsing and schema validation errors
-            try:
-                config = yaml.safe_load(raw)
-                jsonschema.validate(instance=config, schema=self.schema)
-            except jsonschema.exceptions.ValidationError as exc:
-                if "unexpected" in exc.message:
-                    lint_result.add(
-                        Severity.WARNING,
-                        f"{exc.json_path}: {exc.message}",
-                    )
-                else:
-                    details = []
-                    if exc.context:
-                        root_error_location = exc.context[-1].relative_path
-                        for error in reversed(exc.context):
-                            if error.relative_path == root_error_location:
-                                details.append(error.message)
-                            else:
-                                break
-                    lint_result.add(
-                        Severity.FAILED,
-                        f"{exc.json_path}: {exc.message}" + (f" ({details})" if details else ""),
-                    )
-            except jsonschema.exceptions.SchemaError as exc:
-                pc_logging.debug(package.name, str(exc))
-                lint_result.add(Severity.FAILED, f"Internal Error: Invalid schema")
+        # 'open' is inside the try as well: it is what raises when the entry is a
+        # directory named '*.assy', or was removed between the listing and here,
+        # and nothing above catches that - one unreadable entry would end the
+        # whole 'pc lint' run instead of being reported as a failed check.
+        try:
+            async with aiofiles.open(target, mode="r") as file:
+                raw = await file.read()
+        except (OSError, UnicodeDecodeError) as err:
+            lint_result.add(Severity.FAILED, f"Failed to read {os.path.basename(target)}: {err}")
+            return lint_result
+
+        try:
+            diagnostics = validate_source(raw, self.schema(package.name, target))
+        except Exception as exc:  # pylint: disable=broad-except
+            pc_logging.debug(package.name, str(exc))
+            lint_result.add(Severity.FAILED, f"Internal Error: Failed to check {os.path.basename(target)}")
+            return lint_result
+
+        for diagnostic in diagnostics:
+            severity = Severity.WARNING if diagnostic.severity == SEVERITY_WARNING else Severity.FAILED
+            lint_result.add(severity, diagnostic.format(os.path.basename(target)))
 
         return lint_result
 
 
-class AssySchemaLinting(Linting):
-    """Check every ASSY file of a package against the ASSY schema.
+class SchemaLinting(YamlLinting):
+    """Check a package's own `partcad.yaml` against the configuration schema.
 
-    ASSY files are Jinja2 templates, so unlike `partcad.yaml` above they cannot
-    be handed to `yaml.safe_load()` as they are on disk. `partcad_utils.assy_lint`
-    masks the template first and reports each finding at the source line it came
-    from; this wraps that into the package-scoped report `pc lint` prints.
+    One target per package, and it is the file that decides whether the package
+    exists at all -- so it is checked as text, exactly as it is on disk, rather
+    than through the loaded configuration. A `partcad.yaml` broken badly enough
+    that the package will not load is precisely the one worth a finding, and by
+    then there is no `Project` to ask.
+    """
+
+    def get_targets(self, ctx: Context, package: Project) -> list[str]:
+        return [os.path.join(package.config_dir, "partcad.yaml")]
+
+
+class AssySchemaLinting(YamlLinting):
+    """Check every ASSY file of a package against the ASSY schema.
 
     This is the *package* half of ASSY checking: it needs the package graph to
     know which packages, and which of their files, to walk, which is what makes
@@ -115,17 +127,8 @@ class AssySchemaLinting(Linting):
         # them runs against its targets.
         self._flavors: dict = {}
 
-    def get_hash(self, name: str, target: str) -> CacheHash:
-        # As in 'SchemaLinting' above: a schema update has to invalidate the
-        # findings cached against the schema it replaced. The flavor is in here
-        # for the same reason and is not implied by anything else in the hash:
-        # moving a file's declaration from 'assemblies:' to 'scenes:' changes
-        # which schema it is checked against without touching the file.
-        flavor = self._flavors.get((name, target), FLAVOR_ASSEMBLY)
-        hash = super().get_hash(name, target)
-        hash.add_string(json.dumps(get_schema(ASSY_SCHEMA), sort_keys=True))
-        hash.add_string(flavor)
-        return hash
+    def flavor(self, name: str, target: str) -> str:
+        return self._flavors.get((name, target), FLAVOR_ASSEMBLY)
 
     def get_targets(self, ctx: Context, package: Project) -> list[str]:
         config_dir = package.config_dir
@@ -134,11 +137,13 @@ class AssySchemaLinting(Linting):
         # Through the shared helper, which matches the extension case
         # insensitively: 'pc lint --file' and the extension already check a
         # 'Logo.ASSY', and the package walk skipping it is exactly the
-        # editor/CI disagreement this module exists to prevent.
+        # editor/CI disagreement this module exists to prevent. It also excludes
+        # the package's own 'partcad.yaml', which the checker knows a schema for
+        # too and which 'SchemaLinting' above is the one to walk.
         targets = sorted(
             os.path.join(config_dir, f)
             for f in os.listdir(config_dir)
-            if schema_name_for_file(f) is not None and os.path.isfile(os.path.join(config_dir, f))
+            if is_assy_file(f) and os.path.isfile(os.path.join(config_dir, f))
         )
         declared_by_assembly = self._declared_files(package, "assembly")
         declared_by_scene = self._declared_files(package, "scene")
@@ -162,31 +167,3 @@ class AssySchemaLinting(Linting):
             declared = config.get("path") or "%s.assy" % config.get("orig_name", name)
             files.add(os.path.realpath(os.path.join(package.config_dir, declared)))
         return files
-
-    async def validate(self, ctx: Context, package: Project, target: str, lint_ctx: dict = {}) -> LintingReport:
-        lint_result = LintingReport(package.name)
-
-        # 'open' is inside the try as well: it is what raises when the entry is a
-        # directory named '*.assy', or was removed between the listing and here,
-        # and nothing above catches that - one unreadable entry would end the
-        # whole 'pc lint' run instead of being reported as a failed check.
-        try:
-            async with aiofiles.open(target, mode="r") as file:
-                raw = await file.read()
-        except (OSError, UnicodeDecodeError) as err:
-            lint_result.add(Severity.FAILED, f"Failed to read assembly file: {err}")
-            return lint_result
-
-        flavor = self._flavors.get((package.name, target), FLAVOR_ASSEMBLY)
-        try:
-            diagnostics = validate_source(raw, schema_for_file(target, flavor))
-        except Exception as exc:  # pylint: disable=broad-except
-            pc_logging.debug(package.name, str(exc))
-            lint_result.add(Severity.FAILED, "Internal Error: Failed to check the assembly file")
-            return lint_result
-
-        for diagnostic in diagnostics:
-            severity = Severity.WARNING if diagnostic.severity == SEVERITY_WARNING else Severity.FAILED
-            lint_result.add(severity, diagnostic.format(os.path.basename(target)))
-
-        return lint_result

--- a/src/partcad_cli/AGENTS.md
+++ b/src/partcad_cli/AGENTS.md
@@ -44,14 +44,16 @@ drift apart.
 
 **`pc lint` sits on both sides of the line, one mode each.** `pc lint [-P/-r]` checks a *package*: which
 packages, resolved how, with which files, is the package graph, so it is a thin daemon client like any other.
-`pc lint --file` checks the *files named on the command line*, in this process: an ASSY file is a Jinja2
-template rendered to YAML and matched against a schema, which needs no package graph, no CAD runtime and no
-context — and with `--stdin` the content is a buffer an editor has not saved, which the daemon cannot see at
-all. There is deliberately no RPC method for it: sending it would ship the client's own file across a wire to
-have it read back, and would leave the editor silent exactly when the package fails to load *because* of that
-file. The checker (`partcad_client.lint`, over `partcad_utils.assy_lint`) is the same one the daemon runs over a
-package, so an editor and CI cannot disagree. The VS Code extension runs `pc lint --file`, so the two cannot
-drift apart either.
+`pc lint --file` checks the *files named on the command line*, in this process: an ASSY file and a
+`partcad.yaml` are both Jinja2 templates rendered to YAML and matched against a schema, which needs no package
+graph, no CAD runtime and no context — and with `--stdin` the content is a buffer an editor has not saved,
+which the daemon cannot see at all. There is deliberately no RPC method for it: sending it would ship the
+client's own file across a wire to have it read back, and would leave the editor silent exactly when the
+package fails to load *because* of that file — which for a `partcad.yaml` is every time it is wrong. The
+checker (`partcad_client.lint`, over `partcad_utils.assy_lint`) is the same one the daemon runs over a package,
+so an editor and CI cannot disagree. The VS Code extension runs `pc lint --file`, so the two cannot drift apart
+either. `--schema` picks the flavor of an ASSY file; a `partcad.yaml` has none — nothing points at a package
+configuration — so it is ignored for one, and the detection is not even run.
 
 **`pc open` is on the in-process side for a stronger version of the same reason.** Opening a file in a
 third-party CAD application puts a window on a screen, and the only screen a command can put one on is the one

--- a/src/partcad_cli/click/commands/lint.py
+++ b/src/partcad_cli/click/commands/lint.py
@@ -12,19 +12,22 @@ Checking a **package** means walking the package graph -- which packages,
 resolved how, with which files -- so it is daemon work like any other, and
 `--recursive` reaches imported packages the client has never seen.
 
-Checking a **file** is not. An ASSY file is a Jinja2 template rendered to YAML
-and matched against a schema: pure text work, no package graph, no CAD runtime.
-The file is the client's own, sometimes not even saved yet (`--stdin`), and the
-moment it most needs checking is when the package will not load *because* of it.
-So `--file` never leaves this process: it runs `partcad_client.lint` here, which
-is the same checker the daemon runs over a package, and is what the VS Code
-extension reaches by running this command.
+Checking a **file** is not. An ASSY file and a `partcad.yaml` are both Jinja2
+templates rendered to YAML and matched against a schema: pure text work, no
+package graph, no CAD runtime. The file is the client's own, sometimes not even
+saved yet (`--stdin`), and the moment it most needs checking is when the package
+will not load *because* of it -- which for a `partcad.yaml` is every time it is
+wrong. So `--file` never leaves this process: it runs `partcad_client.lint`
+here, which is the same checker the daemon runs over a package, and is what the
+VS Code extension reaches by running this command.
 
-One thing the daemon does know and this side has to work out: whether the file
-is an assembly or a scene, because a scene is checked against the same schema
-with `how` forbidden. `--schema` says which; `auto`, the default, reads the
-`partcad.yaml` files around the file to find out (see
-`partcad_client.lint.detect_flavor`).
+One thing the daemon does know and this side has to work out: whether an ASSY
+file is an assembly or a scene, because a scene is checked against the same
+schema with `how` forbidden. `--schema` says which; `auto`, the default, reads
+the `partcad.yaml` files around the file to find out (see
+`partcad_client.lint.detect_flavor`). A `partcad.yaml` has no flavor -- nothing
+points at a package configuration -- so nothing is worked out for one, and
+`--schema` is ignored if it is named.
 """
 
 import json
@@ -87,7 +90,7 @@ from ..service import run
     help=(
         "Which schema to check an ASSY --file against: the full one ('assembly'), "
         "the same one without 'how' ('scene'), or whichever the packages around the file "
-        "say it is ('auto')."
+        "say it is ('auto'). Ignored for a 'partcad.yaml', which has one schema."
     ),
 )
 @click.pass_context

--- a/src/partcad_client/lint.py
+++ b/src/partcad_client/lint.py
@@ -5,25 +5,29 @@
 #
 """Checking the files this machine is editing, without asking a daemon.
 
-An ASSY file is a Jinja2 template that renders to YAML and then has to match the
-ASSY schema. Checking one is pure text work: no package graph, no CAD runtime,
-no context -- and the file in question is often not on disk at all, but a buffer
-an editor has not saved yet. Sending that to the daemon would be shipping the
-client's own file across a wire to have it read back, and would leave the editor
-silent exactly when the daemon is down or the package fails to load, which is
-usually *because* of the file being typed into.
+An ASSY file and a `partcad.yaml` are both Jinja2 templates that render to YAML
+and then have to match a schema. Checking one is pure text work: no package
+graph, no CAD runtime, no context -- and the file in question is often not on
+disk at all, but a buffer an editor has not saved yet. Sending that to the
+daemon would be shipping the client's own file across a wire to have it read
+back, and would leave the editor silent exactly when the daemon is down or the
+package fails to load, which is usually *because* of the file being typed into.
+A `partcad.yaml` is the sharpest case of that: the file that decides whether the
+package loads at all is the one a daemon cannot tell you about while it is
+broken.
 
 So every client checks locally, through here: `pc lint --file` in the CLI
-process, and the VS Code extension by running that same command (or, on the
-Python backend, by calling this from its bundled language server). The check
+process, and the VS Code extension by running that same command. The check
 itself is `partcad_utils.assy_lint`, shared with the daemon-side package lint so
 an editor and CI cannot disagree about a file.
 
-One thing has to be decided before the check can run: whether the file is an
-**assembly** or a **scene**, because a scene is checked against the same schema
-with ``how`` forbidden (see `partcad.scene`). That is not a property of the
-file -- it is a property of what points at it -- so it is answered best effort,
-by `detect_flavor` below, and a caller that knows better says so instead.
+One thing has to be decided before an **ASSY** file can be checked: whether it
+is an **assembly** or a **scene**, because a scene is checked against the same
+schema with ``how`` forbidden (see `partcad.scene`). That is not a property of
+the file -- it is a property of what points at it -- so it is answered best
+effort, by `detect_flavor` below, and a caller that knows better says so
+instead. A `partcad.yaml` has no flavor: nothing points at a package
+configuration, and there is only one schema for it.
 """
 
 import os
@@ -54,7 +58,7 @@ _ASSY_TYPES = ("assy",)
 class FileReport:
     """The findings for one file, and how it was named on the way in."""
 
-    def __init__(self, path: str, diagnostics: list, checked: bool, flavor: str = assy_lint.FLAVOR_ASSEMBLY):
+    def __init__(self, path: str, diagnostics: list, checked: bool, flavor: str = None):
         self.path = path
         self.diagnostics = diagnostics
         # False when nothing here knows how to check this kind of file, which is
@@ -62,7 +66,9 @@ class FileReport:
         # two apart (`pc lint --file notes.txt` should say so).
         self.checked = checked
         # What the file was read as. Reported back so that a caller can see
-        # which way the detection went, and an editor can show it.
+        # which way the detection went, and an editor can show it. None where
+        # the question does not arise -- a `partcad.yaml`, or a file type
+        # nothing here checks -- rather than a flavor nothing chose.
         self.flavor = flavor
 
     @property
@@ -154,15 +160,21 @@ def _declared_in(config_path: str, target: str):
 def check_file(path: str, text: str = None, flavor: str = None) -> FileReport:
     """Check one file, or ``text`` as its unsaved content.
 
-    ``flavor`` says whether to read the file as an assembly or as a scene (see
-    `assy_lint.FLAVORS`); None works it out with `detect_flavor`.
+    ``flavor`` says whether to read an ASSY file as an assembly or as a scene
+    (see `assy_lint.FLAVORS`); None works it out with `detect_flavor`. It is
+    ignored for a `partcad.yaml`, which has one schema and no flavor -- and the
+    search is not run for one either, so an editor checking a configuration on
+    every keystroke does not walk the tree above it to answer a question that
+    does not apply.
 
     Raises ``OSError`` if ``text`` is None and the file cannot be read: a caller
     that named a file it cannot open wants to hear about it.
     """
     if assy_lint.schema_name_for_file(path) is None:
         return FileReport(path, [], checked=False)
-    if flavor not in assy_lint.FLAVORS:
+    if not assy_lint.is_assy_file(path):
+        flavor = None
+    elif flavor not in assy_lint.FLAVORS:
         flavor = detect_flavor(path)
     if text is None:
         with open(path, "r", encoding="utf-8") as file:

--- a/src/partcad_utils/assy_lint.py
+++ b/src/partcad_utils/assy_lint.py
@@ -3,13 +3,19 @@
 #
 # Licensed under Apache License, Version 2.0.
 #
-"""Position-accurate syntax and schema checking for PartCAD's ASSY files.
+"""Position-accurate syntax and schema checking for PartCAD's YAML documents.
 
-Every ASSY (``*.assy``) file is a Jinja2 template that is rendered into YAML and
-then has to conform to a JSON schema. That is three error classes a user can
-hit -- a broken template, YAML that does not parse, and YAML that parses but
-does not match the schema -- and an editor is only useful if it can point at the
-*source* line of each one.
+PartCAD writes two kinds of them, and they are the same kind of document: an
+ASSY file (``*.assy``) and a package configuration (``partcad.yaml``) are both
+Jinja2 templates that are rendered into YAML and then have to conform to a JSON
+schema. (``partcad.yaml`` is rendered by `ProjectLocal`, with an
+``includePaths`` of its own to pull fragments in.) That is three error classes a
+user can hit in either of them -- a broken template, YAML that does not parse,
+and YAML that parses but does not match the schema -- and an editor is only
+useful if it can point at the *source* line of each one.
+
+Which schema governs a file is `schema_for_file`, and it is the only thing that
+differs between the two: everything below is about the shape they share.
 
 Rendering the template first is not an option here: rendering needs the
 parameter values, which are only known once the whole package is loaded, and it
@@ -33,12 +39,14 @@ lost information is dropped rather than reported. That trades a missed error for
 never underlining correct code, which is the right trade for an editor.
 
 It lives here, next to ``framing`` and ``workspace``, because neither end owns
-it. The daemon checks a package's ASSY files when `pc lint` walks the package
-graph; every client checks the one file somebody is editing, in its own process
+it. The daemon checks a package's files when `pc lint` walks the package graph;
+every client checks the one file somebody is editing, in its own process
 (`partcad_client.lint`). Both are answering the same question about the same
 documents, so a copy on each side is a copy that can disagree -- and a
 disagreement here means the editor and CI contradicting each other about a file.
-Nothing in this module needs a loaded PartCAD context, or ``partcad`` at all.
+Nothing in this module needs a loaded PartCAD context, or ``partcad`` at all --
+which is why both schemas are packaged beside it rather than under ``partcad``,
+where reaching one would import the CAD kernel to read a JSON file.
 """
 
 import copy
@@ -109,12 +117,20 @@ _VALUE_VALIDATORS = frozenset(
 _KEY_VALIDATORS = frozenset({"required", "anyOf", "oneOf", "not", "dependencies"})
 
 ASSY_SCHEMA = "assy.json"
+PARTCAD_SCHEMA = "partcad.json"
 
-# File extensions whose content this module knows how to check. `partcad.yaml`
-# is deliberately absent: it is checked by `partcad.lint.schema.SchemaLinting`,
-# which reports per-package rather than per-position, and turning its schema
-# loose on an editor would surface every gap in it as a squiggle on a working
-# file.
+# What governs a file, by name and then by extension. A package configuration is
+# recognised by its whole filename because that is what makes it one: PartCAD
+# looks for `partcad.yaml` by name, and a `parts.yaml` beside it is somebody's
+# own file that nothing here should have an opinion about.
+#
+# Both lookups are case-insensitive, so a `Logo.ASSY` or a `PartCAD.yaml` on a
+# case-insensitive filesystem is checked rather than silently skipped -- the
+# package walk and the editor have to agree about which files are checked at all,
+# not only about what they say.
+_SCHEMA_BY_FILENAME = {
+    "partcad.yaml": PARTCAD_SCHEMA,
+}
 _SCHEMA_BY_EXTENSION = {
     ".assy": ASSY_SCHEMA,
 }
@@ -199,7 +215,21 @@ def get_schema(filename: str) -> dict:
 
 def schema_name_for_file(path: str):
     """Return the schema filename that governs ``path``, or None if unknown."""
-    return _SCHEMA_BY_EXTENSION.get(os.path.splitext(os.path.basename(path))[1].lower())
+    name = os.path.basename(path).lower()
+    if name in _SCHEMA_BY_FILENAME:
+        return _SCHEMA_BY_FILENAME[name]
+    return _SCHEMA_BY_EXTENSION.get(os.path.splitext(name)[1])
+
+
+def is_assy_file(path: str) -> bool:
+    """Whether ``path`` is an ASSY file, and so has an assembly/scene flavor.
+
+    A `partcad.yaml` has one schema and no flavor: nothing points at a package
+    configuration the way an `assemblies:` or a `scenes:` entry points at an
+    ASSY file. Callers that work a flavor out ask this first, so that they do
+    not spend the search -- or report an answer -- for a file it cannot apply to.
+    """
+    return schema_name_for_file(path) == ASSY_SCHEMA
 
 
 def scene_schema(schema: dict) -> dict:
@@ -230,11 +260,19 @@ def scene_schema(schema: dict) -> dict:
 
 
 def schema_for_file(path: str, flavor: str = FLAVOR_ASSEMBLY):
-    """The schema that governs ``path`` when read as ``flavor``, or None."""
+    """The schema that governs ``path`` when read as ``flavor``, or None.
+
+    ``flavor`` only means anything for an ASSY file; it is ignored for a
+    `partcad.yaml`, which has one schema. A caller that passes one anyway (an
+    editor sending the same parameters for every document, `pc lint --file
+    --schema scene` naming a configuration by mistake) gets the configuration
+    schema rather than a scene-flavored derivative of it, which would be a
+    schema forbidding a `how` no package configuration has.
+    """
     name = schema_name_for_file(path)
     if name is None:
         return None
-    if flavor != FLAVOR_SCENE:
+    if flavor != FLAVOR_SCENE or name != ASSY_SCHEMA:
         return get_schema(name)
     # Cached like the file-backed schemas beside it: an editor checks the same
     # document on every keystroke, and deriving it each time would deep-copy
@@ -449,13 +487,22 @@ def _unexpected_keys(error) -> list:
 
 
 def _most_specific(error):
-    """Descend into a failed anyOf/oneOf for the most informative sub-error."""
-    while error.context:
-        better = jsonschema.exceptions.best_match(error.context)
-        if better is None or better is error:
-            break
-        error = better
-    return error
+    """Descend into a failed anyOf/oneOf for the most informative sub-error.
+
+    ``best_match`` is handed the error itself rather than its ``context``, which
+    is what makes it descend: given a list it takes the *most* relevant member
+    and then walks down through that member's own branches, discarding a branch
+    only when two of them are equally plausible. Given a ``context`` it took the
+    least relevant of the alternatives instead -- so a part declaration failing
+    the `oneOf` of "a path string" and "a declaration object" was reported
+    against the string branch, and a bad ``axis`` came out as "is not of type
+    'string'" rather than as "[1, 2] is too short".
+
+    Answering the same way `jsonschema.validate()` does is the point: that is
+    the wording `pc lint` printed for a `partcad.yaml` before this checker
+    reported it, and the wording the schema's own error messages are written to.
+    """
+    return jsonschema.exceptions.best_match([error]) or error
 
 
 def _describe(error):

--- a/src/partcad_utils/schema/partcad.json
+++ b/src/partcad_utils/schema/partcad.json
@@ -3,7 +3,7 @@
   "type": "object",
   "definitions": {
     "output-section": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "output_dir": { "type": "string", "minLength": 1 }
       },
@@ -410,7 +410,7 @@
       "allOf": [
         { "$ref": "#/definitions/output-section" },
         {
-          "type": "object",
+          "type": ["object", "null"],
           "properties": {
             "png": { "$ref": "#/definitions/raster-output-type" },
             "jpeg": { "$ref": "#/definitions/raster-output-type" }
@@ -451,8 +451,9 @@
       "maxLength": 255
     },
     "desc": {
+      "description": "What this package is, in prose. Rendered at the top of the package's generated README, and allowed the same length as the 'docs' fields beside it.",
       "type": "string",
-      "maxLength": 1000
+      "maxLength": 5000
     },
     "private": {
       "type": "boolean",
@@ -464,7 +465,7 @@
     },
     "unless": { "$ref": "#/definitions/unless" },
     "docs": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "intro": { "type": "string", "maxLength": 5000 },
         "usage": { "type": "string", "maxLength": 5000 }
@@ -506,6 +507,7 @@
     "suppliers":{
       "description": "The providers to consider for the parts and assemblies of this package. A name is a provider of this package unless it is qualified with a package path, which lets a package buy from a provider defined elsewhere.",
       "oneOf":[
+        { "type": "null" },
         { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
         {
           "type": "object",
@@ -517,7 +519,7 @@
       ]
     },
     "cover": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "package": { "type": "string", "minLength": 1 },
         "assembly": { "type": "string", "minLength": 1 }
@@ -527,7 +529,7 @@
     "render": { "$ref": "#/definitions/render" },
     "export": { "$ref": "#/definitions/output-section" },
     "dependencies": {
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "type": "object",
@@ -555,7 +557,7 @@
       "additionalProperties": false
     },
     "parts": {
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "dependencies": { "fileFrom": ["fileUrl"], "fileUrl": ["fileFrom"] },
@@ -567,9 +569,9 @@
                 "type": {
                   "type": "string",
                   "enum": [
-                    "cadquery", "build123d", "chili3d", "svg", "dxf", "extrude", "sweep",
-                    "stl", "step", "scad", "3mf", "enrich", "alias", "brep", "obj",
-                    "kicad", "compound"
+                    "cadquery", "build123d", "chili3d", "sdf", "svg", "dxf", "extrude",
+                    "sweep", "stl", "step", "scad", "3mf", "enrich", "alias", "brep",
+                    "obj", "kicad", "compound"
                   ]
                 },
                 "aliases": {
@@ -743,7 +745,7 @@
       "additionalProperties": false
     },
     "assemblies":{
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "dependencies": { "fileFrom": ["fileUrl"], "fileUrl": ["fileFrom"] },
@@ -826,7 +828,7 @@
       }
     },
     "scenes": {
-      "type": "object",
+      "type": ["object", "null"],
       "description": "Scenes: placed arrangements of objects - a workcell, a table, a simulation world - stating where things are and not how they got there. Declared by pointing at the file that holds one, with no assembly object in between",
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
@@ -894,7 +896,7 @@
       }
     },
     "sketches": {
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "type": "object",
@@ -1029,7 +1031,7 @@
       "additionalProperties": false
     },
     "interfaces": {
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "type": "object",
@@ -1098,7 +1100,7 @@
       "additionalProperties": false
     },
     "providers": {
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "type": "object",
@@ -1134,7 +1136,7 @@
       "additionalProperties": false
     },
     "repositories": {
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "type": "object",
@@ -1161,7 +1163,7 @@
     },
     "software": {
       "description": "The software this package ships: firmware images, binaries, disk images. Software is an object of a package like a part is, and unlike a part it has no geometry - it is always a file. Every type is a file; the types beyond 'raw' will name the firmware flashing procedure the file goes through (which tool, which bootloader), never a different way of pointing at it.",
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "oneOf": [
@@ -1200,7 +1202,7 @@
       "additionalProperties": false
     },
     "partTypes": {
-      "type": "object",
+      "type": ["object", "null"],
       "patternProperties": {
         "^[a-zA-Z0-9_/./-]+$": {
           "type": "object",

--- a/tests/partcad/unit/test_assembly_urdf.py
+++ b/tests/partcad/unit/test_assembly_urdf.py
@@ -48,13 +48,11 @@ def sandbox(tmp_path, packages):
 
 def assert_valid_package_config(config):
     """Check a 'partcad.yaml' against the schema editors validate it with."""
-    import json
-
     from jsonschema import Draft7Validator
 
-    schema_path = Path(pc.__file__).parent / "schema" / "partcad.json"
-    with open(schema_path) as f:
-        schema = json.load(f)
+    from partcad.lint.all import get_partcad_schema
+
+    schema = get_partcad_schema()
     errors = sorted(Draft7Validator(schema).iter_errors(config), key=lambda e: list(e.path))
     assert not errors, "\n".join("%s: %s" % (list(e.path), e.message) for e in errors)
 

--- a/tests/partcad/unit/test_lint_schema.py
+++ b/tests/partcad/unit/test_lint_schema.py
@@ -12,13 +12,23 @@ that load: a configuration broken badly enough to fail the object factories
 never gets that far (see 'test_file.py' for what the loader reports instead).
 These tests go at the schema directly, so every combination is covered
 regardless of what the loader does with it.
+
+The block at the end goes at the package walk instead -- which files each check
+claims, and what a finding looks like once it comes back. Since the editor
+checks the same file with the same checker, a gap here is a squiggle on a
+working file rather than a message nobody reads.
 """
+
+import asyncio
+import os
 
 import jsonschema
 import jsonschema.exceptions
 import pytest
 
+import partcad as pc
 from partcad.lint.all import get_partcad_schema
+from partcad.lint.schema import AssySchemaLinting, SchemaLinting
 
 
 def validate(config):
@@ -156,3 +166,91 @@ def test_schema_a_parameter_default_may_be_any_other_value(kind):
     for default in (20.0, 20, True, ["a", "b"]):
         config = dict(next(iter(ENRICHABLE[kind].values())), parameters={"grade": {"default": default}})
         validate({kind: {"widget": config}})
+
+
+# What the schema has to accept, because PartCAD's own tooling writes it.
+
+
+@pytest.mark.parametrize("section", ["dependencies", "sketches", "parts", "assemblies", "scenes", "software"])
+def test_schema_an_empty_section_is_the_empty_section(section):
+    """'pc init' writes three of these, and 'pc add part' fills one in.
+
+    An empty section parses as null, which is how the loader reads it as well
+    ('config_obj.get(section) or {}'). Rejecting it put an error on every new
+    package -- invisible while only 'pc lint' checked configurations, and three
+    squiggles on an untouched file once the editor did.
+    """
+    validate({section: None})
+
+
+def test_schema_every_registered_part_type_is_accepted():
+    """A type with a factory behind it that the schema does not know is a gap.
+
+    'sdf' was one: registered in 'globals.py', documented, and used by two of
+    the shipped examples, which therefore failed their own schema check.
+    'wrapper' is deliberately not here -- it is what constructs a part whose
+    'type' names a package-defined partType, not a type anybody writes.
+    """
+    for part_type in ("cadquery", "build123d", "chili3d", "sdf", "step", "brep", "stl", "3mf", "obj", "scad"):
+        validate({"parts": {"widget": {"type": part_type}}})
+
+
+# The package walk: which check claims which file, and what it reports.
+
+
+def package(tmp_path, config):
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "partcad.yaml").write_text(config)
+    return root
+
+
+def test_the_configuration_check_claims_the_configuration(tmp_path):
+    root = package(tmp_path, "desc: a package\n")
+    ctx = pc.Context(str(root))
+    targets = SchemaLinting("PartcadSchema").get_targets(ctx, ctx.get_project("//"))
+    assert [os.path.basename(target) for target in targets] == ["partcad.yaml"]
+
+
+def test_the_assy_check_does_not_also_claim_it(tmp_path):
+    """Both checks know a schema for a file now; only one walks each kind.
+
+    'AssySchemaLinting' picks its targets by asking which files have a schema,
+    so the day 'partcad.yaml' got one it would have started checking the
+    configuration too -- reporting every finding twice, under two check names.
+    """
+    root = package(tmp_path, "assemblies:\n  thing:\n    type: assy\n")
+    (root / "thing.assy").write_text("links:\n  - part: cube\n")
+    ctx = pc.Context(str(root))
+    targets = AssySchemaLinting("AssySchema").get_targets(ctx, ctx.get_project("//"))
+    assert [os.path.basename(target) for target in targets] == ["thing.assy"]
+
+
+def test_a_configuration_finding_carries_its_source_position(tmp_path):
+    """The same wording, at the same place, as the editor shows for the file."""
+    root = package(tmp_path, "desc: a package\nprts:\n  cube:\n    type: cadquery\n")
+    ctx = pc.Context(str(root))
+    project = ctx.get_project("//")
+
+    check_run = SchemaLinting("PartcadSchema")
+    report = asyncio.run(check_run.validate(ctx, project, check_run.get_targets(ctx, project)[0]))
+    assert [message for _, message in report.messages] == ["partcad.yaml:2:1: unexpected property 'prts'"]
+
+
+def test_a_templated_configuration_is_not_reported_as_broken_yaml(tmp_path):
+    """'partcad.yaml' is rendered as a Jinja2 template before it is parsed.
+
+    Handing the raw file to 'yaml.safe_load', which is what this check used to
+    do, called every templated configuration broken.
+    """
+    root = package(
+        tmp_path,
+        "parts:\n{% for size in [10, 20] %}\n  cube_{{ size }}:\n    type: cadquery\n    path: cube.py\n{% endfor %}\n",
+    )
+    (root / "cube.py").write_text("# a part\n")
+    ctx = pc.Context(str(root))
+    project = ctx.get_project("//")
+
+    check_run = SchemaLinting("PartcadSchema")
+    report = asyncio.run(check_run.validate(ctx, project, check_run.get_targets(ctx, project)[0]))
+    assert report.messages == []

--- a/tests/partcad/unit/test_scene.py
+++ b/tests/partcad/unit/test_scene.py
@@ -192,13 +192,11 @@ def test_a_world_scene_owns_the_parts_named_under_it(project):
 
 def test_the_package_schema_accepts_the_scene_example():
     """The example package validates against the schema editors use."""
-    import json
-
     from jsonschema import Draft7Validator
 
-    schema_path = os.path.join(os.path.dirname(os.path.abspath(pc.__file__)), "schema", "partcad.json")
-    with open(schema_path) as f:
-        schema = json.load(f)
+    from partcad.lint.all import get_partcad_schema
+
+    schema = get_partcad_schema()
     config = yaml.safe_load(open(os.path.join(EXAMPLES, SCENE_EXAMPLE_PACKAGE, "partcad.yaml")))
     errors = sorted(Draft7Validator(schema).iter_errors(config), key=lambda e: list(e.path))
     assert not errors, "\n".join("%s: %s" % (list(e.path), e.message) for e in errors)

--- a/tests/partcad/unit/test_supply_cart.py
+++ b/tests/partcad/unit/test_supply_cart.py
@@ -5,8 +5,6 @@
 #
 
 import asyncio
-import importlib.resources
-import json
 
 import jsonschema
 import yaml
@@ -179,8 +177,9 @@ def test_fixture_packages_pass_the_schema():
     so a key the code reads has to be a key the schema allows -- for assemblies
     as well as for parts.
     """
-    with importlib.resources.files("partcad.schema").joinpath("partcad.json").open("r") as file:
-        schema = json.load(file)
+    from partcad.lint.all import get_partcad_schema
+
+    schema = get_partcad_schema()
 
     for path in (SUPPLY_BOM_PACKAGE, "tests/partcad/unit/data/supply_bom/sub/partcad.yaml"):
         with open(path) as file:

--- a/tests/partcad_client/test_lint.py
+++ b/tests/partcad_client/test_lint.py
@@ -53,6 +53,67 @@ def test_a_file_type_with_no_checks_is_not_reported_as_clean(tmp_path):
     assert report.failed is False
 
 
+def test_a_package_configuration_is_checked_too(tmp_path):
+    """The file the package fails to load *because* of is the client's to check.
+
+    Sending it to a daemon would mean asking a daemon that cannot load the
+    package about the file that is stopping it.
+    """
+    path = write(tmp_path, "partcad.yaml", "desc: a package\nparts:\n  cube:\n    type: cadquery\n")
+    report = lint.check_file(path)
+    assert report.checked is True
+    assert report.diagnostics == []
+
+    edited = lint.check_file(path, "desc: a package\nprts:\n  cube:\n    type: cadquery\n")
+    assert [d.message for d in edited.diagnostics] == ["unexpected property 'prts'"]
+    assert (edited.diagnostics[0].line, edited.diagnostics[0].column) == (1, 0)
+
+
+def test_a_configuration_has_no_flavor(tmp_path, monkeypatch):
+    """Nothing points at a package configuration, so nothing is worked out.
+
+    The search is not merely ignored, it is not run: an editor re-checks the
+    open configuration on every keystroke, and walking the tree above it each
+    time to answer a question that cannot apply is work for nothing.
+    """
+    monkeypatch.setattr(lint, "detect_flavor", lambda path: pytest.fail("flavor detected for a configuration"))
+    report = lint.check_file(write(tmp_path, "partcad.yaml", "desc: a package\n"))
+    assert report.flavor is None
+    assert report.to_dict()["flavor"] is None
+
+
+def test_a_scene_flavor_named_for_a_configuration_is_ignored(tmp_path):
+    """`--schema scene` aimed at the wrong file gets the configuration schema.
+
+    A scene-flavored configuration schema would forbid a `how` no package
+    configuration has, which is a schema nothing should ever be checked against.
+    """
+    path = write(tmp_path, "partcad.yaml", "desc: a package\nscenes:\n  bench:\n    type: assy\n")
+    report = lint.check_file(path, flavor="scene")
+    assert report.flavor is None
+    assert report.diagnostics == []
+
+
+def test_a_templated_configuration_is_not_mistaken_for_broken_yaml(tmp_path):
+    """`partcad.yaml` is a Jinja2 template too -- it even has `includePaths`."""
+    path = write(
+        tmp_path,
+        "partcad.yaml",
+        "parts:\n{% for size in [10, 20] %}\n  cube_{{ size }}:\n    type: cadquery\n    path: cube.py\n{% endfor %}\n",
+    )
+    assert lint.check_file(path).diagnostics == []
+
+
+def test_what_pc_init_writes_is_clean(tmp_path):
+    """A new package must not be three errors the moment its file is opened.
+
+    An empty section parses as null, which is how the loader reads it as well;
+    `pc init` writes three of them and `pc add part` fills one in.
+    """
+    path = write(tmp_path, "partcad.yaml", "dependencies:\nsketches:\nparts:\nassemblies:\n")
+    assert lint.check_file(path).diagnostics == []
+
+
 def test_a_missing_file_raises(tmp_path):
     # A caller that named a file it cannot open wants to hear about it, rather
     # than get an empty (and therefore reassuring) report back.

--- a/tests/partcad_utils/test_assy_lint.py
+++ b/tests/partcad_utils/test_assy_lint.py
@@ -5,13 +5,18 @@
 # Licensed under Apache License, Version 2.0.
 #
 
-"""Tests for the ASSY checker in ``partcad_utils.assy_lint``.
+"""Tests for the YAML checker in ``partcad_utils.assy_lint``.
 
-An ASSY file is a Jinja2 template, so the checker cannot simply parse it as
-YAML. It masks the template first, which is what lets it keep the source line
-and column of every finding -- and what forces it to stay quiet about anything
-the mask made unknowable. Both halves are pinned here: real errors are found at
-the right place, and templated files that are perfectly correct stay clean.
+An ASSY file and a ``partcad.yaml`` are both Jinja2 templates, so the checker
+cannot simply parse either as YAML. It masks the template first, which is what
+lets it keep the source line and column of every finding -- and what forces it
+to stay quiet about anything the mask made unknowable. Both halves are pinned
+here: real errors are found at the right place, and templated files that are
+perfectly correct stay clean.
+
+Most of what follows uses ASSY files, because the two documents differ only in
+which schema governs them; the block at the end covers what is specific to a
+package configuration.
 """
 
 import pytest
@@ -21,9 +26,13 @@ from partcad_utils.assy_lint import (
     CODE_SCHEMA,
     CODE_TEMPLATE,
     CODE_YAML,
+    FLAVOR_SCENE,
+    PARTCAD_SCHEMA,
     SEVERITY_ERROR,
     SEVERITY_WARNING,
     get_schema,
+    is_assy_file,
+    schema_for_file,
     schema_name_for_file,
     validate_source,
 )
@@ -236,17 +245,94 @@ def test_diagnostic_dict_is_json_rpc_shaped():
     assert payload["endLine"] >= payload["line"]
 
 
-def test_only_assy_files_have_a_schema(tmp_path):
+def test_each_kind_of_file_finds_its_schema(tmp_path):
     # Reading the file, and deciding there is nothing to read it for, is the
     # caller's half of the job (`partcad_client.lint`); all this knows is which
     # names it has a schema for.
     assert schema_name_for_file("/pkg/logo.assy") == ASSY_SCHEMA
     assert schema_name_for_file("/pkg/LOGO.ASSY") == ASSY_SCHEMA
-    assert schema_name_for_file("/pkg/partcad.yaml") is None
+    assert schema_name_for_file("/pkg/partcad.yaml") == PARTCAD_SCHEMA
+    assert schema_name_for_file("/pkg/PartCAD.YAML") == PARTCAD_SCHEMA
+    # A configuration is recognised by its whole name, so a '.yaml' beside it is
+    # somebody's own file rather than a package this has an opinion about.
+    assert schema_name_for_file("/pkg/parts.yaml") is None
     assert schema_name_for_file("/pkg/notes.txt") is None
 
 
-def test_the_schema_ships_with_the_package():
+def test_only_an_assy_file_has_a_flavor():
+    """A `partcad.yaml` is not read as an assembly or as a scene; it is read."""
+    assert is_assy_file("/pkg/logo.assy")
+    assert not is_assy_file("/pkg/partcad.yaml")
+    assert not is_assy_file("/pkg/notes.txt")
+
+
+def test_the_scene_flavor_does_not_reach_a_configuration():
+    """`--schema scene` on a `partcad.yaml` gets the configuration schema.
+
+    Deriving one would forbid a `how` no package configuration has, and hand a
+    caller that sends the same parameters for every document a schema nothing
+    is checked against.
+    """
+    assert schema_for_file("/pkg/partcad.yaml", FLAVOR_SCENE) is get_schema(PARTCAD_SCHEMA)
+    assert schema_for_file("/pkg/logo.assy", FLAVOR_SCENE) is not get_schema(ASSY_SCHEMA)
+
+
+def test_the_schemas_ship_with_the_package():
     schema = get_schema(ASSY_SCHEMA)
     assert schema["$schema"].startswith("http://json-schema.org/draft-07/")
     assert "node" in schema["definitions"]
+
+    schema = get_schema(PARTCAD_SCHEMA)
+    assert schema["$schema"].startswith("http://json-schema.org/draft-07/")
+    assert "parts" in schema["properties"]
+
+
+# A package configuration is the same kind of document as an ASSY file -- a
+# Jinja2 template that renders to YAML and then has to match a schema -- so the
+# whole of the machinery above applies to it. What follows is what is specific
+# to it: which findings it produces, and what it must not produce a finding for.
+
+
+def config_diagnostics(text):
+    return validate_source(text, get_schema(PARTCAD_SCHEMA))
+
+
+def test_a_configuration_is_checked_against_the_configuration_schema():
+    """A part type PartCAD has no factory for, reported at the declaration."""
+    diagnostics = config_diagnostics("parts:\n  cube:\n    type: nonsense\n")
+    assert [(d.severity, d.code, d.path) for d in diagnostics] == [(SEVERITY_ERROR, CODE_SCHEMA, "$.parts.cube")]
+    assert diagnostics[0].line == 2
+
+
+def test_a_misspelled_configuration_key_is_a_warning_at_the_key():
+    diagnostics = config_diagnostics("desc: a package\nfoo: bar\n")
+    assert len(diagnostics) == 1
+    assert diagnostics[0].severity == SEVERITY_WARNING
+    assert diagnostics[0].message == "unexpected property 'foo'"
+    assert (diagnostics[0].line, diagnostics[0].column) == (1, 0)
+
+
+def test_a_freshly_initialized_package_is_clean():
+    """What `pc init` writes, and `pc add part` leaves beside a populated one.
+
+    An empty section parses as null, which is how the loader reads it too
+    ('config_obj.get(section) or {}'). A schema that rejected it would put three
+    errors on every new package the moment its configuration was opened.
+    """
+    assert config_diagnostics("sketches:\nparts:\nassemblies:\ndependencies:\n") == []
+    assert config_diagnostics("sketches:\nparts:\n  cube:\n    type: cadquery\nassemblies:\n") == []
+
+
+def test_jinja2_in_a_configuration_is_not_mistaken_for_broken_yaml():
+    """`partcad.yaml` is rendered as a template too, `includePaths` and all."""
+    assert (
+        config_diagnostics(
+            "parts:\n"
+            "{% for size in [10, 20] %}\n"
+            "  cube_{{ size }}:\n"
+            "    type: cadquery\n"
+            "    path: cube.py\n"
+            "{% endfor %}\n"
+        )
+        == []
+    )


### PR DESCRIPTION
## Copilot Summary

The VS Code extension checked `.assy` files as they were typed and said nothing about `partcad.yaml` — the file that decides whether the package loads at all, and the one a daemon cannot report on while it is broken. Both are the same kind of document: a Jinja2 template rendered to YAML and matched against a JSON schema. So `partcad.yaml` now goes through the same checker, at the same positions, in the editor and in CI.

**YAML syntax highlighting is preserved** because nothing about the language registration changed. Both files stay registered as `yaml` — that is how the editor picks a grammar — and diagnostics are published per document URI into the `partcad` collection, so they need no language id of their own.

### The change

* **Extension** (`ide/vscode/src/PartcadLint.ts`): `isPackageConfigDocument` matches `partcad.yaml` by basename rather than extension (a `parts.yaml` next door is somebody's own file), and `schedule()` accepts it alongside `.assy`. `flavorOf()` returns nothing for a configuration: nothing points at one, so there is no assembly/scene question to answer.
* **`partcad_utils.assy_lint`** maps `partcad.yaml` to its schema by filename, and `is_assy_file` marks the only kind that has a flavor. A scene flavor named for a configuration is ignored rather than deriving a schema that forbids a `how` no configuration has.
* **The schema moves** to `partcad_utils/schema/partcad.json`, beside the ASSY one and the checker that reads both. A client checks the file it is editing without a daemon and without a CAD kernel; a schema under `partcad` would mean importing one to read a JSON file. `get_partcad_schema()` stays the one way in.
* **`lint/schema.py`** puts both package-side checks on `validate_source` through a shared `YamlLinting`. Findings for a `partcad.yaml` now carry their source line and column, all of them are reported rather than just the first, and a templated configuration is no longer called broken YAML. `AssySchemaLinting` picks its targets with `is_assy_file` so it does not also walk the configuration and report everything twice.
* **`_most_specific`** hands `best_match` the error rather than its `context`, which is what makes it descend. Given a context it took the *least* relevant alternative, so a bad `axis` came out as `is not of type 'string'` instead of `[1, 2] is too short`. The wording matches `jsonschema.validate()` again.

### Schema gaps closed

The comment this replaces said `partcad.yaml` was excluded because turning its schema loose on an editor "would surface every gap in it as a squiggle on a working file." That was true, so the gaps are closed:

* **Every section accepts `null`.** `pc init` writes `dependencies:`/`sketches:`/`parts:`/`assemblies:` empty and the loader already reads null as empty (`config_obj.get(section) or {}`) — a freshly initialised package showed four errors the moment its file was opened.
* **`sdf` joins the part types.** It is registered in `globals.py`, documented in `configuration.rst`, and used by two shipped examples that were failing their own schema check. `wrapper` stays out: it constructs a part whose `type` names a package-defined partType, not a type anybody writes.
* **The package `desc` cap goes 1000 → 5000**, matching the `docs` fields beside it. Three of the shipped examples write more than 800 characters there and one exceeded the old cap.

Every `partcad.yaml` in the repository, plus both `pc init` templates, now lints clean.

### Behaviour change to note

`pc lint` findings for a `partcad.yaml` change shape, from `$.parts.part1: <message>` to `partcad.yaml:5:5: <message>` — the same form the ASSY half already used. 16 `features/lint.feature` expectations are updated accordingly; the message text itself is unchanged.

### Testing

* 577 unit tests pass across the affected suites, with new coverage in `test_assy_lint.py`, `test_lint.py` and `test_lint_schema.py` (schema lookup by name, flavor only for ASSY, null sections, templated configurations, and that the two package checks do not claim the same file).
* All 47 `pc lint` behave scenarios pass, including three new ones.
* Extension: `tsc`, `eslint`, `prettier` and `webpack` are clean.
* Built the wheel and confirmed both schemas ship in it.

Two things could not be exercised in this environment and are worth a reviewer's eye: `import build123d` segfaults here, so the CAD-kernel unit tests did not run (`test_assembly_urdf.py` fails identically on the pristine tree — environmental and pre-existing); and there is no Docker daemon, so the dev-container `pre-commit` run was replaced by running the gates it covers individually. The PyInstaller spec change (dropping the `partcad/schema` data directory now that the schema lives under `partcad_utils/schema`, which the spec already copied) is exercised by the reduced-matrix bundle build this PR triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Nbub6C2AHzoruHAnwwkzD

---
_Generated by [Claude Code](https://claude.ai/code/session_012Nbub6C2AHzoruHAnwwkzD)_