### PR TITLE
Open mesh and non-mesh objects in Blender (`pc open --with blender`)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,16 @@ a CAD addon, or documentation.
 
   `external` is the same rule applied to a window instead of an installation. `pc open` (and the VS Code
   extension's per-part "Open in..." menu, by running it) starts FreeCAD on the screen of whoever ran the
-  command — on this machine, with this machine's file, and never over the wire; there is no RPC method for it
-  and none may be added. A machine with no local installation can run the application in a container PartCAD
-  keeps for it, named after the tool (`partcad-freecad`), with the workspace and the daemon's socket mounted
-  at the paths they have here and the host's X display forwarded into it.
+  command — on this machine, with this machine's file, and never over the wire; there is no RPC method for
+  opening a file and none may be added. A machine with no local installation can run the application in a
+  container PartCAD keeps for it, named after the tool (`partcad-freecad`), with the workspace and the
+  daemon's socket mounted at the paths they have here and the host's X display forwarded into it.
+
+  One application in that table reads meshes and nothing else — Blender — so an object that is not already one
+  is converted to STL before it is handed over. That conversion is the single thing `pc open` asks the daemon
+  for, because a CAD wrapper is what does it; the window still opens here, and the registry still has no
+  `open` method. Which object types are meshes is `object_types`, an inlined copy of PartCAD's own tables (a
+  client must stay cheap to import) that a completeness test keeps honest.
 
 * [src/partcad_ide_client](./src/partcad_ide_client/AGENTS.md):
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,9 @@ Subscribe on [LinkedIn], [YouTube], [TikTok], [Facebook], [Instagram], [Threads]
   - Object-Oriented Programming approach to maintaining part interfaces and mating information
   - Live preview of 3D models while working in Visual Studio Code, with the bill of materials, the assembly
     instructions and supplier quotes on tabs beside the 3D view
-  - Open an object in the application that made it (`pc open`): `FreeCAD`, `Gazebo`, `KiCad` — installed
-    locally, or run in a container when it is not
+  - Open an object in the application that made it (`pc open`): `FreeCAD`, `Blender`, `Gazebo`, `KiCad` —
+    installed locally, or run in a container when it is not; an object `Blender` cannot read is converted to
+    a mesh on the way
   - Render 2D projections, from any viewing angle (`--view`, or an arbitrary one), with the connection
     ports and interfaces drawn on top if asked
     - [x] `SVG`

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -102,29 +102,49 @@ Host commands
 
     pc open cube.step                       # in a locally installed FreeCAD
     pc open --use-docker cube.step          # or in a container, when there is none
+    pc open --with blender cube.stl         # a mesh, in Blender
+    pc open --with blender cube.step        # a solid, converted to STL for Blender first
     pc open --with gazebo warehouse.world   # a scene, in Gazebo
     pc open --with kicad Arduino_Nano.step  # a board, in KiCad
 
-  ``--with`` names the application: ``freecad`` (the default), ``gazebo`` for a Gazebo world -- which is what
-  a :ref:`scene <scenes>` of type ``world`` is, and what ``pc export -S -t world`` writes -- and ``kicad`` for
-  a board. A locally installed one is always
+  ``--with`` names the application: ``freecad`` (the default), ``blender``, ``gazebo`` for a Gazebo world --
+  which is what a :ref:`scene <scenes>` of type ``world`` is, and what ``pc export -S -t world`` writes -- and
+  ``kicad`` for a board. A locally installed one is always
   used when there is one: the command looks on the ``PATH``, in ``/Applications`` on macOS, under
   ``Program Files`` on Windows, and for a flatpak on Linux. Gazebo is looked for under all three of the names
   it has had (``gz sim``, ``ign gazebo``, ``gazebo``), and whichever the machine has is the one used.
 
+  Blender reads meshes and nothing else, so a file that is not one is converted to STL and Blender is given
+  that instead: an STL, an OBJ or a glTF is imported as it is, while a STEP file, a CadQuery script or a mesh
+  in a format Blender ships no importer for (3MF) is converted first. This is the one thing ``pc open`` asks
+  the PartCAD daemon for, because turning a solid into a mesh is CAD work; the window still opens on the
+  machine the command was run on. The converted copy is written under this workspace's own directory (never
+  beside your file), named after the object it came from, and reused until that object changes. ``--type``
+  says what the file holds when its name does not -- a ``.py`` is a CadQuery script, a build123d one or an SDF
+  one -- and the VS Code extension passes the declared type of the object you clicked. A ``.blend`` is
+  Blender's own file and is opened, not converted.
+
+  An object that only means something inside a package -- an ASSY file, a URDF -- has nothing to convert
+  ad-hoc, and is refused with that rather than converted wrongly: export it to a mesh first
+  (``pc export -t stl``) and open that.
+
   KiCad is handed the board rather than the file named, when the two are not the same: a ``kicad`` part *is*
   the STEP file KiCad's command line writes out of the board, so ``pc open --with kicad`` on it opens the
-  ``.kicad_pro`` (or ``.kicad_pcb``, or ``.kicad_sch``) beside it. Nothing is created and nothing is
-  converted -- ``pc open`` renders nothing -- so a file with no board beside it is handed over as it is.
+  ``.kicad_pro`` (or ``.kicad_pcb``, or ``.kicad_sch``) beside it. Nothing is created here and nothing is
+  rendered -- a file with no board beside it is handed over as it is. Every application but Blender is given
+  the file it was pointed at, whatever it holds.
 
   With ``--use-docker``, a machine that has no local installation runs the application in a container instead
-  — one container per application, named after it (``partcad-freecad``, ``partcad-gazebo``,
-  ``partcad-kicad``), created from the application's image
+  — one container per application, named after it (``partcad-freecad``, ``partcad-blender``,
+  ``partcad-gazebo``, ``partcad-kicad``), created from the application's image
   (``--docker-image`` overrides it; FreeCAD's is ``linuxserver/freecad:latest``, since the FreeCAD project
-  publishes no image of its own, Gazebo's is ``gazebosim/gz-harmonic:latest``, and KiCad's is the
+  publishes no image of its own, Blender's is ``linuxserver/blender:latest`` for the same reason, Gazebo's is
+  ``gazebosim/gz-harmonic:latest``, and KiCad's is the
   ``ghcr.io/partcad/partcad-container-kicad`` image PartCAD already builds for ``kicad`` parts) the first
   time and reused afterwards, so a container you have prepared
-  keeps being the one that is used. Remove the application's own container (``docker rm -f partcad-freecad``,
+  keeps being the one that is used. Without ``--use-docker``, a machine with neither the application nor
+  Docker is told so rather than being left with a command that quietly did nothing. Remove the application's
+  own container (``docker rm -f partcad-freecad``, ``partcad-blender``,
   ``partcad-gazebo``, ``partcad-kicad``) to have the next ``pc open``
   create a fresh one. The workspace and the directory holding this workspace's daemon socket are mounted **at
   the paths they have on the host**, which is what lets one path mean the same thing on both sides. A file

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -31,11 +31,12 @@ Objects
 - **Display** (inspect) a part, assembly, scene, sketch, or interface in the ``PartCAD Viewer``; parts can
   also be opened for display and editing together, or their source edited directly.
 - **Test** a part, assembly, or scene.
-- **Open in >** — Open the object's own source file in the application that made it: **FreeCAD** for a part
-  or an assembly, **Gazebo** for a scene of type ``world``, **KiCad** for a part of type ``kicad``. This runs
+- **Open in >** — Open the object's own source file in the application that made it: **FreeCAD** or
+  **Blender** for a part or an assembly, **Gazebo** for a scene of type ``world``, **KiCad** for a part of
+  type ``kicad``. This runs
   on your machine rather than on the daemon: the extension runs ``pc open`` (see :doc:`cli`), which starts an
   application installed here, or runs one in a container when there is none and ``partcad.open.useDocker``
-  is on.
+  is on. Blender reads meshes, so an object that is not one is converted to STL on the way.
 
 The Explorer also lists the ``software`` a package ships. Selecting one shows its path and its ``fileHash``
 in the Inspector and leaves the ``PartCAD Viewer`` as it is: software is a file, not geometry, so there is

--- a/features/open.feature
+++ b/features/open.feature
@@ -16,6 +16,7 @@ Feature: `pc open` command
     And OUTPUT should contain "freecad"
     And OUTPUT should contain "gazebo"
     And OUTPUT should contain "kicad"
+    And OUTPUT should contain "blender"
 
   @failure @pc-open
   Scenario: A file that is not there is reported rather than opened
@@ -50,3 +51,41 @@ Feature: `pc open` command
     When I run "pc --no-ansi open --with kicad pcb.kicad_pro"
     Then the command should exit with a non-zero status code
     And OUTPUT should contain "No such file"
+
+  @failure @pc-open
+  Scenario: A part that is not there is reported rather than opened in Blender
+    Given a file named "cube.stl" does not exist
+    When I run "pc --no-ansi open --with blender cube.stl"
+    Then the command should exit with a non-zero status code
+    And OUTPUT should contain "No such file"
+
+  @failure @pc-open
+  Scenario: The declared type is an option, and it is checked with the rest
+    # The VS Code extension passes it for every object it opens; a `pc` that did
+    # not accept it would fail as a usage error rather than for the reason here.
+    Given a file named "cube.py" does not exist
+    When I run "pc --no-ansi open --with blender --type cadquery cube.py"
+    Then the command should exit with a non-zero status code
+    And OUTPUT should contain "No such file"
+
+  @failure @pc-open
+  Scenario: A script whose type cannot be told from its name says what to pass
+    # Blender reads meshes, so this file has to be converted -- and converting
+    # it means running it, as one of the three kinds of script a '.py' can be.
+    # Refused here, before a daemon is asked to guess, and no window is opened.
+    # Read as JSON, which is one unwrapped line: the error panel `pc` draws
+    # otherwise wraps to the terminal's width, and a message split across two
+    # lines is not one a scenario can look for.
+    When I run "pc --no-ansi open --json --with blender $PARTCAD_ROOT/examples/produce_part_cadquery_primitive/cylinder.py"
+    Then the command should exit with a non-zero status code
+    And STDOUT should contain "--type"
+    And STDOUT should contain "cadquery"
+
+  @failure @pc-open
+  Scenario: An ASSY file is refused by name rather than sent to be refused
+    # There is no package around an ad-hoc file to resolve an ASSY against, so
+    # `pc open` says so itself instead of asking the daemon to convert it.
+    When I run "pc --no-ansi open --json --with blender $PARTCAD_ROOT/examples/produce_scene_assy/bench.assy"
+    Then the command should exit with a non-zero status code
+    And STDOUT should contain "only means anything inside a package"
+    And STDOUT should contain "pc export"

--- a/ide/vscode/AGENTS.md
+++ b/ide/vscode/AGENTS.md
@@ -340,12 +340,13 @@ squiggle on a working file, so anything PartCAD's own tooling writes has to vali
 ## Opening a file in a third-party application
 
 The Explorer's per-item **"Open in > ..."** menu hands the item's file to `partcad.openExternal`, which runs
-`pc --no-ansi open --with <tool> [--use-docker] [--docker-image <image>] <path> --json`. Three applications,
-each offered for the objects it can actually open:
+`pc --no-ansi open --with <tool> [--type <type>] [--use-docker] [--docker-image <image>] <path> --json`. Four
+applications, each offered for the objects it can actually open:
 
 | Menu entry | Command | Shown for |
 | --- | --- | --- |
 | FreeCAD | `partcad.openInFreeCAD` | parts and assemblies |
+| Blender | `partcad.openInBlender` | parts and assemblies |
 | Gazebo | `partcad.openInGazebo` | scenes of type `world` (`viewItem == sceneWorld`) |
 | KiCad | `partcad.openInKiCad` | parts of type `kicad` (`viewItem == partKicad`) |
 
@@ -372,11 +373,20 @@ application is for, has none; `config.item_path` is the file the daemon reported
 The menu is therefore on the same items as "Export" and an object that has no file of its own says so when it
 is picked, rather than being silently missing from the menu.
 
+The object's declared `config.type` is handed over too, as `--type`, and it is the *only* other thing this
+tree contributes. It is there because a file name does not always say what it holds -- a `.py` is a CadQuery
+script, a build123d one or an SDF one -- and Blender reads meshes and nothing else, so a part that is not
+already one is converted to STL before it is opened. Which types are meshes
+(`partcad_client.object_types`), whether this one needs converting, where the mesh goes and who does the
+converting are all decided by `pc open`; nothing here branches on the type, and nothing here knows that
+Blender is the application it matters for.
+
 And no more than that is decided here. A `kicad` part's file is the STEP KiCad's command line writes out of
 the board; the board is the `.kicad_pro` beside it, and swapping one for the other is a fact about KiCad that
 lives in `external.TOOLS` (`Tool.companions`), not in this tree. Same for how Gazebo is launched: `gz sim`,
 `ign gazebo` and `gazebo` are three front ends of one application and `Tool.binary_args` is where that is
-written down.
+written down -- as is Blender being handed `--python-expr` rather than a file name, because the only file
+Blender *opens* is a `.blend`.
 
 `partcad.open.useDocker` and `partcad.open.dockerImage` are read here, on the way to that command line, rather
 than being worked out anywhere in Python: PartCAD decides *how* to run the application, and the settings only

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -111,6 +111,10 @@ the application that made it. It is the object's own source file that is opened,
 in a tool that draws, next to what the extension does with it.
 
 * **FreeCAD**, for a part or an assembly.
+* **Blender**, for a part or an assembly. Blender reads meshes and nothing else, so an object that is not
+  already one (a STEP file, a CadQuery script) is converted to STL first and Blender is given that; an STL, an
+  OBJ or a glTF is imported as it is. The converted copy lives under PartCAD's own directory for this
+  workspace, never beside your file, and is reused until the object changes.
 * **Gazebo**, for a scene that *is* a Gazebo world -- one of type `world`, which is also what
   **Export > Gazebo world...** writes out of any scene.
 * **KiCad**, for a part of type `kicad`. What is opened is the board (`.kicad_pro`) beside the STEP the part
@@ -119,14 +123,16 @@ in a tool that draws, next to what the extension does with it.
 This runs on your machine and never goes anywhere near the PartCAD daemon: the extension runs `pc open`, which
 looks for the application installed here and starts it. If there is none, and `partcad.open.useDocker` is on,
 PartCAD runs it in a Docker container instead -- one container per application, named after it
-(`partcad-freecad`, `partcad-gazebo`, `partcad-kicad`), created from the application's image (or
+(`partcad-freecad`, `partcad-blender`, `partcad-gazebo`, `partcad-kicad`), created from the application's image (or
 `partcad.open.dockerImage`) the first time and reused afterwards, with your
 workspace and the PartCAD daemon's socket mounted at the paths they have here, so one path means the same thing
 on both sides. Its windows come out on your X display. On Linux that is the display you are already using; on
 macOS and Windows it needs an X server (XQuartz, VcXsrv) that PartCAD cannot install for you, so it tells you
 which one to install and what to allow rather than starting a container whose windows go nowhere. Remove the
-container of the application in question (`docker rm -f partcad-freecad`, `partcad-gazebo` or
-`partcad-kicad`) to have the next open create a fresh one.
+container of the application in question (`docker rm -f partcad-freecad`, `partcad-blender`,
+`partcad-gazebo` or `partcad-kicad`) to have the next open create a fresh one. With
+`partcad.open.useDocker` off, a machine that has neither the application nor Docker is told so rather than
+left with a menu entry that quietly does nothing.
 
 ## Inspecting published PartCAD packages
 

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -182,13 +182,13 @@
         "properties": {
           "partcad.open.useDocker": {
             "default": false,
-            "description": "Let PartCAD run a third-party application (\"Open in...\": FreeCAD, Gazebo, KiCad) in a Docker container when it is not installed on this machine. The container is named after the application ('partcad-freecad', 'partcad-gazebo', 'partcad-kicad'), keeps the workspace mounted at the path it has here, and shows its windows on this machine's X display - which macOS and Windows need an X server for.",
+            "description": "Let PartCAD run a third-party application (\"Open in...\": FreeCAD, Blender, Gazebo, KiCad) in a Docker container when it is not installed on this machine. The container is named after the application ('partcad-freecad', 'partcad-blender', 'partcad-gazebo', 'partcad-kicad'), keeps the workspace mounted at the path it has here, and shows its windows on this machine's X display - which macOS and Windows need an X server for.",
             "scope": "machine",
             "type": "boolean"
           },
           "partcad.open.dockerImage": {
             "default": "",
-            "description": "Create that container from this image instead of the application's default one (FreeCAD: 'linuxserver/freecad:latest', Gazebo: 'gazebosim/gz-harmonic:latest', KiCad: the 'ghcr.io/partcad/partcad-container-kicad' image of this release). Applies to whichever application is opened next and only when its container is created; remove an existing one to have it recreated.",
+            "description": "Create that container from this image instead of the application's default one (FreeCAD: 'linuxserver/freecad:latest', Blender: 'linuxserver/blender:latest', Gazebo: 'gazebosim/gz-harmonic:latest', KiCad: the 'ghcr.io/partcad/partcad-container-kicad' image of this release). Applies to whichever application is opened next and only when its container is created; remove an existing one to have it recreated.",
             "scope": "machine",
             "type": "string"
           }
@@ -611,6 +611,13 @@
         "group": "Open in",
         "title": "KiCad",
         "icon": "$(link-external)"
+      },
+      {
+        "command": "partcad.openInBlender",
+        "category": "PartCAD",
+        "group": "Open in",
+        "title": "Blender",
+        "icon": "$(link-external)"
       }
     ],
     "submenus": [
@@ -893,6 +900,10 @@
         {
           "command": "partcad.openInKiCad",
           "when": "view == partcadExplorer && viewItem == partKicad"
+        },
+        {
+          "command": "partcad.openInBlender",
+          "when": "view == partcadExplorer && viewItem != sceneWorld"
         }
       ]
     },

--- a/ide/vscode/src/PartcadExplorer.ts
+++ b/ide/vscode/src/PartcadExplorer.ts
@@ -82,6 +82,7 @@ export class PartcadExplorer implements vscode.TreeDataProvider<PartcadItem> {
         vscode.commands.registerCommand(`partcad.openInFreeCAD`, (item) => this.openWith('freecad', item));
         vscode.commands.registerCommand(`partcad.openInGazebo`, (item) => this.openWith('gazebo', item));
         vscode.commands.registerCommand(`partcad.openInKiCad`, (item) => this.openWith('kicad', item));
+        vscode.commands.registerCommand(`partcad.openInBlender`, (item) => this.openWith('blender', item));
 
         vscode.commands.registerCommand(`partcad.test`, (item) => this.test(item));
 
@@ -179,7 +180,18 @@ export class PartcadExplorer implements vscode.TreeDataProvider<PartcadItem> {
                 { location: vscode.ProgressLocation.Notification, title: `${item.name}`, cancellable: false },
                 async (progress) => {
                     progress.report({ message: 'Opening...' });
-                    await vscode.commands.executeCommand('partcad.openExternal', { path: path, tool: tool });
+                    // The declared type travels with the path, because the path
+                    // does not always say: a '.py' is a CadQuery script, a
+                    // build123d one or an SDF one, and PartCAD has to know which
+                    // before it can convert one for an application that reads
+                    // meshes. Everything that is decided from it -- whether a
+                    // conversion is needed at all -- is decided in `pc open`,
+                    // not here.
+                    await vscode.commands.executeCommand('partcad.openExternal', {
+                        path: path,
+                        tool: tool,
+                        type: item?.config?.type,
+                    });
                 },
             );
         } catch (e) {

--- a/ide/vscode/src/common/backend.ts
+++ b/ide/vscode/src/common/backend.ts
@@ -262,14 +262,29 @@ class JsonRpcBackend implements PartcadBackend {
      * Whether a container may be used is the user's setting rather than
      * something worked out here: PartCAD decides how to run the application, and
      * this only says what it is allowed to do.
+     *
+     * `pc open` may make a daemon call of its own on the way -- an application
+     * that reads meshes has to be handed one, and converting a solid into one is
+     * CAD work. That is its connection, not this one, and it is a conversion
+     * rather than an opening: the window still belongs to the machine the
+     * command ran on.
      */
-    private async openExternal(arg: { path?: string; tool?: string }): Promise<{ detail: string; method: string }> {
+    private async openExternal(arg: {
+        path?: string;
+        tool?: string;
+        type?: string;
+    }): Promise<{ detail: string; method: string }> {
         const config = vscode.workspace.getConfiguration('partcad');
         const image = (config.get<string>('open.dockerImage') ?? '').trim();
         const args = [
             'open',
             '--with',
             arg?.tool ?? 'freecad',
+            // What the object was declared as. It matters for an application
+            // that reads meshes only -- Blender -- where a file that is not one
+            // has to be converted first, and a file name does not always say
+            // which type it holds. `pc open` decides what to do with it.
+            ...(arg?.type ? ['--type', arg.type] : []),
             ...(config.get<boolean>('open.useDocker') === true ? ['--use-docker'] : []),
             ...(image ? ['--docker-image', image] : []),
             arg?.path ?? '',

--- a/src/partcad_cli/AGENTS.md
+++ b/src/partcad_cli/AGENTS.md
@@ -59,12 +59,24 @@ configuration — so it is ignored for one, and the detection is not even run.
 third-party CAD application puts a window on a screen, and the only screen a command can put one on is the one
 in front of the user who ran it: a daemon can be remote, where that window would appear on somebody else's
 desk, on a machine that may have no display at all -- and the path on the command line names a file only the
-client has. It needs no package graph, no CAD runtime and no context either, so there is deliberately no RPC
-method for it and none may be added. The application, the container PartCAD keeps for one that is not
-installed, and the X forwarding into it are `partcad_client.external`, so the command never imports the heavy
+client has. It needs no package graph and no context either, so there is deliberately no RPC
+method for *opening a file* and none may be added. The application, the container PartCAD keeps for one that is
+not installed, and the X forwarding into it are `partcad_client.external`, so the command never imports the heavy
 `partcad`. Taking a path rather than a `<package>:<part>` name follows from the same rule: resolving a name is
 a package-graph question, which is exactly the round trip this command does not make. The VS Code extension's
 "Open in..." context menu runs `pc open --json`, so the two cannot drift apart.
+
+**One step inside it does cross the wire, and it is the exception that states the rule.** Blender reads meshes
+and nothing else, so a part that is not already one has to be converted before it is handed over -- and turning
+a solid into a mesh drives a CAD wrapper, whose sandboxed Python runtime lives in the daemon's environment and
+may not exist on the client at all. So `pc open --with blender` sends `adhoc.convert`, the same method
+`pc adhoc convert` sends, on the same absolute paths: file in, file out, `needs_context=False`, nothing left on
+the daemon to go stale, and no new method in the registry. The window still opens here. Which types are meshes
+is `partcad_client.object_types` -- an inlined copy of PartCAD's tables, so the client stays cheap to import,
+with `tests/partcad/unit/test_client_object_types.py` failing when the copy drifts. This is the only daemon
+call an in-process command makes, and `IN_PROCESS_DAEMON_CALLS` in
+`tests/partcad_cli/unit/test_command_boundary.py` is where it is written down -- one method at a time, so
+widening it is a decision somebody makes on purpose.
 
 A command stays **in-process** only when it operates on the client's own state, which does not cross the wire:
 `init` (creates the workspace, before any package or context exists, and adds the `Render` command to the

--- a/src/partcad_cli/click/commands/open.py
+++ b/src/partcad_cli/click/commands/open.py
@@ -5,13 +5,13 @@
 #
 """`pc open` -- open a file in a third-party application.
 
-Entirely in the client process, and deliberately so. Opening a file in FreeCAD
-is not work the daemon can do on anyone's behalf: a daemon can be remote, where
-the window would appear on somebody else's screen (or on a machine with no
-screen at all), and the path named on this command line means nothing on the
-other side of the wire. It needs no package graph, no CAD runtime and no
+Opening the file happens here, in the client process, and deliberately so.
+Opening a file in FreeCAD is not work the daemon can do on anyone's behalf: a
+daemon can be remote, where the window would appear on somebody else's screen
+(or on a machine with no screen at all), and the path named on this command line
+means nothing on the other side of the wire. It needs no package graph and no
 context either -- the file is already on disk -- so there is no RPC method for
-it and none should be added. Same reasoning as `pc lint --file` and
+opening a file, and none should be added. Same reasoning as `pc lint --file` and
 `pc upgrade`; see "Command boundary" in src/partcad_cli/AGENTS.md.
 
 That is also why it takes a path rather than a `<package>:<part>` name:
@@ -21,15 +21,28 @@ context menu passes the source file of the object the user clicked -- and no
 more than that: which file KiCad is actually pointed at, given the STEP a
 `kicad` part is, is a fact about KiCad and lives in the tool table.
 
+**One thing here does cross the wire, and it is not the opening.** Blender reads
+meshes and nothing else, so a part that is not already one has to be converted
+before it is handed over -- and converting a solid into a mesh drives a CAD
+wrapper, whose runtime lives in the daemon's environment and may not exist on
+this machine at all. So the conversion is `adhoc.convert`, the same method
+`pc adhoc convert` sends, on the same absolute paths; it carries no context
+(it is file-in, file-out) and it leaves nothing on the daemon to go stale. The
+window still opens here, from this process, on this machine's display.
+
 The application is run from this machine when it is installed here, and
 otherwise -- with `--use-docker` -- from a container PartCAD keeps for it. The
-finding, the container and the X forwarding are `partcad_client.external`, so
-the extension and the CLI cannot drift apart.
+finding, the container, the X forwarding and the rule about which types are
+meshes are `partcad_client.external` and `partcad_client.object_types`, so the
+extension and the CLI cannot drift apart.
 """
 
 import json
+import os
 
 import rich_click as click
+
+from ..service import run
 
 
 @click.command(help="Open a file in a third-party application, on this machine.")
@@ -40,7 +53,18 @@ import rich_click as click
     default="freecad",
     show_default=True,
     metavar="APPLICATION",
-    help="Which application to open the file in: freecad, gazebo (a scene's world file) or kicad (a board).",
+    help="Which application to open the file in: freecad, blender, gazebo (a scene's world file) "
+    "or kicad (a board).",
+)
+@click.option(
+    "--type",
+    "object_type",
+    type=str,
+    default=None,
+    metavar="TYPE",
+    help="The PartCAD type the object was declared with ('step', 'cadquery', ...). Only needed when "
+    "the file name does not say -- a '.py' is three different script types -- and only for an "
+    "application that reads meshes, which is what decides whether the file has to be converted first.",
 )
 @click.option(
     "--use-docker",
@@ -62,10 +86,31 @@ import rich_click as click
 )
 @click.argument("path", type=str, required=True)
 @click.pass_context
-def cli(click_ctx, tool: str, use_docker: bool, docker_image: str, as_json: bool, path: str) -> None:
+def cli(click_ctx, tool: str, object_type: str, use_docker: bool, docker_image: str, as_json: bool, path: str) -> None:
     # Deferred: `pc --help` imports every command module to print its short
     # help, and there is no reason for that to touch the tool tables.
     from partcad_client import external
+
+    def transcode(source: str, source_type: str, target: str, target_type: str) -> None:
+        """Make ``target`` out of ``source``, on the daemon: this is CAD work.
+
+        The only round trip this command makes, and it is made only for an
+        application that cannot read what the user asked to open. Paths are
+        already absolute (`external` resolved them), which is what
+        `adhoc.convert` expects.
+        """
+        run(
+            click_ctx.obj,
+            "adhoc.convert",
+            {
+                "kind": "part",
+                "input_type": source_type,
+                "output_type": target_type,
+                "input_filename": source,
+                "output_filename": target,
+            },
+            needs_context=False,
+        )
 
     try:
         result = external.open_file(
@@ -73,21 +118,35 @@ def cli(click_ctx, tool: str, use_docker: bool, docker_image: str, as_json: bool
             tool=tool,
             use_docker=use_docker,
             image=docker_image,
+            object_type=object_type,
+            transcode=transcode,
             # Silent under --json: the caller parses stdout, and progress lines
-            # would be in the way of the one thing it is there to read.
+            # would be in the way of the one thing it is there to read. (A
+            # conversion still logs through the shared renderer, which
+            # `--no-ansi` sends to stderr -- which is why anything parsing this
+            # output passes it, as the VS Code extension does.)
             log=None if as_json else click.echo,
         )
-    except external.ExternalToolError as e:
+    except (external.ExternalToolError, click.ClickException) as e:
+        # A failed conversion arrives as a ClickException from `run`, and it is
+        # as much a reason the file could not be opened as a missing X server
+        # is: it has to reach the caller the same way rather than as a bare
+        # non-zero exit.
+        message = e.format_message() if isinstance(e, click.ClickException) else str(e)
         if as_json:
             # Machine-readable and self-contained, so a caller needs neither the
             # log stream nor the exit code to know what to show the user. The
             # message is the whole point of the failure -- it says which X
             # server to install, or how to let PartCAD use a container.
-            click.echo(json.dumps({"ok": False, "tool": tool, "path": path, "error": str(e)}))
+            click.echo(json.dumps({"ok": False, "tool": tool, "path": path, "error": message}))
             click_ctx.exit(1)
-        raise click.ClickException(str(e))
+        raise click.ClickException(message)
 
     if as_json:
         click.echo(json.dumps(result.to_dict()))
         return
+    if result.source is not None:
+        # What was actually handed over, when it is not what was asked for: the
+        # board beside a KiCad part's STEP, or the mesh made out of a solid.
+        click.echo("Opened %s (from %s)." % (os.path.basename(result.path), os.path.basename(result.source)))
     click.echo(result.detail)

--- a/src/partcad_client/__init__.py
+++ b/src/partcad_client/__init__.py
@@ -19,6 +19,9 @@ machine and its own installation**, from the process running out of it.
   including content an editor has not saved yet.
 * :mod:`~partcad_client.external` -- opening one of those files in a third-party
   CAD application: the one installed here, or a container this machine can run.
+* :mod:`~partcad_client.object_types` -- which PartCAD object types are meshes,
+  which is what decides whether a file has to be converted before an application
+  that reads nothing else can open it.
 
 None of it belongs to a daemon. A daemon can be remote, where "update PartCAD"
 would mean updating somebody else's installation and "stop the local daemons"
@@ -30,6 +33,12 @@ a file joins them for the same reason: it is the client's file, sometimes not
 even on disk, and it needs nothing a daemon has. So does opening one in FreeCAD:
 the window belongs on the screen of whoever ran the command, and a remote daemon
 has neither that screen nor that file.
+
+Converting one is the counter-example, and it is why `external` takes a callback
+rather than doing it: making a mesh out of a solid so that Blender can open it
+drives a CAD wrapper, which is exactly the work a daemon exists for. So the
+decision -- is this already a mesh? -- is here, in tables cheap enough for a
+process with no CAD kernel in it, and the conversion is `pc open`'s to ask for.
 
 `partcad-utils` holds what both ends share (logging, telemetry, user config, and
 the client/daemon rendezvous: framing and workspace addressing). The CLI is the

--- a/src/partcad_client/external.py
+++ b/src/partcad_client/external.py
@@ -31,6 +31,17 @@ path on both sides is what keeps the arrangement honest: the file argument, an
 error message, and anything the application writes back all name one path that
 means the same thing inside the container, on the host, and to the daemon.
 
+Some applications read triangles and nothing else. Blender is the one PartCAD
+knows about: its command line takes a `.blend` to open, and any other geometry
+has to be *imported*, which only a mesh format can be. So a file that is not
+already a mesh is converted to STL first, and the application is handed that
+instead. Which types are meshes is `partcad_client.object_types`; making one out
+of a solid is CAD work, so it is not done here -- the caller passes a
+``transcode`` callback, and `pc open` implements it as the same `adhoc.convert`
+the daemon serves `pc adhoc convert` with. The converted copy is written under
+the workspace's own state directory, which is already mounted into the container
+at the path it has here, so one name means the same thing on both sides.
+
 A containerised GUI needs an X server on the host, which is the one place where
 this cannot paper over the difference between platforms. On Linux the display is
 usually a socket that can simply be shared, cookie and all, and nothing has to be
@@ -42,6 +53,7 @@ what to run, rather than a container that starts and silently never shows a wind
 
 import contextlib
 import glob
+import hashlib
 import os
 import platform
 import shutil
@@ -51,7 +63,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from partcad_utils.workspace import determine_root_path, socket_path
 
-from . import __version__
+from . import __version__, object_types
 
 __all__ = [
     "ExternalToolError",
@@ -60,6 +72,7 @@ __all__ = [
     "TOOLS",
     "open_file",
     "tool_names",
+    "transcode_path",
 ]
 
 # How long to wait for the `docker` commands that only ask a question. Generous
@@ -95,6 +108,12 @@ class Tool:
     binaries: Tuple[str, ...] = ()
     # macOS application bundles, looked for under /Applications and ~/Applications.
     macos_apps: Tuple[str, ...] = ()
+    # The executable inside the macOS bundle, relative to it, for an application
+    # that is handed arguments rather than a document. `open -a` is how macOS
+    # launches one and is used everywhere else, but it hands a *running* copy
+    # nothing at all -- so an application whose file arrives as an argument (see
+    # `file_args`) would silently open nothing the second time.
+    macos_executable: Optional[str] = None
     # Windows install locations, as globs relative to the directories in
     # `windows_roots`, so a versioned directory name still matches.
     windows_globs: Tuple[str, ...] = ()
@@ -112,6 +131,26 @@ class Tool:
     # what somebody opening KiCad means -- is the project file next to it, and
     # the tree has no other name for it.
     companions: Tuple[str, ...] = ()
+    # How the file reaches the application, when being the last argument is not
+    # it. Blender's command line takes a `.blend` to open and imports anything
+    # else through a line of Python, which is a fact about Blender and lives
+    # with the rest of them.
+    file_args: Optional[Callable[[str], Tuple[str, ...]]] = None
+    # The format a file that is not already a mesh is converted to before this
+    # application sees it, for an application that reads meshes and nothing
+    # else. None -- every other tool in the table -- means the file is handed
+    # over as it is, whatever it holds.
+    mesh_via: Optional[str] = None
+    # Extensions this application opens whatever they contain, because they are
+    # its own: a `.blend` is not a mesh and must not be converted into one.
+    own_formats: Tuple[str, ...] = ()
+    # The mesh formats this application imports, for one that reads meshes only.
+    # A second question from `mesh_via`, and a different one: PartCAD's tables
+    # say whether a file holds triangles, and this says whether *this*
+    # application can read the file that holds them. 3MF is the case that makes
+    # it two questions -- it is a mesh, and Blender ships no importer for it, so
+    # it takes the STL route like a solid does.
+    imports: Tuple[str, ...] = ()
 
     @property
     def container_name(self) -> str:
@@ -128,6 +167,36 @@ class Tool:
         """
         stem = os.path.splitext(os.path.basename(executable))[0]
         return self.binary_args.get(stem, self.args)
+
+    def file_arguments(self, path: str) -> Tuple[str, ...]:
+        """The arguments that name ``path`` to this application.
+
+        The path itself for every application that takes a file name, which is
+        all of them but Blender; see `file_args`.
+        """
+        if self.file_args is None:
+            return (path,)
+        return tuple(self.file_args(path))
+
+    def needs_mesh(self, path: str, object_type: Optional[str] = None) -> bool:
+        """Whether ``path`` has to be converted before this application sees it.
+
+        False for every application that takes what it is given, and false for
+        one that reads meshes when the file already is a mesh it can read -- or
+        is the application's own project format, which is not a mesh and is not
+        to be converted into one. A mesh in a format it has no importer for is
+        converted like a solid: the point is a file the application opens.
+        """
+        if self.mesh_via is None:
+            return False
+        extension = os.path.splitext(path)[1].lower()
+        if extension in self.own_formats:
+            return False
+        if object_types.is_mesh(path, object_type) is not True:
+            return True
+        # A mesh this application has no importer for is no better off than a
+        # solid: it is converted too, to the one format that always works.
+        return extension not in self.imports
 
     def file_for(self, path: str) -> str:
         """The file this application is really given, from the one it was handed.
@@ -205,9 +274,89 @@ KICAD = Tool(
     companions=(".kicad_pro", ".kicad_pcb", ".kicad_sch"),
 )
 
+# The Python Blender is asked to run when it is handed geometry rather than one
+# of its own files. `blender <file>` *opens* a file, and the only thing Blender
+# opens is a `.blend`: everything else is an import, which is an operator call
+# and nothing else. Written as one expression on the command line rather than a
+# script file because it has to work identically in a container, where a script
+# file would be one more thing to make visible on both sides of the mount.
+#
+# Two names per format: Blender 4.x replaced the old Python importers with C++
+# ones under different operator names ('wm.stl_import' for what used to be
+# 'import_mesh.stl'), and both releases are in use. Whichever exists answers;
+# the loop tries them in turn, newest first, and says so if none does. Reading
+# a home file with no contents first is what leaves the imported object alone in
+# the scene instead of inside Blender's default cube.
+_BLENDER_IMPORT = """\
+import bpy, os
+path = {path!r}
+importers = {{
+    '.stl': ('wm.stl_import', 'import_mesh.stl'),
+    '.obj': ('wm.obj_import', 'import_scene.obj'),
+    '.ply': ('wm.ply_import', 'import_mesh.ply'),
+    '.gltf': ('import_scene.gltf',),
+    '.glb': ('import_scene.gltf',),
+    '.json': ('import_scene.gltf',),
+    '.fbx': ('import_scene.fbx',),
+    '.x3d': ('import_scene.x3d',),
+}}
+extension = os.path.splitext(path)[1].lower()
+bpy.ops.wm.read_homefile(use_empty=True)
+for name in importers.get(extension, ()):
+    category, _, operator = name.partition('.')
+    try:
+        getattr(getattr(bpy.ops, category), operator)(filepath=path)
+        break
+    except Exception as e:
+        print('PartCAD: bpy.ops.' + name + ' did not import ' + path + ': ' + str(e))
+else:
+    print('PartCAD: this Blender has no importer for ' + (extension or path))
+"""
+
+
+def _blender_arguments(path: str) -> Tuple[str, ...]:
+    """How Blender is told about ``path``: opened if it is a `.blend`, else imported."""
+    if os.path.splitext(path)[1].lower() == ".blend":
+        return (path,)
+    return ("--python-expr", _BLENDER_IMPORT.format(path=path))
+
+
+BLENDER = Tool(
+    name="blender",
+    display_name="Blender",
+    # `:latest`, for the reason FreeCAD's is: a user asking for a container
+    # wants the current Blender. The image is a community one because the
+    # Blender project publishes none, and it is this one because it carries a
+    # GUI Blender on `PATH` and is still being rebuilt. `--docker-image`
+    # overrides it, as it does for every other tool here.
+    image="linuxserver/blender:latest",
+    binaries=("blender",),
+    macos_apps=("Blender.app",),
+    # Not through `open -a`: the arguments below are the whole point of the
+    # launch, and `open -a` drops them on a Blender that is already running.
+    macos_executable="Contents/MacOS/Blender",
+    windows_globs=("Blender Foundation/Blender*/blender.exe", "Blender*/blender.exe"),
+    flatpak_id="org.blender.Blender",
+    file_args=_blender_arguments,
+    # What the expression above knows how to import. '.json' is deliberately
+    # absent: PartCAD writes both glTF and three.js to it, and only one of the
+    # two is a file Blender reads -- so a '.json' is converted rather than
+    # guessed at.
+    imports=(".stl", ".obj", ".ply", ".gltf", ".glb", ".fbx", ".x3d"),
+    # Blender reads triangles. Anything else -- a STEP file, a CadQuery script,
+    # a part PartCAD builds -- reaches it as the STL PartCAD makes out of it.
+    # STL rather than a richer mesh format because every part type converts to
+    # it, which is what makes this one rule rather than a table of exceptions.
+    mesh_via="stl",
+    # A `.blend` is Blender's own file: not a mesh, and not something to convert
+    # into one.
+    own_formats=(".blend",),
+)
+
+
 # The tools `pc open --with` accepts. Each is a row here, not a branch anywhere
 # below.
-TOOLS: Dict[str, Tool] = {tool.name: tool for tool in (FREECAD, GAZEBO, KICAD)}
+TOOLS: Dict[str, Tool] = {tool.name: tool for tool in (FREECAD, GAZEBO, KICAD, BLENDER)}
 
 
 def tool_names() -> List[str]:
@@ -225,6 +374,11 @@ class OpenResult:
     path: str
     command: List[str]
     detail: str
+    # The file the caller named, when the application was given another one --
+    # the board beside a KiCad part's STEP, the mesh made out of a solid. None
+    # when it was handed exactly what it was asked about, which is the usual
+    # case; a caller that reports "opened <path>" then needs no special case.
+    source: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
@@ -232,6 +386,7 @@ class OpenResult:
             "tool": self.tool,
             "method": self.method,
             "path": self.path,
+            "source": self.source,
             "command": list(self.command),
             "detail": self.detail,
         }
@@ -243,6 +398,8 @@ def open_file(
     use_docker: bool = False,
     image: Optional[str] = None,
     log: Optional[Callable[[str], None]] = None,
+    object_type: Optional[str] = None,
+    transcode: Optional[Callable[[str, Optional[str], str, str], None]] = None,
 ) -> OpenResult:
     """Open ``path`` in ``tool``, natively if it is installed, else in a container.
 
@@ -250,6 +407,19 @@ def open_file(
     demand for one: a machine with the application installed uses it either way.
     Without that permission, and without a local installation, this raises rather
     than pulling an image nobody asked for.
+
+    ``object_type`` is the PartCAD type the object was declared with, when the
+    caller knows it -- the VS Code tree does, and a file name does not always say
+    (a '.py' is three different script types). It decides nothing on its own; it
+    is one of the two things `object_types.is_mesh` reads.
+
+    ``transcode`` is how a file that is not a mesh becomes one, for an
+    application that reads nothing else. Called as
+    ``transcode(source, source_type, target, target_type)`` and expected to leave
+    ``target`` on disk. It is a callback rather than something done here because
+    turning a solid into a mesh is CAD work: it belongs to the daemon, and this
+    module is the half that must keep running without one. A caller that passes
+    none can still open a mesh in Blender; a solid is refused with the reason.
     """
     say = log or (lambda _message: None)
 
@@ -259,20 +429,30 @@ def open_file(
             "Unknown application '%s'. PartCAD can open files in: %s." % (tool, ", ".join(tool_names()))
         )
 
-    resolved = os.path.abspath(os.path.expanduser(path))
-    if not os.path.exists(resolved):
-        raise ExternalToolError("No such file: %s" % resolved)
-    resolved = spec.file_for(resolved)
+    named = os.path.abspath(os.path.expanduser(path))
+    if not os.path.exists(named):
+        raise ExternalToolError("No such file: %s" % named)
+    resolved = spec.file_for(named)
+
+    # The workspace is worked out from the file the caller named, before any
+    # conversion: a converted copy lives under that workspace's own state
+    # directory, and asking which workspace *it* is in would answer with the
+    # state directory itself.
+    root = _workspace_for(resolved)
+    opened = resolved
+    if spec.needs_mesh(resolved, object_type):
+        opened = _transcode(spec, resolved, root, object_type, transcode, say)
 
     native = native_command(spec)
     if native is not None:
-        command = list(native) + list(spec.launch_args(native[-1])) + [resolved]
-        say("Opening %s in %s..." % (resolved, spec.display_name))
+        command = list(native) + list(spec.launch_args(native[-1])) + list(spec.file_arguments(opened))
+        say("Opening %s in %s..." % (opened, spec.display_name))
         _spawn(command)
         return OpenResult(
             tool=spec.name,
             method="native",
-            path=resolved,
+            path=opened,
+            source=None if opened == named else named,
             command=command,
             detail="%s is installed on this machine." % spec.display_name,
         )
@@ -284,7 +464,92 @@ def open_file(
             "(the 'partcad.open.useDocker' setting in the VS Code extension)." % spec.display_name
         )
 
-    return _open_in_container(spec, resolved, image, say)
+    return _open_in_container(spec, opened, root, image, say, source=None if opened == named else named)
+
+
+# ---------------------------------------------------------------------------
+# Making a mesh out of what the application cannot read
+# ---------------------------------------------------------------------------
+
+
+def transcode_path(root: str, source: str, output_type: str) -> str:
+    """Where the converted copy of ``source`` goes.
+
+    Under the workspace's own directory on this machine -- the one that holds
+    its daemon socket -- rather than beside the file. Two reasons, and both are
+    the reason it is not a temporary directory either:
+
+    * nothing PartCAD generates belongs in the user's source tree, where it
+      would turn up in `git status` after opening a part; and
+    * that directory is mounted into the container, at the path it has here, so
+      the converted file has one name that means the same thing on both sides.
+
+    The name carries a digest of the source path, so two parts called `cube` in
+    different packages do not overwrite each other's mesh, and is otherwise
+    stable, so opening the same part twice reuses the same file.
+    """
+    digest = hashlib.sha256(os.path.realpath(source).encode("utf-8")).hexdigest()[:16]
+    stem = os.path.splitext(os.path.basename(source))[0]
+    return os.path.join(_state_dir(root), "open", "%s-%s.%s" % (stem, digest, output_type))
+
+
+def _transcode(
+    spec: Tool,
+    source: str,
+    root: str,
+    object_type: Optional[str],
+    transcode: Optional[Callable[[str, Optional[str], str, str], None]],
+    say: Callable[[str], None],
+) -> str:
+    """Convert ``source`` to the mesh format ``spec`` reads, and return that file."""
+    source_type = object_types.readable_type(source, object_type)
+    reason = object_types.PACKAGE_ONLY_TYPES.get((source_type or "").lower())
+    if reason is not None:
+        raise ExternalToolError(
+            "%s cannot open %s: %s, so it only means anything inside a package and there is "
+            "nothing here to convert.\n"
+            "Export the object to a mesh first, and open that: pc export -t stl -O <file> <object>"
+            % (spec.display_name, source, reason)
+        )
+    if source_type is None:
+        candidates = object_types.types_of_extension(os.path.splitext(source)[1])
+        raise ExternalToolError(
+            "%s reads meshes, and PartCAD cannot tell from its name what %s holds%s.\n"
+            "Say so with --type ('pc open --type ...'); the VS Code extension passes the "
+            "declared type of the object you clicked."
+            % (
+                spec.display_name,
+                source,
+                (" (it could be: %s)" % ", ".join(candidates)) if candidates else "",
+            )
+        )
+    if transcode is None:
+        # A caller inside `pc open` always passes one. Anything else reaching
+        # here is a caller that cannot convert, and saying so beats opening an
+        # application on a file it will refuse.
+        raise ExternalToolError(
+            "%s reads meshes, and %s is not one. Converting it needs the PartCAD daemon; "
+            "run `pc open` rather than calling this directly." % (spec.display_name, source)
+        )
+
+    target = transcode_path(root, source, spec.mesh_via)
+    if os.path.isfile(target) and os.path.getmtime(target) >= os.path.getmtime(source):
+        # The conversion is the slow part of opening a part, and the source has
+        # not changed since the last one. A `touch` of the source is enough to
+        # ask for it again, and so is deleting the file.
+        say("Reusing %s..." % target)
+        return target
+
+    with contextlib.suppress(OSError):
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+    say("Converting %s to %s for %s..." % (source, spec.mesh_via.upper(), spec.display_name))
+    transcode(source, source_type, target, spec.mesh_via)
+    if not os.path.isfile(target):
+        raise ExternalToolError(
+            "Failed to convert %s to %s for %s; the conversion wrote nothing to %s."
+            % (source, spec.mesh_via.upper(), spec.display_name, target)
+        )
+    return target
 
 
 # ---------------------------------------------------------------------------
@@ -309,11 +574,21 @@ def native_command(spec: Tool) -> Optional[List[str]]:
         for app in spec.macos_apps:
             for directory in ("/Applications", os.path.expanduser("~/Applications")):
                 bundle = os.path.join(directory, app)
-                if os.path.isdir(bundle):
-                    # Through `open`, not the executable inside the bundle: it is
-                    # how macOS launches an application, and it reuses a running
-                    # instance instead of starting a second one.
-                    return ["open", "-a", bundle]
+                if not os.path.isdir(bundle):
+                    continue
+                if spec.macos_executable is not None:
+                    # The executable inside the bundle, because this application
+                    # is handed arguments and `open -a` drops them on a copy
+                    # that is already running -- which would open nothing at
+                    # all, silently, from the second `pc open` onwards.
+                    executable = os.path.join(bundle, spec.macos_executable)
+                    if os.path.isfile(executable):
+                        return [executable]
+                    continue
+                # Through `open`, not the executable inside the bundle: it is
+                # how macOS launches an application, and it reuses a running
+                # instance instead of starting a second one.
+                return ["open", "-a", bundle]
     elif system == "Windows":  # pragma: no cover - exercised only on Windows
         for root in _windows_roots():
             for pattern in spec.windows_globs:
@@ -349,8 +624,21 @@ def _windows_roots() -> List[str]:  # pragma: no cover - exercised only on Windo
 # ---------------------------------------------------------------------------
 
 
-def _open_in_container(spec: Tool, path: str, image: Optional[str], say: Callable[[str], None]) -> OpenResult:
-    """Run ``spec`` in its container, creating and starting one as needed."""
+def _open_in_container(
+    spec: Tool,
+    path: str,
+    root: str,
+    image: Optional[str],
+    say: Callable[[str], None],
+    source: Optional[str] = None,
+) -> OpenResult:
+    """Run ``spec`` in its container, creating and starting one as needed.
+
+    ``root`` is the workspace to mount, worked out by the caller from the file
+    it was asked about rather than from ``path``: the two differ when ``path``
+    is a mesh PartCAD made, which lives under that workspace's state directory
+    and is not in a workspace of its own.
+    """
     if not _docker_available():
         raise ExternalToolError(
             "%s is not installed on this machine and Docker is not available to run it in a container.\n"
@@ -363,8 +651,6 @@ def _open_in_container(spec: Tool, path: str, image: Optional[str], say: Callabl
     # point of the check.
     x11_env, x11_mounts, x11_advice = _x11_forwarding(spec)
     display = x11_env["DISPLAY"]
-
-    root = _workspace_for(path)
 
     state = _container_state(spec.container_name)
     if state is None:
@@ -390,7 +676,7 @@ def _open_in_container(spec: Tool, path: str, image: Optional[str], say: Callabl
         spec.container_name,
         binary,
         *spec.launch_args(binary),
-        path,
+        *spec.file_arguments(path),
     ]
     say("Opening %s in %s (container '%s', DISPLAY=%s)..." % (path, spec.display_name, spec.container_name, display))
     result = _run(command)
@@ -403,7 +689,7 @@ def _open_in_container(spec: Tool, path: str, image: Optional[str], say: Callabl
     detail = "%s runs in the '%s' container, displaying on %s." % (spec.display_name, spec.container_name, display)
     if x11_advice:
         detail += "\n" + x11_advice
-    return OpenResult(tool=spec.name, method="docker", path=path, command=command, detail=detail)
+    return OpenResult(tool=spec.name, method="docker", path=path, source=source, command=command, detail=detail)
 
 
 def _env_args(env: Dict[str, str]) -> List[str]:
@@ -412,6 +698,18 @@ def _env_args(env: Dict[str, str]) -> List[str]:
     for key in sorted(env):
         args += ["--env", "%s=%s" % (key, env[key])]
     return args
+
+
+def _state_dir(root: str) -> str:
+    """The workspace's own directory on this machine, holding its daemon socket.
+
+    Derived from `socket_path` rather than named again, because this is the
+    directory `_create_container` mounts: a converted mesh is written into it
+    (see `transcode_path`) precisely so that it arrives inside the container,
+    and two ways of spelling one directory is how that would quietly stop being
+    true.
+    """
+    return os.path.dirname(socket_path(root))
 
 
 def _workspace_for(path: str) -> str:
@@ -490,7 +788,7 @@ def _create_container(spec: Tool, image: str, root: str, x11_mounts: List[str], 
     # times over. Waiting for a daemon that has not started would mean a
     # container that can never see the one that eventually does -- and the
     # directory is PartCAD's own, which the daemon would create the same way.
-    socket_dir = os.path.dirname(socket_path(root))
+    socket_dir = _state_dir(root)
     with contextlib.suppress(OSError):
         os.makedirs(socket_dir, exist_ok=True)
     if os.path.isdir(socket_dir):

--- a/src/partcad_client/object_types.py
+++ b/src/partcad_client/object_types.py
@@ -1,0 +1,246 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""What a PartCAD object type holds, as far as a client has to care: a mesh or not.
+
+One question is asked here, and `partcad_client.external` is what asks it. Some
+applications read triangles and nothing else -- Blender is the one PartCAD knows
+about -- so handing one a STEP file is not a slow way of opening it, it is a file
+the application cannot read at all. Such a file has to be turned into a mesh
+first, and that is CAD work: it belongs to the daemon (`pc open` sends the same
+`adhoc.convert` a `pc adhoc convert` does), while deciding *whether* it is needed
+is a question about the type, which is what this module answers.
+
+The tables are inlined copies of PartCAD's own, for the reason every other table
+in a client is: `partcad_client` must stay cheap to import, and `import partcad`
+costs seconds and a CAD kernel that a thin client may not even have. A copy that
+can drift is only safe if something notices the drift, so
+`tests/partcad_client/test_object_types.py` compares every table below against
+the `partcad` one it mirrors and fails when a type is added there and not here.
+That test is the reason these are tables and not a handful of `if`s.
+
+"Mesh" means the file itself carries triangles -- what an STL, a 3MF, an OBJ, a
+glTF or a three.js JSON is. Everything else is False, and False means exactly one
+thing to a caller: *this is not already a mesh*, so an application that needs one
+has to be given a converted copy. It is deliberately not a claim that the type
+has no geometry -- `alias` and `enrich` are references, `extrude` and `sweep` are
+built from a sketch, and none of them is a mesh; a mesh is what a conversion
+produces out of any of them.
+"""
+
+import os
+from typing import Dict, Optional, Tuple
+
+__all__ = [
+    "ASSY_EXTENSION",
+    "EXTENSION_ALIASES",
+    "PACKAGE_ONLY_TYPES",
+    "PART_TYPE_EXTENSION",
+    "PART_TYPE_IS_MESH",
+    "is_mesh",
+    "is_mesh_file",
+    "is_mesh_type",
+    "readable_type",
+    "type_of_file",
+    "types_of_extension",
+]
+
+# Every part type PartCAD has, and whether what it names is already a mesh.
+#
+# The keys are the union of two sets, which is what the completeness test
+# checks: the types registered as part factories (`partcad.globals`, which is
+# what a package may declare) and the types the part extension mapping names
+# (`partcad.shape.PART_EXTENSION_MAPPING`, which adds the ones PartCAD only ever
+# writes -- there is no `threejs` factory, but `pc export -t threejs` produces
+# one and `pc open` may well be handed the result).
+#
+# Adding a part type to PartCAD means adding it here. The test says so by name
+# when it is forgotten, because the alternative is silent: a new mesh format
+# would be converted to STL before Blender saw it, which works and is wrong.
+PART_TYPE_IS_MESH: Dict[str, bool] = {
+    # Meshes: triangles on disk, which a mesh application opens as they are.
+    "stl": True,
+    "3mf": True,
+    "obj": True,
+    "gltf": True,
+    "threejs": True,
+    # Boundary representations: surfaces and solids, not triangles.
+    "step": False,
+    "brep": False,
+    "iges": False,
+    # Scripts PartCAD runs to produce a shape. What comes out is a solid; the
+    # file itself is source code, which no CAD application opens as geometry.
+    "cadquery": False,
+    "build123d": False,
+    "chili3d": False,
+    "sdf": False,
+    "scad": False,
+    # Shapes built by PartCAD out of something else in the package.
+    "extrude": False,
+    "sweep": False,
+    "compound": False,
+    # References to another object, which decide nothing themselves: whatever
+    # they point at, a mesh application still gets there through a conversion.
+    "alias": False,
+    "enrich": False,
+    # A part whose type is a package-defined 'partType' (see PartFactoryWrapper).
+    # What the wrapper writes is not knowable from here, so it takes the same
+    # route everything unknown does.
+    "wrapper": False,
+    # A KiCad part is the STEP file `kicad-cli` writes out of a board.
+    "kicad": False,
+    # An assembly description, not a shape: a URDF names the mesh files of its
+    # links. It is in the part extension mapping, so it is answered here too.
+    "urdf": False,
+}
+
+# The file extension each part type is stored in, inlined from
+# `partcad.shape.PART_EXTENSION_MAPPING`. Only the types that are file formats
+# are in it -- `alias`, `kicad` and the rest of the constructed types are not
+# stored as anything.
+PART_TYPE_EXTENSION: Dict[str, str] = {
+    "step": "step",
+    "brep": "brep",
+    "stl": "stl",
+    "3mf": "3mf",
+    "threejs": "json",
+    "obj": "obj",
+    "iges": "iges",
+    "gltf": "json",
+    "urdf": "urdf",
+    "cadquery": "py",
+    "build123d": "py",
+    "chili3d": "chili",
+    "sdf": "py",
+    "scad": "scad",
+}
+
+# Other spellings of the formats above. PartCAD names one extension per type,
+# because that is what it writes; a file a user points `pc open` at was written
+# by something else as often as not, and '.stp' and '.glb' are what that
+# something else calls these.
+EXTENSION_ALIASES: Dict[str, str] = {
+    "stp": "step",
+    "igs": "iges",
+    "gltf": "gltf",
+    "glb": "gltf",
+}
+
+# The extension of an ASSY file. 'assy' is an assembly type rather than a part
+# type, so it is in neither table above -- but it is very much a file `pc open`
+# is handed, and saying what it is beats reporting it as an unknown name.
+ASSY_EXTENSION = "assy"
+
+# Object types that only mean anything inside a package, inlined from
+# `partcad.adhoc.adhoc.PACKAGE_ONLY_TYPES` (the same reason as every other table
+# here, and the same completeness test). A conversion cannot be asked for one:
+# there is no package around the file to resolve it against, so a caller has to
+# say so rather than send a request that is refused.
+PACKAGE_ONLY_TYPES: Dict[str, str] = {
+    "urdf": "a URDF names the meshes of its links and becomes a part per link",
+    "assy": "an ASSY file is a set of references to the parts of a package",
+}
+
+
+def _extension_types() -> Dict[str, Tuple[str, ...]]:
+    """Every extension, and the types that are stored in it.
+
+    More than one type can claim an extension -- '.py' is CadQuery, build123d
+    and SDF alike -- so this maps to a tuple and the callers below say what they
+    do about it. Nothing here guesses.
+    """
+    types: Dict[str, list] = {}
+    for object_type, extension in PART_TYPE_EXTENSION.items():
+        types.setdefault(extension, []).append(object_type)
+    for extension, object_type in EXTENSION_ALIASES.items():
+        if object_type not in types.setdefault(extension, []):
+            types[extension].append(object_type)
+    types.setdefault(ASSY_EXTENSION, []).append("assy")
+    return {extension: tuple(sorted(names)) for extension, names in types.items()}
+
+
+EXTENSION_TYPES: Dict[str, Tuple[str, ...]] = _extension_types()
+
+
+def _extension_of(path: str) -> str:
+    """The extension of ``path``, lowercased and without its dot."""
+    return os.path.splitext(path)[1].lstrip(".").lower()
+
+
+def types_of_extension(extension: str) -> Tuple[str, ...]:
+    """The types stored in ``extension``, in a stable order; empty when unknown."""
+    return EXTENSION_TYPES.get(extension.lstrip(".").lower(), ())
+
+
+def type_of_file(path: str) -> Optional[str]:
+    """The type of ``path``, when its name says so unambiguously.
+
+    None when the extension is unknown, and None when more than one type shares
+    it: a '.py' is a CadQuery script, a build123d script or an SDF one, and which
+    it is is a fact about the package that declares it. A caller that needs the
+    answer has to be told (`pc open --type`), because guessing wrong here means
+    running the file as the wrong kind of script.
+    """
+    names = types_of_extension(_extension_of(path))
+    return names[0] if len(names) == 1 else None
+
+
+def readable_type(path: str, object_type: Optional[str] = None) -> Optional[str]:
+    """The type a conversion should read ``path`` as, or None when nothing says.
+
+    The declared type when it *is* a file format -- which is what a conversion
+    needs, since reading the file means reading it as that format. Not every
+    declared type is one: a `kicad` part is the STEP file `kicad-cli` wrote out
+    of a board, an `alias` is a reference, and a part whose type names a
+    package-defined `partType` (`//package:name`) is whatever that wrapper
+    writes. Reading any of those *as their own type* would be reading the file
+    as something it is not, so they fall through to the name, which describes
+    the file that is actually there.
+
+    A type this PartCAD has never heard of falls through the same way rather
+    than being an error: `//package:name` is exactly that, and legitimate.
+    """
+    if object_type and object_type.lower() in PART_TYPE_EXTENSION:
+        return object_type.lower()
+    return type_of_file(path)
+
+
+def is_mesh_type(object_type: Optional[str]) -> Optional[bool]:
+    """Whether ``object_type`` is a mesh, or None when it is not a type we know."""
+    if not object_type:
+        return None
+    return PART_TYPE_IS_MESH.get(object_type.lower())
+
+
+def is_mesh_file(path: str) -> Optional[bool]:
+    """Whether ``path`` holds a mesh, judged by its name alone.
+
+    Answerable even where `type_of_file` is not: the three types stored in '.py'
+    disagree about nothing that matters here, since none of them is a mesh. Only
+    an extension no type claims -- or one whose types disagreed, which no
+    PartCAD format does and a test keeps that way -- comes back as None.
+    """
+    answers = {is_mesh_type(name) for name in types_of_extension(_extension_of(path))}
+    answers.discard(None)
+    if len(answers) != 1:
+        return None
+    return answers.pop()
+
+
+def is_mesh(path: str, object_type: Optional[str] = None) -> Optional[bool]:
+    """Whether the object in ``path`` is a mesh, from its declared type and its name.
+
+    A declared type settles it by saying *yes*: a part declared `stl` is an STL,
+    whatever it is called. It does not settle it by saying no, because the types
+    that are not mesh formats include the ones that name no file of their own --
+    an `alias` is not a mesh, and neither is what it points at *as an alias*, but
+    the file in hand may well be one. So a "no" defers to the name, and only a
+    file whose extension no type claims comes back with the type's own answer.
+    """
+    answer = is_mesh_type(object_type)
+    if answer:
+        return True
+    from_name = is_mesh_file(path)
+    return answer if from_name is None else from_name

--- a/tests/partcad/unit/test_client_object_types.py
+++ b/tests/partcad/unit/test_client_object_types.py
@@ -1,0 +1,76 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The client's copy of PartCAD's object types, checked against the original.
+
+`partcad_client.object_types` answers one question -- is this object already a
+mesh? -- for `pc open`, in a process that must not `import partcad`: the client
+is deliberately cheap, and a machine running `pc open` may have no CAD kernel on
+it at all. So the type tables are inlined there, the way
+`partcad_cli.click.commands.adhoc.convert.part` inlines the type lists it offers.
+
+An inlined copy is only safe while something notices it drifting, and this is
+that something. It fails by name when a part type is added to PartCAD and not
+classified in the client, which matters more than it looks: an unclassified type
+comes back as "not a mesh", which *works* -- the file is converted to STL and
+Blender opens it -- so a new mesh format would silently take the slow, lossy
+route and nothing would ever say so.
+
+It lives here rather than beside the module it checks because this is the suite
+that already has `partcad` in it; `tests/partcad_client` runs without one, and
+that is worth keeping.
+"""
+
+from partcad import factory
+from partcad.adhoc.adhoc import PACKAGE_ONLY_TYPES
+from partcad.shape import PART_EXTENSION_MAPPING
+from partcad_client import object_types
+
+# Registering the part factories is `partcad.globals`' doing, and it happens on
+# import; `partcad.factory.all` is empty without it.
+import partcad.globals  # noqa: F401  isort:skip
+
+
+def test_every_part_type_partcad_has_is_classified():
+    """Every type a package may declare, and every type PartCAD writes."""
+    expected = set(factory.all["part"]) | set(PART_EXTENSION_MAPPING)
+    classified = set(object_types.PART_TYPE_IS_MESH)
+    missing = sorted(expected - classified)
+    assert not missing, (
+        f"These PartCAD part types are not classified in partcad_client.object_types: {', '.join(missing)}. "
+        "Add each one to PART_TYPE_IS_MESH with True when the file it names carries triangles and False "
+        "when it does not. Leaving one out is not a no-op: `pc open --with blender` would convert it to "
+        "STL first, which works and is wrong for a format Blender could have read as it is."
+    )
+
+
+def test_nothing_is_classified_that_partcad_does_not_have():
+    """A stale entry is a type nobody can declare, and a reader's wild goose chase."""
+    expected = set(factory.all["part"]) | set(PART_EXTENSION_MAPPING)
+    extra = sorted(set(object_types.PART_TYPE_IS_MESH) - expected)
+    assert not extra, (
+        f"partcad_client.object_types classifies types PartCAD does not have: {', '.join(extra)}. "
+        "Remove them, or restore them in partcad.globals if the removal was the mistake."
+    )
+
+
+def test_the_extension_of_each_type_is_the_one_partcad_uses():
+    """The client infers a type from a file name; PartCAD decides what that name is."""
+    assert object_types.PART_TYPE_EXTENSION == PART_EXTENSION_MAPPING
+
+
+def test_the_types_that_only_mean_something_in_a_package_are_the_same_ones():
+    """`pc open` refuses these by name instead of sending a conversion that is refused."""
+    assert object_types.PACKAGE_ONLY_TYPES == PACKAGE_ONLY_TYPES
+
+
+def test_the_extensions_that_are_other_spellings_name_types_that_exist():
+    """'.stp' is a STEP file; a spelling that named nothing would silently mean nothing."""
+    unknown = sorted(
+        object_type
+        for object_type in set(object_types.EXTENSION_ALIASES.values())
+        if object_type not in object_types.PART_TYPE_IS_MESH
+    )
+    assert not unknown, f"EXTENSION_ALIASES maps to types that do not exist: {', '.join(unknown)}"

--- a/tests/partcad_cli/unit/test_command_boundary.py
+++ b/tests/partcad_cli/unit/test_command_boundary.py
@@ -80,6 +80,26 @@ IN_PROCESS = {
     "system/set/telemetry/sentryDsn.py": "writes the client's own user configuration",
 }
 
+# The one thing an in-process command may ask the daemon for, and what it may
+# ask. An in-process command works on client-only state, and that stays true of
+# every command listed above -- but `pc open` has one step in the middle that is
+# not client work at all: an application that reads meshes has to be handed one,
+# and turning a solid into a mesh drives a CAD wrapper, whose Python runtime
+# lives in the daemon's environment and may not exist on this machine.
+#
+# So the *conversion* crosses the wire and the *window* does not, which is the
+# boundary applied rather than bent: there is still no `open` method in the
+# daemon's registry and none may be added. What it sends is `adhoc.convert` --
+# file in, file out, no context, nothing left on the daemon to go stale, and
+# exactly what `pc adhoc convert` sends for the same job.
+#
+# Each entry names the methods that command may send. A method that is not
+# listed fails the test below, so widening this is a decision somebody makes on
+# purpose, in this file, next to the reason.
+IN_PROCESS_DAEMON_CALLS = {
+    "open.py": ("adhoc.convert",),
+}
+
 # Commands that have not been migrated to the daemon yet. This list is a debt
 # ledger, not a target: it may only shrink. Nothing new belongs here -- a new
 # command that needs the package graph or a CAD wrapper is written as a thin
@@ -325,6 +345,7 @@ def test_in_process_commands_do_not_call_the_daemon():
         for module in COMMAND_MODULES
         if module.rel in IN_PROCESS
         for lineno, method in module.run_calls
+        if method not in IN_PROCESS_DAEMON_CALLS.get(module.rel, ())
     ]
     offenders += [
         (module.rel, lineno, "<computed>")
@@ -344,7 +365,38 @@ def test_in_process_commands_do_not_call_the_daemon():
                 side entirely -- splitting it leaves half of the work reading a context the
                 other half already invalidated. Move the whole command, and drop it from
                 IN_PROCESS at the top of this file.
+
+                The one exception is a step that is neither: contextless, file-in file-out
+                work that only the daemon's CAD runtime can do, wrapped in a command whose
+                result belongs on this machine. `pc open` converting a solid to a mesh for
+                Blender is that, and IN_PROCESS_DAEMON_CALLS at the top of this file is
+                where such a step is named -- one method at a time, with the reason.
                 """).format(details=details))
+
+
+def test_in_process_daemon_calls_are_not_stale():
+    """The exception list is the contract too; an entry nobody uses widens it silently."""
+    missing = [rel for rel in IN_PROCESS_DAEMON_CALLS if rel not in IN_PROCESS]
+    assert not missing, (
+        f"IN_PROCESS_DAEMON_CALLS names commands that are not in-process: {', '.join(sorted(missing))}. "
+        "A command that is not in-process is a thin client and needs no exemption."
+    )
+    called = {
+        (module.rel, method)
+        for module in COMMAND_MODULES
+        if module.rel in IN_PROCESS_DAEMON_CALLS
+        for _lineno, method in module.run_calls
+    }
+    unused = sorted(
+        f"{rel} -> {method}"
+        for rel, methods in IN_PROCESS_DAEMON_CALLS.items()
+        for method in methods
+        if (rel, method) not in called
+    )
+    assert not unused, (
+        f"These daemon calls are allowed for an in-process command but nothing makes them: {', '.join(unused)}. "
+        "Remove them -- an exemption nobody is using is one nobody is watching."
+    )
 
 
 def test_boundary_lists_have_no_stale_entries():

--- a/tests/partcad_cli/unit/test_open.py
+++ b/tests/partcad_cli/unit/test_open.py
@@ -12,6 +12,11 @@ reads it, and on a failure the message it carries is the whole answer (which X
 server to install, or how to let PartCAD use a container), so it has to survive
 a non-zero exit rather than be replaced by one.
 
+The one thing this command sends to the daemon is pinned here too: an
+application that reads meshes has to be handed one, and making a mesh out of a
+solid is CAD work. Which method that is, and on what, is the whole contract --
+that it is allowed at all is `test_command_boundary.py`'s to say.
+
 Which side of the command boundary this command is on is checked by
 `test_command_boundary.py`; nothing here starts an application or a container.
 """
@@ -22,6 +27,7 @@ from collections.abc import Iterator
 import pytest
 from click.testing import CliRunner
 from partcad_cli.click.command import cli
+from partcad_cli.click.commands import open as open_command
 from partcad_client import external
 
 
@@ -41,8 +47,20 @@ def opened(monkeypatch):
                 detail="FreeCAD is installed on this machine.",
             )
 
-        def open_file(self, path, tool="freecad", use_docker=False, image=None, log=None):
-            self.calls.append({"path": path, "tool": tool, "use_docker": use_docker, "image": image, "log": log})
+        def open_file(
+            self, path, tool="freecad", use_docker=False, image=None, log=None, object_type=None, transcode=None
+        ):
+            self.calls.append(
+                {
+                    "path": path,
+                    "tool": tool,
+                    "use_docker": use_docker,
+                    "image": image,
+                    "log": log,
+                    "object_type": object_type,
+                    "transcode": transcode,
+                }
+            )
             if self.error:
                 raise self.error
             return self.result
@@ -68,6 +86,8 @@ def test_the_options_reach_the_opener(click_runner: Iterator[CliRunner], opened)
             "use_docker": True,
             "image": "freecad/freecad:weekly",
             "log": opened.calls[0]["log"],
+            "object_type": None,
+            "transcode": opened.calls[0]["transcode"],
         }
     ]
 
@@ -91,6 +111,7 @@ def test_json_reports_what_happened_in_full(click_runner: Iterator[CliRunner], o
         "tool": "freecad",
         "method": "native",
         "path": "/w/cube.step",
+        "source": None,
         "command": ["/usr/bin/freecad", "/w/cube.step"],
         "detail": "FreeCAD is installed on this machine.",
     }
@@ -117,3 +138,81 @@ def test_a_failure_keeps_its_message_under_json(click_runner: Iterator[CliRunner
     reported = json.loads(result.output)
     assert reported["ok"] is False
     assert "XQuartz" in reported["error"]
+
+
+def test_the_declared_type_is_handed_over(click_runner: Iterator[CliRunner], opened) -> None:
+    """A '.py' is three different script types, and the tree knows which."""
+    _invoke(click_runner, "--with", "blender", "--type", "cadquery", "cube.py")
+    assert opened.calls[0]["object_type"] == "cadquery"
+    assert opened.calls[0]["tool"] == "blender"
+
+
+def test_a_conversion_is_the_daemon_s_adhoc_convert(click_runner: Iterator[CliRunner], opened, monkeypatch) -> None:
+    """Making a mesh out of a solid is CAD work, so it crosses the wire.
+
+    The opening does not: what `pc open` sends is the same file-in, file-out
+    conversion `pc adhoc convert` sends, and nothing else.
+    """
+    sent = []
+    monkeypatch.setattr(open_command, "run", lambda cli_ctx, method, params, **kw: sent.append((method, params, kw)))
+
+    _invoke(click_runner, "--with", "blender", "/w/cube.step")
+    opened.calls[0]["transcode"]("/w/cube.step", "step", "/state/cube-0123.stl", "stl")
+
+    assert sent == [
+        (
+            "adhoc.convert",
+            {
+                "kind": "part",
+                "input_type": "step",
+                "output_type": "stl",
+                "input_filename": "/w/cube.step",
+                "output_filename": "/state/cube-0123.stl",
+            },
+            {"needs_context": False},
+        )
+    ]
+
+
+def test_a_failed_conversion_is_reported_like_any_other_reason(
+    click_runner: Iterator[CliRunner], opened, monkeypatch
+) -> None:
+    """A daemon error arrives as a ClickException, and it is a reason like the rest.
+
+    Left to itself it would exit non-zero with the message on stderr, which is
+    exactly what the JSON is there to prevent: the extension shows `error` and
+    has nothing else.
+    """
+    import rich_click as click
+
+    def explode(path, **kwargs):
+        kwargs["transcode"]("/w/cube.step", "step", "/state/cube.stl", "stl")
+
+    monkeypatch.setattr(
+        open_command,
+        "run",
+        lambda *args, **kw: (_ for _ in ()).throw(click.ClickException("The daemon could not read cube.step")),
+    )
+    monkeypatch.setattr(external, "open_file", explode)
+
+    result = _invoke(click_runner, "--json", "--with", "blender", "/w/cube.step")
+
+    assert result.exit_code == 1
+    reported = json.loads(result.output)
+    assert reported["ok"] is False
+    assert "could not read cube.step" in reported["error"]
+
+
+def test_what_was_converted_is_said_as_well_as_what_was_opened(click_runner: Iterator[CliRunner], opened) -> None:
+    """A user who asked for a STEP file has to be told a mesh is what Blender got."""
+    opened.result = external.OpenResult(
+        tool="blender",
+        method="native",
+        path="/state/cube-0123.stl",
+        source="/w/cube.step",
+        command=["/usr/bin/blender"],
+        detail="Blender is installed on this machine.",
+    )
+    result = _invoke(click_runner, "--with", "blender", "/w/cube.step")
+    assert "cube-0123.stl" in result.output
+    assert "cube.step" in result.output

--- a/tests/partcad_cli/unit/test_open.py
+++ b/tests/partcad_cli/unit/test_open.py
@@ -12,10 +12,14 @@ reads it, and on a failure the message it carries is the whole answer (which X
 server to install, or how to let PartCAD use a container), so it has to survive
 a non-zero exit rather than be replaced by one.
 
-The one thing this command sends to the daemon is pinned here too: an
-application that reads meshes has to be handed one, and making a mesh out of a
-solid is CAD work. Which method that is, and on what, is the whole contract --
-that it is allowed at all is `test_command_boundary.py`'s to say.
+The one thing this command sends to the daemon is pinned here too, from both
+sides: an application that reads meshes has to be handed one, and making a mesh
+out of a solid is CAD work -- but *only* that. A `pc open` that needed no
+conversion and connected anyway would start a daemon to open a file that was
+already on disk, on a machine that may have neither a CAD environment nor any
+use for one, and would fail where it used to work. Which method is sent, on
+what, and that nothing is sent otherwise, is the whole contract; that a daemon
+call is allowed here at all is `test_command_boundary.py`'s to say.
 
 Which side of the command boundary this command is on is checked by
 `test_command_boundary.py`; nothing here starts an application or a container.
@@ -216,3 +220,125 @@ def test_what_was_converted_is_said_as_well_as_what_was_opened(click_runner: Ite
     result = _invoke(click_runner, "--with", "blender", "/w/cube.step")
     assert "cube-0123.stl" in result.output
     assert "cube.step" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Nothing to convert, nothing to connect to
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_daemon(monkeypatch):
+    """Fail loudly if the command connects to the daemon at all.
+
+    Both doors are shut, not just the one this command holds the key to:
+    `service.run` is what `pc open` calls, and `client.connect` is what would
+    answer if anything else in the invocation reached for a daemon.
+    """
+    import partcad_client.client
+
+    def refuse(*_args, **_kwargs):
+        raise AssertionError("pc open reached for the daemon when nothing needed converting")
+
+    monkeypatch.setattr(open_command, "run", refuse)
+    monkeypatch.setattr(partcad_client.client, "connect", refuse)
+
+
+@pytest.fixture
+def installed_blender(monkeypatch):
+    """A machine with Blender on it, and nothing actually started."""
+    started = []
+    monkeypatch.setattr(external, "native_command", lambda _spec: ["/usr/bin/blender"])
+    monkeypatch.setattr(external, "_spawn", lambda args: started.append(list(args)))
+    return started
+
+
+@pytest.fixture
+def mesh(tmp_path):
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    path = tmp_path / "cube.stl"
+    path.write_text("solid cube\nendsolid cube\n")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def workspace_state(monkeypatch, tmp_path):
+    """Put this workspace's own directory under the test's, not under `$HOME`.
+
+    A converted mesh is written there (`external.transcode_path`), and a unit
+    test has no business leaving one in the directory a real daemon serves.
+    """
+    monkeypatch.setattr(external, "socket_path", lambda _root: str(tmp_path / ".partcad" / "hash" / "socket"))
+
+
+def test_a_mesh_is_opened_without_a_daemon(click_runner, no_daemon, installed_blender, mesh) -> None:
+    """The whole point of `pc open` staying a client command, kept true.
+
+    This one goes through the real `partcad_client.external`, not the recorder
+    above: what is being checked is that no conversion is *decided on*, which
+    the recorder would hide by never asking.
+    """
+    result = _invoke(click_runner, "--json", "--with", "blender", str(mesh))
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["path"] == str(mesh)
+    assert installed_blender[0][0] == "/usr/bin/blender"
+
+
+def test_the_declared_type_does_not_make_it_a_daemon_command(click_runner, no_daemon, installed_blender, mesh) -> None:
+    """The extension passes `--type` for every object it opens, mesh or not."""
+    result = _invoke(click_runner, "--json", "--with", "blender", "--type", "stl", str(mesh))
+    assert result.exit_code == 0, result.output
+
+
+def test_an_application_that_takes_what_it_is_given_never_connects(click_runner, no_daemon, monkeypatch, mesh) -> None:
+    """FreeCAD, Gazebo and KiCad read what they are handed; there is nothing to ask."""
+    started = []
+    monkeypatch.setattr(external, "native_command", lambda _spec: ["/usr/bin/freecad"])
+    monkeypatch.setattr(external, "_spawn", lambda args: started.append(list(args)))
+
+    result = _invoke(click_runner, "--json", "--with", "freecad", str(mesh))
+
+    assert result.exit_code == 0, result.output
+    assert started == [["/usr/bin/freecad", str(mesh)]]
+
+
+def test_a_failure_with_nothing_to_convert_does_not_connect_either(click_runner, no_daemon, monkeypatch, mesh) -> None:
+    """A machine with no Blender is told so; it is not told to start a daemon first."""
+    monkeypatch.setattr(external, "native_command", lambda _spec: None)
+
+    result = _invoke(click_runner, "--json", "--with", "blender", str(mesh))
+
+    assert result.exit_code == 1
+    assert "--use-docker" in json.loads(result.output)["error"]
+
+
+def test_a_solid_is_the_one_case_that_connects(click_runner, installed_blender, monkeypatch, tmp_path) -> None:
+    """The other half of the contract: the conversion really does go to the daemon.
+
+    Driven through the real `external`, so what is pinned is that the decision
+    to convert is what reaches `service.run` -- not a callback a test invoked.
+    """
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    solid = tmp_path / "cube.step"
+    solid.write_text("ISO-10303-21;\n")
+    sent = []
+
+    def convert(_cli_ctx, method, params, **kwargs):
+        sent.append((method, params, kwargs))
+        # The daemon's job, done here so that `external` finds the file it
+        # asked for and the command carries on to the opening.
+        open(params["output_filename"], "w").write("solid converted\nendsolid converted\n")
+
+    monkeypatch.setattr(open_command, "run", convert)
+
+    result = _invoke(click_runner, "--json", "--with", "blender", str(solid))
+
+    assert result.exit_code == 0, result.output
+    assert [method for method, _params, _kwargs in sent] == ["adhoc.convert"]
+    assert sent[0][1]["input_type"] == "step"
+    assert sent[0][1]["output_type"] == "stl"
+    assert sent[0][2] == {"needs_context": False}
+    reported = json.loads(result.output)
+    assert reported["source"] == str(solid)
+    assert reported["path"] == sent[0][1]["output_filename"]

--- a/tests/partcad_client/test_external.py
+++ b/tests/partcad_client/test_external.py
@@ -389,9 +389,9 @@ def test_the_result_says_how_the_file_was_opened(part, docker):
 
 
 def test_every_tool_can_be_named_and_has_a_container_of_its_own():
-    assert external.tool_names() == ["freecad", "gazebo", "kicad"]
+    assert external.tool_names() == ["freecad", "gazebo", "kicad", "blender"]
     names = {external.TOOLS[name].container_name for name in external.tool_names()}
-    assert names == {"partcad-freecad", "partcad-gazebo", "partcad-kicad"}
+    assert names == {"partcad-freecad", "partcad-gazebo", "partcad-kicad", "partcad-blender"}
 
 
 def test_the_kicad_container_is_the_image_partcad_already_builds():
@@ -524,3 +524,248 @@ def test_a_launcher_that_is_not_the_program_supplies_its_own_arguments():
     assert gazebo.launch_args(os.path.join("Gazebo", "bin", "gz.exe")) == ("sim",)
     assert gazebo.launch_args("org.gazebosim.Gazebo") == ()
     assert gazebo.launch_args("/Applications/Gazebo.app") == ()
+
+
+# ---------------------------------------------------------------------------
+# Blender: the application that reads meshes and nothing else
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mesh(tmp_path):
+    """An STL inside a workspace: what Blender can be handed as it is."""
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    path = tmp_path / "cube.stl"
+    path.write_text("solid cube\nendsolid cube\n")
+    return path
+
+
+@pytest.fixture
+def converter():
+    """A conversion that writes the file it was asked for, and records the ask."""
+
+    class Converter:
+        def __init__(self):
+            self.calls = []
+            self.writes = True
+
+        def __call__(self, source, source_type, target, target_type):
+            self.calls.append((source, source_type, target, target_type))
+            if self.writes:
+                open(target, "w").write("solid converted\nendsolid converted\n")
+
+    return Converter()
+
+
+def test_a_mesh_is_imported_rather_than_opened(monkeypatch, spawned, mesh):
+    """`blender <file>` opens a `.blend`; anything else is an import, in Python."""
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    result = external.open_file(str(mesh), tool="blender")
+
+    assert result.method == "native"
+    assert result.path == str(mesh)
+    # Nothing was converted, so there is nothing to report as converted from.
+    assert result.source is None
+    command = spawned[0]
+    assert command[:2] == ["/usr/bin/blender", "--python-expr"]
+    assert repr(str(mesh)) in command[2]
+    assert "stl_import" in command[2]
+
+
+def test_blender_s_own_file_is_opened_and_never_converted(monkeypatch, spawned, tmp_path, converter):
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    scene = tmp_path / "scene.blend"
+    scene.write_text("BLENDER")
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    external.open_file(str(scene), tool="blender", transcode=converter)
+
+    assert spawned == [["/usr/bin/blender", str(scene)]]
+    assert converter.calls == []
+
+
+def test_a_solid_is_converted_to_a_mesh_first(monkeypatch, spawned, part, converter, workspace_socket):
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    result = external.open_file(str(part), tool="blender", transcode=converter)
+
+    # The conversion is asked for by type, not left to be guessed at the far end.
+    source, source_type, target, target_type = converter.calls[0]
+    assert (source, source_type, target_type) == (str(part), "step", "stl")
+    # It lands under the workspace's own directory -- not beside the user's
+    # file, and not in a temporary directory the container cannot see.
+    assert target.startswith(str(workspace_socket))
+    assert result.path == target
+    assert result.source == str(part)
+    assert repr(target) in spawned[0][2]
+
+
+def test_the_converted_mesh_is_reused_until_the_source_changes(monkeypatch, spawned, part, converter):
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    first = external.open_file(str(part), tool="blender", transcode=converter)
+    second = external.open_file(str(part), tool="blender", transcode=converter)
+    assert second.path == first.path
+    assert len(converter.calls) == 1
+
+    # Touching the source is how a user asks for it again.
+    os.utime(str(part), (os.path.getmtime(first.path) + 10,) * 2)
+    external.open_file(str(part), tool="blender", transcode=converter)
+    assert len(converter.calls) == 2
+
+
+def test_two_parts_of_the_same_name_do_not_share_a_mesh(monkeypatch, spawned, part, converter, tmp_path):
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    twin = other / "cube.step"
+    twin.write_text("ISO-10303-21;\n")
+
+    first = external.open_file(str(part), tool="blender", transcode=converter)
+    second = external.open_file(str(twin), tool="blender", transcode=converter)
+
+    assert first.path != second.path
+
+
+def test_a_conversion_that_writes_nothing_is_a_failure_not_a_window(monkeypatch, spawned, part, converter):
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+    converter.writes = False
+
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), tool="blender", transcode=converter)
+
+    assert "Failed to convert" in str(caught.value)
+    assert spawned == []
+
+
+def test_a_mesh_blender_has_no_importer_for_is_converted_too(monkeypatch, spawned, tmp_path, converter):
+    """3MF is a mesh, and Blender ships nothing that reads one."""
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    box = tmp_path / "box.3mf"
+    box.write_text("PK\n")
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    external.open_file(str(box), tool="blender", transcode=converter)
+
+    source, source_type, _target, target_type = converter.calls[0]
+    assert (source, source_type, target_type) == (str(box), "3mf", "stl")
+
+
+def test_a_declared_type_says_what_the_file_name_cannot(monkeypatch, spawned, tmp_path, converter):
+    """A '.py' is a CadQuery script, a build123d one or an SDF one."""
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    script = tmp_path / "cube.py"
+    script.write_text("# a part\n")
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    external.open_file(str(script), tool="blender", object_type="build123d", transcode=converter)
+
+    assert converter.calls[0][1] == "build123d"
+
+
+def test_a_declared_type_that_is_not_a_format_does_not_become_one(monkeypatch, spawned, part, converter):
+    """A `kicad` part is the STEP that KiCad's CLI wrote; it is read as a STEP.
+
+    The tree hands over whatever the object was declared as, and several of
+    those types name no file format at all. Sending one as the input type would
+    ask the daemon to read a STEP file as a KiCad board.
+    """
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    external.open_file(str(part), tool="blender", object_type="kicad", transcode=converter)
+
+    assert converter.calls[0][1] == "step"
+
+
+def test_a_file_whose_type_cannot_be_told_is_refused_with_what_to_pass(monkeypatch, spawned, tmp_path, converter):
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    script = tmp_path / "cube.py"
+    script.write_text("# a part\n")
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(script), tool="blender", transcode=converter)
+
+    assert "--type" in str(caught.value)
+    assert "cadquery" in str(caught.value)
+    assert converter.calls == []
+
+
+def test_an_assy_is_refused_by_name_rather_than_sent_to_be_refused(monkeypatch, spawned, tmp_path, converter):
+    """There is no package around an ad-hoc file to resolve an ASSY against."""
+    (tmp_path / "partcad.yaml").write_text("name: test\n")
+    assembly = tmp_path / "logo.assy"
+    assembly.write_text("links: []\n")
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(assembly), tool="blender", transcode=converter)
+
+    assert "inside a package" in str(caught.value)
+    assert "pc export" in str(caught.value)
+    assert converter.calls == []
+
+
+def test_without_a_converter_a_solid_says_so_instead_of_opening_nothing(monkeypatch, spawned, part):
+    """Nothing but `pc open` has a daemon to convert with, and it says which."""
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/blender" if name == "blender" else None)
+
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), tool="blender")
+
+    assert "pc open" in str(caught.value)
+    assert spawned == []
+
+
+def test_blender_runs_in_its_own_container_on_the_converted_mesh(part, docker, converter, workspace_socket):
+    docker.binaries = ["/usr/bin/blender"]
+
+    result = external.open_file(str(part), tool="blender", use_docker=True, transcode=converter)
+
+    assert result.method == "docker"
+    created = docker.command("docker", "run")
+    assert "partcad-blender" in created
+    assert external.BLENDER.image in created
+    # The workspace that holds the *source* is what gets mounted: the mesh lives
+    # under that workspace's state directory, which is mounted beside it, and a
+    # workspace worked out from the mesh would have been the state directory.
+    assert "%s:%s" % (workspace_socket, workspace_socket) in created
+    started = docker.command("docker", "exec", "--detach")
+    assert started[-3:-1] == ["/usr/bin/blender", "--python-expr"]
+    assert repr(result.path) in started[-1]
+
+
+def test_a_solid_without_docker_or_blender_says_both(part, converter):
+    """The refusal a machine with neither gets, which has to name both ways out."""
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), tool="blender", transcode=converter)
+    assert "Blender was not found" in str(caught.value)
+    assert "--use-docker" in str(caught.value)
+
+
+def test_docker_that_does_not_answer_names_blender_and_docker(part, docker, converter):
+    docker.available = False
+    with pytest.raises(external.ExternalToolError) as caught:
+        external.open_file(str(part), tool="blender", use_docker=True, transcode=converter)
+    assert "Blender is not installed" in str(caught.value)
+    assert "docker info" in str(caught.value)
+
+
+def test_macos_runs_the_executable_inside_the_bundle(monkeypatch):
+    """`open -a` hands a running Blender nothing at all, and the arguments are the point."""
+    monkeypatch.setattr(external.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(external.shutil, "which", lambda _name: None)
+    bundle = "/Applications/Blender.app"
+    executable = bundle + "/Contents/MacOS/Blender"
+    monkeypatch.setattr(external.os.path, "isdir", lambda path: path == bundle)
+    monkeypatch.setattr(external.os.path, "isfile", lambda path: path == executable)
+
+    assert external.native_command(external.BLENDER) == [executable]
+
+
+def test_the_other_applications_are_still_handed_the_file_itself(monkeypatch, spawned, part):
+    """Only Blender imports; converting for FreeCAD would be a loss, not a favour."""
+    monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/" + name if name == "freecad" else None)
+    external.open_file(str(part), tool="freecad")
+    assert spawned == [["/usr/bin/freecad", str(part)]]

--- a/tests/partcad_client/test_external.py
+++ b/tests/partcad_client/test_external.py
@@ -764,6 +764,37 @@ def test_macos_runs_the_executable_inside_the_bundle(monkeypatch):
     assert external.native_command(external.BLENDER) == [executable]
 
 
+def test_macos_opens_the_bundle_for_an_application_that_takes_a_file(monkeypatch):
+    """The other half of that rule, and the one every other tool takes.
+
+    FreeCAD is handed a document rather than arguments, so `open -a` is right
+    for it: it is how macOS launches an application, and it reuses a running
+    instance instead of starting a second one.
+    """
+    monkeypatch.setattr(external.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(external.shutil, "which", lambda _name: None)
+    bundle = "/Applications/FreeCAD.app"
+    monkeypatch.setattr(external.os.path, "isdir", lambda path: path == bundle)
+
+    assert external.native_command(external.FREECAD) == ["open", "-a", bundle]
+
+
+def test_a_bundle_without_the_executable_in_it_is_not_a_local_installation(monkeypatch):
+    """A `Blender.app` with nothing runnable inside is not something to launch.
+
+    Falling back to `open -a` here would be worse than finding nothing: the
+    import expression would be dropped and Blender would open empty, which
+    looks like PartCAD doing nothing at all. Finding nothing is honest, and
+    leaves the container route to say what to install.
+    """
+    monkeypatch.setattr(external.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(external.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(external.os.path, "isdir", lambda path: path.endswith("Blender.app"))
+    monkeypatch.setattr(external.os.path, "isfile", lambda _path: False)
+
+    assert external.native_command(external.BLENDER) is None
+
+
 def test_the_other_applications_are_still_handed_the_file_itself(monkeypatch, spawned, part):
     """Only Blender imports; converting for FreeCAD would be a loss, not a favour."""
     monkeypatch.setattr(external.shutil, "which", lambda name: "/usr/bin/" + name if name == "freecad" else None)

--- a/tests/partcad_client/test_object_types.py
+++ b/tests/partcad_client/test_object_types.py
@@ -1,0 +1,159 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Tests for `partcad_client.object_types`: which object types are meshes.
+
+What the tables *say* is checked against PartCAD's own in
+`tests/partcad/unit/test_client_object_types.py`, which is where the heavy
+import belongs. What they *mean* is here, and so is the one property that makes
+answering by file name legitimate at all: no extension is shared by a mesh type
+and a solid one, so a name is enough even where it does not name a single type.
+
+Nothing here imports `partcad`. That is the point of the module under test --
+`partcad_client` answers this question in a process that has no CAD kernel in
+it -- and a test that needed one would be testing something else.
+"""
+
+import pytest
+
+from partcad_client import object_types
+
+# ---------------------------------------------------------------------------
+# The table itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_mesh_formats_are_the_ones_that_hold_triangles():
+    meshes = {name for name, mesh in object_types.PART_TYPE_IS_MESH.items() if mesh}
+    assert meshes == {"stl", "3mf", "obj", "gltf", "threejs"}
+
+
+def test_every_type_answers_yes_or_no_and_nothing_else():
+    """A missing answer would be read as 'not a mesh', which is a guess."""
+    assert all(isinstance(mesh, bool) for mesh in object_types.PART_TYPE_IS_MESH.values())
+
+
+def test_a_type_nobody_declared_is_unknown_rather_than_solid():
+    # None and False are different answers: False is "PartCAD knows this type
+    # and it is not a mesh", None is "PartCAD has never heard of it".
+    assert object_types.is_mesh_type("stl") is True
+    assert object_types.is_mesh_type("step") is False
+    assert object_types.is_mesh_type("solidworks") is None
+    assert object_types.is_mesh_type(None) is None
+
+
+def test_the_type_is_read_case_insensitively():
+    assert object_types.is_mesh_type("STL") is True
+
+
+# ---------------------------------------------------------------------------
+# Answering from the file name
+# ---------------------------------------------------------------------------
+
+
+def test_no_extension_is_claimed_by_both_a_mesh_and_a_solid():
+    """The property that makes `is_mesh_file` an answer rather than a guess.
+
+    '.py' is CadQuery, build123d and SDF at once, and '.json' is glTF and
+    three.js at once -- but the members of each group agree about this one
+    question, so the name still answers it. A format added on the other side of
+    one of those groups would break that, and this is where it says so.
+    """
+    for extension, names in object_types.EXTENSION_TYPES.items():
+        answers = {object_types.is_mesh_type(name) for name in names}
+        answers.discard(None)
+        assert len(answers) <= 1, "'.%s' is claimed by types that disagree: %s" % (extension, ", ".join(names))
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("/w/cube.stl", True),
+        ("/w/cube.STL", True),
+        ("/w/cube.3mf", True),
+        ("/w/cube.obj", True),
+        ("/w/cube.step", False),
+        ("/w/cube.stp", False),
+        ("/w/cube.brep", False),
+        # Three script types, one extension, one answer: none of them is a mesh.
+        ("/w/cube.py", False),
+        ("/w/cube.scad", False),
+        # Neither PartCAD nor anything else claims it.
+        ("/w/cube.sldprt", None),
+        ("/w/cube", None),
+    ],
+)
+def test_the_name_answers_where_it_can(path, expected):
+    assert object_types.is_mesh_file(path) is expected
+
+
+def test_the_other_spellings_of_a_format_are_the_same_format():
+    """A file `pc open` is handed was written by something else as often as not."""
+    assert object_types.type_of_file("/w/cube.stp") == "step"
+    assert object_types.type_of_file("/w/cube.igs") == "iges"
+    assert object_types.type_of_file("/w/scene.glb") == "gltf"
+
+
+def test_an_extension_more_than_one_type_shares_names_none_of_them():
+    """Which of the three a '.py' is decides how it is *run*; a guess is not it."""
+    assert object_types.type_of_file("/w/cube.py") is None
+    assert object_types.types_of_extension(".py") == ("build123d", "cadquery", "sdf")
+
+
+def test_an_assy_is_recognized_even_though_it_is_not_a_part_type():
+    """So that opening one is refused by name rather than as an unknown file."""
+    assert object_types.type_of_file("/w/logo.assy") == "assy"
+    assert "assy" in object_types.PACKAGE_ONLY_TYPES
+
+
+# ---------------------------------------------------------------------------
+# The two together
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_mesh_type_settles_it_whatever_the_file_is_called():
+    assert object_types.is_mesh("/w/cube.dat", "stl") is True
+
+
+def test_a_type_that_names_no_file_of_its_own_defers_to_the_file():
+    """An `alias` is not a mesh; what it points at may well be one.
+
+    This is the case that decides the precedence rule, and it is not academic:
+    the VS Code tree hands `pc open` the declared type of the object the user
+    clicked, and for a reference type that type says nothing about the file.
+    """
+    assert object_types.is_mesh_type("alias") is False
+    assert object_types.is_mesh("/w/cube.stl", "alias") is True
+    assert object_types.is_mesh("/w/cube.step", "alias") is False
+
+
+def test_with_nothing_to_go_on_the_answer_is_unknown():
+    assert object_types.is_mesh("/w/cube.sldprt") is None
+    assert object_types.is_mesh("/w/cube.sldprt", "solidworks") is None
+
+
+# ---------------------------------------------------------------------------
+# What a conversion should read the file as
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_file_format_is_what_the_file_is_read_as():
+    assert object_types.readable_type("/w/cube.dat", "build123d") == "build123d"
+
+
+def test_a_type_that_is_not_a_file_format_falls_through_to_the_name():
+    """Reading a KiCad part 'as kicad' would run KiCad on the STEP it already wrote.
+
+    A `kicad` part *is* that STEP file, an `alias` is a reference, and neither
+    names a format anything can be read as. The file in hand does.
+    """
+    assert object_types.readable_type("/w/board.step", "kicad") == "step"
+    assert object_types.readable_type("/w/cube.stl", "alias") == "stl"
+
+
+def test_a_partType_reference_is_not_an_error_it_is_just_not_a_format():
+    """`type: //package:name` is a legitimate declaration, and it names a wrapper."""
+    assert object_types.readable_type("/w/cube.step", "//package:mine") == "step"
+    assert object_types.readable_type("/w/cube.dat", "//package:mine") is None


### PR DESCRIPTION
## Copilot Summary

Blender joins FreeCAD, Gazebo and KiCad in `pc open` and in the VS Code extension's **Open in >** menu, under the same rule as the rest: a locally installed Blender is used when there is one, `--use-docker` runs it in the `partcad-blender` container otherwise, and a machine with neither is told so rather than left with a command that quietly did nothing.

Blender reads triangles and nothing else, which the other three do not, so two things are new.

### Which object types are meshes

`src/partcad_client/object_types.py` holds `PART_TYPE_IS_MESH` — every part type PartCAD registers **and** every type its extension mapping names (`threejs`, `gltf`, `iges`, `urdf` have no factory, but PartCAD writes them and `pc open` may well be handed the result). `stl`, `3mf`, `obj`, `gltf` and `threejs` are `True`; everything else is `False`, which means one thing to a caller: *not already a mesh*, so an application that needs one gets a converted copy.

The tables are inlined copies of PartCAD's own, for the reason every other table in a client is: `partcad_client` must stay importable in a process with no CAD kernel in it. A copy that can drift is only safe if something notices, so `tests/partcad/unit/test_client_object_types.py` compares each table against the `partcad` one it mirrors and fails **by name** when a part type is added there and left unclassified here. That matters more than it looks: an unclassified type reads as "not a mesh", which *works* — the file is converted to STL and Blender opens it — so a new mesh format would silently take the lossy route with nothing to say so.

Answering from a file name is legitimate because no extension is claimed by both a mesh type and a solid one; `.py` is CadQuery, build123d and SDF at once and they agree, and a test keeps that true. A declared type settles the question by saying *yes* and defers to the name when it says no, because the types that are not mesh formats include the ones that name no file at all — an `alias` is not a mesh, but the file it points at may be.

### The one thing that crosses the wire

An object that is not already a mesh Blender can import is converted to STL first. `pc open` sends `adhoc.convert` for that — the same method `pc adhoc convert` sends, file in, file out, `needs_context=False`, nothing left on the daemon to go stale — because turning a solid into a mesh drives a CAD wrapper whose runtime lives in the daemon's environment and may not exist on the client at all. The window still opens on the machine the command ran on, and the registry still has no `open` method.

That is a real change to the command boundary, so it is written down rather than slipped in: `IN_PROCESS_DAEMON_CALLS` in `tests/partcad_cli/unit/test_command_boundary.py` names the one command and the one method it may send, and `src/partcad_cli/AGENTS.md` and the root `AGENTS.md` explain why. **It happens only for a conversion** — five tests drive the real `partcad_client.external` with both `service.run` and `client.connect` replaced by raising stubs and pin that a mesh, a `--type`, another application, and a "Blender not found" refusal all complete without reaching for a daemon.

The converted copy goes under the workspace's own state directory — never beside the user's file, and already mounted into the container at the path it has on the host, so one name means the same thing on both sides — and is reused until the source changes.

### Odds and ends

* `blender <file>` *opens* a `.blend` and nothing else, so geometry is handed over as a `--python-expr` import instead, trying Blender 4.x's operator names (`wm.stl_import`) before the 3.x ones (`import_mesh.stl`). On macOS that means the executable inside `Blender.app` rather than `open -a`, which drops arguments on an already-running copy.
* 3MF is a mesh and Blender ships no importer for it, so `Tool.imports` is a second question from "is this a mesh": what *this* application can read.
* `--type` carries the declared type for a file whose name does not say; the extension passes `config.type` for every object it opens. A type that names no file format — `kicad`, `alias`, a `//package:name` `partType` reference — falls through to the file name rather than being read as itself, and an ASSY or a URDF is refused with what to do instead of being sent to a conversion that cannot resolve it.
* The container image is `linuxserver/blender:latest`, chosen for the reason FreeCAD's is: the project publishes none, and this one carries a GUI Blender on `PATH` (`/usr/bin/blender`) and is still being rebuilt.

### Validation

Docker was not available in this environment, so the dev container could not be started and `pre-commit` could not be run; the gates were run directly instead. `black` and `flake8` clean on every changed file; `eslint`, `prettier` and `tsc` clean on the extension; 245 tests pass across `tests/partcad_client`, `test_open.py`, `test_command_boundary.py` and the new completeness test, and 405 across `tests/partcad_cli`, `tests/partcad_client` and `tests/partcad_utils`. Three failures in `tests/partcad_cli` (`test_version`, `test_status`, `test_logging_teardown`) reproduce on an unmodified tree here and need a working daemon. `behave` was **not** run — the four new `features/open.feature` scenarios are unexercised locally and CI is the first thing to run them.

Both routes were also driven by hand: with a stub `blender` on `PATH`, a mesh reaches it as a `--python-expr` import, and a STEP file is converted (into `~/.partcad/workspaces/<hash>/open/`) and reused on the second open. The completeness test was verified to fail, naming the type, when an entry is removed from the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSdKziaafNC8EU9h3cSXob

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSdKziaafNC8EU9h3cSXob)_