### PR TITLE
Carry a conda in every standalone bundle

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -712,25 +712,58 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # No conda is installed here, on purpose. PartCAD runs CAD scripts in a
-      # conda sandbox it provisions at runtime, and the bundle now carries the
-      # conda that provisions it -- so this job builds the whole CAD stack
-      # through the payload, on a machine that has nothing of its own. That is
-      # the end-to-end proof the build's own smoke test cannot be: it can only
-      # show that a conda was *resolved*, not that a sandbox solved and ran.
+      # No conda reachable here, on purpose. PartCAD runs CAD scripts in a conda
+      # sandbox it provisions at runtime, and the bundle now carries the conda
+      # that provisions it -- so this job builds the whole CAD stack through the
+      # payload, on a machine with nothing of its own. That is the end-to-end
+      # proof the build's own smoke test cannot be: it can only show that a conda
+      # was *resolved*, not that a sandbox solved and ran.
       #
       # This used to install Miniforge here (`setup-miniconda`, conda-forge
       # only). The bundled micromamba resolves from conda-forge with no
       # configuration at all, which is the same channel policy for the same
       # reason -- see the comments in `.github/actions/setup-all/action.yml`.
-      - name: Check that this machine has no conda of its own
+      #
+      # Taking one *off* PATH rather than trusting it to be absent: the hosted
+      # images ship a conda (`$CONDA`) and put it on PATH on some of them --
+      # ubuntu-24.04 does. `partcad_utils.conda` prefers the host's by design, so
+      # one left there would quietly turn this back into a test of the runner's
+      # conda, which is exactly the mistake that let the bundle ship without one.
+      # Matched by looking for the executable in each PATH entry rather than by
+      # the entry's name, so a workspace path that happens to spell "conda" is
+      # not dropped. POSIX only; this job runs on Linux and macOS.
+      - name: Take any host conda off PATH
         shell: bash
         run: |
-          if command -v mamba >/dev/null 2>&1 || command -v conda >/dev/null 2>&1; then
-            echo "::error::a conda is on PATH, so this job would exercise it rather than"
-            echo "::error::the one the bundle carries. Take it off PATH for this job."
+          kept=""
+          IFS=':' read -ra entries <<< "${PATH}"
+          for entry in "${entries[@]}"; do
+            if [ -x "${entry}/conda" ] || [ -x "${entry}/mamba" ]; then
+              echo "taking '${entry}' off PATH"
+              continue
+            fi
+            kept="${kept:+${kept}:}${entry}"
+          done
+          # An empty PATH would fail every step below with "command not found"
+          # and nothing saying why, so refuse to write one.
+          if [ -z "${kept}" ]; then
+            echo "::error::every PATH entry held a conda; refusing to leave this job with no PATH"
             exit 1
           fi
+          echo "PATH=${kept}" >> "${GITHUB_ENV}"
+
+      # Asserted after the fact, and under `bash -el` -- the shell the steps
+      # below use. A login shell re-reads the profile scripts, so "PATH has no
+      # conda in it" is only true if it is still true there.
+      - name: Check that no conda is reachable
+        shell: bash -el {0}
+        run: |
+          if command -v mamba >/dev/null 2>&1 || command -v conda >/dev/null 2>&1; then
+            echo "::error::a conda is still on PATH ($(command -v mamba || command -v conda)),"
+            echo "::error::so this job would exercise it rather than the one the bundle carries."
+            exit 1
+          fi
+          echo "no conda on PATH: the bundle's own is the only one available"
 
       # The libraries the bundled OpenSCAD AppImage resolves from the host: it is
       # not fully self-contained (see dev-tools/pyinstaller/build.sh). A desktop

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -724,46 +724,56 @@ jobs:
       # configuration at all, which is the same channel policy for the same
       # reason -- see the comments in `.github/actions/setup-all/action.yml`.
       #
-      # Taking one *off* PATH rather than trusting it to be absent: the hosted
-      # images ship a conda (`$CONDA`) and put it on PATH on some of them --
-      # ubuntu-24.04 does. `partcad_utils.conda` prefers the host's by design, so
-      # one left there would quietly turn this back into a test of the runner's
-      # conda, which is exactly the mistake that let the bundle ship without one.
-      # Matched by looking for the executable in each PATH entry rather than by
-      # the entry's name, so a workspace path that happens to spell "conda" is
-      # not dropped. POSIX only; this job runs on Linux and macOS.
-      - name: Take any host conda off PATH
+      # Taking one *out of the way* rather than trusting it to be absent: the
+      # hosted images ship a conda (`$CONDA`) and put a launcher for it on PATH
+      # on some of them -- ubuntu-24.04 has `/usr/bin/conda`.
+      # `partcad_utils.conda` prefers the host's by design, so one left reachable
+      # would quietly turn this back into a test of the runner's conda, which is
+      # exactly the mistake that let the bundle ship without one.
+      #
+      # The launcher itself, not the directory holding it: it lives in `/usr/bin`
+      # alongside every other system tool, so dropping that directory from PATH
+      # takes `sudo`, `apt-get` and the rest of the job with it. Only what
+      # `command -v` actually resolves is removed, and only from a hosted runner
+      # that is discarded when the job ends. `$CONDA` is untouched, so a job that
+      # wants the runner's conda still has it.
+      - name: Take the runner's conda out of the way
         shell: bash
         run: |
-          kept=""
-          IFS=':' read -ra entries <<< "${PATH}"
-          for entry in "${entries[@]}"; do
-            if [ -x "${entry}/conda" ] || [ -x "${entry}/mamba" ]; then
-              echo "taking '${entry}' off PATH"
-              continue
+          for _ in 1 2 3 4 5; do
+            found="$(command -v mamba || command -v conda || true)"
+            [ -n "${found}" ] || break
+            echo "removing the launcher at '${found}' (CONDA=${CONDA:-unset} is left alone)"
+            sudo rm -f "${found}"
+            # Fail on the first one that will not go, rather than looping over
+            # it and leaving the check below to report a puzzle.
+            if [ -e "${found}" ]; then
+              echo "::error::could not remove the conda launcher at '${found}'"
+              exit 1
             fi
-            kept="${kept:+${kept}:}${entry}"
           done
-          # An empty PATH would fail every step below with "command not found"
-          # and nothing saying why, so refuse to write one.
-          if [ -z "${kept}" ]; then
-            echo "::error::every PATH entry held a conda; refusing to leave this job with no PATH"
-            exit 1
-          fi
-          echo "PATH=${kept}" >> "${GITHUB_ENV}"
 
-      # Asserted after the fact, and under `bash -el` -- the shell the steps
-      # below use. A login shell re-reads the profile scripts, so "PATH has no
-      # conda in it" is only true if it is still true there.
-      - name: Check that no conda is reachable
+      # Asserted afterwards rather than assumed, and under `bash -el` -- the
+      # shell the steps below use. A login shell re-reads the profile scripts, so
+      # "no conda is reachable" is only true if it is still true there. The
+      # second half is this step's own lesson: the first attempt at it removed
+      # `/usr/bin` from PATH, which passed this check and broke everything after
+      # it, so what the job needs is checked too.
+      - name: Check that no conda is reachable, and the rest of PATH survived
         shell: bash -el {0}
         run: |
           if command -v mamba >/dev/null 2>&1 || command -v conda >/dev/null 2>&1; then
-            echo "::error::a conda is still on PATH ($(command -v mamba || command -v conda)),"
+            echo "::error::a conda is still reachable ($(command -v mamba || command -v conda)),"
             echo "::error::so this job would exercise it rather than the one the bundle carries."
             exit 1
           fi
-          echo "no conda on PATH: the bundle's own is the only one available"
+          for needed in sudo tar curl git sh; do
+            if ! command -v "${needed}" >/dev/null 2>&1; then
+              echo "::error::'${needed}' is no longer on PATH; the step above took too much with it"
+              exit 1
+            fi
+          done
+          echo "no conda reachable, and PATH still has what this job runs"
 
       # The libraries the bundled OpenSCAD AppImage resolves from the host: it is
       # not fully self-contained (see dev-tools/pyinstaller/build.sh). A desktop

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -495,6 +495,28 @@ jobs:
           pc --no-ansi healthcheck --filters openscad 2>&1 | tee healthcheck.log
           grep -q "OpenSCAD: Passed" healthcheck.log
 
+      # The same for the bundled conda, and on every platform rather than one:
+      # without it PartCAD has no CAD sandbox at all on a machine that has no
+      # conda, which is the machine this bundle exists for. The executable bit
+      # is the part the archive can lose; `--version` is the part a truncated
+      # download would.
+      - name: Run the bundled conda after installation
+        shell: bash
+        run: |
+          export PATH="${HOME}/partcad-bin:${PATH}"
+          cd "${HOME}"
+          # By the installed path rather than by resolving the `pc` symlink:
+          # this step runs on macOS too, and only one version is installed.
+          bundled="$(ls -d "${HOME}"/partcad-standalone/*/_internal/conda/micromamba)"
+          test -x "${bundled}"
+          "${bundled}" --version
+          # Reported rather than asserted: these runners keep their conda off
+          # PATH, so this check can only pass through the bundle -- but that is
+          # a property of the image, not something this job controls.
+          echo "host conda: $(command -v mamba || command -v conda || echo none)"
+          pc --no-ansi healthcheck --filters conda 2>&1 | tee healthcheck-conda.log
+          grep -q "CondaAvailable: Passed" healthcheck-conda.log
+
       - name: Uninstall with install.sh
         shell: bash
         run: |
@@ -615,7 +637,7 @@ jobs:
           # ~/.partcad is still created and still holds the user configuration
           # and the telemetry id -- that is by design (see dev-tools/snap/README.md).
           # What must not be there is the state PC_INTERNAL_STATE_DIR redirects.
-          for leftover in cache git tar external sandbox; do
+          for leftover in cache git tar external sandbox conda; do
             if [ -e "${HOME}/.partcad/${leftover}" ]; then
               echo "::error::PartCAD wrote '${leftover}' into ~/.partcad rather than the snap directory"
               exit 1
@@ -623,17 +645,26 @@ jobs:
           done
           ls -la "${HOME}/.partcad" "${HOME}/snap/partcad/common" || true
 
-      # A snap does not carry the user's shell environment, so a conda under
-      # $HOME or a git outside the standard prefixes is not visible to it. That
-      # is accepted: PartCAD falls back to `pythonSandbox: none` and reports both
-      # as missing. The health check is run for the record, and deliberately not
-      # allowed to fail the job over them.
+      # A snap does not carry the user's shell environment, so a git outside the
+      # standard prefixes is not visible to it. That is accepted: PartCAD
+      # reports it missing. The health check is run for the record, and
+      # deliberately not allowed to fail the job over it.
+      #
+      # conda used to be in the same sentence and no longer is: the snap wraps
+      # the bundle, the bundle carries a conda, and a payload inside the snap is
+      # visible to it whatever the user's shell says. So this is also where the
+      # snap gets its CAD sandbox back -- which is why the conda half *is*
+      # asserted below while git stays informational.
       - name: Health check (informational)
         run: |
           export PATH="/snap/bin:${PATH}"
           cd "${HOME}"
           pc --no-ansi healthcheck 2>&1 | tee healthcheck.log || true
-          echo "conda and git are expected to be reported missing here."
+          echo "git is expected to be reported missing here."
+          grep -q "CondaAvailable: Passed" healthcheck.log || {
+            echo "::error::the snap did not resolve the conda the bundle carries"
+            exit 1
+          }
 
       - name: Remove the snap
         run: sudo snap remove --purge partcad
@@ -681,23 +712,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # PartCAD runs CAD scripts in a conda sandbox it provisions at runtime, so
-      # the bundle still needs conda/mamba on PATH -- the one host prerequisite
-      # it does not carry, exactly as for the wheels.
-      - uses: conda-incubator/setup-miniconda@v4
-        with:
-          miniforge-version: 24.11.3-0
-          use-mamba: true
-          # conda-forge only, for the same ABI reason as in setup-all -- see the
-          # comment there. The runtime sandbox PartCAD provisions below inherits
-          # this channel list, so leaving 'defaults' in would let Anaconda builds
-          # into it too.
-          channels: conda-forge
-          # Only base is needed -- PartCAD creates its own sandbox env at
-          # runtime. No named env, which is the part of setup-all that is flaky
-          # enough to need continue-on-error.
-          auto-activate-base: true
-          activate-environment: ""
+      # No conda is installed here, on purpose. PartCAD runs CAD scripts in a
+      # conda sandbox it provisions at runtime, and the bundle now carries the
+      # conda that provisions it -- so this job builds the whole CAD stack
+      # through the payload, on a machine that has nothing of its own. That is
+      # the end-to-end proof the build's own smoke test cannot be: it can only
+      # show that a conda was *resolved*, not that a sandbox solved and ran.
+      #
+      # This used to install Miniforge here (`setup-miniconda`, conda-forge
+      # only). The bundled micromamba resolves from conda-forge with no
+      # configuration at all, which is the same channel policy for the same
+      # reason -- see the comments in `.github/actions/setup-all/action.yml`.
+      - name: Check that this machine has no conda of its own
+        shell: bash
+        run: |
+          if command -v mamba >/dev/null 2>&1 || command -v conda >/dev/null 2>&1; then
+            echo "::error::a conda is on PATH, so this job would exercise it rather than"
+            echo "::error::the one the bundle carries. Take it off PATH for this job."
+            exit 1
+          fi
 
       # The libraries the bundled OpenSCAD AppImage resolves from the host: it is
       # not fully self-contained (see dev-tools/pyinstaller/build.sh). A desktop

--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ Subscribe on [LinkedIn], [YouTube], [TikTok], [Facebook], [Instagram], [Threads]
 Note, it's not required but highly recommended that you have [conda] installed. If you experience any difficulty
 installing or using any PartCAD tool, then make sure to install [conda].
 
+That applies to the Python packages below. The standalone command line tools, the snap and the PartCAD IDE
+carry a conda of their own and need none installed — they use yours when you have one.
+
 ### Plugin for Claude Code
 
 Already using [Claude Code](https://claude.com/claude-code)? This is the shortest way in, and it installs

--- a/cad/freecad/README.md
+++ b/cad/freecad/README.md
@@ -21,8 +21,10 @@ import the result into the document you are working on.
 
 - FreeCAD 0.21 or newer (tested against the 1.x line).
 - Network access the first time, to fetch the PartCAD service.
-- `git` and `conda`/`mamba` on `PATH` for the packages and CAD scripts PartCAD builds in a sandbox — the same
-  prerequisites the PartCAD command line tools have. `pc healthcheck` reports what is missing.
+- Nothing else, and in particular no conda: the standalone bundle this addon downloads carries the conda that
+  provisions the CAD sandbox, so a machine with none still builds parts. A `conda` or `mamba` already on
+  `PATH` is used in preference to it, as it is everywhere else. `git` on `PATH` is read for its configuration
+  where there is one; packages are cloned either way. `pc healthcheck` reports what is missing.
 
 You do **not** need Python skills, a Python environment, or a PartCAD installation. The addon drives the
 standalone `partcad-json-rpc` service — a self-contained bundle carrying its own interpreter — because

--- a/dev-tools/pyinstaller/README.md
+++ b/dev-tools/pyinstaller/README.md
@@ -10,10 +10,11 @@ with [`install.sh`](../../install.sh) and never see Python.
 | Install | `pip install -U partcad` | `curl -fsSL .../install.sh \| sh` |
 | Upgrade | `pc upgrade` (runs `pip`) | `pc upgrade` (fetches the release archive) |
 | Needs Python | yes, 3.10-3.14 | no |
-| Size | ~15MB plus whatever pip resolves | ~180MB unpacked, ~57MB compressed (Linux x86_64, OpenSCAD included) |
+| Size | ~15MB plus whatever pip resolves | ~200MB unpacked, ~63MB compressed (Linux x86_64, OpenSCAD and conda included) |
 | Optional extras (`lint`, `memcache`, `aws`) | installed on demand | always included |
 | Importable as a library | yes | no, it is only the CLI |
-| CAD kernel | not a dependency either way — every shape is built in a conda sandbox | same, see `EXCLUDES` in the spec |
+| CAD kernel | not a dependency either way — every shape is built in a sandbox | same, see `EXCLUDES` in the spec |
+| conda, which builds the best sandbox | the user's, or the `venv` fallback | carried, see [conda](#conda) |
 
 ## One build per OS version
 
@@ -242,8 +243,12 @@ frozen, so `build.sh` imports them all before it builds and says which import fa
 
 Freezing replaces the *installation*, not the architecture. PartCAD still runs CAD scripts (CadQuery,
 build123d, OpenSCAD) in a separate Python interpreter that it provisions itself with conda, and still clones
-package repositories with `git`. Both remain external prerequisites of the standalone bundle, exactly as they
-are for the wheels. `pc healthcheck` reports what is missing.
+package repositories with `git`.
+
+The difference is who supplies them. The bundle carries its own conda (see [conda](#conda) below), so a machine
+with none still builds CAD, and it carries OpenSCAD on the platforms where that is possible. `git` is what is
+left, and it was never a hard prerequisite: packages are cloned through `libgit2`, and the command line tool is
+read for its *configuration* where there is one. `pc healthcheck` reports what is missing.
 
 ## No CAD kernel
 
@@ -265,7 +270,8 @@ importable, so nothing can call it. The paths the programs do reach never hold a
   OCP object", which is the right answer in a process that has no OCP, and nothing calls the other two.
 
 So `pc` from a bundle needs conda for CAD exactly as `pc` from a wheel does, exactly as it did before -- the
-kernel it carried never ran. What it cost: OCP is ~250MB of extension module and OpenCASCADE libraries,
+kernel it carried never ran. What changed since is where the conda comes from, not whether one is needed: the
+bundle now carries that too, at ~12-22MB rather than the ~600MB the kernel cost. What it cost: OCP is ~250MB of extension module and OpenCASCADE libraries,
 `build123d` pulls scipy, sympy, scikit-learn, numpy, IPython and ezdxf in at *import* time, and the VTK-enabled
 `cadquery-ocp` the bundle pinned pulls VTK (another ~336MB) on top.
 
@@ -324,6 +330,93 @@ mechanisms were quietly breaking it before these entries existed:
 The check is cheap: install something unrelated into the build virtualenv, freeze, and diff the bundle against
 one frozen without it. With the AI SDKs, `cryptography`, `pydantic`, `httpx` and setuptools 8x installed, the
 two are identical today.
+
+## conda
+
+Every bundle carries a conda, on every platform. PartCAD imports no CAD kernel -- it provisions a Python
+environment and runs every CAD script in that -- and conda is the only sandbox that provisions an *interpreter*
+along with it. It used to ask the host for one, which is exactly backwards for an artifact whose reason to exist
+is that the host has nothing installed: the PartCAD IDE, which launches `partcad-json-rpc` out of a bundle,
+failed on a clean machine for want of a `conda` executable.
+
+The `venv` sandbox added since is not the answer to that, on this artifact. A virtual environment is built
+*from* an interpreter -- `RuntimePythonVenv._host_interpreter()` looks for `python3` and falls back to
+`sys.executable`, which inside a frozen bundle is `pc` rather than a Python -- so on the machine the bundle
+exists for, the one with no Python at all, there is nothing to build it from. `venv` is the right fallback for
+a wheel, where a Python is a given. Here the sandbox has to come with the tools.
+
+What ships is **micromamba**, pinned in `build.sh` (`MICROMAMBA_VERSION`) and downloaded from
+[`mamba-org/micromamba-releases`](https://github.com/mamba-org/micromamba-releases) at build time,
+checksum-verified against the `.sha256` published beside it. It is mamba -- the same implementation CI
+provisions through Miniforge (`use-mamba: true` in `.github/actions/setup-all/action.yml`), and the one
+`partcad_utils.conda` already preferred over `conda` -- in its single-file build.
+
+Not the Miniforge installer itself, for two reasons that both decide it:
+
+* **A conda installation is not relocatable.** Its entry points hardcode the prefix they were installed into,
+  and this bundle is unpacked wherever its installer puts it -- `~/.local/share/partcad/<version>` for
+  `install.sh`, elsewhere for the VS Code extension, the FreeCAD addon and the IDE. One static executable has
+  no prefix to hardcode and runs from wherever it finds itself.
+* **Size.** Miniforge is around 500MB installed, against 12-22MB here. Taking the CAD kernel out is what got
+  the bundle from ~1010MB to ~180MB; a conda distribution would have put three times its size back.
+
+micromamba also resolves from conda-forge with no configuration at all, which is the channel policy the
+comments in that CI action insist on -- mixing Anaconda's `defaults` into a conda-forge environment is what made
+the macOS jobs segfault. A Miniforge install would have had to carry a `.condarc` saying the same thing.
+
+Unlike OpenSCAD there is no platform that goes without: upstream builds micromamba for all five
+`<os>-<arch>` combinations this bundle is built for, and `stage_conda()` fails the build on one it has no
+mapping for rather than quietly producing a bundle that cannot do CAD. Like OpenSCAD it is **not** declared in
+`partcad.spec` -- `build.sh` copies it into `_internal/conda/` after PyInstaller has run.
+
+| | what ships | size |
+| --- | --- | --- |
+| Linux x86_64 | `micromamba-linux-64` | ~18MB, ~6MB in the archive |
+| Linux arm64 | `micromamba-linux-aarch64` | ~21MB |
+| macOS arm64 | `micromamba-osx-arm64` | ~14MB |
+| macOS x86_64 | `micromamba-osx-64` | ~16MB |
+| Windows x86_64 | `micromamba-win-64`, staged as `micromamba.exe` | ~11MB |
+
+(The release publishes `micromamba-win-64.exe` too, byte for byte the same file, but only the name without the
+suffix has a `.sha256` beside it -- and a payload nobody can verify is not one worth having.)
+
+### The host's conda wins
+
+`partcad_utils.conda.find_executable()` tries the host's `mamba`, then the host's `conda`, and only then the
+bundled copy. That is the opposite of what the bundled OpenSCAD does, on purpose, and the difference is worth
+stating because it will look like an inconsistency otherwise:
+
+OpenSCAD is one self-contained program with no state, so preferring the bundled copy costs a user nothing and
+makes the bundle behave identically everywhere. conda is not a program but an *installation* -- a channel
+configuration the user chose, and a package cache holding the gigabytes the CAD sandbox is made of. Preferring
+ours would strand that cache and re-download the whole CAD stack beside it, on a machine that was working
+perfectly well. So a machine that has conda keeps behaving exactly as it did, and the bundled copy is what
+makes a machine that has none work at all. There is no `--ignore-bundled-conda` for the same reason: nothing is
+being displaced, and the sandbox setting already says it better -- `pythonSandbox: venv` for an environment
+PartCAD builds without conda at all, `none` for no environment whatever.
+
+The bundled conda is given `MAMBA_ROOT_PREFIX` inside PartCAD's internal state directory (`<state dir>/conda`,
+beside the `sandbox` directory holding the environments it creates), and only the bundled one -- a host conda
+knows its own root prefix, and telling it otherwise would move a package cache the user has been filling for
+years. It has to be told something: micromamba's own default is `~/.local/share/mamba`, a directory PartCAD
+would be creating in the user's home without ever having said so -- outside what `pc system status` reports and
+`pc system reset` clears, and outside what `snap remove --purge` takes away, since the snap redirects PartCAD's
+state with `PC_INTERNAL_STATE_DIR` precisely so that it does. The internal state directory is the one PartCAD
+already owns and already documents.
+
+### What tests this
+
+Three things, at three levels:
+
+* `tests/partcad_utils/test_conda.py` pins the ordering and the root prefix. Nothing about either is observable
+  from a build -- a bundle built on a machine with no conda passes its smoke test whichever way round the two
+  are tried -- so it is asserted where a bundled copy and a host copy can be made to exist at once.
+* `build.sh`'s smoke test runs the staged payload (`--version`, against `MICROMAMBA_VERSION`) and then asks
+  `pc healthcheck --filters conda` whether PartCAD resolves a conda at all.
+* The `Standalone` workflow installs the archive and runs the payload out of the *installed* bundle, which is
+  the part the build cannot show -- an archive can lose an executable bit. Its `Examples ... via bundle` jobs
+  then install no conda at all and build the whole CAD stack through the payload; they fail loudly if a conda
+  turns up on `PATH`, because that would silently turn them back into a test of the host's.
 
 ## OpenSCAD
 

--- a/dev-tools/pyinstaller/README.md
+++ b/dev-tools/pyinstaller/README.md
@@ -404,6 +404,13 @@ would be creating in the user's home without ever having said so -- outside what
 state with `PC_INTERNAL_STATE_DIR` precisely so that it does. The internal state directory is the one PartCAD
 already owns and already documents.
 
+`bundled_command_env()` sets it only when it is unset, though, and that exception is worth stating because it
+takes the payload's cache back out of PartCAD's lifecycle: a user who runs their own micromamba has a
+`MAMBA_ROOT_PREFIX` and a warm cache under it, and sharing it is the point -- but their cache is then where
+they put it, so `pc system status` does not report it, `pc system reset` does not clear it, and
+`snap remove --purge` does not take it away. That is the right trade (PartCAD does not empty caches it did not
+fill, exactly as it leaves a host conda's alone), and it is a trade rather than a free win.
+
 ### What tests this
 
 Three things, at three levels:

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -44,6 +44,7 @@ fi
 SPEC_DIR="${REPO_ROOT}/dev-tools/pyinstaller"
 OUTPUT_DIR="${REPO_ROOT}/dist/standalone"
 OPENSCAD_STAGE_DIR="${REPO_ROOT}/build/openscad"
+CONDA_STAGE_DIR="${REPO_ROOT}/build/conda"
 PYTHON="${PYTHON:-python3}"
 
 # The OpenSCAD the bundle carries. Pinned rather than tracking the latest, so a
@@ -56,6 +57,15 @@ OPENSCAD_VERSION="2021.01"
 # builds, and CI aside, nobody wipes it by hand). Stale siblings are harmless:
 # `build/` is gitignored, and only the matching directory is ever read.
 OPENSCAD_PAYLOAD_DIR="${OPENSCAD_STAGE_DIR}/payload-${OPENSCAD_VERSION}"
+
+# The conda the bundle carries, as the tag of a `micromamba-releases` release --
+# "<micromamba version>-<build>", where `micromamba --version` prints only the
+# first half. Pinned rather than tracking "latest" for the same reason OpenSCAD
+# is: a rebuild of a given PartCAD version has to produce the same bundle.
+MICROMAMBA_VERSION="2.9.0-0"
+# Keyed by version like the OpenSCAD payload, so a bump refetches rather than
+# silently reusing whatever an old `build/` still holds.
+CONDA_PAYLOAD_DIR="${CONDA_STAGE_DIR}/payload-${MICROMAMBA_VERSION}"
 
 INSTALL_DEPENDENCIES=1
 CREATE_ARCHIVE=1
@@ -249,6 +259,44 @@ if [ "${INSTALL_DEPENDENCIES}" = "1" ]; then
   # ran either way. `pc healthcheck` reports it.
 fi
 
+#############################################  PAYLOAD FETCH  ################################################
+
+# Fetch a URL and the ".sha256" its upstream publishes beside it, and check the
+# one against the other. Used for both payloads the bundle carries -- OpenSCAD
+# and conda -- so that neither can be staged from a truncated or substituted
+# download.
+#
+# Fetched and verified with the Python this script already depends on, rather
+# than with curl and sha256sum, whose presence and flags differ across the three
+# platforms this runs on. The two upstreams do not publish the checksum in the
+# same shape -- OpenSCAD's reads "<hash>  releases/<name>", micromamba's is the
+# bare hash with no trailing newline -- so the first whitespace-separated field
+# is what is compared and anything after it ignored.
+fetch_and_verify() {
+  local url="$1" destination="$2"
+
+  "${PYTHON}" - "${url}" "${destination}" <<'FETCH'
+import sys
+import urllib.request
+
+for url, destination in ((sys.argv[1], sys.argv[2]), (sys.argv[1] + ".sha256", sys.argv[2] + ".sha256")):
+    urllib.request.urlretrieve(url, destination)
+FETCH
+
+  "${PYTHON}" - "${destination}" <<'VERIFY'
+import hashlib
+import pathlib
+import sys
+
+artifact = pathlib.Path(sys.argv[1])
+expected = pathlib.Path(str(artifact) + ".sha256").read_text().split()[0]
+actual = hashlib.sha256(artifact.read_bytes()).hexdigest()
+if actual != expected:
+    sys.exit(f"error: checksum mismatch for {artifact.name}: expected {expected}, got {actual}")
+print(f"    checksum verified: {artifact.name}")
+VERIFY
+}
+
 ###############################################  OPENSCAD  ###################################################
 
 # The bundle carries OpenSCAD, so `pc` can build .scad parts on a machine that
@@ -308,31 +356,7 @@ stage_openscad() {
   rm -rf "${payload_dir}"
   mkdir -p "${download_dir}" "${payload_dir}"
 
-  # Fetched and verified with the Python this script already depends on, rather
-  # than with curl and sha256sum, whose presence and flags differ across the
-  # three platforms this runs on.
-  "${PYTHON}" - "https://files.openscad.org/${artifact}" "${download_dir}/${artifact}" <<'FETCH'
-import sys
-import urllib.request
-
-for url, destination in ((sys.argv[1], sys.argv[2]), (sys.argv[1] + ".sha256", sys.argv[2] + ".sha256")):
-    urllib.request.urlretrieve(url, destination)
-FETCH
-
-  "${PYTHON}" - "${download_dir}/${artifact}" <<'VERIFY'
-import hashlib
-import pathlib
-import sys
-
-archive = pathlib.Path(sys.argv[1])
-# Published as "<hash>  releases/<name>": take the hash, ignore the path, which
-# names the location on the upstream server rather than the local file.
-expected = pathlib.Path(str(archive) + ".sha256").read_text().split()[0]
-actual = hashlib.sha256(archive.read_bytes()).hexdigest()
-if actual != expected:
-    sys.exit(f"error: checksum mismatch for {archive.name}: expected {expected}, got {actual}")
-print(f"    checksum verified: {archive.name}")
-VERIFY
+  fetch_and_verify "https://files.openscad.org/${artifact}" "${download_dir}/${artifact}"
 
   case "${artifact}" in
   *.AppImage)
@@ -360,6 +384,99 @@ VERIFY
 }
 
 stage_openscad
+
+################################################  CONDA  #####################################################
+
+# The bundle carries a conda, so that `pc` can build the CAD sandbox on a machine
+# that has none.
+#
+# It did not, and that was the flaw this fixes. PartCAD imports no CAD kernel: it
+# provisions a Python environment and runs every CAD script in that, and conda is
+# the only sandbox that provisions an *interpreter* along with it. The bundle
+# exists so that a machine with no Python can run PartCAD -- and it then asked
+# that machine for conda, which the PartCAD IDE discovered by launching the
+# daemon out of a bundle on a clean machine and failing.
+#
+# The `venv` sandbox is not the fallback here that it is for a wheel: a virtual
+# environment is built *from* an interpreter, and the machine this artifact is
+# for is the one with no Python to build it from (see `partcad_utils.conda`).
+#
+# What is staged is micromamba: mamba in its single-file, dependency-free build,
+# published by the mamba project. mamba because that is the implementation CI
+# provisions through Miniforge (`use-mamba: true` in
+# `.github/actions/setup-all/action.yml`) and the one `partcad_utils.conda`
+# already preferred over conda. Not the Miniforge installer itself, for two
+# reasons that both matter here:
+#
+#   1. A conda *installation* is not relocatable. Its entry points hardcode the
+#      prefix they were installed into, and this bundle is unpacked to a path
+#      nobody knows at build time -- `~/.local/share/partcad/<version>` for
+#      `install.sh`, somewhere else for the extension, the addon and the IDE.
+#      One static executable has no prefix to hardcode.
+#   2. Miniforge is around 500MB installed, against 12-22MB here. The bundle is
+#      ~200MB unpacked precisely because the CAD kernel was taken out of it; a
+#      conda distribution would put three times that back.
+#
+# micromamba also resolves from conda-forge with no configuration at all, which
+# is the channel policy the comments in that CI action insist on -- mixing
+# Anaconda's `defaults` into a conda-forge environment is what made the macOS
+# jobs segfault. A Miniforge install would have had to carry a `.condarc` saying
+# the same thing.
+#
+# Unlike OpenSCAD, there is no platform that goes without: upstream builds
+# micromamba for every platform this bundle is built for, and a bundle without a
+# conda is the bug. An unmapped platform therefore fails the build rather than
+# quietly producing one.
+#
+# `partcad_utils.conda` is the other half of this: where the payload is looked
+# for at run time, and why the host's conda still comes first when there is one.
+stage_conda() {
+  local artifact download_dir payload_dir entry_point
+  download_dir="${CONDA_STAGE_DIR}/download-${MICROMAMBA_VERSION}"
+  payload_dir="${CONDA_PAYLOAD_DIR}"
+
+  # Keyed on the operating system and architecture rather than on PLATFORM: one
+  # micromamba build serves every version of an operating system, exactly as one
+  # OpenSCAD build does.
+  case "${OS_NAME}-${ARCH_NAME}" in
+  linux-x86_64) artifact="micromamba-linux-64" ;;
+  linux-arm64) artifact="micromamba-linux-aarch64" ;;
+  macos-x86_64) artifact="micromamba-osx-64" ;;
+  macos-arm64) artifact="micromamba-osx-arm64" ;;
+  # The release also publishes "micromamba-win-64.exe", byte for byte the same
+  # file -- but only the name without the suffix has a ".sha256" beside it, and
+  # a payload nobody can verify is not one worth having. The staged copy is
+  # renamed to "micromamba.exe" below, which is the name that matters.
+  windows-x86_64) artifact="micromamba-win-64" ;;
+  *)
+    echo "error: no micromamba build is mapped for ${PLATFORM}, and a bundle" >&2
+    echo "       without a conda cannot build a CAD sandbox on a host that" >&2
+    echo "       has none -- add the mapping rather than shipping without it" >&2
+    exit 1
+    ;;
+  esac
+
+  entry_point="${payload_dir}/micromamba${EXE_SUFFIX}"
+  if [ -e "${entry_point}" ]; then
+    echo "==> micromamba ${MICROMAMBA_VERSION} already staged"
+    return 0
+  fi
+
+  echo "==> Fetching micromamba ${MICROMAMBA_VERSION} for ${PLATFORM}"
+  rm -rf "${payload_dir}"
+  mkdir -p "${download_dir}" "${payload_dir}"
+
+  fetch_and_verify \
+    "https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/${artifact}" \
+    "${download_dir}/${artifact}"
+
+  cp "${download_dir}/${artifact}" "${entry_point}"
+  chmod +x "${entry_point}"
+
+  echo "    staged $(du -sh "${payload_dir}" | cut -f1) in ${payload_dir}"
+}
+
+stage_conda
 
 ##############################################  PRE-FLIGHT  ##################################################
 
@@ -484,6 +601,9 @@ rm -rf "${OUTPUT_DIR}/partcad"
 BUNDLE_DIR="${OUTPUT_DIR}/partcad"
 # `sys._MEIPASS`, which is where `partcad.healthcheck.openscad` looks for the payload.
 OPENSCAD_BUNDLED_DIR="${BUNDLE_DIR}/_internal/openscad"
+# The same directory, and the same reasoning, for the conda payload:
+# `partcad_utils.conda.BUNDLED_SUBPATH` is where it is looked for.
+CONDA_BUNDLED_DIR="${BUNDLE_DIR}/_internal/conda"
 
 # OpenSCAD is copied in after the freeze rather than declared in the spec.
 # PyInstaller reclassifies shared libraries found among data files as binaries
@@ -498,6 +618,13 @@ if [ -d "${OPENSCAD_PAYLOAD_DIR}" ]; then
   rm -rf "${OPENSCAD_BUNDLED_DIR}"
   cp -a "${OPENSCAD_PAYLOAD_DIR}" "${OPENSCAD_BUNDLED_DIR}"
 fi
+
+# conda is copied in the same way and for the same reason -- it is a payload
+# PyInstaller has no business analysing -- but unconditionally: `stage_conda`
+# either staged it or stopped the build.
+echo "==> Installing the bundled conda"
+rm -rf "${CONDA_BUNDLED_DIR}"
+cp -a "${CONDA_PAYLOAD_DIR}" "${CONDA_BUNDLED_DIR}"
 
 ##############################################  ONE PAYLOAD  #################################################
 
@@ -575,6 +702,38 @@ if [ -d "${OPENSCAD_BUNDLED_DIR}" ]; then
     exit 1
   }
 fi
+
+# The bundled conda: that the payload runs, that it is the version pinned above
+# (which catches a stale `build/` from a different MICROMAMBA_VERSION and a copy
+# that arrived without its executable bit), and then that `pc` resolves a conda
+# at all. `micromamba --version` prints the version without the release's build
+# number, so only the half before the "-" is compared.
+conda_version_output="$(cd "${SMOKE_DIR}" && "${CONDA_BUNDLED_DIR}/micromamba${EXE_SUFFIX}" --version 2>&1)"
+echo "    micromamba ${conda_version_output}"
+# A prefix match rather than an equality: micromamba prints the version and
+# nothing else, but it prints it through a stream that Windows opens in text
+# mode, so what comes back there ends in a carriage return.
+case "${conda_version_output}" in
+"${MICROMAMBA_VERSION%-*}"*) ;;
+*)
+  echo "error: bundled micromamba is not ${MICROMAMBA_VERSION%-*}: '${conda_version_output}'" >&2
+  exit 1
+  ;;
+esac
+
+# What this proves is the same as for OpenSCAD, and no more: the health check
+# reports that a conda was resolved, so it demonstrates the *bundled* one was
+# used only on a machine that has none of its own -- hence the host is reported
+# beside it. That a host conda still wins over the bundled copy, which is the
+# ordering `partcad_utils.conda` deliberately has, is pinned down by the unit
+# tests, where both can be made to exist at once.
+echo "    host conda: $(command -v mamba || command -v conda || echo "none, so the check below can only pass via the bundle")"
+(cd "${SMOKE_DIR}" && "${BUNDLE_DIR}/pc${EXE_SUFFIX}" --no-ansi healthcheck --filters conda 2>&1) |
+  tee "${SMOKE_DIR}/healthcheck-conda.log"
+grep -q "CondaAvailable: Passed" "${SMOKE_DIR}/healthcheck-conda.log" || {
+  echo "error: PartCAD did not resolve a conda executable" >&2
+  exit 1
+}
 
 if [ "${CREATE_ARCHIVE}" = "0" ]; then
   echo "==> Bundle: ${BUNDLE_DIR}"

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -63,9 +63,8 @@ OPENSCAD_PAYLOAD_DIR="${OPENSCAD_STAGE_DIR}/payload-${OPENSCAD_VERSION}"
 # first half. Pinned rather than tracking "latest" for the same reason OpenSCAD
 # is: a rebuild of a given PartCAD version has to produce the same bundle.
 MICROMAMBA_VERSION="2.9.0-0"
-# Keyed by version like the OpenSCAD payload, so a bump refetches rather than
-# silently reusing whatever an old `build/` still holds.
-CONDA_PAYLOAD_DIR="${CONDA_STAGE_DIR}/payload-${MICROMAMBA_VERSION}"
+# CONDA_PAYLOAD_DIR is set below, once the platform is known: unlike OpenSCAD's,
+# it has to be keyed by platform as well as by version. See the note there.
 
 INSTALL_DEPENDENCIES=1
 CREATE_ARCHIVE=1
@@ -197,6 +196,23 @@ else
   ARCHIVE_EXT="tar.xz"
   EXE_SUFFIX=""
 fi
+
+# Keyed by version *and* platform, and set here rather than beside
+# MICROMAMBA_VERSION because it needs OS_NAME and ARCH_NAME, which the block
+# above is what settles.
+#
+# Version, so that bumping MICROMAMBA_VERSION refetches rather than silently
+# reusing whatever an old `build/` still holds -- the reason the OpenSCAD payload
+# is keyed too. Platform, because every platform stages a payload under the same
+# file name (`micromamba`), where OpenSCAD stages one on two platforms whose
+# workspaces nothing shares. Two builds for different platforms out of one
+# workspace -- an arm64 and an amd64 container over the same bind mount, an
+# Apple silicon Mac building the Intel bundle under `arch -x86_64` -- would
+# otherwise find the first build's executable already staged, pass
+# `stage_conda`'s entry-point check, and copy it into the second build's bundle.
+# The smoke test would catch it, since the executable would not run at all; that
+# is a confusing way to find out about a one-line key.
+CONDA_PAYLOAD_DIR="${CONDA_STAGE_DIR}/payload-${MICROMAMBA_VERSION}-${OS_NAME}-${ARCH_NAME}"
 
 VERSION="$("${PYTHON}" -c "
 import re, pathlib

--- a/dev-tools/snap/README.md
+++ b/dev-tools/snap/README.md
@@ -14,6 +14,7 @@ because the snap is classic, a manual store review — see [Publishing](#publish
 | Install | `pip install -U partcad` | `curl -fsSL .../install.sh \| sh` | `snap install --classic partcad`, once published |
 | Needs Python | yes, 3.10-3.14 | no | no |
 | Platforms | Linux, macOS, Windows | one build per supported OS version | linux amd64 and arm64 |
+| Carries a conda | no | yes | yes, from the bundle |
 | Sees the host's conda/git | yes | yes | no, see below |
 | Upgrades | `pip install -U` | re-run `install.sh` | automatic, by snapd |
 | Root to install | no | no | yes |
@@ -123,21 +124,30 @@ where it lives — it used to be derived independently by the writer and by `pc 
 agreed only for as long as nothing set `PC_INTERNAL_STATE_DIR`. This snap was the first thing that did, which is how
 the split was found; `tests/partcad/unit/test_telemetry_id_path.py` pins it.
 
-## conda and git are not found, and that is fine
+## The host's conda and git are not found, and that is fine
 
 A snap does not carry the user's shell environment, so a conda installed under `$HOME` — the usual place — is not
-visible to it, and neither is a git outside the standard system prefixes. This is accepted rather than worked around:
-PartCAD already handles both. `pythonSandbox` defaults to `conda` only when a conda is importable or on `PATH`, and to
-`none` otherwise, so CAD scripts run without a sandbox; git dependencies are simply unavailable. `pc healthcheck`
-reports both as missing, and the CI job runs it for the record without letting it fail the build.
+visible to it, and neither is a git outside the standard system prefixes.
 
-Anyone who needs the conda sandbox or git dependencies should use the standalone bundle or the wheels, which run with
-the user's own environment.
+For conda that no longer costs anything, and this section used to say it did. The snap wraps the standalone bundle,
+the bundle carries its own conda (see the standalone README), and a payload inside the snap is visible to it whatever
+the user's shell says — so `pythonSandbox` defaults to `conda` here as everywhere else and CAD scripts get their
+sandbox. The CI job asserts exactly that. What the snap still does not get is the user's *own* conda, and with it the
+package cache they have already filled: it builds its sandbox from scratch the first time, into
+`~/snap/partcad/common`.
+
+git is accepted rather than worked around: git dependencies are cloned through `libgit2` as everywhere else, and what
+the snap cannot see is the user's git configuration. `pc healthcheck` reports it missing, and the CI job runs the
+check for the record without letting that half fail the build.
+
+Anyone who needs their git configuration, or wants to share a conda package cache they already have, should use the
+standalone bundle or the wheels, which run with the user's own environment.
 
 ## What ships in it
 
 Everything the standalone bundle carries, unchanged: the interpreter, every Python dependency including the optional
-extras, the CAD kernel, and OpenSCAD on amd64 (the arm64 bundle carries none — see the standalone README).
+extras, the conda that provisions the CAD sandbox, and OpenSCAD on amd64 (the arm64 bundle carries none — see the
+standalone README). No CAD kernel: the bundle stopped freezing one in, and every shape is built in the sandbox.
 
 ## CI
 

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -140,12 +140,16 @@ That is what lets one package render against build123d 0.11 while another wants
 ==================== =========================================================================
 ``conda``            An environment conda provisions, **interpreter included**. The only one
                      that can give a package the Python version it asks for, so it is the
-                     default wherever conda or mamba is installed.
+                     default wherever conda or mamba is installed -- and in the
+                     :ref:`standalone tools <standalone-cli>`, the :ref:`snap <snap-package>`
+                     and the :ref:`PartCAD IDE <partcad-ide>`, which carry a conda of their
+                     own and use yours in preference to it when you have one.
 ``venv``             A plain virtual environment of PartCAD's own, one per interpreter
                      version, under the internal state directory. The default when conda is
                      not installed. Built from whichever Python the host has, so a package
                      asking for a version the host does not have is rendered on the host's
-                     and told so.
+                     and told so -- and so not something the standalone tools can fall back
+                     to, since the machine they exist for is the one with no Python.
 ``none``             No environment at all: scripts run on the host's own interpreter and
                      their dependencies are installed **into it**. Fast and shares whatever
                      is already there, at the price of writing the CAD stack into the Python

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -80,6 +80,10 @@ getting tested on Linux, macOS and Windows.
   If that doesn't help (e.g. macOS+arm64) then try ``mamba``.
   On Windows, PartCAD must be used inside a ``conda`` environment.
 
+  This applies to the wheels. The :ref:`standalone command line tools <standalone-cli>`, the
+  :ref:`snap <snap-package>` and the :ref:`PartCAD IDE <partcad-ide>` carry a conda of their own and need
+  none installed.
+
 .. note::
 
   On Ubuntu, try ``apt install libcairo2-dev`` if ``pip install`` fails to install ``cairo``.
@@ -179,12 +183,11 @@ That downloads the bundle for the current operating system and architecture from
 Nothing else on the system is touched, and no ``sudo`` is asked for. If ``~/.local/bin`` is not on your
 ``PATH``, the installer says so and prints the line to add.
 
-The bundle is around 180MB unpacked and 57MB to download on Linux x86_64, and about half that on macOS and
+The bundle is around 200MB unpacked and 63MB to download on Linux x86_64, and about half that on macOS and
 on Linux arm64, which carry no bundled OpenSCAD. It carries no CAD kernel: PartCAD builds every shape in a
-sandbox it provisions itself, so what is said about ``conda`` for the wheels applies here too: it is not
-required -- PartCAD falls back to a virtual environment of its own -- but it is what lets a package be built
-on a Python version this machine does not have (see :ref:`python-sandbox`). ``pc healthcheck`` reports what
-this machine is missing.
+sandbox it provisions itself -- and it carries the conda that provisions it, so nothing has to be installed
+first, and the ``conda`` sandbox is what you get rather than the ``venv`` fallback the wheels use when there
+is no conda (see :ref:`python-sandbox`). ``pc healthcheck`` reports what this machine is missing.
 
 Supported platforms are Linux on x86_64 and arm64, and macOS on Apple silicon and on Intel. Windows is
 covered by the ``.zip`` archives under :ref:`manual installation <standalone-manual>`.
@@ -349,9 +352,22 @@ extended afterwards: the Python linter (``lint``) is in it, ready to run.
 
 What it does **not** carry is a CAD kernel. The bundle is three console programs, not a library to import, and
 every shape those programs build, render, export or tessellate is produced in the sandbox PartCAD provisions
-and comes back as geometry the commands never open themselves. That sandbox is a conda environment where the
-machine has conda and a plain virtual environment otherwise (see :ref:`python-sandbox`); either way, leaving
-OpenCASCADE out of the bundle is most of why it is around 180MB rather than around 1GB.
+and comes back as geometry the commands never open themselves. Leaving OpenCASCADE out of the bundle is most
+of why it is around 200MB rather than around 1GB.
+
+It does carry the **conda** that builds that sandbox. Elsewhere conda is optional -- without it PartCAD builds
+a plain virtual environment instead (see :ref:`python-sandbox`) -- but a virtual environment is built *from*
+an interpreter, and the machine this bundle exists for is the machine with no Python to build one from. So
+every bundle, on every platform, ships `micromamba <https://mamba.readthedocs.io/>`_, a single self-contained
+executable of about 12-22MB, and PartCAD uses it when the machine has no conda of its own.
+
+If you already have ``conda`` or ``mamba``, yours is used and the bundled copy is ignored. That is deliberate:
+your conda has the channels you configured and a package cache holding the gigabytes a CAD sandbox is built
+from, and taking ours instead would strand that cache and download all of it again. Nothing needs to be
+configured either way; ``pc healthcheck`` says which conda was found.
+
+The bundled conda keeps its package cache in ``~/.partcad/conda``, beside the sandboxes it creates in
+``~/.partcad/sandbox``. Deleting ``~/.partcad`` removes both, and the next command rebuilds them.
 
 On Linux x86_64 and on Windows it also carries **OpenSCAD**, which PartCAD runs as an external program to
 build ``.scad`` parts. The bundled copy is used in preference to any OpenSCAD installed on the machine, so that the
@@ -373,13 +389,9 @@ reason -- upstream publishes that release for x86_64 only. The Intel macOS bundl
 that both macOS builds behave the same way. On all of them, install OpenSCAD yourself and PartCAD will use
 it.
 
-Two other things are deliberately not in the bundle, because PartCAD runs them as external programs rather
-than importing them, exactly as the wheels do:
-
-* **git**, used to fetch package repositories.
-* **conda** (or **mamba**), used to build the sandbox in which PartCAD runs CAD scripts. Optional: without it
-  PartCAD builds a plain virtual environment instead (see :ref:`python-sandbox`); conda is what lets a package
-  ask for a Python version the host does not have.
+One thing is deliberately not in the bundle, because PartCAD runs it as an external program rather than
+importing it, exactly as the wheels do: **git**, used for your git configuration when packages are fetched
+from git repositories. Packages are cloned either way, through ``libgit2``.
 
 Run ``pc healthcheck`` to see what is missing on the current machine.
 
@@ -444,9 +456,15 @@ conda and git
 =============
 
 A snap does not carry your shell environment, so a conda installed under your home directory -- the usual
-place -- is not visible to it, and neither is a git outside the standard system prefixes. This is expected
-and accepted rather than worked around: PartCAD notices, falls back to a virtual environment of its own
-(``pythonSandbox: venv`` -- see :ref:`python-sandbox`), and reports both as missing. Packages imported from git repositories are
+place -- is not visible to it, and neither is a git outside the standard system prefixes.
+
+conda no longer matters, and that is the one thing to know here that changed. The snap wraps the standalone
+bundle, the bundle carries its own conda, and a payload inside the snap is visible to it whatever your shell
+says -- so the snap gets the ``conda`` sandbox (see :ref:`python-sandbox`) rather than falling back to a
+virtual environment. What it will not pick up is *your* conda, and with it your package cache: the snap
+builds its sandbox from scratch the first time.
+
+git is still expected and accepted rather than worked around. Packages imported from git repositories are
 still cloned, through ``libgit2`` as everywhere else; what the snap cannot see is your git *configuration*
 (see :ref:`git-configuration`).
 
@@ -454,8 +472,8 @@ still cloned, through ``libgit2`` as everywhere else; what the snap cannot see i
 
   $ pc healthcheck
 
-If you need the conda sandbox, or your own git configuration, use the :ref:`standalone bundle
-<standalone-cli>` or the wheels, which run with your own environment.
+If you need your own git configuration, or want the snap to share the conda package cache you already have,
+use the :ref:`standalone bundle <standalone-cli>` or the wheels, which run with your own environment.
 
 To remove the snap, including its data:
 
@@ -510,8 +528,9 @@ The installer is not signed, so SmartScreen shows a warning: choose "More info",
 
 It unpacks to around 500MB: an editor, a Python interpreter, the command line tools and the extensions, all
 in one archive. Like the standalone bundle inside it, it carries no CAD kernel -- shapes are built in a
-sandbox PartCAD provisions on the machine, using conda where there is conda and a virtual environment of its
-own otherwise (see :ref:`python-sandbox`).
+sandbox PartCAD provisions on the machine. The conda that provisions it comes from the same place: the IDE
+ships the standalone bundle, and the bundle carries a conda, so there is nothing to install alongside the IDE
+either (see :ref:`python-sandbox`).
 
 The first start
 ===============

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -366,8 +366,13 @@ your conda has the channels you configured and a package cache holding the gigab
 from, and taking ours instead would strand that cache and download all of it again. Nothing needs to be
 configured either way; ``pc healthcheck`` says which conda was found.
 
-The bundled conda keeps its package cache in ``~/.partcad/conda``, beside the sandboxes it creates in
-``~/.partcad/sandbox``. Deleting ``~/.partcad`` removes both, and the next command rebuilds them.
+By default the bundled conda keeps its package cache in ``~/.partcad/conda``, beside the sandboxes it creates
+in ``~/.partcad/sandbox``. Deleting ``~/.partcad`` removes both, ``pc system status`` reports their size and
+``pc system reset`` clears them, and the next command rebuilds them.
+
+The exception is ``MAMBA_ROOT_PREFIX``: if you already have that set -- because you run micromamba yourself --
+the bundled copy uses your prefix rather than making a second cache of its own, and then none of the sentence
+above applies to it. It is your cache, in your location, and PartCAD neither reports nor deletes it.
 
 On Linux x86_64 and on Windows it also carries **OpenSCAD**, which PartCAD runs as an external program to
 build ``.scad`` parts. The bundled copy is used in preference to any OpenSCAD installed on the machine, so that the

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -47,6 +47,7 @@ Feature: `pc daemon` commands
     And STDERR should contain "Tar cache size:"
     And STDERR should contain "Git cache size:"
     And STDERR should contain "Sandbox environments size:"
+    And STDERR should contain "Conda package cache size:"
     And STDERR should contain "Total internal data storage size:"
     And STDERR should contain "DONE: Status: global:"
     When I run "pc --no-ansi daemon stop"

--- a/features/status.feature
+++ b/features/status.feature
@@ -14,6 +14,7 @@ Feature: `pc system status` command
     And STDOUT should match the regex "Tar cache size: \d\.\d+[KMGT]B"
     And STDOUT should match the regex "Git cache size: \d\.\d+[KMGT]B"
     And STDOUT should contain "Sandbox environments size:"
+    And STDOUT should contain "Conda package cache size:"
     And STDOUT should contain "Total internal data storage size:"
     And STDOUT should contain "DONE: Status: global:"
 

--- a/features/system/reset.feature
+++ b/features/system/reset.feature
@@ -42,3 +42,6 @@ Feature: `pc system reset` command
     Then the command should exit with a status code of "0"
     And STDERR should contain "Git cache size: 0.00MB"
     And STDERR should contain "Tar cache size: 0.00MB"
+    # The package cache the bundled conda fills goes with the sandboxes it built
+    # -- a reset that left gigabytes of packages behind would not have reset much.
+    And STDERR should contain "Conda package cache size: 0.00MB"

--- a/ide/standalone/README.md
+++ b/ide/standalone/README.md
@@ -11,7 +11,8 @@ first time it starts.
 | Needs Python          | yes, 3.10-3.14               | no                            | no                              |
 | Needs an editor       | -                            | -                             | no, it is one                   |
 | What you get          | `pc`, `partcad`, the library | `pc`, `partcad`               | the editor, the extension, `pc` |
-| Size (Linux, unpacked)| ~15MB plus dependencies      | ~185MB                        | ~500MB                          |
+| Needs conda installed | yes, for CAD                 | no, it carries one            | no, from the tools inside it    |
+| Size (Linux, unpacked)| ~15MB plus dependencies      | ~205MB                        | ~500MB                          |
 
 It is built from [VSCodium](https://vscodium.com/), rebranded, with the extensions this repository recommends
 installed into it and the [standalone command line tools](../dev-tools/pyinstaller/README.md) inside it. The
@@ -136,6 +137,13 @@ is the bundle directory that becomes `PartCAD IDE.app`.
 **The command line tools are embedded** at `<resources>/partcad-cli`, beside `<resources>/app` rather than
 inside it, so that no extension scan walks a gigabyte of Python. The bootstrap extension finds them there
 relative to `appRoot`, which is the same relative path on all three platforms.
+
+That embedding is also where the IDE gets its **conda**. PartCAD builds every shape in a conda sandbox, and
+the IDE has nothing of its own to build one with -- it is an editor and a JSON-RPC client; the daemon it
+launches is `partcad-json-rpc` out of that bundle. The bundle carries a conda (see
+[the standalone README](../../dev-tools/pyinstaller/README.md#conda)), so the IDE inherits one by carrying the
+bundle and adds nothing here. Before it did, the IDE started fine on a clean machine and then failed the
+moment a part had to be built, for want of a `conda` executable the user was never told to install.
 
 **The result is checked** (`tools/verify_bundle.py`): branding applied, every required extension present, no
 extension present that the policy skips, the tools where they should be, the launcher runnable. Each of those

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -159,6 +159,11 @@ and finally your `PATH`. That last one means `pip install partcad` in a Python e
 — the extension picks it up and downloads nothing. If it finds none of them, it offers to download a standalone
 bundle, which needs no Python at all.
 
+Nor any conda: PartCAD builds every shape in a conda sandbox, and the bundle carries the conda that builds it,
+so a machine with none still renders parts. A `conda` or `mamba` you have installed is used in preference to
+the bundled copy — see
+[the standalone README](https://github.com/partcad/partcad/blob/main/dev-tools/pyinstaller/README.md#conda).
+
 `pc upgrade` run inside a bundle this extension downloaded will refuse and tell you to update the extension
 instead: the extension owns that bundle, and upgrading it from underneath would leave a copy the extension does
 not know about.

--- a/install.sh
+++ b/install.sh
@@ -738,6 +738,7 @@ case ":${PATH}:" in
 esac
 
 log ""
-log "PartCAD runs CAD scripts in a sandbox it builds with conda, and clones"
-log "package repositories with git. Install conda and git to use those parts;"
+log "PartCAD runs CAD scripts in a sandbox it builds with conda, and the bundle"
+log "carries the conda that builds it -- nothing to install first. It clones"
+log "package repositories with git; install git to use those parts."
 log "'pc healthcheck' reports what is missing."

--- a/src/partcad/healthcheck/conda_installed.py
+++ b/src/partcad/healthcheck/conda_installed.py
@@ -4,6 +4,15 @@
 # Licensed under Apache License, Version 2.0.
 #
 
+"""Whether this machine can build a conda sandbox at all.
+
+The standalone bundle carries a conda of its own, so on a machine that has none
+this check passes through the bundled copy -- which is the point of carrying it.
+The wheels carry nothing, and there this reports what it always did.
+"""
+
+from partcad_utils import conda as pc_conda
+
 from partcad.runtime_python_conda import CondaPythonRuntime
 
 from .tests import HealthCheckReport, HealthCheckTest
@@ -29,7 +38,14 @@ class CondaAvailableCheck(HealthCheckTest):
         conda_path = CondaPythonRuntime.find_conda_executable()
         if conda_path is None:
             self.findings.append("Conda is not installed or not available in the PATH.")
-        return HealthCheckReport(self.name, self.findings, False)
+        report = HealthCheckReport(self.name, self.findings, False)
+        if conda_path is not None:
+            # Which one, because "a conda works here" and "the conda you
+            # installed works here" are different statements, and on a machine
+            # that has both this is the only thing that says which was taken.
+            source = "carried by this bundle" if pc_conda.is_bundled(conda_path) else "found on this machine"
+            report.debug("Using the conda %s: %s" % (source, conda_path))
+        return report
 
     def fix(self) -> bool:
         return False

--- a/src/partcad/runtime_javascript_conda.py
+++ b/src/partcad/runtime_javascript_conda.py
@@ -19,6 +19,8 @@ import shutil
 import subprocess
 import sys
 
+from partcad_utils import conda as pc_conda
+
 from . import runtime_javascript
 from . import runtime_python_conda
 from . import sandbox_lock
@@ -119,6 +121,18 @@ class CondaJavaScriptRuntime(runtime_javascript.JavaScriptRuntime):
         env["LD_LIBRARY_PATH"] = env_lib + (os.pathsep + previous if previous else "")
         return env
 
+    def conda_command_env(self):
+        """The environment to run the conda executable itself in.
+
+        The twin of CondaPythonRuntime.conda_command_env(), and for the same
+        reason: the conda a standalone bundle carries has no root prefix of its
+        own, so it is told to keep its package cache under PartCAD's internal
+        state directory. A host conda is left entirely alone.
+        """
+        if not pc_conda.is_bundled(self.conda_path):
+            return None
+        return pc_conda.bundled_command_env(self.ctx.user_config.internal_state_dir)
+
     def once(self):
         with self.sync_lock():
             self.once_conda_locked()
@@ -190,6 +204,7 @@ class CondaJavaScriptRuntime(runtime_javascript.JavaScriptRuntime):
                         stderr=subprocess.PIPE,
                         shell=False,
                         encoding="utf-8",
+                        env=self.conda_command_env(),
                     )
                     _, stderr = p.communicate()
 

--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -15,6 +15,8 @@ import subprocess
 import sys
 import json
 
+from partcad_utils import conda as pc_conda
+
 from . import runtime_python
 from . import sandbox_lock
 from . import sandbox_versions
@@ -115,14 +117,21 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
 
     @staticmethod
     def find_conda_executable():
-        conda_path = shutil.which("mamba")
+        # The host's mamba or conda, and -- when the host has neither -- the copy
+        # the standalone bundle carries. Shared with `user_config`, which decides
+        # from the same answer whether `pythonSandbox` defaults to conda at all;
+        # a second implementation of "is there a conda here" is a second answer,
+        # and the two disagreeing means a sandbox configured and then not found.
+        conda_path = pc_conda.find_executable()
         if conda_path:
             return conda_path
 
-        conda_path = shutil.which("conda")
-        if conda_path:
-            return conda_path
-
+        # Nothing on PATH and nothing in the bundle. An importable conda module
+        # is the last resort: PartCAD installed into a conda environment can be
+        # run by an interpreter that never had conda's own bin directory on
+        # PATH. It is asked last because answering costs two conda subprocesses,
+        # and it can only ever answer in a wheel install -- no conda module is
+        # frozen into the bundle.
         try:
             conda_cli = importlib.import_module("conda.cli.python_api")
             conda_cli.run_command(conda_cli.Commands.CONFIG, "--quiet")
@@ -276,6 +285,22 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
         env["LD_LIBRARY_PATH"] = env_lib + (os.pathsep + previous if previous else "")
         return env
 
+    def conda_command_env(self):
+        """The environment to run the *conda executable itself* in.
+
+        Not to be confused with _subprocess_env() above, which is about running
+        what conda installed. None means "inherit this process's environment",
+        which is the answer for every host conda: it has a root prefix, a package
+        cache and a configuration of its own, and PartCAD has no business
+        rewriting any of them.
+
+        The conda the bundle carries has none of that -- see
+        `partcad_utils.conda`.
+        """
+        if not pc_conda.is_bundled(self.conda_path):
+            return None
+        return pc_conda.bundled_command_env(self.ctx.user_config.internal_state_dir)
+
     def once(self):
         # 'provisioned' is raised by the base implementation below, once the
         # whole of this has run. Without the check, every command run in this
@@ -374,6 +399,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     stderr=subprocess.PIPE,
                     shell=False,
                     encoding="utf-8",
+                    env=self.conda_command_env(),
                 )
                 try:
                     _, stderr = p.communicate(timeout=300)
@@ -447,6 +473,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                             stderr=subprocess.PIPE,
                             shell=False,
                             encoding="utf-8",
+                            env=self.conda_command_env(),
                         )
                         stdout, stderr = p.communicate()
 
@@ -560,6 +587,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                         stderr=subprocess.PIPE,
                         shell=False,
                         encoding="utf-8",
+                        env=self.conda_command_env(),
                     )
                     stdout, stderr = p.communicate()
 

--- a/src/partcad_cli/click/commands/system/reset.py
+++ b/src/partcad_cli/click/commands/system/reset.py
@@ -10,6 +10,7 @@ import shutil
 
 import partcad as pc
 from partcad.user_config import user_config
+from partcad_utils import conda as pc_conda
 
 
 @click.option(
@@ -52,6 +53,18 @@ def cli(cli_ctx, repo_only: bool, sandbox_only: bool, cache_only: bool) -> None:
                             sandbox_subdir = os.path.join(sandbox_dir, subdir)
                             shutil.rmtree(sandbox_subdir)
                             pc.logging.info(f"Removed sandbox: '{subdir}'")
+
+                # The packages those environments were built from, which only the
+                # conda a standalone bundle carries keeps here -- a host conda has
+                # a package cache of its own, elsewhere, and PartCAD does not
+                # empty caches it did not fill. It goes with the environments
+                # rather than being left behind: it is the larger of the two, and
+                # a reset that leaves gigabytes in place has not reset much.
+                conda_dir = os.path.join(user_config.internal_state_dir, pc_conda.ROOT_PREFIX_SUBDIR)
+                if os.path.exists(conda_dir):
+                    with pc.logging.Action("Sandbox", "conda"):
+                        shutil.rmtree(conda_dir)
+                        pc.logging.info(f"Removed the conda package cache: '{conda_dir}'")
 
             if cache_only or not (repo_only or sandbox_only):
                 cache_dir = os.path.join(user_config.internal_state_dir, "cache")

--- a/src/partcad_cli/click/commands/system/status.py
+++ b/src/partcad_cli/click/commands/system/status.py
@@ -17,6 +17,7 @@ import partcad as pc
 import partcad.user_config as user_config
 from opentelemetry import context as otel_context
 from partcad_cli.click.cli_context import CliContext
+from partcad_utils import conda as pc_conda
 from partcad_utils.utils import directory_size_mb
 
 path = user_config.internal_state_dir
@@ -61,6 +62,22 @@ def get_sandbox(context):
     otel_context.detach(token)
 
 
+def get_conda(context):
+    """Report the size of the bundled conda's package cache.
+
+    Only the standalone bundle's conda keeps anything here -- a host conda has a
+    package cache of its own and is left alone. It is reported separately from
+    the sandboxes because it is the larger of the two and the less obvious: the
+    environments are what the user asked for, this is what they were built from.
+    """
+    token = otel_context.attach(context)
+    with pc.logging.Action("Status", "conda"):
+        conda_path = os.path.join(path, pc_conda.ROOT_PREFIX_SUBDIR)
+        conda_total = directory_size_mb(conda_path)
+        pc.logging.info("Conda package cache size: %.2fMB" % conda_total)
+    otel_context.detach(token)
+
+
 @click.command(help="Display the state of internal data used by PartCAD")
 @click.pass_obj
 def cli(cli_ctx: CliContext) -> None:
@@ -83,15 +100,18 @@ def cli(cli_ctx: CliContext) -> None:
             thread_git = threading.Thread(target=get_git, args=(otel_context.get_current(),))
             thread_tar = threading.Thread(target=get_tar, args=(otel_context.get_current(),))
             thread_sandbox = threading.Thread(target=get_sandbox, args=(otel_context.get_current(),))
+            thread_conda = threading.Thread(target=get_conda, args=(otel_context.get_current(),))
 
             # Launch threads
             thread_total.start()
             thread_git.start()
             thread_tar.start()
             thread_sandbox.start()
+            thread_conda.start()
 
             # Wait for threads to finish
             thread_total.join()
             thread_git.join()
             thread_tar.join()
             thread_sandbox.join()
+            thread_conda.join()

--- a/src/partcad_service_json_rpc/core/operations.py
+++ b/src/partcad_service_json_rpc/core/operations.py
@@ -23,6 +23,7 @@ from urllib.request import url2pathname
 
 import yaml
 from packaging.specifiers import SpecifierSet
+from partcad_utils import conda as pc_conda
 from partcad_utils.utils import directory_size_mb
 
 from ..rpc.dispatcher import JsonRpcError
@@ -1006,6 +1007,18 @@ def daemon_reset(session, params):
                         shutil.rmtree(os.path.join(sandbox_dir, subdir))
                         pc.logging.info("Removed sandbox: '%s'" % subdir)
 
+            # The packages those environments were built from, which only the
+            # conda a standalone bundle carries keeps here -- a host conda has a
+            # package cache of its own, elsewhere, and PartCAD does not empty
+            # caches it did not fill. Not nested under the directory above: the
+            # cache outlives the environments, and a machine that has the one
+            # without the other is what a previous half-reset leaves behind.
+            conda_dir = os.path.join(user_config.internal_state_dir, pc_conda.ROOT_PREFIX_SUBDIR)
+            if os.path.exists(conda_dir):
+                with pc.logging.Action("Sandbox", "conda"):
+                    shutil.rmtree(conda_dir)
+                    pc.logging.info("Removed the conda package cache: '%s'" % conda_dir)
+
         if cache_only or not (repo_only or sandbox_only):
             cache_dir = os.path.join(user_config.internal_state_dir, "cache")
             if os.path.exists(cache_dir):
@@ -1042,6 +1055,10 @@ def daemon_status(session, params):
             pc.logging.info("Tar cache size: %.2fMB" % directory_size_mb(os.path.join(root, "tar")))
         with pc.logging.Action("Status", "sandbox"):
             pc.logging.info("Sandbox environments size: %.2fMB" % directory_size_mb(os.path.join(root, "sandbox")))
+        with pc.logging.Action("Status", "conda"):
+            pc.logging.info(
+                "Conda package cache size: %.2fMB" % directory_size_mb(os.path.join(root, pc_conda.ROOT_PREFIX_SUBDIR))
+            )
     return None
 
 

--- a/src/partcad_utils/conda.py
+++ b/src/partcad_utils/conda.py
@@ -1,0 +1,134 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""conda/mamba: where PartCAD finds it, and the copy the standalone bundle carries.
+
+PartCAD imports no CAD kernel. It provisions a Python environment and runs every
+CAD script in that, and conda is the only sandbox that provisions an *interpreter*
+along with it. For the wheels, asking the user for one is fair -- they brought
+their own Python and can bring their own conda, and ``pythonSandbox`` falls back
+to ``venv`` when they have not. For the standalone bundle neither half holds: the
+bundle exists so that a machine with no Python at all can run PartCAD, and it
+then turned around and asked that machine for conda. That is how the PartCAD IDE,
+launching the daemon out of a bundle, failed on a clean machine.
+
+The ``venv`` fallback does not rescue it either. A virtual environment is built
+*from* an interpreter -- ``RuntimePythonVenv._host_interpreter()`` looks for
+``python3`` and falls back to ``sys.executable``, which in a frozen bundle is
+``pc`` and not a Python -- so on exactly the machine this artifact is for there
+is nothing to build one from.
+
+So the bundle carries one, and this module is the single place that knows where.
+``dev-tools/pyinstaller/build.sh`` stages the payload after the freeze (the same
+way it stages OpenSCAD) and ``find_bundled_executable()`` finds it again at run
+time.
+
+**The host's conda wins, and the bundled copy is the fallback.** That is the
+opposite of what ``partcad.healthcheck.openscad`` does with the bundled OpenSCAD,
+deliberately: OpenSCAD is one self-contained program with no state, so preferring
+the bundled copy costs a user nothing and makes the bundle behave the same
+everywhere. conda is not a program, it is an *installation* -- a channel
+configuration the user chose and a package cache they have already paid
+gigabytes for. Preferring ours would strand that cache and re-download the whole
+CAD stack beside it, on a machine that was working perfectly well. So a machine
+that has conda keeps behaving exactly as it did, and the bundled copy is what
+makes a machine that has none work at all.
+
+What the bundle carries is **micromamba**: mamba in its single-file,
+dependency-free build. mamba because that is what PartCAD's CI provisions
+(``use-mamba: true`` in ``.github/actions/setup-all/action.yml``) and what PartCAD
+has always preferred over conda anyway; the single-file build because a
+bundle is unpacked to an unpredictable path, and a Miniforge installation is not
+relocatable -- its entry points hardcode the prefix they were installed into --
+while this is one static executable that runs from wherever it finds itself. It
+also resolves from conda-forge with no configuration at all, which is the channel
+policy the comments in that CI action insist on: mixing Anaconda's ``defaults``
+into a conda-forge environment is what made the macOS jobs segfault.
+"""
+
+import os
+import shutil
+import sys
+
+# Where the bundle keeps its conda, relative to the directory holding the frozen
+# interpreter. `build.sh` copies it there after PyInstaller has run, so this path
+# exists only in a bundle -- a wheel and a source checkout have no payload.
+BUNDLED_SUBPATH = ("conda", "micromamba.exe") if os.name == "nt" else ("conda", "micromamba")
+
+# Where the bundled conda is told to keep its own state -- its package cache
+# above all -- relative to PartCAD's internal state directory, beside the
+# `sandbox` directory holding the environments it creates.
+#
+# It has to be told. micromamba's own default is `~/.local/share/mamba` (or
+# `~/micromamba` for older releases), which is a directory PartCAD would be
+# creating in the user's home without ever having said so -- outside anything
+# `pc system status` reports or `pc system reset` clears, and outside what
+# `snap remove --purge` takes away, since the snap moves PartCAD's state with
+# `PC_INTERNAL_STATE_DIR` precisely so that it does. The internal state directory
+# is the one PartCAD already owns, already documents, and already redirects.
+ROOT_PREFIX_SUBDIR = "conda"
+
+
+def find_bundled_executable() -> "str | None":
+    """Return the conda shipped inside the standalone bundle, or None.
+
+    None whenever PartCAD is not running from a bundle, and also when it is
+    running from one built without the payload (a `pyinstaller partcad.spec` run
+    by hand -- `build.sh` is what stages it).
+    """
+    if not getattr(sys, "frozen", False):
+        return None
+
+    # PyInstaller points `sys._MEIPASS` at the directory it unpacked the bundle
+    # into, which is where the payload lives.
+    bundle_dir = getattr(sys, "_MEIPASS", None)
+    if not bundle_dir:
+        return None
+
+    path = os.path.join(bundle_dir, *BUNDLED_SUBPATH)
+    if os.path.isfile(path) and os.access(path, os.X_OK):
+        return path
+    return None
+
+
+def find_executable() -> "str | None":
+    """Return the conda executable to run, or None if there is none.
+
+    The host's mamba first, the host's conda second, the bundled copy last -- see
+    the note at the top of this module for why the bundle does not go first.
+    mamba before conda is the older preference of the two: it solves the CAD
+    stack in a fraction of the time.
+
+    This is deliberately cheap -- two PATH lookups and a stat, no subprocess --
+    because `user_config` asks it on startup to decide whether `pythonSandbox`
+    defaults to conda at all. `CondaPythonRuntime.find_conda_executable()` is the one that
+    goes on to interrogate an importable conda module when this finds nothing.
+    """
+    for name in ("mamba", "conda"):
+        path = shutil.which(name)
+        if path:
+            return path
+
+    return find_bundled_executable()
+
+
+def is_bundled(conda_path: "str | None") -> bool:
+    """Whether `conda_path` is the copy this bundle carries rather than a host one."""
+    return bool(conda_path) and conda_path == find_bundled_executable()
+
+
+def bundled_command_env(internal_state_dir: str, env: "dict | None" = None) -> dict:
+    """The environment the *bundled* conda has to be run in.
+
+    Only the bundled one: a host conda knows its own root prefix, and telling it
+    otherwise would move a package cache the user has been filling for years.
+
+    An existing `MAMBA_ROOT_PREFIX` is left alone -- someone who runs their own
+    micromamba has a cache worth sharing, and this is how they say so.
+    """
+    env = dict(os.environ if env is None else env)
+    if not env.get("MAMBA_ROOT_PREFIX"):
+        env["MAMBA_ROOT_PREFIX"] = os.path.join(internal_state_dir, ROOT_PREFIX_SUBDIR)
+    return env

--- a/src/partcad_utils/user_config.py
+++ b/src/partcad_utils/user_config.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import vyper
 
+from . import conda as pc_conda
 from . import logging as pc_logging
 from .booleans import to_bool
 from .utils import is_editable_install
@@ -509,7 +510,17 @@ class UserConfig(vyper.Vyper):
         # surprising thing to do to somebody's Python and impossible on a host
         # whose Python is not writable. It stays available for a host that wants
         # exactly that, and is chosen rather than fallen back to.
-        if shutil.which("conda") is not None or importlib.util.find_spec("conda") is not None:
+        #
+        # `pc_conda.find_executable()` rather than `shutil.which("conda")`: it is
+        # the same question the sandbox itself asks later
+        # (`CondaPythonRuntime.find_conda_executable`), and asking it differently
+        # here is how the two came to disagree. It answers for a host `mamba`
+        # with no `conda` beside it -- which the sandbox has always preferred and
+        # this default used to miss -- and for the conda a standalone bundle
+        # carries. That last one is why the bundle is not left to the `venv`
+        # fallback: a venv is built *from* an interpreter, and the machine a
+        # bundle exists for is the machine with no Python to build one from.
+        if pc_conda.find_executable() is not None or importlib.util.find_spec("conda") is not None:
             self.set_default("pythonSandbox", "conda")
         else:
             self.set_default("pythonSandbox", "venv")
@@ -522,7 +533,7 @@ class UserConfig(vyper.Vyper):
         # works if conda can supply one.
         if shutil.which("node") is not None:
             self.set_default("javascriptSandbox", "none")
-        elif shutil.which("conda") is not None or importlib.util.find_spec("conda") is not None:
+        elif pc_conda.find_executable() is not None or importlib.util.find_spec("conda") is not None:
             self.set_default("javascriptSandbox", "conda")
         else:
             self.set_default("javascriptSandbox", "none")

--- a/tests/partcad_cli/unit/test_status.py
+++ b/tests/partcad_cli/unit/test_status.py
@@ -30,6 +30,7 @@ EXPECTED = [
     "Git cache size:",
     "Tar cache size:",
     "Sandbox environments size:",
+    "Conda package cache size:",
 ]
 
 

--- a/tests/partcad_cli/unit/test_system_reset.py
+++ b/tests/partcad_cli/unit/test_system_reset.py
@@ -1,0 +1,81 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""`pc system reset` and the package cache the bundled conda fills.
+
+A standalone bundle carries its own conda, which keeps its packages under
+PartCAD's internal state directory (`partcad_utils.conda.ROOT_PREFIX_SUBDIR`).
+That is the largest thing PartCAD writes there -- gigabytes, against megabytes
+for the environments built out of it -- so a reset that left it behind would not
+have reset much.
+
+The case pinned here is the one that is easy to get wrong by indentation alone:
+the cache has to go even when there is no `sandbox` directory beside it. That
+happens whenever the environments were removed and the cache was not, which is
+precisely the state a previous half-reset leaves behind.
+"""
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from partcad.user_config import user_config
+from partcad_cli.click.command import cli
+from partcad_utils import conda as pc_conda
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    """Point PartCAD's internal state directory at a throwaway one."""
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setattr(user_config, "internal_state_dir", str(state))
+    return state
+
+
+def _make_conda_cache(state):
+    cache = state / pc_conda.ROOT_PREFIX_SUBDIR / "pkgs"
+    cache.mkdir(parents=True)
+    (cache / "somepackage.conda").write_text("")
+    return state / pc_conda.ROOT_PREFIX_SUBDIR
+
+
+def test_reset_removes_the_conda_package_cache(click_runner: Iterator[CliRunner], state_dir) -> None:
+    conda_dir = _make_conda_cache(state_dir)
+    (state_dir / "sandbox" / "pc-py-conda-3.13").mkdir(parents=True)
+
+    result = click_runner.invoke(cli, ["--no-ansi", "system", "reset"])
+    logging.debug("result.output: %s", result.output)
+
+    assert result.exit_code == 0
+    assert not conda_dir.exists()
+
+
+def test_reset_removes_the_conda_cache_with_no_sandbox_beside_it(click_runner: Iterator[CliRunner], state_dir) -> None:
+    """The cache is not nested under "there are environments to remove".
+
+    Gating it on the `sandbox` directory existing would leave the whole cache in
+    place here, and nothing in the output would say so.
+    """
+    conda_dir = _make_conda_cache(state_dir)
+    assert not (state_dir / "sandbox").exists()
+
+    result = click_runner.invoke(cli, ["--no-ansi", "system", "reset"])
+    logging.debug("result.output: %s", result.output)
+
+    assert result.exit_code == 0
+    assert not conda_dir.exists()
+
+
+def test_reset_leaves_the_conda_cache_alone_for_the_other_options(click_runner: Iterator[CliRunner], state_dir) -> None:
+    """It belongs to the sandboxes, so the repo and cache resets do not take it."""
+    conda_dir = _make_conda_cache(state_dir)
+
+    for option in ("--repo-only", "--cache-only"):
+        result = click_runner.invoke(cli, ["--no-ansi", "system", "reset", option])
+        assert result.exit_code == 0, option
+        assert conda_dir.exists(), option

--- a/tests/partcad_utils/test_conda.py
+++ b/tests/partcad_utils/test_conda.py
@@ -1,0 +1,142 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Which conda PartCAD runs, and in what environment it runs it.
+
+The standalone bundle carries a conda so that a machine with no conda can still
+build a CAD sandbox -- and it must not displace a conda the machine already has,
+whose package cache holds the gigabytes the sandbox is made of. Neither half of
+that is observable from a build: a bundle built on a machine with no conda passes
+its smoke test whichever way round the two are tried. So it is pinned down here,
+where a bundled copy and a host copy can be made to exist at the same time.
+"""
+
+import os
+import stat
+
+import pytest
+
+from partcad_utils import conda as pc_conda
+
+
+@pytest.fixture
+def bundle(tmp_path, monkeypatch):
+    """Make PartCAD look like a frozen bundle whose payload is under tmp_path."""
+    monkeypatch.setattr(pc_conda.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(pc_conda.sys, "_MEIPASS", str(tmp_path), raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def no_host_conda(monkeypatch):
+    """A machine with neither mamba nor conda on PATH."""
+    monkeypatch.setattr(pc_conda.shutil, "which", lambda _name: None)
+
+
+def _make_payload(bundle_dir):
+    """Create an executable at the path the bundle is expected to carry."""
+    executable = bundle_dir.joinpath(*pc_conda.BUNDLED_SUBPATH)
+    executable.parent.mkdir(parents=True, exist_ok=True)
+    executable.write_text("")
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    return str(executable)
+
+
+def test_bundled_executable_is_found_in_a_bundle(bundle):
+    expected = _make_payload(bundle)
+    assert pc_conda.find_bundled_executable() == expected
+
+
+def test_bundled_executable_is_none_outside_a_bundle(tmp_path, monkeypatch):
+    """A wheel or a source checkout has no payload, however sys is configured."""
+    monkeypatch.delattr(pc_conda.sys, "frozen", raising=False)
+    monkeypatch.setattr(pc_conda.sys, "_MEIPASS", str(tmp_path), raising=False)
+    _make_payload(tmp_path)
+    assert pc_conda.find_bundled_executable() is None
+
+
+def test_bundled_executable_is_none_when_the_bundle_carries_no_payload(bundle):
+    """A `pyinstaller partcad.spec` run by hand: `build.sh` is what stages it."""
+    assert pc_conda.find_bundled_executable() is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the executable bit is a POSIX notion")
+def test_a_payload_that_lost_its_executable_bit_is_not_offered(bundle):
+    """Better to report no conda than to hand back a path that cannot be run."""
+    executable = bundle.joinpath(*pc_conda.BUNDLED_SUBPATH)
+    executable.parent.mkdir(parents=True, exist_ok=True)
+    executable.write_text("")
+    executable.chmod(0o644)
+    assert pc_conda.find_bundled_executable() is None
+
+
+def test_the_bundled_conda_is_used_when_the_host_has_none(bundle, no_host_conda):
+    """The whole point: a machine with no conda gets one anyway."""
+    expected = _make_payload(bundle)
+    assert pc_conda.find_executable() == expected
+
+
+def test_the_host_conda_wins_over_the_bundled_one(bundle, monkeypatch):
+    """Deliberately the opposite of the bundled OpenSCAD.
+
+    conda is not a program but an installation -- a channel configuration the
+    user chose and a package cache they have already paid gigabytes for. Taking
+    ours instead would strand that cache and re-download the whole CAD stack
+    beside it, on a machine that was working perfectly well.
+    """
+    _make_payload(bundle)
+    monkeypatch.setattr(pc_conda.shutil, "which", lambda name: "/usr/bin/" + name)
+    assert pc_conda.find_executable() == "/usr/bin/mamba"
+
+
+def test_mamba_is_preferred_over_conda(monkeypatch):
+    """The older of the two preferences: mamba solves the CAD stack far faster."""
+    monkeypatch.delattr(pc_conda.sys, "frozen", raising=False)
+    monkeypatch.setattr(pc_conda.shutil, "which", lambda name: "/usr/bin/" + name)
+    assert pc_conda.find_executable() == "/usr/bin/mamba"
+
+
+def test_the_host_conda_is_used_when_there_is_no_mamba(monkeypatch):
+    monkeypatch.delattr(pc_conda.sys, "frozen", raising=False)
+    monkeypatch.setattr(pc_conda.shutil, "which", lambda name: None if name == "mamba" else "/usr/bin/conda")
+    assert pc_conda.find_executable() == "/usr/bin/conda"
+
+
+def test_none_when_there_is_no_conda_anywhere(monkeypatch, no_host_conda):
+    """A wheel on a machine with nothing installed: `pythonSandbox` is "none"."""
+    monkeypatch.delattr(pc_conda.sys, "frozen", raising=False)
+    assert pc_conda.find_executable() is None
+
+
+def test_is_bundled_tells_the_two_apart(bundle, no_host_conda):
+    bundled = _make_payload(bundle)
+    assert pc_conda.is_bundled(bundled)
+    assert not pc_conda.is_bundled("/usr/bin/mamba")
+    assert not pc_conda.is_bundled(None)
+
+
+def test_the_bundled_conda_keeps_its_state_under_the_internal_state_dir(monkeypatch):
+    """Not in the user's home directory, which is micromamba's own default.
+
+    PartCAD would be creating `~/.local/share/mamba` without ever having said so,
+    outside everything that reports and clears its state -- `pc system status`,
+    `pc system reset`, and the `PC_INTERNAL_STATE_DIR` redirect that lets
+    `snap remove --purge` take the whole of it away.
+    """
+    monkeypatch.delenv("MAMBA_ROOT_PREFIX", raising=False)
+    env = pc_conda.bundled_command_env(os.path.join("/state", "partcad"))
+    assert env["MAMBA_ROOT_PREFIX"] == os.path.join("/state", "partcad", pc_conda.ROOT_PREFIX_SUBDIR)
+
+
+def test_an_existing_root_prefix_is_left_alone(monkeypatch):
+    """Someone running their own micromamba has a cache worth sharing."""
+    monkeypatch.setenv("MAMBA_ROOT_PREFIX", "/home/user/micromamba")
+    assert pc_conda.bundled_command_env("/state/partcad")["MAMBA_ROOT_PREFIX"] == "/home/user/micromamba"
+
+
+def test_the_rest_of_the_environment_is_carried_over(monkeypatch):
+    """It is this process's environment plus one variable, not a replacement."""
+    monkeypatch.setenv("PARTCAD_TEST_MARKER", "kept")
+    assert pc_conda.bundled_command_env("/state/partcad")["PARTCAD_TEST_MARKER"] == "kept"


### PR DESCRIPTION
## Copilot Summary

`#deepTest` — this changes what is frozen, so the full platform matrix has to build it (see `dev-tools/pyinstaller/README.md`).

### The problem

PartCAD imports no CAD kernel: it provisions a Python environment and runs every CAD script in that, and conda is the only sandbox that provisions an *interpreter* along with it. The standalone bundle exists so that a machine with no Python can run PartCAD — and it then turned around and asked that machine for conda. The PartCAD IDE found this by launching `partcad-json-rpc` out of a bundle on a clean machine, where it failed for want of a `conda` executable the user was never told to install.

The `venv` sandbox from #590 does not rescue this artifact. A virtual environment is built *from* an interpreter — `RuntimePythonVenv._host_interpreter()` looks for `python3` and falls back to `sys.executable`, which inside a frozen bundle is `pc` rather than a Python — so on exactly the machine the bundle exists for there is nothing to build one from. `venv` is the right fallback for a wheel, where a Python is a given.

### What ships

Every bundle, on every platform, now carries **micromamba** — mamba in its single-file, dependency-free build. mamba because that is the implementation CI provisions through Miniforge (`use-mamba: true`) and the one PartCAD already preferred over conda. The single-file build rather than the Miniforge installer for two reasons that both decide it:

1. **A conda installation is not relocatable.** Its entry points hardcode the prefix they were installed into, and this bundle is unpacked wherever its installer puts it — `~/.local/share/partcad/<version>` for `install.sh`, elsewhere for the extension, the addon and the IDE. One static executable has no prefix to hardcode.
2. **Size.** Miniforge is ~500MB installed against 12–22MB here, on a bundle that is ~200MB precisely because the CAD kernel came out of it.

It also resolves from conda-forge with no configuration at all, which is the channel policy the comments in `.github/actions/setup-all/action.yml` insist on — mixing Anaconda's `defaults` into a conda-forge environment is what made the macOS jobs segfault.

`build.sh` stages it the way it stages OpenSCAD: pinned version, downloaded at build time, verified against the `.sha256` published beside it, copied into `_internal/conda/` after the freeze. An unmapped platform fails the build rather than producing a bundle that cannot do CAD. The fetch-and-verify step is now shared between the two payloads.

### The host's conda still wins

Deliberately the opposite of the bundled OpenSCAD, and worth stating because it looks like an inconsistency otherwise. OpenSCAD is a self-contained program with no state, so preferring the bundled copy costs a user nothing. conda is an *installation* — a channel configuration the user chose and a package cache holding the gigabytes a CAD sandbox is built from — and preferring ours would strand that cache and download all of it again, on a machine that was working perfectly well.

New `partcad_utils/conda.py` is the single resolver — host `mamba`, host `conda`, then the payload — shared with `user_config` so that "is there a conda here" cannot be answered two ways. That also fixes a host with only `mamba` and no `conda` beside it, which the `pythonSandbox` default used to miss. Only the bundled copy is given a `MAMBA_ROOT_PREFIX`, at `<state dir>/conda`, which `pc system status` now reports and `pc system reset` now clears; a host conda is left entirely alone.

### Everything downstream inherits it

The IDE, the VS Code extension and the FreeCAD addon get a conda by shipping or downloading the bundle, and add nothing of their own. The snap does too — so its CI job now *asserts* conda instead of expecting it missing, and its state-leak check covers the new directory. The `Examples via bundle` jobs install no conda at all: they build the whole CAD stack through the payload and fail loudly if a conda turns up on `PATH`, so the coverage cannot be silently lost.

### Verification

- 13 new tests in `tests/partcad_utils/test_conda.py` pin the resolution order and the root prefix — neither is observable from a build, since a bundle built on a machine with no conda passes its smoke test whichever way round the two are tried.
- `build.sh`'s smoke test runs the staged payload and asks `pc healthcheck --filters conda`; the `Install` jobs run it out of the *installed* bundle, which is where an archive can lose an executable bit.
- Verified against the real 2.9.0-0 binary that the exact commands PartCAD issues work: `create -y -q --json -p <prefix> python=3.13 python_abi==3.13=*_cp313` solves to the GIL build (`h…_cp313`, `lib/python3.13`), the `install` that follows solves, and `clean --packages --tarballs -y` is supported.
- `pytest` on `partcad_utils`, `partcad_cli`, `partcad_client`, `partcad_ide_client`, `partcad_service_json_rpc` and the sandbox/openscad unit tests: 960 passed. `behave` on the two features touched: pass. black, flake8, shellcheck, workflow schema and the Sphinx build: clean.
- Not runnable in this environment: `pytest tests/partcad` in full (segfaults importing OCP here, on the pristine tree too) and the bundle build itself, which needs CI.

### Docs

The PyInstaller README gets a `## conda` section; `docs/source/installation.rst` and `features.rst`, the snap README, the root README, and the IDE, extension and FreeCAD addon READMEs stop calling conda a prerequisite of the tools that now carry one. `install.sh`'s closing message says so too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENmy31jEdZwaw1SUPs2VHF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENmy31jEdZwaw1SUPs2VHF)_