### PR TITLE
Fix the Windows Pytest failure from #593: build the macOS bundle paths the way the code does

### DIFF
--- a/tests/partcad_client/test_external.py
+++ b/tests/partcad_client/test_external.py
@@ -753,11 +753,18 @@ def test_docker_that_does_not_answer_names_blender_and_docker(part, docker, conv
 
 
 def test_macos_runs_the_executable_inside_the_bundle(monkeypatch):
-    """`open -a` hands a running Blender nothing at all, and the arguments are the point."""
+    """`open -a` hands a running Blender nothing at all, and the arguments are the point.
+
+    The two paths are built with `os.path.join`, the way `native_command` builds
+    them, rather than spelled out with slashes. This test runs on every platform
+    -- including Windows, where `os.path.join` uses a backslash, so a hand-spelled
+    "/Applications/Blender.app" is not the string the code under test compares
+    against and the mocked `isdir` never matches.
+    """
     monkeypatch.setattr(external.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(external.shutil, "which", lambda _name: None)
-    bundle = "/Applications/Blender.app"
-    executable = bundle + "/Contents/MacOS/Blender"
+    bundle = os.path.join("/Applications", "Blender.app")
+    executable = os.path.join(bundle, external.BLENDER.macos_executable)
     monkeypatch.setattr(external.os.path, "isdir", lambda path: path == bundle)
     monkeypatch.setattr(external.os.path, "isfile", lambda path: path == executable)
 
@@ -773,7 +780,7 @@ def test_macos_opens_the_bundle_for_an_application_that_takes_a_file(monkeypatch
     """
     monkeypatch.setattr(external.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(external.shutil, "which", lambda _name: None)
-    bundle = "/Applications/FreeCAD.app"
+    bundle = os.path.join("/Applications", "FreeCAD.app")
     monkeypatch.setattr(external.os.path, "isdir", lambda path: path == bundle)
 
     assert external.native_command(external.FREECAD) == ["open", "-a", bundle]


### PR DESCRIPTION
## Copilot Summary

`devel` is red on Windows. Four `Pytest` cells — `windows-2022` 3.10/3.12/3.14 and `windows-latest` 3.14 — fail in [run 33707458906](https://github.com/partcad/partcad/actions/runs/33707458906) with one test, out of `1 failed, 1980 passed, 33 skipped`:

```
FAILED tests/partcad_client/test_external.py::test_macos_runs_the_executable_inside_the_bundle
AssertionError: assert None == ['/Applications/Blender.app/Contents/MacOS/Blender']
```

### What is wrong

`native_command` builds the bundle path the ordinary way:

```python
bundle = os.path.join(directory, app)
executable = os.path.join(bundle, spec.macos_executable)
```

On Windows `os.path.join` uses a backslash, so `bundle` is `/Applications\Blender.app`. The test spelled the same path by hand with slashes and mocked `isdir` to match that exact string — which the code under test never asks about. So `isdir` said no, the loop fell through, `native_command` returned `None`, and the assertion failed. The `open -a` test added beside it has the same flaw and would have failed next; `-x` stopped the run first.

**The code under test is fine.** That branch only executes when `platform.system() == "Darwin"`, where the separator is a slash either way. It was the tests that were not portable, and the suite runs on every platform.

### The fix

Both tests now build the paths with `os.path.join`, exactly as `native_command` does, and derive the executable from `Tool.macos_executable` so the test and the code cannot disagree about it. `test_a_launcher_that_is_not_the_program_supplies_its_own_arguments` already spells its Windows form this way, with a comment saying why — these two now follow it.

No production code changes.

### How it was verified

Beyond running the suite on Linux (which is what missed this the first time), I ran `native_command` with `os.path` swapped for `ntpath` and `isdir`/`isfile` answering for a Windows-shaped bundle, so the code takes the macOS branch under Windows path semantics:

```
blender bundle     : /Applications\Blender.app
blender executable : /Applications\Blender.app\Contents/MacOS/Blender
native_command     : ['/Applications\\Blender.app\\Contents/MacOS/Blender']
freecad            : ['open', '-a', '/Applications\\FreeCAD.app']
no executable      : None
```

All three macOS branches — the executable inside the bundle, `open -a`, and a bundle with nothing runnable in it — return what the tests assert. The third one already passed on Windows because it matched with `endswith`; it is unchanged.

`black` and `flake8` clean; 408 tests pass locally. (Three failures in `tests/partcad_cli` — `test_version`, `test_status`, `test_logging_teardown` — reproduce on an unmodified tree in this environment and need a working daemon.)

### Why this is a separate pull request

#593 merged ~40 seconds after its last push, before any Windows `Pytest` cell had finished, so this never had a chance to show up there. A merged pull request cannot track follow-up work, hence a new one.

For the record, the two other things #593 left unverified did pass on `devel`: `Behave (ubuntu-latest, 3.10, 1)` and `Behave (windows-latest, 3.14, 1)` are green, and those are the shard that runs `features/open.feature` (confirmed with `dev-tools/behave_shard.py`), so the four new scenarios hold on Linux and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSdKziaafNC8EU9h3cSXob

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSdKziaafNC8EU9h3cSXob)_