### PR TITLE
Let the CAD sandbox install on an Intel Mac

### DIFF
--- a/src/partcad/runtime_python.py
+++ b/src/partcad/runtime_python.py
@@ -55,9 +55,36 @@ def get_local_partcad_pkg(dep: str) -> str:
 #
 # ocpsvg is bounded for the same reason: it depends on the proxy directly and
 # build123d's own bound on it is wide.
+#
+# The numba entry is a different problem that lands in the same file: a platform
+# gap, the one sandbox_versions.NLOPT documents, one layer further down and with
+# the opposite failure mode. 'cadquery' 2.8 depends on numba, numba depends on
+# llvmlite, and the two dropped macOS x86_64 wheels in lockstep -- numba 0.62.1
+# and llvmlite 0.45.1 are the last releases that publish one (cp310 through
+# cp313), and from numba 0.63.0 / llvmlite 0.46.0 there are none at all.
+#
+# Unlike nlopt, both still publish an sdist. So pip does not run out of
+# candidates and fall back to an older release; it takes the newest and tries to
+# *build* it, and building llvmlite needs an LLVM the runner does not have:
+# "CMake Error at CMakeLists.txt:21 (find_package): Could not find a package
+# configuration file provided by 'LLVM'", which fails the whole
+# "pip install cadquery==2.8.0" and leaves the sandbox with no CAD stack. A bare
+# version range cannot fix that the way NLOPT's does -- the bound has to be one
+# pip applies on Intel macOS and nowhere else, which is what the marker is for.
+#
+# Capping numba alone is enough: numba 0.62.1 declares 'llvmlite<0.46', so the
+# llvmlite installed beside it is 0.45.1 by construction. Its other bound,
+# 'numpy<2.4', still intersects sandbox_versions.NUMPY ('numpy>=2.2,<3').
+#
+# Every other platform is left entirely unconstrained, which is the point of the
+# marker: the resolve on Linux, Windows and Apple silicon is unchanged.
+#
+# The residual gap NLOPT describes applies here too: Intel macOS wheels stop at
+# cp313, so a 3.14 sandbox on that platform still finds nothing to install.
 PIP_CONSTRAINTS = [
     "cadquery-ocp-proxy>=7.9,<8.0",
     "ocpsvg>=0.6,<0.7",
+    'numba<=0.62.1; sys_platform == "darwin" and platform_machine == "x86_64"',
 ]
 
 

--- a/src/partcad/sandbox_versions.py
+++ b/src/partcad/sandbox_versions.py
@@ -33,24 +33,27 @@ TYPING_EXTENSIONS = "typing_extensions==4.16.0"
 # nlopt release covers every platform PartCAD runs on, so pip picks per platform.
 #
 # 2.11.0 publishes no macOS x86_64 wheel at all -- five for arm64, none for
-# Intel -- and neither release ships an sdist, so there is nothing for pip to
-# fall back to and build. Pinned exactly at 2.11.0 this left every Intel Mac
+# Intel -- and it ships no sdist either, so there is nothing for pip to fall back
+# to and build. Pinned exactly at 2.11.0 this left every Intel Mac
 # unable to provision a CAD sandbox at all: "Could not find a version that
 # satisfies the requirement nlopt==2.11.0", and then every script-defined part
 # failing on an import of something that was never installed. It went unnoticed
 # because nothing ran a sandbox on that platform until the macos-15-x86_64
 # bundle got an "Examples" job in "build-standalone.yml".
 #
-# 2.9.1 is the newest release that does publish Intel macOS wheels, so the
-# specifier admits both and each platform resolves to the newest it can install:
-# 2.11.0 on Linux, Windows and Apple silicon, 2.9.1 on Intel macOS.
+# 2.9.1 is where Intel macOS support stops: it publishes cp39 through cp313 for
+# that platform, and 2.10.0 and 2.11.0 publish none at all. So the range admits
+# three releases -- 2.9.1, 2.10.0 and 2.11.0 -- and each platform resolves to the
+# newest it can install: 2.11.0 on Linux, Windows and Apple silicon, 2.9.1 on
+# Intel macOS. 2.10.0 is never the answer anywhere, having the same platform
+# coverage as 2.11.0 and a lower version.
 #
-# The bound is closed on both ends, which keeps this as deterministic as an
-# exact pin: versions only ever go up, so the candidate set (2.4.2.post1 through
-# 2.11.0) cannot grow. And nlopt is deliberately not in the "pins must be exact"
-# set that 'test_cad_pins_are_exact' guards -- that rule exists because two OCP
-# builds in one sandbox crash the wrapper with no traceback, and nlopt writes no
-# part of the OCP native module.
+# The bound is closed on both ends, which keeps this as deterministic as an exact
+# pin: versions only ever go up, so those three are the whole candidate set for
+# good. And nlopt is deliberately not in the "pins must be exact" set that
+# 'test_cad_pins_are_exact' guards -- that rule exists because two OCP builds in
+# one sandbox crash the wrapper with no traceback, and nlopt writes no part of
+# the OCP native module.
 #
 # One gap remains and this does not close it: nlopt publishes Intel macOS wheels
 # up to cp313 only, so a 3.14 sandbox there still finds no candidate. The default

--- a/src/partcad/sandbox_versions.py
+++ b/src/partcad/sandbox_versions.py
@@ -29,7 +29,34 @@ BUILD123D = "build123d==0.11.1"
 CADQUERY = "cadquery==2.8.0"
 OCP_TESSELLATE = "ocp-tessellate==3.4.1"
 TYPING_EXTENSIONS = "typing_extensions==4.16.0"
-NLOPT = "nlopt==2.11.0"
+# A range for the same reason NUMPY below is one, on a different axis: no single
+# nlopt release covers every platform PartCAD runs on, so pip picks per platform.
+#
+# 2.11.0 publishes no macOS x86_64 wheel at all -- five for arm64, none for
+# Intel -- and neither release ships an sdist, so there is nothing for pip to
+# fall back to and build. Pinned exactly at 2.11.0 this left every Intel Mac
+# unable to provision a CAD sandbox at all: "Could not find a version that
+# satisfies the requirement nlopt==2.11.0", and then every script-defined part
+# failing on an import of something that was never installed. It went unnoticed
+# because nothing ran a sandbox on that platform until the macos-15-x86_64
+# bundle got an "Examples" job in "build-standalone.yml".
+#
+# 2.9.1 is the newest release that does publish Intel macOS wheels, so the
+# specifier admits both and each platform resolves to the newest it can install:
+# 2.11.0 on Linux, Windows and Apple silicon, 2.9.1 on Intel macOS.
+#
+# The bound is closed on both ends, which keeps this as deterministic as an
+# exact pin: versions only ever go up, so the candidate set (2.4.2.post1 through
+# 2.11.0) cannot grow. And nlopt is deliberately not in the "pins must be exact"
+# set that 'test_cad_pins_are_exact' guards -- that rule exists because two OCP
+# builds in one sandbox crash the wrapper with no traceback, and nlopt writes no
+# part of the OCP native module.
+#
+# One gap remains and this does not close it: nlopt publishes Intel macOS wheels
+# up to cp313 only, so a 3.14 sandbox there still finds no candidate. The default
+# is 3.11 and CAD sandboxes cap at MAX_PYTHON_VERSION_CAD, which is not platform
+# aware; see the note there.
+NLOPT = "nlopt>=2.9.1,<=2.11.0"
 # No single numpy release covers Python 3.10 through 3.14 (2.3 dropped 3.10),
 # so this one stays a range and pip picks per interpreter.
 NUMPY = "numpy>=2.2,<3"
@@ -201,6 +228,15 @@ MIN_PYTHON_VERSION_SAFE_PATH = "3.11"
 # every script-defined part in it fails on an import of something that was never
 # installed.
 #
+# This is one number for every platform, and on one of them it is a version too
+# high: nlopt publishes Intel macOS wheels only up to cp313 (see NLOPT above), so
+# a 3.14 sandbox there hits the missing-candidate failure this ceiling exists to
+# prevent. Nothing reaches it by default -- DEFAULT_PYTHON_VERSION is 3.11 -- so
+# it takes a package that asks for 3.14 by name on an Intel Mac. Making the
+# ceiling platform aware is the fix if that ever bites; it is a constant that
+# 'context.get_python_runtime' and two test modules read, so it is a change with
+# a blast radius rather than a one-liner, and it is deliberately not made here.
+#
 # The ceiling this is applied as (see Context.get_python_runtime) is not a claim
 # about what PartCAD supports - it is what *these pins* are built for, and it
 # moves with them. The floor above is a different kind of thing: it belongs to
@@ -292,8 +328,8 @@ def python_abi_requirement(python_version: str, exact: bool = True) -> str | Non
     Nothing in PartCAD wants that build, and the whole CAD stack is unusable in
     it: cadquery-ocp and nlopt publish "cp314-cp314" wheels and no "cp314t" ones,
     so pip finds no candidate at all ("Could not find a version that satisfies
-    the requirement nlopt==2.11.0"), and every part defined by a script then dies
-    with "No module named 'OCP'". Remove this and that comes back.
+    the requirement nlopt>=2.9.1,<=2.11.0"), and every part defined by a script
+    then dies with "No module named 'OCP'". Remove this and that comes back.
 
     The pin goes on 'python_abi' rather than on the 'python' spec itself. A build
     string can only be given in conda's three-field "name=version=build" form, so

--- a/src/partcad/sandbox_versions.py
+++ b/src/partcad/sandbox_versions.py
@@ -232,13 +232,24 @@ MIN_PYTHON_VERSION_SAFE_PATH = "3.11"
 # installed.
 #
 # This is one number for every platform, and on one of them it is a version too
-# high: nlopt publishes Intel macOS wheels only up to cp313 (see NLOPT above), so
-# a 3.14 sandbox there hits the missing-candidate failure this ceiling exists to
-# prevent. Nothing reaches it by default -- DEFAULT_PYTHON_VERSION is 3.11 -- so
-# it takes a package that asks for 3.14 by name on an Intel Mac. Making the
-# ceiling platform aware is the fix if that ever bites; it is a constant that
-# 'context.get_python_runtime' and two test modules read, so it is a change with
-# a blast radius rather than a one-liner, and it is deliberately not made here.
+# high. Three of the things a CAD sandbox installs stop at cp313 on Intel macOS:
+# nlopt (see NLOPT above), and numba and llvmlite, which 'cadquery' pulls in and
+# which runtime_python.PIP_CONSTRAINTS caps there for the same reason. So a 3.14
+# sandbox on that platform hits the missing-candidate failure this ceiling exists
+# to prevent. Nothing reaches it by default -- DEFAULT_PYTHON_VERSION is 3.11 --
+# so it takes a package that asks for 3.14 by name on an Intel Mac.
+#
+# Note it is those three and not the CAD kernel: cadquery-ocp 7.9.3.1.1 does
+# publish a cp314 Intel macOS wheel. That is worth knowing before reaching for
+# the obvious-looking fix of building and shipping a wheel of our own for the
+# gap, because one such wheel would not lift the ceiling -- it would move the
+# failure from the first of the three to the second, which is precisely what
+# capping nlopt alone did.
+#
+# Making the ceiling platform aware is the fix if this ever bites; it is a
+# constant that 'context.get_python_runtime' and two test modules read, so it is
+# a change with a blast radius rather than a one-liner, and it is deliberately
+# not made here.
 #
 # The ceiling this is applied as (see Context.get_python_runtime) is not a claim
 # about what PartCAD supports - it is what *these pins* are built for, and it

--- a/tests/partcad/unit/test_runtime_python_deps.py
+++ b/tests/partcad/unit/test_runtime_python_deps.py
@@ -13,6 +13,7 @@ import re
 import signal
 
 import pytest
+from packaging.requirements import Requirement
 
 import partcad as pc
 from partcad import sandbox_versions
@@ -68,6 +69,39 @@ def test_constraints_bound_ocp_and_ocpsvg():
     assert "<8.0" in joined
     assert "ocpsvg" in joined
     assert "<0.7" in joined
+
+
+def test_numba_is_capped_on_intel_macos_and_nowhere_else():
+    """The one constraint that must NOT apply everywhere.
+
+    numba and llvmlite stopped publishing macOS x86_64 wheels at 0.63.0/0.46.0,
+    and both still publish an sdist -- so without a bound pip builds llvmlite
+    from source there, finds no LLVM, and the cadquery install dies with it. The
+    cap has to be scoped by marker: every other platform still resolves numba
+    freely, and a cap that leaked onto them would hold the whole fleet at a
+    release chosen for a runner none of them are.
+
+    Asserted on the parsed requirement, not on the text: the marker has to
+    actually evaluate that way, and the specifier has to actually admit the last
+    Intel-macOS release while excluding the first one without a wheel.
+    """
+    capped = [c for c in PIP_CONSTRAINTS if Requirement(c).name == "numba"]
+    assert len(capped) == 1, capped
+    requirement = Requirement(capped[0])
+
+    assert requirement.marker is not None
+    assert requirement.marker.evaluate({"sys_platform": "darwin", "platform_machine": "x86_64"})
+    for elsewhere in (
+        {"sys_platform": "darwin", "platform_machine": "arm64"},
+        {"sys_platform": "linux", "platform_machine": "x86_64"},
+        {"sys_platform": "linux", "platform_machine": "aarch64"},
+        {"sys_platform": "win32", "platform_machine": "AMD64"},
+    ):
+        assert not requirement.marker.evaluate(elsewhere), elsewhere
+
+    # The last numba with an Intel macOS wheel, and the first without one.
+    assert "0.62.1" in requirement.specifier
+    assert "0.63.0" not in requirement.specifier
 
 
 def test_build123d_install_demands_a_cadquery_ocp_reassert(tmp_path):

--- a/tests/partcad/unit/test_sandbox_versions.py
+++ b/tests/partcad/unit/test_sandbox_versions.py
@@ -34,6 +34,10 @@ def test_cad_pins_are_exact():
 
     Two different OCP builds in one sandbox crash the wrapper process with no
     traceback, so these may not drift apart on their own.
+
+    NLOPT is deliberately absent: the rule is about the packages that write the
+    OCP native module, and nlopt writes none of it. The test below explains why
+    it cannot be a single version.
     """
     for pin in (
         sandbox_versions.CADQUERY_OCP,
@@ -43,6 +47,37 @@ def test_cad_pins_are_exact():
         sandbox_versions.OCP_TESSELLATE,
     ):
         assert "==" in pin, pin
+
+
+def test_nlopt_spans_the_platform_gap():
+    """nlopt is the one CAD requirement no single version can satisfy.
+
+    2.11.0 publishes no macOS x86_64 wheel and neither release ships an sdist,
+    so an exact pin there leaves pip with no candidate at all and every
+    script-defined part on an Intel Mac dies on a missing import. 2.9.1 is the
+    newest release that does publish one, so the specifier has to admit both and
+    let each platform resolve to the newest it can install.
+    """
+    assert "2.9.1" in sandbox_versions.NLOPT
+    assert "2.11.0" in sandbox_versions.NLOPT
+    assert "==" not in sandbox_versions.NLOPT
+
+
+def test_nlopt_range_still_reconciles_like_a_pin():
+    """A range must not weaken the guard that forces the CAD stack's versions.
+
+    'reconcile_requirement' finds a pin by distribution name, so the specifier
+    has to stay parseable by 'distribution_name' -- a range written in a way that
+    did not would silently stop overriding a package's own nlopt version, which
+    is the drift PINNED_REQUIREMENTS exists to prevent.
+    """
+    assert sandbox_versions.distribution_name(sandbox_versions.NLOPT) == "nlopt"
+    reconciled, superseded = sandbox_versions.reconcile_requirement("nlopt==2.7.1")
+    assert reconciled == sandbox_versions.NLOPT
+    assert superseded == "nlopt==2.7.1"
+    # And an environment marker the caller attached still survives the override.
+    reconciled, _ = sandbox_versions.reconcile_requirement('nlopt==2.7.1; sys_platform == "linux"')
+    assert reconciled == '%s; sys_platform == "linux"' % sandbox_versions.NLOPT
 
 
 def test_default_python_version_is_supported():

--- a/tests/partcad/unit/test_sandbox_versions.py
+++ b/tests/partcad/unit/test_sandbox_versions.py
@@ -6,6 +6,7 @@
 #
 
 import pytest
+from packaging.specifiers import SpecifierSet
 
 from partcad import sandbox_versions
 
@@ -52,14 +53,23 @@ def test_cad_pins_are_exact():
 def test_nlopt_spans_the_platform_gap():
     """nlopt is the one CAD requirement no single version can satisfy.
 
-    2.11.0 publishes no macOS x86_64 wheel and neither release ships an sdist,
-    so an exact pin there leaves pip with no candidate at all and every
+    2.10.0 and 2.11.0 publish no macOS x86_64 wheel and no sdist either, so an
+    exact pin at one of them leaves pip with no candidate at all and every
     script-defined part on an Intel Mac dies on a missing import. 2.9.1 is the
-    newest release that does publish one, so the specifier has to admit both and
-    let each platform resolve to the newest it can install.
+    last release that does publish one, so the specifier has to admit both ends
+    and let each platform resolve to the newest it can install.
+
+    Asserted on the parsed specifier rather than on the text. Both bounds have to
+    be *inclusive*: '>2.9.1,<2.11.0' reads almost the same and contains both
+    version numbers, so a substring check passes for it while it admits neither
+    the version Intel macOS needs nor the one every other platform gets.
     """
-    assert "2.9.1" in sandbox_versions.NLOPT
-    assert "2.11.0" in sandbox_versions.NLOPT
+    specifier = SpecifierSet(sandbox_versions.NLOPT.partition("nlopt")[2])
+    # The two that matter, each the answer on some platform.
+    assert "2.9.1" in specifier
+    assert "2.11.0" in specifier
+    # And the floor still bites, so this stays a bounded range rather than drift.
+    assert "2.8.0" not in specifier
     assert "==" not in sandbox_versions.NLOPT
 
 

--- a/tests/partcad/unit/test_sandbox_versions.py
+++ b/tests/partcad/unit/test_sandbox_versions.py
@@ -68,8 +68,13 @@ def test_nlopt_spans_the_platform_gap():
     # The two that matter, each the answer on some platform.
     assert "2.9.1" in specifier
     assert "2.11.0" in specifier
-    # And the floor still bites, so this stays a bounded range rather than drift.
+    # And both bounds still bite, so this stays a closed range rather than drift.
+    # The ceiling is the half that is easy to lose: without it the specifier
+    # admits whatever nlopt publishes next, sight unseen, which is the opposite
+    # of the "as deterministic as an exact pin" property the comment beside
+    # NLOPT claims for it.
     assert "2.8.0" not in specifier
+    assert "2.11.1" not in specifier
     assert "==" not in sandbox_versions.NLOPT
 
 


### PR DESCRIPTION
## Copilot Summary

Fixes the one job that has been red on `devel` since #594 landed: `Examples PartCAD via bundle (macos-15-x86_64)`.

Two separate gaps, one behind the other. The first was found from the job's log, the second from the log of the run that the first fix unblocked.

### 1. `nlopt` — no candidate at all

```
pip install nlopt==2.11.0
ERROR: Could not find a version that satisfies the requirement nlopt==2.11.0
       (from versions: 2.4.2.post1, 2.4.2.post2, 2.6.2, 2.7.1, 2.9.1)
```

`nlopt==2.11.0` publishes **no macOS x86_64 wheel** — five for arm64, none for Intel — and ships no sdist either, so there was nothing for pip to fall back to and build. Provisioning a CAD sandbox on an Intel Mac failed outright, and every script-defined part after it died on an import of something that was never installed. `pc list` and `pc init` worked; anything that builds a shape did not.

**This is not new, and not specific to the standalone bundle.** The sandbox is provisioned identically for the wheels, so an Intel Mac has never been able to render a part. Nothing noticed because nothing ever ran a sandbox on that platform — the `macos-15-x86_64` bundle's `Examples` job is the first thing that did. The blind spot is visible in hindsight in the comment on `MAX_PYTHON_VERSION_CAD`: it reasons carefully about which *Python versions* the pins have wheels for, and never about architectures.

`NLOPT` becomes a closed range instead of an exact version — already this module's idiom for a requirement no single release can satisfy, since `NUMPY` is one for the same reason on the Python-version axis:

```python
NLOPT = "nlopt>=2.9.1,<=2.11.0"
```

Each platform resolves to the newest it can install: **2.9.1** on Intel macOS, 2.11.0 everywhere else (unchanged). Closed on both ends, so it stays as deterministic as a pin: versions only go up, so the candidate set cannot grow. nlopt was already outside the "pins must be exact" set that `test_cad_pins_are_exact` guards — rightly, since that rule exists because two OCP builds in one sandbox crash the wrapper with no traceback, and nlopt writes no part of the OCP native module.

### 2. `numba`/`llvmlite` — a candidate that cannot be built

With nlopt resolved the job got past that install and into the next one:

```
pip install --constraint partcad-constraints.txt cadquery==2.8.0
  × Building wheel for llvmlite (pyproject.toml) did not run successfully.
    CMake Error at CMakeLists.txt:21 (find_package):
      Could not find a package configuration file provided by "LLVM"
```

`cadquery` 2.8 depends on `numba`, `numba` depends on `llvmlite`, and the two dropped macOS x86_64 wheels together — **numba 0.62.1** and **llvmlite 0.45.1** are the last releases that publish one, and from numba 0.63.0 / llvmlite 0.46.0 there are none.

**A version range cannot fix this one.** nlopt's newer releases ship no sdist, so pip runs out of candidates on Intel macOS and falls back by itself. numba and llvmlite both *do* ship an sdist, so pip takes the newest and tries to **build** it — and building llvmlite needs an LLVM the runner does not have. The bound has to be one pip applies on that platform and nowhere else, which is what an environment marker in the constraints file is for:

```python
PIP_CONSTRAINTS = [
    "cadquery-ocp-proxy>=7.9,<8.0",
    "ocpsvg>=0.6,<0.7",
    'numba<=0.62.1; sys_platform == "darwin" and platform_machine == "x86_64"',
]
```

Capping `numba` alone is enough: 0.62.1 declares `llvmlite<0.46`, so the llvmlite beside it is 0.45.1 by construction. Its other bound, `numpy<2.4`, still intersects `NUMPY` (`numpy>=2.2,<3`).

### What the earlier revision of this description got wrong

It claimed nlopt was the **only** gap, from a table of the pinned packages' own wheels. That table was right and the conclusion was not: it checked the pins, not what the pins pull in. `cadquery` is a pure-Python wheel — and it depends on numba, which is not. Every directly pinned package does have an Intel macOS candidate; the gap was one edge further out, and only a resolve of the whole closure finds that.

### Verification

Resolved against PyPI for `macosx_15_0_x86_64` / cp311 with `--only-binary=:all:`, so anything without a wheel is a hard failure rather than a source build:

| environment | numba | llvmlite | nlopt |
| --- | --- | --- | --- |
| **macOS x86_64, cp311** | **0.62.1** | **0.45.1** | **2.9.1** |
| macOS arm64, cp311 | 0.67.0 | 0.49.0 | 2.11.0 |
| Linux x86_64, cp311 | 0.67.0 | 0.49.0 | 2.11.0 |
| Windows amd64, cp311 | 0.67.0 | 0.49.0 | 2.11.0 |

Every row resolves to the same 44 packages, all wheels (numpy 2.3.5 on Intel macOS, under numba 0.62.1's own `numpy<2.4`). The last three rows are **identical with and without the new constraint** — the marker changes nothing off Intel macOS.

### One gap this does not close

Both nlopt and numba publish Intel macOS wheels only up to **cp313**, so a 3.14 sandbox there still finds no candidate. Nothing reaches it by default (`DEFAULT_PYTHON_VERSION` is 3.11), so it takes a package asking for 3.14 by name on an Intel Mac. Making `MAX_PYTHON_VERSION_CAD` platform-aware is the fix if that ever bites; it is a constant read by `context.get_python_runtime` and two test modules, so it is a change with a blast radius rather than a one-liner. Documented at both sites rather than silently left.

### Tests

- `NLOPT`'s specifier admits both endpoints and rejects outside them, asserted on the parsed `SpecifierSet` — `nlopt>2.9.1,<2.11.0` reads almost the same and contains both version numbers, so a substring check passes for it while it admits neither version that matters.
- A range does not weaken `reconcile_requirement`, which finds a pin by distribution name — a specifier `distribution_name` could not parse would silently stop overriding a package's own nlopt version, the drift `PINNED_REQUIREMENTS` exists to prevent.
- The numba cap's **marker** evaluates true on Intel macOS and false on macOS arm64, Linux x86_64, Linux aarch64 and Windows amd64, and its specifier admits 0.62.1 while rejecting 0.63.0. Asserted on the parsed `Requirement`.

Each was confirmed by mutation — dropping the marker, moving the cap to 0.63.0, swapping `x86_64` for `arm64`, removing the entry, and removing nlopt's ceiling each fail the test that covers them.

`#deepTest` — the failing job is on a deep-only platform, so without it this pull request would not run the thing it repairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxYfXwJ5L8SBEDZhNuqyZi