### PR TITLE
fix(ci): read pytest's own verdict, not its exit code, in the Pytest job

### DIFF
--- a/.devcontainer/pytest_hook.sh
+++ b/.devcontainer/pytest_hook.sh
@@ -33,10 +33,12 @@ TIMEOUT="${PC_PYTEST_TIMEOUT:-900}"
 
 # pytest has been observed to exit 0 despite failures on some platforms (Windows
 # in particular), so the exit code alone cannot be trusted. Instead the pytest
-# session writes an explicit verdict to a marker file (see conftest.py), and this
-# hook reads that. The marker path carries this shell's PID so concurrent hook
-# runs never collide, lives under a temp dir rather than in the repo, and is
-# removed both before and after the run so nothing is left behind.
+# session writes an explicit verdict to a marker file (see 'conftest.py' at the
+# repository root, which is also where the "Pytest" job in
+# '.github/workflows/test.yml' reads its verdict from), and this hook reads that.
+# The marker path carries this shell's PID so concurrent hook runs never collide,
+# lives under a temp dir rather than in the repo, and is removed both before and
+# after the run so nothing is left behind.
 MARKER="${TMPDIR:-/tmp}/partcad-pytest-result-$$"
 export PYTEST_RESULT_MARKER="$MARKER"
 rm -f "$MARKER"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -330,10 +330,11 @@ jobs:
           # 'conftest.py' at the repository root is the one place that writes it.
           #
           # It cannot paint a broken run green. The session writes "failure"
-          # whenever pytest's own exit status is dirty or it counted a failed
-          # test, and a run that dies before 'pytest_sessionfinish' -- a
-          # collection error, a crash mid-suite, a runner that goes away --
-          # writes nothing at all, which is not "success" either.
+          # whenever pytest's final exit status is dirty or it counted a failed
+          # test -- a collection error included, which pytest reports as exit
+          # status 2 -- and a run that never reaches the hook at all, a crash
+          # mid-suite or a runner that goes away, writes nothing, which is not
+          # "success" either.
           #
           # The path is relative on purpose: Git Bash and the native interpreter
           # do not agree on what an absolute POSIX path means on Windows, but

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,10 +124,16 @@ env:
   # Windows on 3.12 (see the note below). 40 -> 21 combinations.
   #
   # NOTE: windows + Python 3.12 used to be excluded on its own, for an
-  # 'ensurepip' failure (see #374), NOT for a missing cadquery-ocp wheel. It is
-  # deliberately back in the matrix here: the toolchain underneath it has moved
-  # a long way (miniforge 24.11 -> 26.3, setup-miniconda v3 -> v4), so this run
-  # is what tells us whether #374 is still real. Re-exclude it if it is.
+  # 'ensurepip' failure (see #374), NOT for a missing cadquery-ocp wheel. It was
+  # put back in the matrix by #564 to find out whether #374 was still real, and
+  # it stays here now that the answer is in: the environment builds and the
+  # whole suite passes, and then the interpreter exits 127 with nothing printed
+  # after the summary line. Both Windows images do it, on 3.12 and no other
+  # version, and it reproduced on #596 -- an eleven-line change to one test
+  # file -- as readily as on #598. That is an exit code contradicting a session
+  # pytest called clean, which is what the result marker in the "Pytest" job
+  # below exists to see through, so re-excluding the combination would now cost
+  # the coverage and buy nothing.
   EXCLUDES: >-
     [{"os": "ubuntu-22.04", "python-version": "3.11"},
     {"os": "ubuntu-22.04", "python-version": "3.12"},
@@ -311,15 +317,59 @@ jobs:
           mamba activate ${{ format('env-test-pytest-{0}', matrix.python-version) }}
 
           mkdir -pv pytest-test-results
+
+          # The verdict comes from the session, not from the process exit code.
+          #
+          # On Windows the two disagree, in both directions. #444 was written
+          # because pytest exited 0 with a test having failed; the
+          # 'windows-*, 3.12' cells here do the opposite, printing
+          # "2639 passed, 38 skipped" and then exiting 127 with nothing in
+          # between -- so under 'set -e' a fully green suite fails the job. The
+          # marker is how the pre-commit gate has answered this since #444
+          # ('.devcontainer/pytest_hook.sh'); this is the same mechanism, and
+          # 'conftest.py' at the repository root is the one place that writes it.
+          #
+          # It cannot paint a broken run green. The session writes "failure"
+          # whenever pytest's own exit status is dirty or it counted a failed
+          # test, and a run that dies before 'pytest_sessionfinish' -- a
+          # collection error, a crash mid-suite, a runner that goes away --
+          # writes nothing at all, which is not "success" either.
+          #
+          # The path is relative on purpose: Git Bash and the native interpreter
+          # do not agree on what an absolute POSIX path means on Windows, but
+          # they do share this step's working directory. '$$' keeps it unique
+          # per shell, as the pre-commit hook's does.
+          marker="pytest-test-results/session-verdict-$$"
+          export PYTEST_RESULT_MARKER="${marker}"
+          rm -f "${marker}"
+
           # '--junitxml' overrides the one in 'pyproject.toml', which writes to
           # 'pytest-results/' -- a directory this job neither uploads nor hands
           # to Codecov, so the JUnit report was written and then thrown away and
           # Codecov said "JUnit XML file not found" on every run. Point it at the
           # directory the upload step below actually reads.
+          rc=0
           pytest \
             tests cad/freecad \
             --junitxml=pytest-test-results/junit.xml \
-            -x -p no:error-for-skips -p no:warnings --dist no
+            -x -p no:error-for-skips -p no:warnings --dist no || rc=$?
+
+          verdict="$(cat "${marker}" 2>/dev/null || true)"
+          rm -f "${marker}"
+
+          if [ "${verdict}" != "success" ]; then
+            echo "::error::pytest recorded '${verdict:-no verdict}' (process exit code ${rc})"
+            # Report pytest's code when it had one, so the log still says what
+            # the process did; 1 when it exited 0 and the session said failure.
+            exit "$(( rc != 0 ? rc : 1 ))"
+          fi
+          if [ "${rc}" -ne 0 ]; then
+            # Not fatal, but not swept away either: something is wrong with how
+            # the interpreter shuts down on this cell, and the annotation is
+            # what keeps it visible while the job stays honest about the tests.
+            echo "::warning::every test passed but the pytest process exited ${rc}; trusting the session's verdict"
+          fi
+
           coverage xml --rcfile=./dev-tools/coverage.rc --data-file=.coverage -o ./pytest-test-results/coverage.xml
           mamba deactivate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,16 @@ that decides; `docs/source/contributing.rst` explains it to contributors. Note t
 matrix at all unless its head commit message starts with `Version updated` — the `set-matrix` job, and every
 job that depends on it, is skipped otherwise.
 
+**Neither gate trusts pytest's exit code.** On Windows it disagrees with the run in both directions — exit `0`
+with a test having failed (which is what #444 was written for), and exit `127` after a session where every test
+passed (which is what `Pytest (windows-*, 3.12)` does today). So the `pytest` `pre-commit` hook and the
+`Pytest` job both set `PYTEST_RESULT_MARKER` to a PID-unique path they then read, and the `pytest_sessionfinish`
+hook in the repository's root `conftest.py` writes `success` into it only when pytest's own exit status is
+clean **and** it counted no failed tests. That hook belongs at the root and nowhere else: a copy scoped to one
+package's tests records nothing for a run that does not collect that directory, and a gate reading no marker
+fails — which is also what keeps a crash mid-suite from passing. Do not move it, and do not let anything read
+the exit code instead.
+
 The packages under `examples/` are a third suite. The images and `README.md` files there are what
 `cd examples && pc render -r` produces, and they are checked in so that a change in how PartCAD renders is a
 diff someone has to look at rather than something a reader of the README discovers. If a change affects a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,11 +206,14 @@ job that depends on it, is skipped otherwise.
 with a test having failed (which is what #444 was written for), and exit `127` after a session where every test
 passed (which is what `Pytest (windows-*, 3.12)` does today). So the `pytest` `pre-commit` hook and the
 `Pytest` job both set `PYTEST_RESULT_MARKER` to a PID-unique path they then read, and the `pytest_sessionfinish`
-hook in the repository's root `conftest.py` writes `success` into it only when pytest's own exit status is
-clean **and** it counted no failed tests. That hook belongs at the root and nowhere else: a copy scoped to one
-package's tests records nothing for a run that does not collect that directory, and a gate reading no marker
-fails — which is also what keeps a crash mid-suite from passing. Do not move it, and do not let anything read
-the exit code instead.
+hook in the repository's root `conftest.py` writes `success` into it only when pytest's **final** exit status is
+clean **and** it counted no failed tests. It is the outermost wrapper and reads `session.exitstatus` rather than
+the status it is handed, because pytest's terminal reporter can still raise that status after the inner session
+hooks have run — `--max-warnings` being exceeded is how — and reading the argument would record a success for a
+session pytest then failed. That hook belongs at the root and nowhere else: a copy scoped to one package's tests
+records nothing for a run that does not collect that directory, and a gate reading no marker fails — which is
+also what keeps a crash mid-suite from passing. Do not move it, do not make it a plain (non-wrapper) hook, and
+do not let anything read the exit code instead.
 
 The packages under `examples/` are a third suite. The images and `README.md` files there are what
 `cd examples && pc render -r` produces, and they are checked in so that a change in how PartCAD renders is a

--- a/conftest.py
+++ b/conftest.py
@@ -23,11 +23,13 @@ pytest counted no failed tests, and `failure` otherwise. Two callers do:
 
 Both choose a path carrying their shell's PID, so concurrent runs never collide,
 and both remove it before and after the run; neither leaves anything behind. A
-run that dies before `pytest_sessionfinish` -- a collection error, a crash
-mid-suite, a runner that goes away -- writes no marker at all, and a caller that
-finds none must fail. That is the property that keeps this from being a way to
-paint a broken run green: it can only ever forgive an exit code that contradicts
-a session pytest itself called clean.
+run that never reaches this hook -- a crash mid-suite, a runner that goes away,
+an exception in another session hook -- writes no marker at all, and a caller
+that finds none must fail. (A collection error does reach it: pytest reports
+that as exit status 2, so it is recorded as `failure` like any other unclean
+session.) That is the property that keeps this from being a way to paint a
+broken run green: it can only ever forgive an exit code that contradicts a
+session pytest itself called clean.
 
 This lives at the repository root rather than beside one package's tests so that
 the verdict is recorded for whatever paths a caller passes. It used to live in
@@ -42,17 +44,31 @@ import pathlib
 import pytest
 
 
-@pytest.hookimpl(trylast=True)
+@pytest.hookimpl(wrapper=True, tryfirst=True)
 def pytest_sessionfinish(session, exitstatus):
-    """Write the session's verdict to `PYTEST_RESULT_MARKER`, if a caller asked for one."""
+    """Write the session's verdict to `PYTEST_RESULT_MARKER`, if a caller asked for one.
+
+    A wrapper, and `tryfirst` so that it is the outermost one, because the
+    `exitstatus` handed to this hook is not always the status pytest goes on to
+    exit with. pytest's own terminal reporter implements `pytest_sessionfinish`
+    as a wrapper too, and after the inner hooks have run it can still raise
+    `session.exitstatus` -- `--max-warnings` being exceeded turns a `0` into
+    `ExitCode.MAX_WARNINGS_ERROR` there. A plain `trylast` hook reading the
+    argument would record "success" for a session pytest then failed, which is
+    the one direction this must never get wrong. Running last of all, after the
+    yield, and reading `session.exitstatus` rather than the argument, is what
+    makes the verdict the final one.
+    """
+    result = yield
+
     marker = os.environ.get("PYTEST_RESULT_MARKER")
     if not marker:
-        return
+        return result
 
     # Under xdist only the controller sees the aggregate result; the workers
     # each report their own subset and must not write the verdict.
     if hasattr(session.config, "workerinput"):
-        return
+        return result
 
     path = pathlib.Path(marker)
     if not path.is_absolute():
@@ -66,7 +82,8 @@ def pytest_sessionfinish(session, exitstatus):
 
     # An exit status of 5 (no tests collected) is a failure here, deliberately:
     # a run that tested nothing is not a run that passed.
-    passed = exitstatus == 0 and session.testsfailed == 0
+    passed = session.exitstatus == 0 and session.testsfailed == 0
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("success" if passed else "failure")
+    return result

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,72 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The one thing every pytest run in this repository can be asked to record: its own verdict.
+
+pytest's process exit code is not the session's verdict. It has been observed to
+disagree in both directions on Windows -- exiting 0 with a test having failed,
+which is what #444 was written for, and exiting non-zero after a session in
+which every test passed, which is what the `Pytest (windows-*, 3.12)` cells do
+today: `2639 passed, 38 skipped` and then `Process completed with exit code 127`,
+with nothing printed in between. So neither a caller that must not miss a
+failure nor one that must not invent one can build on the exit code alone.
+
+A caller that wants the truth passes a path in `PYTEST_RESULT_MARKER`; the hook
+below writes `success` into it only when pytest's own exit status is clean *and*
+pytest counted no failed tests, and `failure` otherwise. Two callers do:
+
+* `.devcontainer/pytest_hook.sh`, the pre-commit gate, which is where the
+  mechanism started (#444).
+* the `Pytest` job in `.github/workflows/test.yml`.
+
+Both choose a path carrying their shell's PID, so concurrent runs never collide,
+and both remove it before and after the run; neither leaves anything behind. A
+run that dies before `pytest_sessionfinish` -- a collection error, a crash
+mid-suite, a runner that goes away -- writes no marker at all, and a caller that
+finds none must fail. That is the property that keeps this from being a way to
+paint a broken run green: it can only ever forgive an exit code that contradicts
+a session pytest itself called clean.
+
+This lives at the repository root rather than beside one package's tests so that
+the verdict is recorded for whatever paths a caller passes. It used to live in
+`tests/partcad/conftest.py`, which recorded nothing for a run that did not
+collect that directory -- and `pyproject.toml` already carries the scar of a job
+that ran nothing and reported success.
+"""
+
+import os
+import pathlib
+
+import pytest
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    """Write the session's verdict to `PYTEST_RESULT_MARKER`, if a caller asked for one."""
+    marker = os.environ.get("PYTEST_RESULT_MARKER")
+    if not marker:
+        return
+
+    # Under xdist only the controller sees the aggregate result; the workers
+    # each report their own subset and must not write the verdict.
+    if hasattr(session.config, "workerinput"):
+        return
+
+    path = pathlib.Path(marker)
+    if not path.is_absolute():
+        # Anchor a relative path to the directory pytest was started in rather
+        # than to the current one, so that a test which changed directory
+        # cannot decide where the verdict lands. A relative path is what lets
+        # the caller and the session name the same file on Windows, where a
+        # POSIX path means one thing to Git Bash and another to the native
+        # interpreter this hook runs in.
+        path = pathlib.Path(session.config.invocation_params.dir) / path
+
+    # An exit status of 5 (no tests collected) is a failure here, deliberately:
+    # a run that tested nothing is not a run that passed.
+    passed = exitstatus == 0 and session.testsfailed == 0
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("success" if passed else "failure")

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -556,6 +556,16 @@ hour cold takes minutes warm. The ``pytest`` ``pre-commit`` hook allows 15 minut
 (``PC_PYTEST_TIMEOUT`` overrides it); a test reported as timing out on a cold cache is worth simply running
 again before it is treated as a bug.
 
+**A gate reads the session's verdict, not pytest's exit code.** The two disagree on Windows, in both
+directions: pytest has exited ``0`` with a test having failed, and it exits ``127`` after a session in which
+every test passed. So a caller that must not be wrong sets ``PYTEST_RESULT_MARKER`` to a path, and the
+``pytest_sessionfinish`` hook in the repository's root ``conftest.py`` writes ``success`` there only when
+pytest's own exit status is clean *and* it counted no failed tests, and ``failure`` otherwise. Both gates do
+this -- the ``pytest`` ``pre-commit`` hook and the ``Pytest`` job in CI -- and both fail unless they read
+``success``, so a run that never reached ``pytest_sessionfinish`` (a collection error, a crash mid-suite)
+writes no marker and fails too. Nothing is written unless that variable is set, so an ordinary
+``poetry run pytest`` is unaffected.
+
 Behave
 ^^^^^^
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -560,10 +560,13 @@ again before it is treated as a bug.
 directions: pytest has exited ``0`` with a test having failed, and it exits ``127`` after a session in which
 every test passed. So a caller that must not be wrong sets ``PYTEST_RESULT_MARKER`` to a path, and the
 ``pytest_sessionfinish`` hook in the repository's root ``conftest.py`` writes ``success`` there only when
-pytest's own exit status is clean *and* it counted no failed tests, and ``failure`` otherwise. Both gates do
-this -- the ``pytest`` ``pre-commit`` hook and the ``Pytest`` job in CI -- and both fail unless they read
-``success``, so a run that never reached ``pytest_sessionfinish`` (a collection error, a crash mid-suite)
-writes no marker and fails too. Nothing is written unless that variable is set, so an ordinary
+pytest's *final* exit status is clean *and* it counted no failed tests, and ``failure`` otherwise -- a
+collection error included, which pytest reports as exit status 2. "Final" is load-bearing: pytest's terminal
+reporter can still raise the status after the inner session hooks have run (exceeding ``--max-warnings`` is
+how), so the hook is the outermost wrapper and reads ``session.exitstatus`` rather than the status it was
+handed. Both gates do this -- the ``pytest`` ``pre-commit`` hook and the ``Pytest`` job in CI -- and both fail
+unless they read ``success``, so a run that never reaches the hook at all (a crash mid-suite, a runner that
+goes away) writes no marker and fails too. Nothing is written unless that variable is set, so an ordinary
 ``poetry run pytest`` is unaffected.
 
 Behave

--- a/tests/dev_tools/test_session_verdict.py
+++ b/tests/dev_tools/test_session_verdict.py
@@ -39,6 +39,7 @@ def load_root_conftest():
 
 @pytest.fixture(scope="module")
 def root_conftest():
+    """Module-scoped: the file is read once, and nothing here mutates it."""
     return load_root_conftest()
 
 
@@ -63,6 +64,7 @@ def test_the_hook_is_a_no_op_without_a_marker_path(root_conftest, tmp_path, monk
 
 
 def test_a_clean_session_is_recorded_as_a_success(root_conftest, tmp_path, monkeypatch):
+    """The only case that may write "success", and the only one a gate accepts."""
     marker = tmp_path / "verdict"
     monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
 
@@ -85,6 +87,12 @@ def test_a_clean_session_is_recorded_as_a_success(root_conftest, tmp_path, monke
 def test_anything_but_a_clean_session_is_recorded_as_a_failure(
     root_conftest, tmp_path, monkeypatch, exitstatus, testsfailed, why
 ):
+    """Every other way a session can end, including the two that look like success.
+
+    Exit status 5 means nothing was collected, which a gate must not read as a
+    pass; and exit status 0 with a failed test is the Windows behaviour #444 was
+    written for, which is why the verdict needs both halves rather than either.
+    """
     marker = tmp_path / "verdict"
     monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
 

--- a/tests/dev_tools/test_session_verdict.py
+++ b/tests/dev_tools/test_session_verdict.py
@@ -1,0 +1,157 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The repository-root `conftest.py` hook that records a pytest session's verdict.
+
+Two gates read that verdict instead of pytest's exit code -- the pre-commit hook
+and the `Pytest` job in CI -- so what it writes decides whether a commit lands
+and whether a build is green. The property that keeps that safe is narrow: it
+may forgive an exit code that contradicts a clean session, and nothing else. So
+these check both halves, and in particular that every way a run can be *not*
+clean still writes "failure".
+
+The module is loaded by path rather than imported by name. `pyproject.toml` puts
+`ide/standalone/tests` on `pythonpath` so its own tests can do
+`from conftest import REPO_ROOT`, which means a bare `import conftest` here would
+find that file instead of this one.
+"""
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CONFTEST = REPO_ROOT / "conftest.py"
+
+
+def load_root_conftest():
+    """The real repository-root conftest, as a module of its own."""
+    spec = importlib.util.spec_from_file_location("partcad_root_conftest", CONFTEST)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def root_conftest():
+    return load_root_conftest()
+
+
+def session(testsfailed=0, invocation_dir=None, worker=False):
+    """The parts of a `pytest.Session` the hook actually reads."""
+    config = types.SimpleNamespace(
+        invocation_params=types.SimpleNamespace(dir=invocation_dir or pathlib.Path.cwd()),
+    )
+    if worker:
+        config.workerinput = {}
+    return types.SimpleNamespace(config=config, testsfailed=testsfailed)
+
+
+def test_the_hook_is_a_no_op_without_a_marker_path(root_conftest, tmp_path, monkeypatch):
+    """Nobody asked for a verdict, so nothing is written anywhere."""
+    monkeypatch.delenv("PYTEST_RESULT_MARKER", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    root_conftest.pytest_sessionfinish(session(), 0)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_clean_session_is_recorded_as_a_success(root_conftest, tmp_path, monkeypatch):
+    marker = tmp_path / "verdict"
+    monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
+
+    root_conftest.pytest_sessionfinish(session(testsfailed=0), 0)
+
+    assert marker.read_text() == "success"
+
+
+@pytest.mark.parametrize(
+    "exitstatus, testsfailed, why",
+    [
+        (1, 1, "a test failed"),
+        (2, 0, "the run was interrupted"),
+        (3, 0, "an internal error"),
+        (4, 0, "pytest was misused"),
+        (5, 0, "no tests were collected, so nothing passed"),
+        (0, 1, "pytest exited 0 with a failed test, which is why this hook exists"),
+    ],
+)
+def test_anything_but_a_clean_session_is_recorded_as_a_failure(
+    root_conftest, tmp_path, monkeypatch, exitstatus, testsfailed, why
+):
+    marker = tmp_path / "verdict"
+    monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
+
+    root_conftest.pytest_sessionfinish(session(testsfailed=testsfailed), exitstatus)
+
+    assert marker.read_text() == "failure", why
+
+
+def test_an_xdist_worker_writes_no_verdict(root_conftest, tmp_path, monkeypatch):
+    """Only the controller sees the aggregate result.
+
+    A worker's `testsfailed` counts its own subset, so letting one write would
+    let the last worker to finish overwrite the controller's verdict with a
+    "success" that speaks for a fraction of the run.
+    """
+    marker = tmp_path / "verdict"
+    monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
+
+    root_conftest.pytest_sessionfinish(session(testsfailed=0, worker=True), 0)
+
+    assert not marker.exists()
+
+
+def test_a_relative_marker_is_anchored_to_the_invocation_directory(root_conftest, tmp_path, monkeypatch):
+    """CI passes a relative path, and a test may have changed directory since.
+
+    The two have to name the same file: on Windows the caller is Git Bash and
+    the session is a native interpreter, and the one thing they agree on is the
+    directory pytest was started in.
+    """
+    invocation_dir = tmp_path / "workspace"
+    invocation_dir.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.setenv("PYTEST_RESULT_MARKER", "results/verdict")
+    monkeypatch.chdir(elsewhere)
+
+    root_conftest.pytest_sessionfinish(session(invocation_dir=invocation_dir), 0)
+
+    assert (invocation_dir / "results" / "verdict").read_text() == "success"
+    assert not (elsewhere / "results").exists()
+
+
+def test_the_hook_runs_last(root_conftest):
+    """`trylast` so the verdict is written after every other session hook.
+
+    One of those writes the HTML report the job uploads; a verdict recorded
+    before them would be a verdict for a session that had not finished.
+    """
+    assert root_conftest.pytest_sessionfinish.pytest_impl["trylast"] is True
+
+
+def test_the_repository_root_is_where_the_hook_lives():
+    """It used to live beside one package's tests, and recorded nothing for a
+    run that did not collect that directory. Both gates now pass paths of their
+    own choosing, so the hook has to be somewhere every run loads."""
+    assert CONFTEST.is_file()
+    assert "pytest_sessionfinish" not in (REPO_ROOT / "tests" / "partcad" / "conftest.py").read_text()
+
+
+def test_it_needs_nothing_from_partcad(root_conftest):
+    """The gate must record a verdict even for a run that could not import the
+    package under test, so the hook imports only the standard library and
+    pytest."""
+    assert CONFTEST.is_file()
+    source = CONFTEST.read_text()
+    for line in source.splitlines():
+        if line.startswith(("import ", "from ")):
+            module = line.split()[1].split(".")[0]
+            assert module in sys.stdlib_module_names or module == "pytest", line

--- a/tests/dev_tools/test_session_verdict.py
+++ b/tests/dev_tools/test_session_verdict.py
@@ -12,6 +12,11 @@ may forgive an exit code that contradicts a clean session, and nothing else. So
 these check both halves, and in particular that every way a run can be *not*
 clean still writes "failure".
 
+Most of it is checked by driving the hook directly, which is quick and lets a
+session be posed in states that are awkward to produce for real. The last two
+run pytest for real, in a subprocess, because what they are about is *when* the
+hook runs relative to pytest's own -- something no stand-in can show.
+
 The module is loaded by path rather than imported by name. `pyproject.toml` puts
 `ide/standalone/tests` on `pythonpath` so its own tests can do
 `from conftest import REPO_ROOT`, which means a bare `import conftest` here would
@@ -19,8 +24,11 @@ find that file instead of this one.
 """
 
 import importlib.util
+import os
 import pathlib
+import subprocess
 import sys
+import textwrap
 import types
 
 import pytest
@@ -43,14 +51,29 @@ def root_conftest():
     return load_root_conftest()
 
 
-def session(testsfailed=0, invocation_dir=None, worker=False):
+def session(exitstatus=0, testsfailed=0, invocation_dir=None, worker=False):
     """The parts of a `pytest.Session` the hook actually reads."""
     config = types.SimpleNamespace(
         invocation_params=types.SimpleNamespace(dir=invocation_dir or pathlib.Path.cwd()),
     )
     if worker:
         config.workerinput = {}
-    return types.SimpleNamespace(config=config, testsfailed=testsfailed)
+    return types.SimpleNamespace(config=config, exitstatus=exitstatus, testsfailed=testsfailed)
+
+
+def run_hook(root_conftest, session_obj, argument_exitstatus=0):
+    """Drive the hook the way pluggy drives a wrapper: run to the yield, then resume.
+
+    The default `argument_exitstatus` is deliberately the *clean* one, so that a
+    caller passing an unclean `session.exitstatus` is asking whether the hook
+    reads the session rather than the argument.
+    """
+    generator = root_conftest.pytest_sessionfinish(session_obj, argument_exitstatus)
+    next(generator)
+    try:
+        generator.send(None)
+    except StopIteration:
+        pass
 
 
 def test_the_hook_is_a_no_op_without_a_marker_path(root_conftest, tmp_path, monkeypatch):
@@ -58,7 +81,7 @@ def test_the_hook_is_a_no_op_without_a_marker_path(root_conftest, tmp_path, monk
     monkeypatch.delenv("PYTEST_RESULT_MARKER", raising=False)
     monkeypatch.chdir(tmp_path)
 
-    root_conftest.pytest_sessionfinish(session(), 0)
+    run_hook(root_conftest, session())
 
     assert list(tmp_path.iterdir()) == []
 
@@ -68,7 +91,7 @@ def test_a_clean_session_is_recorded_as_a_success(root_conftest, tmp_path, monke
     marker = tmp_path / "verdict"
     monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
 
-    root_conftest.pytest_sessionfinish(session(testsfailed=0), 0)
+    run_hook(root_conftest, session(exitstatus=0, testsfailed=0))
 
     assert marker.read_text() == "success"
 
@@ -77,11 +100,12 @@ def test_a_clean_session_is_recorded_as_a_success(root_conftest, tmp_path, monke
     "exitstatus, testsfailed, why",
     [
         (1, 1, "a test failed"),
-        (2, 0, "the run was interrupted"),
+        (2, 0, "the run was interrupted, which is also how a collection error ends"),
         (3, 0, "an internal error"),
         (4, 0, "pytest was misused"),
         (5, 0, "no tests were collected, so nothing passed"),
-        (0, 1, "pytest exited 0 with a failed test, which is why this hook exists"),
+        (6, 0, "more warnings than --max-warnings allows"),
+        (0, 1, "exit status 0 with a failed test, which is why this hook exists"),
     ],
 )
 def test_anything_but_a_clean_session_is_recorded_as_a_failure(
@@ -91,14 +115,31 @@ def test_anything_but_a_clean_session_is_recorded_as_a_failure(
 
     Exit status 5 means nothing was collected, which a gate must not read as a
     pass; and exit status 0 with a failed test is the Windows behaviour #444 was
-    written for, which is why the verdict needs both halves rather than either.
+    written for. Between them they are why the verdict needs both halves rather
+    than either alone.
     """
     marker = tmp_path / "verdict"
     monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
 
-    root_conftest.pytest_sessionfinish(session(testsfailed=testsfailed), exitstatus)
+    run_hook(root_conftest, session(exitstatus=exitstatus, testsfailed=testsfailed))
 
     assert marker.read_text() == "failure", why
+
+
+def test_the_session_decides_the_verdict_rather_than_the_argument(root_conftest, tmp_path, monkeypatch):
+    """The `exitstatus` argument can be stale by the time this hook writes.
+
+    pytest's terminal reporter raises `session.exitstatus` after the inner
+    session hooks have run, so the argument is the status *before* that. Reading
+    the argument is what would let a `--max-warnings` failure be recorded as a
+    success; this pins the hook to the session instead.
+    """
+    marker = tmp_path / "verdict"
+    monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
+
+    run_hook(root_conftest, session(exitstatus=6), argument_exitstatus=0)
+
+    assert marker.read_text() == "failure"
 
 
 def test_an_xdist_worker_writes_no_verdict(root_conftest, tmp_path, monkeypatch):
@@ -111,7 +152,7 @@ def test_an_xdist_worker_writes_no_verdict(root_conftest, tmp_path, monkeypatch)
     marker = tmp_path / "verdict"
     monkeypatch.setenv("PYTEST_RESULT_MARKER", str(marker))
 
-    root_conftest.pytest_sessionfinish(session(testsfailed=0, worker=True), 0)
+    run_hook(root_conftest, session(worker=True))
 
     assert not marker.exists()
 
@@ -130,19 +171,22 @@ def test_a_relative_marker_is_anchored_to_the_invocation_directory(root_conftest
     monkeypatch.setenv("PYTEST_RESULT_MARKER", "results/verdict")
     monkeypatch.chdir(elsewhere)
 
-    root_conftest.pytest_sessionfinish(session(invocation_dir=invocation_dir), 0)
+    run_hook(root_conftest, session(invocation_dir=invocation_dir))
 
     assert (invocation_dir / "results" / "verdict").read_text() == "success"
     assert not (elsewhere / "results").exists()
 
 
-def test_the_hook_runs_last(root_conftest):
-    """`trylast` so the verdict is written after every other session hook.
+def test_the_hook_is_the_outermost_wrapper(root_conftest):
+    """A wrapper, and `tryfirst`, so that it writes after every other session hook.
 
-    One of those writes the HTML report the job uploads; a verdict recorded
-    before them would be a verdict for a session that had not finished.
+    pytest's terminal reporter is a wrapper here too, and it can still raise
+    `session.exitstatus` after the inner hooks return. Only the outermost
+    wrapper's code after the yield is guaranteed to see that final status.
     """
-    assert root_conftest.pytest_sessionfinish.pytest_impl["trylast"] is True
+    options = root_conftest.pytest_sessionfinish.pytest_impl
+    assert options["wrapper"] is True
+    assert options["tryfirst"] is True
 
 
 def test_the_repository_root_is_where_the_hook_lives():
@@ -163,3 +207,57 @@ def test_it_needs_nothing_from_partcad(root_conftest):
         if line.startswith(("import ", "from ")):
             module = line.split()[1].split(".")[0]
             assert module in sys.stdlib_module_names or module == "pytest", line
+
+
+def real_pytest_run(tmp_path, *arguments):
+    """Run pytest for real, in its own process, with the repository's own hook.
+
+    A stand-in session cannot show *when* this hook runs relative to pytest's
+    own, which is the whole of what the two tests below are about. The copy is
+    the real file; `cwd` is a directory with no `pyproject.toml`, so the
+    repository's `addopts` do not follow it in.
+    """
+    (tmp_path / "conftest.py").write_text(CONFTEST.read_text())
+    (tmp_path / "test_warns.py").write_text(textwrap.dedent("""
+            import warnings
+
+            def test_warns():
+                warnings.warn("a warning", UserWarning)
+            """))
+    marker = tmp_path / "verdict"
+    environment = dict(os.environ, PYTEST_RESULT_MARKER=str(marker))
+    environment.pop("PYTEST_ADDOPTS", None)
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", "-q", *arguments],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    return completed, marker.read_text() if marker.exists() else None
+
+
+def test_a_real_clean_run_records_a_success(tmp_path):
+    """The control for the regression below: without the flag, this run passes.
+
+    Without it the test below would pass even if the hook had stopped writing
+    anything at all.
+    """
+    completed, verdict = real_pytest_run(tmp_path)
+
+    assert completed.returncode == 0, completed.stdout
+    assert verdict == "success"
+
+
+def test_a_real_max_warnings_failure_records_a_failure(tmp_path):
+    """The regression: pytest raises the status after the inner session hooks run.
+
+    The same run, with `--max-warnings=0`, exits 6 while every test passed. A
+    hook reading its `exitstatus` argument records "success" here and the gate
+    accepts a session pytest called a failure.
+    """
+    completed, verdict = real_pytest_run(tmp_path, "--max-warnings=0")
+
+    assert completed.returncode == 6, completed.stdout
+    assert verdict == "failure"

--- a/tests/partcad/conftest.py
+++ b/tests/partcad/conftest.py
@@ -5,7 +5,6 @@
 #
 
 import copy
-import os
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -66,28 +65,3 @@ def mocked_git_open():
         return patch("partcad.project_factory_git.open", mock_open(read_data=""), create=True)
 
     return _patch
-
-
-@pytest.hookimpl(trylast=True)
-def pytest_sessionfinish(session, exitstatus):
-    """Record the run's verdict for the pre-commit gate.
-
-    pytest has been observed to exit 0 despite failures on some platforms
-    (Windows in particular), so the pre-commit hook cannot rely on the process
-    exit code alone. When it wants a reliable verdict it passes a marker path
-    via PYTEST_RESULT_MARKER; this writes "success" only when the exit status is
-    clean AND pytest counted no failed tests, so a run that exits 0 with a
-    failure (via session.testsfailed) is still recorded as "failure". The hook
-    (.devcontainer/pytest_hook.sh) chooses a PID-unique path so concurrent runs
-    never collide, and it is the hook that reads this file and removes it.
-    """
-    marker = os.environ.get("PYTEST_RESULT_MARKER")
-    if not marker:
-        return
-    # Under xdist only the controller sees the aggregate result; workers each
-    # report their own subset and must not write the verdict.
-    if hasattr(session.config, "workerinput"):
-        return
-    passed = exitstatus == 0 and session.testsfailed == 0
-    with open(marker, "w") as f:
-        f.write("success" if passed else "failure")


### PR DESCRIPTION
## Copilot Summary

Your memory was right about the mechanism and one step off about where it lives. The marker was never removed — it is alive in `.devcontainer/pytest_hook.sh` and has been since #444. **CI has simply never used it.** I checked every revision of the `Test with pytest` step back to #234 (Feb 2025): it has always been a bare `pytest`, and `PYTEST_RESULT_MARKER` has never appeared anywhere under `.github/`. So this recovers the fix by pointing the existing machinery at the job that needs it.

### What is failing

`Pytest (windows-2022, 3.12)` and `Pytest (windows-latest, 3.12)`, on a run where nothing failed:

```
- Generated html report: file:///D:/a/partcad/partcad/pytest-results/report.html -
================ 2639 passed, 38 skipped in 1969.23s (0:32:49) ================
##[error]Process completed with exit code 127.
```

Nothing is printed between those two lines, so under `bash -el`'s `set -e` the failing status is pytest's own — the session finished clean and the process then exited abnormally. Both Windows images, 3.12 and no other version, and it reproduces on #596 (eleven lines in one test file) as readily as it did on #598. It is the cell, not any branch.

### The history this recovers

| | |
|---|---|
| #310 | `pytest_sessionfinish` writes `.pytest_success` when nothing failed |
| #443/#444 first pass | dropped it — the fixed path raced between the check and the `rm` |
| **#444 final** | reinstated on review, with the reasoning that still holds: *"Trusting pytest's exit code is not reliable: on some platforms (Windows in particular) pytest has been observed to exit 0 even when a test errored. So the gate must key off pytest's own internal result, not the process exit code."* PID-scoped path under a temp dir, explicit `success`/`failure`, removed before and after |

#444 saw the exit code lie in one direction (0 with a failure); the 3.12 cells lie in the other (127 with none). One mechanism covers both.

### The change

* **`conftest.py` at the repository root** (moved from `tests/partcad/conftest.py`). Scoped to one package's tests, the hook records nothing for a run that does not collect that directory — and `pyproject.toml` already carries the scar of a job that ran nothing and reported success. A *relative* marker path now resolves against `invocation_params.dir`: a test that changed directory cannot decide where the verdict lands, and the caller and the session can name the same file on Windows, where Git Bash and the native interpreter disagree about what an absolute POSIX path means.
* **The `Pytest` job** sets the marker, keeps pytest's exit code instead of letting `set -e` end the step, and decides on the verdict. A disagreement is annotated, not swallowed: `::warning::` when a green session exited non-zero, `::error::` with pytest's own code when the verdict is `failure` or missing.
* **The `EXCLUDES` note** asked whether #374 was still real and said to re-exclude windows + 3.12 if so. The answer is in — the environment builds and the whole suite passes — so it stays in the matrix and the note records what was found.
* **`.devcontainer/pytest_hook.sh`**, `AGENTS.md` and `docs/source/contributing.rst` updated to say where the hook lives and that both gates read it.

### It cannot paint a broken run green

`failure` is written whenever pytest's exit status is dirty **or** it counted a failed test — exit status 5, nothing collected, included. A run that dies before `pytest_sessionfinish` (collection error, crash mid-suite, runner loss) writes nothing at all, and nothing is not `success`. The step can only ever forgive an exit code that contradicts a session pytest itself called clean.

The shutdown crash underneath is still worth root-causing; the `::warning::` is what keeps it visible instead of letting it become invisible.

### Verification

Both halves exercised directly, since neither can be reached from a Linux runner.

The hook, against real pytest sessions from the repository root:

| session | marker |
|---|---|
| all passing | `success` |
| a failing test, under `-x` | `failure` |
| nothing collected (exit 5) | `failure` |
| collection error | `failure` |
| exit 0 with a failed test (#444's direction) | `failure` |
| xdist worker | not written |

Loaded for nested args too (`cad/freecad/tests`, `tests/partcad_utils`), which is what proves the root placement works for the job's `pytest tests cad/freecad`.

The step's shell logic, against a stubbed pytest:

| pytest does | step |
|---|---|
| green session, exits 127 | **passes**, with the warning annotation |
| real failure, exits 1 | fails, exit 1 |
| failure but exits 0 | fails, exit 1 |
| no marker, exits 4 | fails, exit 4 |
| ordinary green run | passes, silently |

13 unit tests in `tests/dev_tools/test_session_verdict.py` cover the hook, including that it imports nothing but the standard library and `pytest` (a gate must record a verdict even for a run that could not import the package under test) and that the old copy is gone. `black`, `isort`, `flake8` (120) and `shellcheck` clean; the workflow YAML parses and the rendered step body was reviewed.

**One gap, stated plainly:** the `pre-commit` gate did not run. This environment has no working Docker, so the dev container cannot be started, and its hooks hardcode interpreter paths that exist only inside it. The full suite likewise could not run here — `opentelemetry`, `pytest-cov`, `allure` and `pytest-html` are not installed — so `tests/dev_tools` was run with `-o addopts=""`. CI is the check on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2GCocmoGAR8JuyXBMzya

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL2GCocmoGAR8JuyXBMzya)_