### PR TITLE
Retry the bundle's payload downloads

### DIFF
--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -302,17 +302,26 @@ fi
 # took 75 seconds to fail at the OS level, and a stalled transfer would have sat
 # there until the job's own deadline.
 #
-# Two things are deliberately NOT retried. A 4xx is an answer rather than a
+# Three things are deliberately NOT retried. A 4xx is an answer rather than a
 # hiccup -- the URL is wrong, and asking four more times will not make it right.
-# And a checksum mismatch stays a hard failure below: retrying it would paper
-# over the truncated-or-substituted download that the checksum is there to
-# catch.
+# A certificate failure is the one TLS error that means what it says, so only
+# the abrupt-EOF one is retried and `ssl.SSLError` as a whole is not: a bundle
+# that fetched its payload from something it could not authenticate is worse
+# than a bundle that failed to build. And a checksum mismatch stays a hard
+# failure below: retrying it would paper over the truncated-or-substituted
+# download that the checksum is there to catch.
+#
+# The EOF case has to be named because the read happens outside `urlopen`:
+# `do_open` wraps a handshake-time OSError into a URLError, but a TLS EOF part
+# way through `copyfileobj` is raised bare, and an 18 MB payload is a lot of
+# transfer to leave unguarded.
 fetch_and_verify() {
   local url="$1" destination="$2"
 
   "${PYTHON}" - "${url}" "${destination}" <<'FETCH'
 import http.client
 import shutil
+import ssl
 import sys
 import time
 import urllib.error
@@ -335,7 +344,16 @@ def fetch(url, destination):
             if failure.code < 500 or attempt == ATTEMPTS:
                 raise
             reason = failure
-        except (urllib.error.URLError, TimeoutError, http.client.HTTPException, ConnectionError) as failure:
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            http.client.HTTPException,
+            ConnectionError,
+            # A TLS connection dropped without a close_notify. Named on its own
+            # rather than catching ssl.SSLError, which would also swallow a
+            # certificate failure -- see the note above.
+            ssl.SSLEOFError,
+        ) as failure:
             if attempt == ATTEMPTS:
                 raise
             reason = failure

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -288,15 +288,67 @@ fi
 # same shape -- OpenSCAD's reads "<hash>  releases/<name>", micromamba's is the
 # bare hash with no trailing newline -- so the first whitespace-separated field
 # is what is compared and anything after it ignored.
+#
+# The download retries, because a single connection failure here fails the whole
+# bundle. This is the only network operation in the build without one, and it
+# cost a run: "Fetching micromamba 2.9.0-0" died on
+# "TimeoutError: [Errno 60] Operation timed out" at connect, after the wheel had
+# already built, and took the `Examples` job that depends on this bundle with it.
+# The same shape as `.github/actions/setup-all/mamba-create-retry.sh`, which
+# exists because conda-forge downloads flake in exactly this way.
+#
+# `urlopen` rather than `urlretrieve` only because `urlretrieve` takes no
+# timeout, and an unbounded read is the other half of this: the connect above
+# took 75 seconds to fail at the OS level, and a stalled transfer would have sat
+# there until the job's own deadline.
+#
+# Two things are deliberately NOT retried. A 4xx is an answer rather than a
+# hiccup -- the URL is wrong, and asking four more times will not make it right.
+# And a checksum mismatch stays a hard failure below: retrying it would paper
+# over the truncated-or-substituted download that the checksum is there to
+# catch.
 fetch_and_verify() {
   local url="$1" destination="$2"
 
   "${PYTHON}" - "${url}" "${destination}" <<'FETCH'
+import http.client
+import shutil
 import sys
+import time
+import urllib.error
 import urllib.request
 
+ATTEMPTS = 5
+TIMEOUT = 60
+
+
+def fetch(url, destination):
+    """Download one file, retrying the failures that are worth retrying."""
+    for attempt in range(1, ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=TIMEOUT) as response:
+                with open(destination, "wb") as out:
+                    shutil.copyfileobj(response, out)
+            return
+        except urllib.error.HTTPError as failure:
+            # Must come first: HTTPError is a URLError.
+            if failure.code < 500 or attempt == ATTEMPTS:
+                raise
+            reason = failure
+        except (urllib.error.URLError, TimeoutError, http.client.HTTPException, ConnectionError) as failure:
+            if attempt == ATTEMPTS:
+                raise
+            reason = failure
+        delay = 2**attempt
+        print(
+            "    fetch failed (%s); retrying in %ds [attempt %d/%d]" % (reason, delay, attempt, ATTEMPTS),
+            file=sys.stderr,
+        )
+        time.sleep(delay)
+
+
 for url, destination in ((sys.argv[1], sys.argv[2]), (sys.argv[1] + ".sha256", sys.argv[2] + ".sha256")):
-    urllib.request.urlretrieve(url, destination)
+    fetch(url, destination)
 FETCH
 
   "${PYTHON}" - "${destination}" <<'VERIFY'


### PR DESCRIPTION
## Copilot Summary

`fetch_and_verify` in `dev-tools/pyinstaller/build.sh` was the one network operation in the standalone build with **no retry and no timeout** — a bare `urlretrieve` for each payload and its `.sha256`:

```python
for url, destination in ((sys.argv[1], sys.argv[2]), (sys.argv[1] + ".sha256", sys.argv[2] + ".sha256")):
    urllib.request.urlretrieve(url, destination)
```

It fetches **both** payloads the bundle carries — OpenSCAD and micromamba — on all five platforms, so one connection failure fails the whole bundle, on `build-standalone.yml` and in `deploy.yml`.

### What it cost

During #597 it took out a run:

```
==> Fetching micromamba 2.9.0-0 for macos-15-x86_64
   ... 75s ...
    sock.connect(sa)
TimeoutError: [Errno 60] Operation timed out
urllib.error.URLError: <urlopen error [Errno 60] Operation timed out>
```

The `partcad` wheel had already built. Because the bundle build failed, `Examples PartCAD via bundle (macos-15-x86_64)` — the job that PR existed to repair — never ran at all.

### Why this shape

The repository had already settled this question everywhere else. `.github/actions/setup-all/mamba-create-retry.sh` exists precisely because conda-forge downloads flake this way, and `version-bump.yml` and `test-dev.yml` both wrap their network work in attempt loops. This was the one place the idiom was missing.

`urlopen` replaces `urlretrieve` only because **`urlretrieve` takes no timeout**, and the unbounded read is the other half of the problem: the connect above took 75 seconds to surface at the OS level, and a stalled transfer would have sat there until the job's own deadline instead.

Two things are deliberately **not** retried:

* **A 4xx** is an answer, not a hiccup — the URL is wrong, and asking four more times will not make it right.
* **A checksum mismatch** stays the hard failure it already was. Retrying it would paper over the truncated-or-substituted download the checksum exists to catch.

### Verification

Against a local HTTP stub and the real release:

| case | result |
| --- | --- |
| happy path | succeeds, checksum verifies, no added delay |
| two 503s then success | recovers after 2s + 4s backoff |
| 404 | fails immediately, **exactly one** request, 0s |
| persistent 503 | **exactly five** attempts over ~30s (2+4+8+16), then raises |
| real `micromamba-linux-64` (18 MB, via GitHub's redirect) | downloads; sha256 matches upstream's published digest |
| tampered payload | checksum mismatch still fails hard |

The whole `fetch_and_verify` function was also run end to end as the build script calls it, printing the same `checksum verified:` line as before. `shellcheck -e SC1091` is clean on the file, as it was on `devel` beforehand — no new findings.

### Scope

One file, comment and the fetch helper only. No behaviour change on the happy path, and nothing about what gets staged or verified changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxYfXwJ5L8SBEDZhNuqyZi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxYfXwJ5L8SBEDZhNuqyZi)_