### PR TITLE
Weigh a URDF link by what its parts are made of

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1829,6 +1829,32 @@ nothing gets inertial properties computed from its geometry. A property PartCAD
 holds that URDF has no way to state is reported rather than dropped in silence
 (see :doc:`simulation`).
 
+Where the density for that computation comes from, most specific first:
+
+1. The ``density`` option (kg/m^3), when one is set - in the ``export:``
+   section of a package's ``partcad.yaml``, the way every other file-type
+   option is. Setting it is a deliberate "weigh all of this as
+   such-and-such", so it wins over everything derived.
+2. The part's own :ref:`material <materials>`, which is what
+   ``properties: material:`` points at. Its density is per part, so a link
+   assembled from parts of different materials is weighed material by material
+   - the masses add, and the centre of mass is pulled towards the denser part -
+   rather than averaged under one density.
+3. Aluminium, 2700 kg/m^3, as a last resort. Every link weighed this way is
+   named in a warning: a plastic part silently weighed as aluminium is wrong by
+   a factor of two, and nothing in the file says so.
+
+.. code-block:: yaml
+
+  # partcad.yaml -- weigh everything as steel, whatever the parts are made of
+  export:
+    urdf:
+      density: 7850.0
+
+A part that states ``physics: mass:`` never reaches any of this. The
+``<material>`` element is named after the material's ``formal`` name (``PLA``)
+where the reference resolves, rather than after the package path.
+
 ``pc convert assembly`` goes further than exporting: it rewrites the package
 around the assembly and switches its declared type.
 

--- a/src/partcad/builtin/export/export_urdf.py
+++ b/src/partcad/builtin/export/export_urdf.py
@@ -38,8 +38,19 @@ What the part states about itself wins over anything computed here: mass,
 centre of mass, inertia, friction and the contact parameters are named PartCAD
 properties, and this writes each of them back into the URDF element that states
 it. Only a part that says nothing gets computed inertial properties, from its
-solid and the configured density. A property PartCAD has and URDF has no
-spelling for is reported rather than dropped in silence - see URDF_STATED.
+solid and a density. A property PartCAD has and URDF has no spelling for is
+reported rather than dropped in silence - see URDF_STATED.
+
+Where that density comes from, most specific first:
+
+  1. The caller's ``density`` option, when one was given. Naming it is a
+     deliberate "weigh all of this as such-and-such", so it wins.
+  2. The part's own material, resolved to a density before the request reached
+     this sandbox (see 'Shape._material_index()'). This is per part, so a link
+     that mixes materials is weighed material by material rather than averaged.
+  3. DEFAULT_DENSITY, which is a guess and now says so: every link that falls
+     back to it is named in a warning, because a plastic part silently weighed
+     as aluminium is wrong by a factor of two.
 """
 
 import math
@@ -58,17 +69,17 @@ import urdf_common  # noqa: E402
 # in millimetres and URDF reads mesh coordinates as metres after scaling.
 MESH_SCALE = 1.0 / urdf_common.MM_PER_M
 
-# Density used to turn a volume into a mass when the caller does not name one,
-# in kg/m^3. Aluminium: a middle-of-the-road value for a machined part, and one
-# whose provenance is obvious in the output rather than looking like a
-# measurement.
+# Density used to turn a volume into a mass when neither the caller nor the
+# part's material names one, in kg/m^3. Aluminium: a middle-of-the-road value
+# for a machined part, and one whose provenance is obvious in the output rather
+# than looking like a measurement. Falling back to it is reported - see
+# 'densities_of()'.
 DEFAULT_DENSITY = 2700.0
 
-# mm^5 -> m^5. The second moment OCCT integrates has units of length^5, so this
-# is what converts it once the density (kg/m^3) is applied.
-MM5_TO_M5 = 1e-15
-# mm^3 -> m^3.
-MM3_TO_M3 = 1e-9
+# mm^5 -> m^5 and mm^3 -> m^3. Shared with the SDFormat exporter, and with the
+# arithmetic that combines solids of differing densities.
+MM5_TO_M5 = urdf_common.MM5_TO_M5
+MM3_TO_M3 = urdf_common.MM3_TO_M3
 
 # URDF link and joint names end up as XML attributes and as ROS graph names, so
 # anything outside this set is replaced.
@@ -165,19 +176,58 @@ def write_mesh(shape, path, options):
         raise Exception("Failed to write the mesh file: %s" % path)
 
 
-def inertial_of(placed, density, warnings, link_name):
+def densities_of(shape_nodes, state, link_name):
+    """The density (kg/m^3) to weigh each of a link's solids with.
+
+    One per node, in the order they were given, so that a link built from parts
+    of different materials is weighed part by part. The order of preference is
+    the one the module docstring sets out; whichever wins, a link that ends up
+    on DEFAULT_DENSITY is named in a warning, once, listing the materials that
+    were not resolvable rather than only that something was guessed.
+    """
+    override = state["options"]["density"]
+    materials = state["materials"]
+    densities = []
+    guessed = []
+    for node in shape_nodes:
+        name = node.get("name")
+        if override is not None:
+            densities.append(override)
+            continue
+        density = urdf_common.density_from_material(materials.get(name))
+        if density is None:
+            densities.append(DEFAULT_DENSITY)
+            stated = (state["properties"].get(name) or {}).get("material")
+            guessed.append("%s (%s)" % (name or "?", stated) if stated else (name or "?"))
+        else:
+            densities.append(density)
+    if guessed:
+        state["warnings"].append(
+            "Link '%s' has no density for %s, so it is weighed as aluminium (%g kg/m^3); "
+            "state 'physics: mass:', give the part a material with a density, or pass 'density'"
+            % (link_name, ", ".join(guessed), DEFAULT_DENSITY)
+        )
+    return densities
+
+
+def inertial_of(placed, densities, warnings, link_name):
     """The URDF ``<inertial>`` for a link's solids, or None when they have none.
 
     'placed' is the (shape, packed placement) pairs the link is made of - one for
     an ordinary link, several for a URDF link with more than one ``<visual>``.
-    Each is put where it belongs before the moments are taken, so the result is
-    about the link as a whole.
+    'densities' is one density (kg/m^3) per pair, in the same order.
 
-    OCCT's GProp_GProps.MatrixOfInertia() is already the tensor about the centre
-    of mass, which is the frame URDF's ``<inertia>`` is stated in, so no
-    parallel-axis shift is needed - only the units and the density. GProp
-    integrates at unit density in the shape's own (millimetre) units, so the
-    volume becomes a mass and the second moment (length^5) becomes kg.m^2.
+    Each solid is measured where it belongs and weighed with its own density,
+    and the results are combined by 'urdf_common.combine_inertials()': the
+    masses add, the centre of mass is their weighted mean, and each tensor is
+    carried to that combined centre by the parallel-axis theorem. A link of one
+    material comes out exactly as it did when one density was applied to the
+    whole compound.
+
+    OCCT's GProp_GProps.MatrixOfInertia() is the tensor about the shape's own
+    centre of mass - it does not change when the shape is translated - which is
+    the frame URDF's ``<inertia>`` is stated in, so the only shift needed is
+    the one between solids.
 
     A link with no volume (a mesh imported as a shell, an empty compound) has no
     inertia to compute: it is reported and the link goes out without an
@@ -187,34 +237,36 @@ def inertial_of(placed, density, warnings, link_name):
     from OCP.GProp import GProp_GProps
     from urdf_parser_py.urdf import Inertia, Inertial, Pose
 
-    props = GProp_GProps()
-    BRepGProp.VolumeProperties_s(combined(placed), props)
-    volume = props.Mass()
-    if volume <= 0.0:
+    solids = []
+    for (shape, placement), density in zip(placed, densities):
+        props = GProp_GProps()
+        BRepGProp.VolumeProperties_s(combined([(shape, placement)]), props)
+        volume = props.Mass()
+        if volume <= 0.0:
+            continue
+        com = props.CentreOfMass()
+        matrix = props.MatrixOfInertia()
+        solids.append(
+            (
+                volume,
+                (com.X(), com.Y(), com.Z()),
+                [[matrix.Value(row, col) for col in (1, 2, 3)] for row in (1, 2, 3)],
+                density,
+            )
+        )
+
+    result = urdf_common.combine_inertials(solids)
+    if result is None:
         warnings.append(
             "Link '%s' has no computable volume (an open shell or a mesh), so it carries no <inertial>" % link_name
         )
         return None
 
-    com = props.CentreOfMass()
-    centre = (com.X(), com.Y(), com.Z())
-    matrix = props.MatrixOfInertia()
-    # Row/column indices in OCCT's gp_Mat are 1-based.
-    inertia = [[matrix.Value(row, col) for col in (1, 2, 3)] for row in (1, 2, 3)]
-
-    mass = volume * MM3_TO_M3 * density
-    factor = density * MM5_TO_M5
+    mass, centre, inertia = result
     return Inertial(
         mass=mass,
-        origin=Pose(xyz=[v * MESH_SCALE for v in centre], rpy=[0.0, 0.0, 0.0]),
-        inertia=Inertia(
-            ixx=inertia[0][0] * factor,
-            ixy=inertia[0][1] * factor,
-            ixz=inertia[0][2] * factor,
-            iyy=inertia[1][1] * factor,
-            iyz=inertia[1][2] * factor,
-            izz=inertia[2][2] * factor,
-        ),
+        origin=Pose(xyz=list(centre), rpy=[0.0, 0.0, 0.0]),
+        inertia=Inertia(**inertia),
     )
 
 
@@ -271,13 +323,23 @@ def carried_inertial(physics):
     )
 
 
-def carried_material(properties, state):
-    """The ``<material>`` a part's own 'material'/'color' properties state."""
+def carried_material(properties, material, state):
+    """The ``<material>`` a part's own 'material'/'color' properties state.
+
+    'material' is what the reference resolved to, when it did. Its formal name
+    is what the URDF should call the material: 'PLA' reads as a material, while
+    the sanitized package path it would otherwise get
+    ('pub-std-manufacturing-material-plastic-pla') reads as an accident. A
+    reference that resolved to nothing - a URDF's own material name, most often,
+    which was never a PartCAD reference - is used as it stands.
+    """
     from urdf_parser_py.urdf import Color, LinkMaterial
 
     name, color = properties.get("material"), properties.get("color")
     if not name and not color:
         return None
+    if name and isinstance(material, dict) and material.get("name"):
+        name = material["name"]
     built = LinkMaterial(name=sanitize_name(name or color, "material"))
     rgba = color_rgba(color, state) if color else None
     if rgba is not None:
@@ -377,6 +439,7 @@ def build_link(node, link_name, elements, state):
     physics = (state["properties"].get(node.get("name")) or {}).get("physics") or {}
 
     placed = []
+    placed_nodes = []
     for shape_node, placement in elements:
         shape = node_geometry(shape_node)
         if shape is None:
@@ -390,10 +453,15 @@ def build_link(node, link_name, elements, state):
             origin = Pose(xyz=xyz, rpy=rpy)
         # The appearance belongs to the shape, not to the link: a link built
         # from several parts may well have a colour per part.
-        material = carried_material(state["properties"].get(shape_node.get("name")) or {}, state)
+        material = carried_material(
+            state["properties"].get(shape_node.get("name")) or {},
+            state["materials"].get(shape_node.get("name")),
+            state,
+        )
         link.add_aggregate("visual", Visual(geometry=geometry, origin=origin, material=material))
         link.add_aggregate("collision", Collision(geometry=geometry, origin=origin))
         placed.append((shape, placement))
+        placed_nodes.append(shape_node)
 
     if not placed:
         # A frame that carries children, with no geometry of its own. URDF has
@@ -401,8 +469,10 @@ def build_link(node, link_name, elements, state):
         return link
 
     if state["options"]["inertial"]:
+        # 'or' short-circuits, so a link that states its own mass never reaches
+        # 'densities_of' - and so never warns about a density it does not use.
         link.inertial = carried_inertial(physics) or inertial_of(
-            placed, state["options"]["density"], state["warnings"], link_name
+            placed, densities_of(placed_nodes, state, link_name), state["warnings"], link_name
         )
     gazebo = gazebo_element(link_name, physics, state)
     if gazebo is not None:
@@ -472,6 +542,11 @@ def process(path, request):
         # mass, inertia and friction here, and they go back out rather than
         # being recomputed.
         "properties": request.get("properties") or {},
+        # Shape full name -> what its material is: the density (g/mm^3) to weigh
+        # it with and the formal name to call it in the URDF. Resolved in the
+        # PartCAD process, because a reference to another package cannot be
+        # followed from here. See 'Shape._material_index()'.
+        "materials": request.get("materials") or {},
         "gazebo": [],
         # PartCAD properties URDF has no spelling for, reported once at the end.
         "unsupported": set(),
@@ -480,7 +555,9 @@ def process(path, request):
             "angularTolerance": request.get("angularTolerance", 0.1),
             "ascii": request.get("ascii", False),
             "inertial": request.get("inertial", True),
-            "density": request.get("density") or DEFAULT_DENSITY,
+            # None when the caller named none, which is what lets a part's own
+            # material decide. Only an explicit option overrides the material.
+            "density": request.get("density") or None,
         },
         "warnings": warnings,
     }

--- a/src/partcad/builtin/export/partcad.yaml
+++ b/src/partcad/builtin/export/partcad.yaml
@@ -182,8 +182,11 @@ export:
     tolerance: 0.1
     angularTolerance: 0.1
     ascii: false
-    # Write an '<inertial>' for every link, computing one from the solid and
-    # 'density' (kg/m^3) for a part that does not state its own.
+    # Write an '<inertial>' for every link, computing one from the solid for a
+    # part that does not state its own mass. The density comes from the part's
+    # material, unless 'density' (kg/m^3) is given here - naming one is a
+    # deliberate "weigh all of this as such-and-such" and overrides the
+    # materials. A part with neither is weighed as aluminium, and said to be.
     inertial: true
     # 'robot_name' defaults to the object's label, 'mesh_dir' to
     # '<file stem>_meshes' next to the URDF, 'mesh_prefix' to empty (which makes

--- a/src/partcad/output.py
+++ b/src/partcad/output.py
@@ -142,6 +142,13 @@ SCRIPT_KEY = "__script__"
 # placement is baked into the shape instead of staying readable as data.
 DECODE_KEY = "__decode__"
 
+# The request key carrying what each shape's material is: '<package>:<name>' ->
+# {"density": g/mm^3, "name": the formal name}. Filled only for a file type that
+# asked for 'properties', and only in the PartCAD process - a sandboxed
+# implementation is handed the material as a string and has no context to
+# resolve it in. See 'Shape._material_index()'.
+MATERIALS_KEY = "materials"
+
 
 class Implementation:
     """Who writes a file of a given type, and with what.

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -22,7 +22,7 @@ from .cache_hash import CacheHash
 from .cache_shape import properties_key
 from . import output
 from .shape_config import ShapeConfiguration
-from .utils import total_size
+from .utils import normalize_resource_path, total_size
 from . import logging as pc_logging
 from .sync_threads import threadpool_manager
 from . import render_overlay
@@ -121,6 +121,42 @@ SERIALIZED_PART_TYPES = (
 TEXT_PART_TYPES = frozenset({"step", "iges", "brep", "obj", "threejs", "svg", "dxf"})
 
 SUPPORTED_PART_TYPES = frozenset(LIVE_OBJECT_PART_TYPES | SERIALIZED_PART_TYPES)
+
+
+def envelope_material_refs(envelope):
+    """Every node of an envelope tree that names a material, and which one.
+
+    Read from the envelope about to be sent rather than from the live
+    object, because the envelope is what the exporter will actually see: the
+    index it looks properties up in is built from these very nodes (see
+    'properties_index()' in wrappers/wrapper_export.py), so reading anything
+    else risks answering about a different tree. An assembly served from the
+    cache is the case that makes this more than a preference - it has no
+    instantiated children to walk, and walking them would silently find no
+    materials and weigh everything as the default.
+
+    Keyed by the node's full name, which is the key the exporter uses. That
+    name is '<package>:<object>', so it also says which package declared the
+    reference - and therefore what a relative one means, wherever the shape
+    was later placed.
+    """
+    refs = {}
+
+    def visit(node):
+        if not isinstance(node, dict):
+            return
+        name = node.get("name")
+        properties = node.get(shape_envelope.KEY_PROPERTIES)
+        if name and isinstance(properties, dict):
+            reference = properties.get("material")
+            if isinstance(reference, str) and reference.strip():
+                package = name.rsplit(":", 1)[0] if ":" in name else name
+                refs[name] = normalize_resource_path(package, reference.strip())
+        for child in node.get(shape_envelope.KEY_ASSEMBLY) or []:
+            visit(child)
+
+    visit(envelope)
+    return refs
 
 
 @telemetry.instrument(exclude=["locked"])
@@ -497,6 +533,35 @@ class Shape(ShapeConfiguration):
         cached, _ = await ctx.cache_shapes.read_async(self.hash, [key])
         properties = cached.get(key)
         return properties if isinstance(properties, dict) and properties else None
+
+    def _material_index(self, ctx, envelope):
+        """What each shape's material is, for an exporter that needs to weigh it.
+
+        A sandboxed exporter is handed a material as a *string* - it has no
+        PartCAD context and cannot look a package up - so anything it needs to
+        know about that material has to be resolved here and travel with the
+        request. What it needs is the density, to turn a volume into a mass, and
+        the formal name, which is what a URDF or SDFormat '<material>' should be
+        called rather than the package path.
+
+        Only shapes whose reference resolves appear. A reference that does not
+        is not an error and is not reported: a part imported from a URDF carries
+        the URDF's own material name ('grey'), which was never a PartCAD
+        reference and is still perfectly good as an appearance name.
+        """
+        from . import material as pc_material
+
+        index = {}
+        for full_name, reference in envelope_material_refs(envelope).items():
+            _, resolved = pc_material.lookup(ctx, reference, quiet=True)
+            if resolved is None:
+                continue
+            entry = {"name": resolved.formal or resolved.name}
+            if resolved.density is not None:
+                # g/mm^3, as the material states it. The exporter converts.
+                entry["density"] = resolved.density
+            index[full_name] = entry
+        return index
 
     def _shape_metadata(self):
         """The (full_name, label) stamped onto this shape's envelope."""
@@ -1059,6 +1124,17 @@ class Shape(ShapeConfiguration):
 
         request = await self._output_request(obj, impl, kwargs, overlay=effective_overlay, ports=ports)
         request[output.SCRIPT_KEY] = os.path.abspath(script)
+        # What the shapes report about themselves reaches the sandbox on the
+        # envelopes, but a material among those properties is only a
+        # *reference*: resolving it means reading another package, which a
+        # sandbox cannot do. So it is resolved here, where there is a context to
+        # resolve it in, and travels with the request. Added beside the other
+        # keys the caller fills in rather than inside '_output_request', which is
+        # the configuration merge and has no business needing a context.
+        if impl.parameters.get("properties"):
+            materials = self._material_index(ctx, obj)
+            if materials:
+                request[output.MATERIALS_KEY] = materials
         # Whether the sandbox rebuilds the envelopes into live geometry before
         # the implementation sees them. Off for an implementation that needs what
         # the envelopes say about each node (the URDF exporter names every link

--- a/src/partcad/wrappers/urdf_common.py
+++ b/src/partcad/wrappers/urdf_common.py
@@ -208,3 +208,103 @@ def round_packed(packed, precision):
         [round(v, precision) for v in axis],
         round(angle, precision),
     ]
+
+
+# Cubic and quintic millimetres to their metre counterparts. A volume becomes a
+# mass once a density (kg/m^3) is applied; the second moment OCCT integrates has
+# units of length^5, so it needs the fifth power.
+MM3_TO_M3 = 1e-9
+MM5_TO_M5 = 1e-15
+
+# A PartCAD material states its density in g/mm^3, the units every length in
+# PartCAD is already in. URDF and SDFormat state density in kg/m^3. One g/mm^3 is
+# 1e-3 kg per 1e-9 m^3, so the factor is 1e6: PLA at 0.00132 g/mm^3 is
+# 1320 kg/m^3, which is the 1.32 g/cm^3 a datasheet quotes.
+G_MM3_TO_KG_M3 = 1e6
+
+
+def density_from_material(material):
+    """A material's density as kg/m^3, or None if it states none.
+
+    'material' is what the exporter was handed for one shape: the resolved
+    density of that shape's material, in g/mm^3, under 'density'. Resolving the
+    reference is the caller's job and happens in the PartCAD process - a
+    sandboxed exporter has no context to look a package up in.
+    """
+    if not isinstance(material, dict):
+        return None
+    density = material.get("density")
+    if density is None:
+        return None
+    try:
+        density = float(density)
+    except (TypeError, ValueError):
+        return None
+    return density * G_MM3_TO_KG_M3 if density > 0.0 else None
+
+
+def combine_inertials(solids):
+    """The mass, centre of mass and inertia of solids of differing densities.
+
+    Each entry of 'solids' is ``(volume, com, inertia, density)``:
+
+      * ``volume`` in mm^3 and ``com`` in mm, in the link's frame;
+      * ``inertia`` the 3x3 unit-density second moment **about that solid's own
+        centre of mass**, in mm^5 -- which is what OCCT's
+        ``GProp_GProps.MatrixOfInertia()`` returns for
+        ``BRepGProp.VolumeProperties_s`` (verified: the value does not change
+        when the shape is translated away from the origin);
+      * ``density`` in kg/m^3.
+
+    Returns ``(mass, com, inertia)`` with the mass in kg, the centre of mass in
+    metres and the inertia a dict of the six URDF/SDFormat components in kg.m^2
+    about that centre of mass -- the frame both formats state ``<inertia>`` in.
+    None when there is no volume to compute from.
+
+    One density for the whole link cannot express a link that mixes materials -
+    a steel insert in a plastic housing weighs what neither material alone
+    would say - so each solid is weighed with its own density and the results
+    are combined: the masses add, the centre of mass is their weighted mean,
+    and each solid's tensor is carried from its own centre of mass to the
+    combined one by the parallel-axis theorem. With a single solid this reduces
+    to exactly the old arithmetic (the shift is zero), which is why converting
+    a single-material link changes nothing.
+    """
+    entries = []
+    for volume, com, inertia, density in solids:
+        if volume is None or volume <= 0.0:
+            continue
+        mass = volume * MM3_TO_M3 * density
+        if mass <= 0.0:
+            continue
+        entries.append((mass, tuple(float(v) for v in com), inertia, density))
+    if not entries:
+        return None
+
+    total = sum(entry[0] for entry in entries)
+    # Millimetres, to stay in the frame the centres arrived in.
+    centre_mm = tuple(sum(entry[0] * entry[1][axis] for entry in entries) / total for axis in (0, 1, 2))
+
+    combined = [[0.0] * 3 for _ in range(3)]
+    for mass, com, inertia, density in entries:
+        factor = density * MM5_TO_M5
+        # From this solid's own centre of mass to the combined one, in metres.
+        offset = [(com[axis] - centre_mm[axis]) / MM_PER_M for axis in (0, 1, 2)]
+        squared = sum(value * value for value in offset)
+        for row in (0, 1, 2):
+            for col in (0, 1, 2):
+                shift = mass * ((squared if row == col else 0.0) - offset[row] * offset[col])
+                combined[row][col] += float(inertia[row][col]) * factor + shift
+
+    return (
+        total,
+        tuple(value / MM_PER_M for value in centre_mm),
+        {
+            "ixx": combined[0][0],
+            "ixy": combined[0][1],
+            "ixz": combined[0][2],
+            "iyy": combined[1][1],
+            "iyz": combined[1][2],
+            "izz": combined[2][2],
+        },
+    )

--- a/tests/partcad/unit/data/urdf_material/partcad.yaml
+++ b/tests/partcad/unit/data/urdf_material/partcad.yaml
@@ -1,0 +1,48 @@
+desc: A package whose parts say what they are made of
+
+sketches:
+  plate:
+    type: basic
+    square: 20
+
+materials:
+  pla:
+    formal: PLA
+    full: Polylactic Acid
+    density: 0.00132 # g/mm^3 == 1320 kg/m^3
+  steel:
+    formal: Steel
+    density: 0.00785 # g/mm^3 == 7850 kg/m^3
+  unweighed:
+    full: Something nobody stated a density for
+
+parts:
+  # 20 x 20 x 5 mm == 2000 mm^3 exactly, so the mass is checkable by hand.
+  plastic-plate:
+    type: extrude
+    sketch: plate
+    depth: 5
+    properties:
+      material: pla
+  steel-plate:
+    type: extrude
+    sketch: plate
+    depth: 5
+    properties:
+      material: steel
+  # No material at all: the exporter has to fall back and say so.
+  bare-plate:
+    type: extrude
+    sketch: plate
+    depth: 5
+  # A material that states no density: the same fallback, by another route.
+  unweighed-plate:
+    type: extrude
+    sketch: plate
+    depth: 5
+    properties:
+      material: unweighed
+
+assemblies:
+  rig:
+    type: assy

--- a/tests/partcad/unit/data/urdf_material/rig.assy
+++ b/tests/partcad/unit/data/urdf_material/rig.assy
@@ -1,0 +1,7 @@
+links:
+  - part: plastic-plate
+    location: [[0, 0, 0], [0, 0, 1], 0]
+  - part: steel-plate
+    location: [[50, 0, 0], [0, 0, 1], 0]
+  - part: bare-plate
+    location: [[100, 0, 0], [0, 0, 1], 0]

--- a/tests/partcad/unit/test_assembly_urdf.py
+++ b/tests/partcad/unit/test_assembly_urdf.py
@@ -832,3 +832,115 @@ def test_info_reports_the_urdf_without_building_it():
     assert info["RootLink"] == "base_link"
     assert info["UrdfMovableJoints"] == ["shoulder_pan (revolute)"]
     assert DROPPED_LABELS["joint_kinematics"] in info["UrdfDropped"]
+
+
+#
+# Where the mass comes from
+#
+
+MATERIAL_DATA = "tests/partcad/unit/data/urdf_material"
+
+# Each plate in the fixture is 20 x 20 x 5 mm.
+PLATE_VOLUME_M3 = 20.0 * 20.0 * 5.0 * 1e-9
+
+
+def _link_mass(robot, name):
+    for link in robot.findall("link"):
+        if link.get("name") == name:
+            inertial = link.find("inertial")
+            return None if inertial is None else float(inertial.find("mass").get("value"))
+    raise AssertionError("no link named %s" % name)
+
+
+def test_the_material_index_resolves_what_each_part_is_made_of():
+    """What travels to the sandbox: a density and a name, per shape.
+
+    The reference cannot be resolved in the sandbox - it names another package
+    - so it is resolved here, in the PartCAD process, and sent along.
+    """
+    ctx = pc.init(MATERIAL_DATA)
+    rig = ctx._get_assembly("//:rig")
+    # Read from the envelope that would be sent, which is what the exporter
+    # sees - and what an assembly served from the cache still has, where it has
+    # no instantiated children to walk.
+    index = rig._material_index(ctx, asyncio.run(rig.get_shape(ctx)))
+
+    assert index["//:plastic-plate"] == {"density": 0.00132, "name": "PLA"}
+    assert index["//:steel-plate"] == {"density": 0.00785, "name": "Steel"}
+    # No material at all, so nothing to resolve and nothing to send.
+    assert "//:bare-plate" not in index
+
+
+def test_a_part_is_weighed_with_its_own_material(tmp_path):
+    """The mass in the URDF is the part's volume times its material's density.
+
+    Before materials, every part that did not state a mass was weighed as
+    aluminium. A plastic plate came out twice as heavy as it is.
+    """
+    ctx = pc.init(MATERIAL_DATA)
+    rig = ctx._get_assembly("//:rig")
+    robot = ET.parse(_export_urdf(ctx, rig, str(tmp_path), name="rig")).getroot()
+
+    # 1320 kg/m^3 and 7850 kg/m^3, from 'materials:' in the fixture.
+    assert _link_mass(robot, "plastic-plate") == pytest.approx(PLATE_VOLUME_M3 * 1320.0)
+    assert _link_mass(robot, "steel-plate") == pytest.approx(PLATE_VOLUME_M3 * 7850.0)
+    # Same geometry, different materials: the masses must differ.
+    assert _link_mass(robot, "plastic-plate") != pytest.approx(_link_mass(robot, "steel-plate"))
+
+
+def test_a_part_with_no_material_falls_back_and_says_so(tmp_path, caplog):
+    """The guess is still there, but it is no longer silent."""
+    ctx = pc.init(MATERIAL_DATA)
+    rig = ctx._get_assembly("//:rig")
+    with caplog.at_level("WARNING"):
+        robot = ET.parse(_export_urdf(ctx, rig, str(tmp_path), name="rig")).getroot()
+
+    assert _link_mass(robot, "bare-plate") == pytest.approx(PLATE_VOLUME_M3 * 2700.0)
+    # Named, so the reader knows which link was guessed at rather than only
+    # that something was.
+    messages = "\n".join(record.message for record in caplog.records)
+    assert "bare-plate" in messages and "aluminium" in messages
+    # The parts that had a material are not complained about.
+    assert "plastic-plate" not in messages
+
+
+def test_an_explicit_density_option_overrides_the_materials(tmp_path):
+    """Naming a density is a deliberate 'weigh all of this as such-and-such'."""
+    ctx = pc.init(MATERIAL_DATA)
+    rig = ctx._get_assembly("//:rig")
+    robot = ET.parse(_export_urdf(ctx, rig, str(tmp_path), name="rig", density=1000.0)).getroot()
+
+    for name in ("plastic-plate", "steel-plate", "bare-plate"):
+        assert _link_mass(robot, name) == pytest.approx(PLATE_VOLUME_M3 * 1000.0)
+
+
+def test_the_urdf_material_is_called_by_its_formal_name(tmp_path):
+    """'PLA', not the sanitized package path the reference would become."""
+    ctx = pc.init(MATERIAL_DATA)
+    rig = ctx._get_assembly("//:rig")
+    robot = ET.parse(_export_urdf(ctx, rig, str(tmp_path), name="rig")).getroot()
+
+    names = {material.get("name") for material in robot.findall("link/visual/material")}
+    assert "PLA" in names
+    assert "Steel" in names
+
+
+def test_a_stated_mass_still_wins_over_the_material(tmp_path, caplog):
+    """A measurement beats anything derived, and derivation must not run for it.
+
+    The URDF example's 'base' states its mass, so exporting it back reproduces
+    that number and never reaches the density at all - which is why 'base' is
+    not among the links reported as guessed. Its 'forearm' and 'wrist' state no
+    mass and have no material, so they are: that was always a guess, and the
+    only change is that it is no longer a silent one.
+    """
+    ctx = pc.init(EXAMPLES)
+    robot_obj = ctx._get_assembly(URDF_EXAMPLE)
+    with caplog.at_level("WARNING"):
+        exported = ET.parse(_export_urdf(ctx, robot_obj, str(tmp_path), name="robot")).getroot()
+
+    assert float(exported.find("link/inertial/mass").get("value")) == pytest.approx(0.78)
+
+    guessed = "\n".join(record.message for record in caplog.records)
+    assert "'base'" not in guessed
+    assert "'forearm'" in guessed and "'wrist'" in guessed

--- a/tests/partcad/unit/test_urdf_common.py
+++ b/tests/partcad/unit/test_urdf_common.py
@@ -146,3 +146,102 @@ def test_is_identity():
     assert urdf_common.is_identity((urdf_common.IDENTITY_Q, urdf_common.IDENTITY_T))
     assert not urdf_common.is_identity((urdf_common.IDENTITY_Q, (0.0, 0.0, 1.0)))
     assert not urdf_common.is_identity((urdf_common.axis_angle_to_quat((0, 0, 1), 5.0), urdf_common.IDENTITY_T))
+
+
+#
+# Turning a volume and a material into a mass and an inertia
+#
+
+
+def test_a_material_density_becomes_kg_per_cubic_metre():
+    """PartCAD states g/mm^3; URDF and SDFormat state kg/m^3."""
+    # PLA at 1.32 g/cm^3, which is 0.00132 g/mm^3, is 1320 kg/m^3.
+    assert urdf_common.density_from_material({"density": 0.00132}) == pytest.approx(1320.0)
+    assert urdf_common.density_from_material({"density": 0.00785}) == pytest.approx(7850.0)
+
+
+def test_a_material_with_nothing_usable_has_no_density():
+    # Each of these means "weigh it some other way", never "weigh it as zero".
+    assert urdf_common.density_from_material(None) is None
+    assert urdf_common.density_from_material({}) is None
+    assert urdf_common.density_from_material({"name": "PLA"}) is None
+    assert urdf_common.density_from_material({"density": None}) is None
+    assert urdf_common.density_from_material({"density": 0.0}) is None
+    assert urdf_common.density_from_material({"density": "heavy"}) is None
+
+
+def _box(a, b, c, centre, density):
+    """A box as 'combine_inertials' takes it: unit-density moments about its own centre."""
+    volume = a * b * c
+    inertia = [
+        [volume * (b * b + c * c) / 12.0, 0.0, 0.0],
+        [0.0, volume * (a * a + c * c) / 12.0, 0.0],
+        [0.0, 0.0, volume * (a * a + b * b) / 12.0],
+    ]
+    return (volume, centre, inertia, density)
+
+
+def test_one_solid_is_its_own_volume_times_its_density():
+    mass, centre, inertia = urdf_common.combine_inertials([_box(10.0, 20.0, 30.0, (5.0, 10.0, 15.0), 2700.0)])
+    # 6000 mm^3 of aluminium.
+    assert mass == pytest.approx(6000.0 * 1e-9 * 2700.0)
+    # The centre of mass comes back in metres.
+    assert centre == pytest.approx((0.005, 0.010, 0.015))
+    # ixx = V(b^2+c^2)/12 * density * mm^5->m^5.
+    assert inertia["ixx"] == pytest.approx(650000.0 * 2700.0 * 1e-15)
+    assert inertia["ixy"] == pytest.approx(0.0)
+
+
+def test_a_link_of_two_materials_weighs_what_both_say():
+    """The case one density for the whole link cannot express.
+
+    A steel insert in a plastic housing weighs what neither material alone
+    would say, and the centre of mass is pulled towards the steel.
+    """
+    plastic = _box(20.0, 20.0, 5.0, (0.0, 0.0, 0.0), 1320.0)
+    steel = _box(20.0, 20.0, 5.0, (40.0, 0.0, 0.0), 7850.0)
+    mass, centre, _ = urdf_common.combine_inertials([plastic, steel])
+
+    plastic_mass = 2000.0 * 1e-9 * 1320.0
+    steel_mass = 2000.0 * 1e-9 * 7850.0
+    assert mass == pytest.approx(plastic_mass + steel_mass)
+    # Weighted towards the steel, not the midpoint at 0.020 m.
+    expected_x = (plastic_mass * 0.0 + steel_mass * 0.040) / (plastic_mass + steel_mass)
+    assert centre[0] == pytest.approx(expected_x)
+    assert centre[0] > 0.030
+
+
+def test_combining_carries_each_tensor_to_the_shared_centre():
+    """Two identical solids apart on one axis, against the closed form.
+
+    Each contributes its own tensor plus m*d^2 about the combined centre, which
+    for this arrangement is the midpoint.
+    """
+    a = b = c = 10.0
+    half = 25.0
+    left = _box(a, b, c, (-half, 0.0, 0.0), 1000.0)
+    right = _box(a, b, c, (half, 0.0, 0.0), 1000.0)
+    mass, centre, inertia = urdf_common.combine_inertials([left, right])
+
+    each = 1000.0 * 1e-9 * 1000.0  # 1000 mm^3 at 1000 kg/m^3
+    assert mass == pytest.approx(2.0 * each)
+    assert centre == pytest.approx((0.0, 0.0, 0.0))
+    # About x the offset is along the axis, so nothing is added.
+    own_ixx = 1000.0 * (b * b + c * c) / 12.0 * 1000.0 * 1e-15
+    assert inertia["ixx"] == pytest.approx(2.0 * own_ixx)
+    # About y and z each solid is carried 0.025 m off the centre.
+    own_izz = 1000.0 * (a * a + b * b) / 12.0 * 1000.0 * 1e-15
+    assert inertia["izz"] == pytest.approx(2.0 * (own_izz + each * 0.025**2))
+
+
+def test_solids_with_no_volume_are_left_out():
+    real = _box(10.0, 10.0, 10.0, (0.0, 0.0, 0.0), 1000.0)
+    empty = (0.0, (0.0, 0.0, 0.0), [[0.0] * 3] * 3, 1000.0)
+    assert urdf_common.combine_inertials([real, empty]) == urdf_common.combine_inertials([real])
+
+
+def test_nothing_to_weigh_is_none_not_zero():
+    # A mesh or an open shell has no volume. None is what makes the caller
+    # write no <inertial> at all rather than one full of zeroes.
+    assert urdf_common.combine_inertials([]) is None
+    assert urdf_common.combine_inertials([(0.0, (0.0, 0.0, 0.0), [[0.0] * 3] * 3, 2700.0)]) is None


### PR DESCRIPTION
## Copilot Summary

Stacked on #601, which introduces the `material` object type. **Base retargets to `devel` once #601 merges** — the diff shown here is this change alone.

### The problem

`export_urdf.py` computes an `<inertial>` for any link whose part does not state a mass, and weighed every one of them as **aluminium** — `DEFAULT_DENSITY = 2700.0`, a guess, applied in silence. A plastic part came out roughly twice as heavy as it is, and neither the file nor the log said the number was invented.

The part usually knows better: `properties: material:` already names what it is made of, and a material now states a density. `carried_material()` even had that reference in hand — it just used it as a `<material>` name for appearance and ignored it for mass.

### Order of preference, specific over general

1. A stated `physics: mass:` / `inertia:` — a measurement, unchanged, and `or` short-circuits so a link that states one never even resolves a density.
2. The `density` option, where one is set in the `export:` section — a deliberate "weigh all of this as such-and-such".
3. **The part's own material.**
4. Aluminium — still there, but every link weighed that way is now **named in a warning**, listing the materials it could not weigh.

That last point surfaced something immediately: the `produce_assembly_urdf` example's `forearm` and `wrist` state no mass and have no material. They were always guessed at; the only change is that it is no longer silent.

### Per part, not per link

Density is resolved per solid, so a link assembled from parts of different materials is weighed material by material — a steel insert in a plastic housing weighs what neither material alone would say. The masses add, the centre of mass is their weighted mean, and each solid's tensor is carried to that combined centre by the parallel-axis theorem (`urdf_common.combine_inertials`). A single-material link comes out exactly as before, because the shift is then zero.

### Two things checked against OCCT rather than assumed

- `GProp_GProps.MatrixOfInertia()` from `VolumeProperties_s` is the tensor about the shape's **own centre of mass** — verified by translating a box 1 m from the origin and watching the value not change. The existing comment claiming this was right; had it been about the origin, every exported tensor would have been wrong.
- The combination reproduces what OCCT reports for the equivalent compound to floating-point precision (`rel < 1e-14` on all six components, off-diagonal signs included).

### Where the resolution happens

A material reference names another package, and a sandboxed exporter has no context to read one in — so it is resolved in the PartCAD process and travels in the request as `{shape full name: {density, name}}`.

It is read off **the envelope tree about to be sent**, not off the live object. That matters: an assembly served from the cache has no instantiated children to walk, and an earlier draft that walked `self.children` passed every test in isolation and then failed as soon as the suite ran warm — silently finding no materials and weighing everything as the default.

The injection sits at the call site in `_render_one_async`, beside `SCRIPT_KEY` and `DECODE_KEY`, rather than inside `_output_request` — that method is the configuration merge and has no business needing a context (and `test_render_views` calls it directly to assert exactly that).

### Also

The URDF `<material>` is named after the material's `formal` name (`PLA`) rather than the sanitized package path (`pub-std-manufacturing-material-plastic-pla`). A reference that resolves to nothing — a URDF's own material name like `grey` — is used as it stands.

### Testing

- 9 new pure-Python tests for the shared maths in `test_urdf_common.py` (unit conversion, mixed materials, the parallel-axis carry, no-volume and no-density cases).
- 6 new end-to-end tests in `test_assembly_urdf.py` over a fixture whose plates are 20x20x5 mm, so masses are checkable by hand: 2000 mm³ x 1320 / 7850 / 2700 kg/m³.
- Targeted regression runs: **232 passed / 0 failed** across URDF export, SDFormat export, the shared maths, materials, shape properties, the output layer, scenes and derived parts; **192 passed / 8 failed** across render, convert, adhoc and tags — the 8 are `prism_scad` cases and this environment has no `openscad` installed.

### Not in this change

`export_world.py` (SDFormat/Gazebo) has the identical gap at lines 429 and 538: one density for the whole link, defaulting to 2700 in silence. It already imports `urdf_common` via `gazebo_common`, so the helpers added here drop straight in — but it is a different exporter than the one asked about, so it is left alone rather than widened into.

The import direction (URDF -> ASSY) needs nothing: URDF states mass and inertia outright, and the reader already records both into `properties: physics:` in PartCAD's units. There is no weight to derive there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X42sdohAMTb2XVscT4zNvh)_