### PR TITLE
Fix the `pc test` daemon hang, and stop the CLI waiting forever on a stalled service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -546,13 +546,20 @@ jobs:
           # Through 'bounded.sh', which aborts a command that stops making
           # progress and dumps every thread's stack -- see the file for why.
           #
-          # KNOWN OPEN: on 'ubuntu-24.04-arm' the 'test' command below stops
-          # producing output shortly after '//pub/examples/partcad/produce_assembly_urdf'
-          # and never resumes; the same commands pass on 'ubuntu-latest' (x86_64)
-          # in the same run, on both sandbox Pythons. Every version-bump CI run
-          # on 'devel' from 0.8.19 onward ended up cancelled on it. The wrapper
-          # does not fix that hang. It makes the next occurrence say where the
-          # threads are stopped, which is what nobody has had so far.
+          # The hang this wrapper was written for is fixed: 'pc test' admitted
+          # its tests through a plain 'asyncio.Semaphore', and 'CamTest' runs the
+          # whole suite over everything an assembly is procured from from inside
+          # the call that semaphore had already admitted. Once as many callers as
+          # 'threadsMax' were each waiting on such a nested run, every permit was
+          # held by somebody waiting for a permit; the loop stopped, the daemon
+          # never answered 'test.run', and the CLI sat in 'framing.read_message'
+          # until this wrapper's bound. See 'partcad.concurrency.ReentrantGate'.
+          #
+          # The wrapper stays. It is the bound that turned that into a reported
+          # failure with a traceback rather than a job cancelled at
+          # 'timeout-minutes' with the log ending mid-sentence -- which is how
+          # every version-bump run on 'devel' from 0.8.19 onward ended, and how
+          # the next hang would end without it.
           ../dev-tools/ci/bounded.sh coverage run --rcfile=../dev-tools/coverage.rc --data-file=.coverage.1 -m partcad_cli.click.command --no-ansi list all -r //pub/examples/partcad
           # TODO(clairbee): Limit RAM usage by restricting the number of threads?
           ../dev-tools/ci/bounded.sh coverage run --rcfile=../dev-tools/coverage.rc --data-file=.coverage.2 -m partcad_cli.click.command --no-ansi --threads-max 4 test -r --package //pub/examples/partcad

--- a/src/partcad/AGENTS.md
+++ b/src/partcad/AGENTS.md
@@ -46,6 +46,16 @@ isort --check src/partcad tests/partcad
   it waits for its parts, and each of those takes a thread from the constrained one -- assemblies waiting there
   is how enough of them at once run it out of threads, every one waiting for a part with nowhere left to run.
 
+- **Admission limits**: `threadsMax` also caps how many tests and how many linting checks run at once, and both
+  go through `concurrency.ReentrantGate` rather than a bare `asyncio.Semaphore`. A check may run the other
+  checks itself -- `CamTest` runs the whole suite over everything an assembly is procured from, from inside the
+  call the gate has already admitted -- so nested work is charged to the permit its caller already holds. A
+  semaphore counts it as a new arrival instead, and once as many callers as the limit are each waiting on a
+  nested call, every permit is held by somebody waiting for one and the loop stops for good. That is what hung
+  `pc test -r`, and with it the daemon serving it. The gate keeps one semaphore per event loop for the same
+  reason `sandbox_lock.py` polls: these are taken from several loops at once, and the daemon runs one
+  `asyncio.run()` per request, so a semaphore kept for the process belongs to whichever request created it.
+
 - **Sandbox concurrency**: a wrapper runs in a sandbox *environment* -- the runtime's own conda prefix, or the
   session v-env of a package that has requirements of its own -- and `sandbox_lock.py` is what holds those
   apart. `EnvironmentLock` is a readers/writer lock keyed on the environment's path: running a wrapper reads it,

--- a/src/partcad/concurrency.py
+++ b/src/partcad/concurrency.py
@@ -1,0 +1,88 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""Capping how much of one kind of work runs at once, without deadlocking on it.
+
+PartCAD gates its tests and its linting checks so that a recursive run does not
+start every check on every object of every package at once. The gate has to hold
+two properties that a bare :class:`asyncio.Semaphore` does not, and losing either
+one stops the event loop for good rather than slowing it down.
+
+**It is re-entrant.** A check may run the other checks itself: ``CamTest.test``
+walks everything an assembly is procured from and runs the whole suite over each
+of those objects, and it does that from inside the very call the gate has already
+admitted. A plain semaphore counts that nested call as a new arrival, so once as
+many callers as the limit are each waiting on a nested call, every permit is held
+by somebody waiting for a permit and nothing ever completes. Nested work is
+charged to the permit its caller already holds instead.
+
+**It is per event loop.** ``asyncio.Semaphore`` is not thread-safe and binds
+itself to the loop it first blocks on, while PartCAD runs an ``asyncio.run()``
+per worker thread (``ThreadPoolManager.run_async``) and the JSON-RPC daemon runs
+one per request. A single process-wide semaphore is therefore shared between
+loops that cannot see each other's waiters -- and, in a daemon, outlives the loop
+it was bound to, so the second command of a session is refused by a primitive
+belonging to the first command's closed loop.
+"""
+
+import asyncio
+import contextvars
+import os
+import threading
+import weakref
+
+
+def default_limit() -> int:
+    """How many operations to admit when nothing has said."""
+    return max(os.cpu_count() or 1, 8)
+
+
+class ReentrantGate:
+    """An admission limit that nested work passes straight through.
+
+    One instance per kind of work: the limits are unrelated, and so is the
+    question of whether a caller is already inside one.
+    """
+
+    def __init__(self, name: str):
+        # Whether the calling task is already inside this gate. A ContextVar
+        # rather than an attribute because the answer is per task: an
+        # asyncio.Task copies the context it is created in, so the tasks a check
+        # spawns inherit the admission of the check that spawned them, while a
+        # task started elsewhere on the same loop does not.
+        self._admitted = contextvars.ContextVar(name, default=False)
+        # Keyed weakly on the loop, so a loop that has been run and discarded
+        # takes its semaphore with it instead of leaving one behind for every
+        # request the daemon has ever served.
+        self._semaphores: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
+        # A plain lock around that mapping, because the loops reaching it are on
+        # different threads and 'WeakKeyDictionary' is not thread-safe. It is
+        # never held across an await -- only for the lookup.
+        self._lock = threading.Lock()
+
+    def _semaphore(self, limit) -> asyncio.Semaphore:
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            semaphore = self._semaphores.get(loop)
+            if semaphore is None:
+                semaphore = asyncio.Semaphore(limit if limit else default_limit())
+                self._semaphores[loop] = semaphore
+            return semaphore
+
+    async def run(self, limit, func, *args, **kwargs):
+        """Await ``func(*args, **kwargs)``, admitting at most ``limit`` at once.
+
+        A caller already admitted by this gate is not counted again -- it is the
+        same unit of work, further in.
+        """
+        if self._admitted.get():
+            return await func(*args, **kwargs)
+
+        async with self._semaphore(limit):
+            token = self._admitted.set(True)
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                self._admitted.reset(token)

--- a/src/partcad/lint/lint.py
+++ b/src/partcad/lint/lint.py
@@ -1,20 +1,23 @@
 import json
-import asyncio
 from enum import Enum
 from abc import ABC, abstractmethod
 
 from ..project import Project
 from ..context import Context
 from .. import logging as pc_logging
+from ..concurrency import ReentrantGate
 from partcad.cache_hash import CacheHash
+
+# Separate from the tests' gate: the two limits are unrelated. Per loop for the
+# same reason, though -- the daemon runs one 'asyncio.run()' per request, so a
+# semaphore kept in a class attribute belongs to whichever request created it
+# and refuses every request after that one.
+_gate = ReentrantGate("partcad.lint.concurrency")
 
 
 def semaphore_wrapper(f):
     async def wrapper(*args, **kwargs):
-        if Linting.semaphore is None:
-            Linting.semaphore = asyncio.Semaphore(Linting.MAX_CONCURRENT_CHECKS)
-        async with Linting.semaphore:
-            return await f(*args, **kwargs)
+        return await _gate.run(Linting.MAX_CONCURRENT_CHECKS, f, *args, **kwargs)
 
     return wrapper
 
@@ -47,7 +50,6 @@ class LintingReport:
 
 
 class Linting(ABC):
-    semaphore = None
     MAX_CONCURRENT_CHECKS = None
 
     def __init__(self, name: str) -> None:

--- a/src/partcad/test/test.py
+++ b/src/partcad/test/test.py
@@ -9,17 +9,24 @@
 
 from abc import ABC, abstractmethod
 import copy
-import asyncio
 
 from .. import logging as pc_logging
+from ..concurrency import ReentrantGate
+
+# Shared by every Test, because MAX_CONCURRENT_TESTS is a cap on tests as a
+# whole rather than on any one of them.
+#
+# Re-entrant, and it has to be: 'CamTest.test' runs the whole suite over every
+# object the assembly under test is procured from, from inside the call this
+# gate has already admitted. Counting those nested runs as new arrivals is what
+# used to wedge 'pc test -r' for good -- with every permit held by a caller
+# waiting for a permit, no test ever finished and the daemon stopped answering.
+_gate = ReentrantGate("partcad.test.concurrency")
 
 
 def semaphore_wrapper(f):
     async def wrapper(*args, **kwargs):
-        if Test.semaphore is None:
-            Test.semaphore = asyncio.Semaphore(Test.MAX_CONCURRENT_TESTS)
-        async with Test.semaphore:
-            return await f(*args, **kwargs)
+        return await _gate.run(Test.MAX_CONCURRENT_TESTS, f, *args, **kwargs)
 
     return wrapper
 
@@ -30,8 +37,6 @@ class Test(ABC):
     TEST_FAILED = False
     TEST_PASSED = True
     MAX_CONCURRENT_TESTS = None
-
-    semaphore = None
 
     def __init__(self, name: str) -> None:
         self.name = name

--- a/src/partcad_cli/click/service.py
+++ b/src/partcad_cli/click/service.py
@@ -81,6 +81,13 @@ def run(cli_ctx, method: str, params: dict = None, span_name: str = None, needs_
                 )
                 call_params["context"] = result.get("context")
             return conn.call(method, call_params, on_event=_on_event)
+    except _client.DaemonStalled as e:
+        # The command is over either way; this only decides how it reads. A
+        # ClickException exits 1 with one line, where the traceback a bare
+        # RuntimeError produces would bury the report the client has already
+        # written to the log -- and would suggest a fault in the CLI rather than
+        # in the service it was waiting for.
+        raise click.ClickException(str(e))
     except _client.DaemonError as e:
         code = getattr(e, "code", None)
         if code == _INVALID_CONFIG:

--- a/src/partcad_client/client.py
+++ b/src/partcad_client/client.py
@@ -20,13 +20,38 @@ JSON-RPC and delivers server notifications to an optional callback while waiting
 for the matching response.
 """
 
+import logging
 import os
 import socket
 import subprocess
 import sys
+import threading
+import time
 from typing import Callable, Optional
 
 from partcad_utils.framing import read_message, write_message
+from partcad_utils.workspace import pid_path
+
+_logger = logging.getLogger(__name__)
+
+# How long the service may say *nothing at all* before the client stops waiting
+# for it.
+#
+# A bound on silence, not on the operation. A recursive render or test runs for
+# many minutes and is meant to; what it also does is stream a log event for
+# every action it takes, so a healthy command is never quiet for long. A daemon
+# that has stopped -- deadlocked, or waiting on something that is not coming --
+# is quiet forever, and until this bound existed so was the client: in CI that
+# cost the job's own 40-minute watchdog and a run reported as cancelled with the
+# log ending mid-sentence, and at a terminal it cost the session.
+#
+# Five minutes, because the quiet stretch to beat is one big shape being built
+# in a sandbox, which says nothing between starting and finishing.
+DEFAULT_IDLE_TIMEOUT = 300.0
+
+# How often the stdio watchdog looks at the clock. Only the coarseness of the
+# bound, not its length -- see '_watch_for_stall'.
+_STALL_POLL_SECONDS = 1.0
 
 
 class DaemonError(RuntimeError):
@@ -36,6 +61,27 @@ class DaemonError(RuntimeError):
         super().__init__(error.get("message", "service error"))
         self.code = error.get("code")
         self.data = error.get("data")
+
+
+class DaemonStalled(RuntimeError):
+    """The service stopped saying anything before it answered.
+
+    Distinct from :class:`DaemonError`, which is the service answering with an
+    error, and from a closed connection, which is it going away. This is it
+    still being there and no longer talking.
+    """
+
+
+def idle_timeout() -> float:
+    """The silence bound in seconds; zero or less waits forever, as before."""
+    raw = os.environ.get("PC_DAEMON_IDLE_TIMEOUT")
+    if raw is None or not raw.strip():
+        return DEFAULT_IDLE_TIMEOUT
+    try:
+        return float(raw)
+    except ValueError:
+        _logger.warning("PC_DAEMON_IDLE_TIMEOUT is not a number of seconds (%r); using %gs.", raw, DEFAULT_IDLE_TIMEOUT)
+        return DEFAULT_IDLE_TIMEOUT
 
 
 def launcher_argv() -> list:
@@ -90,33 +136,168 @@ def _launcher_output(result: subprocess.CompletedProcess) -> str:
 
 
 class DaemonClient:
-    """A framed JSON-RPC client over a single service connection."""
+    """A framed JSON-RPC client over a single service connection.
 
-    def __init__(self, read_stream, write_stream, closer: Optional[Callable[[], None]] = None):
+    ``timeout`` is how long the service may say nothing before the client gives
+    up on it; see :data:`DEFAULT_IDLE_TIMEOUT`. ``endpoint`` is how it is
+    reached, and is only used to say so when it stops answering -- a socket path
+    there is also where its logs and its pid file are.
+
+    How the wait is bounded depends on what the connection is made of, so the
+    connector says. A socket can simply be given a timeout, and a read that
+    reaches it raises. A pipe cannot -- ``select`` does not take one on Windows,
+    which is the platform the stdio channel exists for -- so the connector
+    passes ``interrupt``, a way to unblock a read that is never going to return,
+    and a watchdog calls it. Neither is offered for the Windows named pipe,
+    which nothing reaches this class through today.
+    """
+
+    def __init__(
+        self,
+        read_stream,
+        write_stream,
+        closer: Optional[Callable[[], None]] = None,
+        timeout: Optional[float] = None,
+        endpoint: Optional[str] = None,
+        interrupt: Optional[Callable[[], None]] = None,
+    ):
         self._read = read_stream
         self._write = write_stream
         self._closer = closer
         self._next_id = 0
+        self._timeout = timeout or 0.0
+        self._endpoint = endpoint
+        self._interrupt = interrupt
+        # Written by the request thread on every message and read by the
+        # watchdog. A float assignment is atomic under the GIL and the watchdog
+        # only ever compares it against the clock, so this needs no lock.
+        self._last_heard = 0.0
+        self._stall: Optional[str] = None
 
     def call(self, method: str, params=None, on_event: Optional[Callable[[str, object], None]] = None):
-        """Send a request; forward notifications to ``on_event`` until the response."""
+        """Send a request; forward notifications to ``on_event`` until the response.
+
+        Raises :class:`DaemonStalled` if the service says nothing for longer
+        than this client's timeout, :class:`DaemonError` if it answers with an
+        error, and ``RuntimeError`` if it closes the connection.
+        """
         self._next_id += 1
         request_id = self._next_id
         # Only default when params is absent: an explicit [] or {} is a valid
         # (empty positional / empty named) parameter list and must be preserved.
         request = {"jsonrpc": "2.0", "id": request_id, "method": method}
         request["params"] = {} if params is None else params
-        write_message(self._write, request)
-        while True:
-            message = read_message(self._read)
-            if message is None:
-                raise RuntimeError("the PartCAD service closed the connection")
-            if message.get("id") == request_id and ("result" in message or "error" in message):
-                if "error" in message:
-                    raise DaemonError(message["error"])
-                return message.get("result")
-            if "method" in message and "id" not in message and on_event is not None:
-                on_event(message["method"], message.get("params"))
+        self._stall = None
+        self._last_heard = time.monotonic()
+
+        stop = threading.Event()
+        watchdog = None
+        if self._timeout > 0 and self._interrupt is not None:
+            watchdog = threading.Thread(
+                target=self._watch_for_stall, args=(method, stop), name="partcad-service-watchdog", daemon=True
+            )
+            watchdog.start()
+        try:
+            try:
+                write_message(self._write, request)
+            except TimeoutError as e:
+                # The service is not reading. Rare -- a request is small enough
+                # to fit in the socket buffer whatever the service is doing --
+                # but it is the same stall seen from the other end.
+                raise self._stalled(method, "sending") from e
+
+            while True:
+                try:
+                    message = read_message(self._read)
+                except TimeoutError as e:
+                    raise self._stalled(method, "waiting for an answer") from e
+                self._last_heard = time.monotonic()
+                if message is None:
+                    # The watchdog closes the connection to break the read, so
+                    # an end of stream it caused is a stall rather than the
+                    # service having gone away of its own accord.
+                    if self._stall is not None:
+                        raise DaemonStalled(self._stall)
+                    raise RuntimeError("the PartCAD service closed the connection")
+                if message.get("id") == request_id and ("result" in message or "error" in message):
+                    if "error" in message:
+                        raise DaemonError(message["error"])
+                    return message.get("result")
+                if "method" in message and "id" not in message and on_event is not None:
+                    on_event(message["method"], message.get("params"))
+        finally:
+            stop.set()
+            if watchdog is not None:
+                watchdog.join(timeout=_STALL_POLL_SECONDS * 2)
+
+    def _watch_for_stall(self, method: str, stop: threading.Event) -> None:
+        """Unblock a read that the service is never going to satisfy.
+
+        Polls rather than arming a timer for the deadline, because the deadline
+        moves: every notification the service sends is a sign of life and pushes
+        it out again. The poll interval is how late the report can be, not how
+        long the wait is.
+        """
+        while not stop.wait(_STALL_POLL_SECONDS):
+            silent_for = time.monotonic() - self._last_heard
+            if silent_for < self._timeout:
+                continue
+            self._stall = self._stall_report(method, silent_for, "waiting for an answer")
+            try:
+                self._interrupt()
+            except Exception:  # pylint: disable=broad-except
+                # Nothing left to try: the read stays blocked and the caller
+                # waits, but the report above has already been made.
+                pass
+            return
+
+    def _stalled(self, method: str, doing: str) -> "DaemonStalled":
+        """Report the stall loudly and return the error to raise for it."""
+        return DaemonStalled(self._stall_report(method, self._timeout, doing))
+
+    def _stall_report(self, method: str, silent_for: float, doing: str) -> str:
+        """Say what stopped, for how long, and where to look -- to the log and
+        to the caller.
+
+        Written to the log as well as carried by the exception because the two
+        are read in different places: the exception ends the command, while the
+        log line lands in the output stream at the moment it happened, which in
+        a CI job is directly under the last thing the service managed to say.
+        """
+        summary = "The PartCAD service stopped responding: nothing for %gs while %s for '%s'." % (
+            silent_for,
+            doing,
+            method,
+        )
+        _logger.error("%s\n%s", summary, self._where_to_look())
+        return summary
+
+    def _where_to_look(self) -> str:
+        """Where the stalled service is, and what it left behind.
+
+        Its endpoint, its process, and the directory it logs into -- named
+        rather than read, so that this stays a few stat() calls and says
+        something useful even when the service is too wedged to have written
+        anything recently.
+        """
+        lines = []
+        if self._endpoint:
+            lines.append("  endpoint:  %s" % self._endpoint)
+        # The logs and the pid file sit beside the socket; a named pipe has no
+        # directory to look in, so there is nothing to point at there.
+        if self._endpoint and not self._endpoint.startswith("\\\\.\\pipe\\"):
+            wdir = os.path.dirname(self._endpoint)
+            if wdir:
+                lines.append("  logs:      %s" % wdir)
+                try:
+                    with open(pid_path(wdir), encoding="utf-8") as f:
+                        pid = f.read().strip()
+                except OSError:
+                    pid = ""
+                if pid:
+                    lines.append("  process:   %s (its stacks say where it stopped)" % pid)
+        lines.append("  'pc daemon stop' clears it; PC_DAEMON_IDLE_TIMEOUT=<seconds> waits longer, 0 forever.")
+        return "\n".join(lines)
 
     def close(self) -> None:
         if self._closer is not None:
@@ -130,9 +311,15 @@ def _connect_socket(cwd: Optional[str], extra_args) -> DaemonClient:
     path = start_daemon(cwd, extra_args)
     if path.startswith("\\\\.\\pipe\\"):  # Windows named pipe
         stream = open(path, "r+b", buffering=0)  # pragma: no cover - Windows only
-        return DaemonClient(stream, stream, closer=stream.close)
+        return DaemonClient(stream, stream, closer=stream.close, endpoint=path)
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(path)
+    # Set before makefile(): a socket may carry a timeout under a file object
+    # (only a non-blocking one may not), and a read that reaches it raises
+    # TimeoutError, which is what 'call' turns into the report. The buffer is
+    # left in an undefined state by a read that times out, which costs nothing
+    # here because a client that has given up on this connection closes it.
+    sock.settimeout(idle_timeout())
     stream = sock.makefile("rwb")
 
     def closer():
@@ -141,7 +328,7 @@ def _connect_socket(cwd: Optional[str], extra_args) -> DaemonClient:
         finally:
             sock.close()
 
-    return DaemonClient(stream, stream, closer=closer)
+    return DaemonClient(stream, stream, closer=closer, timeout=idle_timeout(), endpoint=path)
 
 
 def _connect_stdio(cwd: Optional[str], extra_args) -> DaemonClient:
@@ -165,7 +352,24 @@ def _connect_stdio(cwd: Optional[str], extra_args) -> DaemonClient:
             except Exception:  # pylint: disable=broad-except
                 pass
 
-    return DaemonClient(proc.stdout, proc.stdin, closer=closer)
+    def interrupt():
+        # Killing it is what ends the read: a pipe takes no timeout, and this
+        # service is a child of this process and serves nobody else, so there is
+        # nothing here to take away from anyone. The socket daemon is the
+        # opposite on both counts, which is why it is bounded with a timeout
+        # instead of being stopped from under whoever else is using it.
+        proc.kill()
+
+    return DaemonClient(
+        proc.stdout,
+        proc.stdin,
+        closer=closer,
+        timeout=idle_timeout(),
+        # Not a path: this service listens nowhere and logs to this process's
+        # stderr, so its pid is the whole of what there is to point at.
+        endpoint="stdio, pid %d" % proc.pid,
+        interrupt=interrupt,
+    )
 
 
 def connect(cwd: Optional[str] = None, extra_args=()) -> DaemonClient:

--- a/tests/partcad/unit/test_concurrency.py
+++ b/tests/partcad/unit/test_concurrency.py
@@ -1,0 +1,156 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The admission gate that 'pc test' and 'pc lint' run behind.
+
+Every case here is written against a wall clock, because what is being tested is
+that something completes at all. A regression does not make these slow, it makes
+them never return -- so each one is driven through 'asyncio.wait_for()' and a
+timeout is the failure.
+"""
+
+import asyncio
+
+import pytest
+
+from partcad.concurrency import ReentrantGate
+from partcad.test.test import Test
+
+
+def test_nested_admission_does_not_deadlock():
+    """A gated call made from inside a gated call must pass straight through.
+
+    Regression (the 'Examples (PartCAD)' hang on 'ubuntu-24.04-arm'): 'CamTest'
+    runs the whole suite over every object an assembly is procured from, from
+    inside the call the gate has already admitted. While the gate was a plain
+    'asyncio.Semaphore', as many of those as the limit allowed would each hold a
+    permit while waiting for one, and 'pc test -r' stopped for good -- taking the
+    daemon's answer with it, so the CLI waited on a response that never came.
+    """
+    limit = 4
+    gate = ReentrantGate("test.nested")
+
+    async def leaf():
+        return 1
+
+    async def branch():
+        # As many nested calls as the limit, from as many admitted callers.
+        return sum(await asyncio.gather(*(gate.run(limit, leaf) for _ in range(limit))))
+
+    async def main():
+        return await asyncio.gather(*(gate.run(limit, branch) for _ in range(limit)))
+
+    assert asyncio.run(asyncio.wait_for(main(), timeout=30)) == [limit] * limit
+
+
+def test_admission_is_capped_for_unrelated_callers():
+    """Nested calls are free; independent ones still queue behind the limit."""
+    limit = 2
+    gate = ReentrantGate("test.capped")
+    live = 0
+    peak = 0
+
+    async def work():
+        nonlocal live, peak
+        live += 1
+        peak = max(peak, live)
+        await asyncio.sleep(0.01)
+        live -= 1
+
+    async def main():
+        await asyncio.gather(*(gate.run(limit, work) for _ in range(10)))
+
+    asyncio.run(asyncio.wait_for(main(), timeout=30))
+    assert peak == limit
+
+
+def test_a_sibling_task_is_not_admitted_by_its_neighbour():
+    """The admission a task inherits is its caller's, not any task's.
+
+    'asyncio.Task' copies the context it is created in, which is what carries the
+    admission into nested work. A task created outside an admitted call carries
+    nothing, or the cap would evaporate the moment anything was admitted at all.
+    """
+    gate = ReentrantGate("test.sibling")
+    order = []
+
+    async def slow(tag):
+        order.append(tag)
+        await asyncio.sleep(0.05)
+
+    async def main():
+        first = asyncio.create_task(gate.run(1, slow, "first"))
+        await asyncio.sleep(0)  # let 'first' take the only permit
+        second = asyncio.create_task(gate.run(1, slow, "second"))
+        await asyncio.gather(first, second)
+
+    asyncio.run(asyncio.wait_for(main(), timeout=30))
+    # 'second' had to wait for 'first' rather than being waved through.
+    assert order == ["first", "second"]
+
+
+def test_each_loop_gets_its_own_semaphore():
+    """A gate survives the loop it was first used on.
+
+    The daemon runs one 'asyncio.run()' per request, so a semaphore kept for the
+    process belongs to whichever request created it: 'asyncio.Semaphore' binds
+    itself to the loop it first blocks on and refuses every later one.
+    """
+    gate = ReentrantGate("test.per_loop")
+
+    async def contend():
+        # Blocking on the semaphore is what binds it to a loop, so contend.
+        await asyncio.gather(*(gate.run(1, asyncio.sleep, 0) for _ in range(4)))
+
+    for _ in range(3):
+        asyncio.run(asyncio.wait_for(contend(), timeout=30))
+
+
+class _RecursiveTest(Test):
+    """A stand-in for 'CamTest', which tests the objects an assembly is made of."""
+
+    async def test(self, tests_to_run, ctx, shape, test_ctx={}):
+        children = shape.get("children", [])
+        results = await asyncio.gather(
+            *(t.test_cached(tests_to_run, ctx, child, test_ctx) for child in children for t in tests_to_run)
+        )
+        return self.TEST_PASSED if all(results) else self.TEST_FAILED
+
+
+class _NoCacheShape(dict):
+    hash = "hash"
+    name = "shape"
+    project_name = "pkg"
+
+    def get_cacheable(self):
+        return False
+
+
+def test_recursive_test_cached_completes():
+    """The real 'Test.test_cached' wrapper, nested the way 'CamTest' nests it."""
+    Test.MAX_CONCURRENT_TESTS = 4
+    suite = [_RecursiveTest("cam")]
+
+    def assembly():
+        return _NoCacheShape(children=[_NoCacheShape() for _ in range(4)])
+
+    async def main():
+        return await asyncio.gather(
+            *(suite[0].test_cached(suite, None, assembly()) for _ in range(Test.MAX_CONCURRENT_TESTS))
+        )
+
+    results = asyncio.run(asyncio.wait_for(main(), timeout=60))
+    assert results == [Test.TEST_PASSED] * Test.MAX_CONCURRENT_TESTS
+
+
+@pytest.mark.parametrize("limit", [None, 0])
+def test_an_unset_limit_still_admits(limit):
+    """'MAX_CONCURRENT_TESTS' is None until 'partcad.test.all.tests()' sets it."""
+    gate = ReentrantGate("test.unset")
+
+    async def main():
+        return await asyncio.gather(*(gate.run(limit, asyncio.sleep, 0) for _ in range(4)))
+
+    asyncio.run(asyncio.wait_for(main(), timeout=30))

--- a/tests/partcad/unit/test_test_cache.py
+++ b/tests/partcad/unit/test_test_cache.py
@@ -44,7 +44,9 @@ class _PassTest(Test):
 
 def _cache_read_identity(manufacturable):
     Test.MAX_CONCURRENT_TESTS = 8
-    Test.semaphore = None  # let each asyncio.run() build its own in its own loop
+    # No semaphore to reset between the two asyncio.run() calls below: the gate
+    # in 'partcad.concurrency' keeps one per loop, which is what a daemon
+    # serving a second command needs too.
     ctx = _FakeCtx()
     asyncio.run(_PassTest("cam").test_cached([], ctx, _FakeShape(manufacturable)))
     # The (shape_hash, (cache_key,)) the test looked up in the cache.

--- a/tests/partcad_client/test_client.py
+++ b/tests/partcad_client/test_client.py
@@ -5,6 +5,9 @@
 #
 """Tests for the DaemonClient (request/response + notification delivery)."""
 
+import io
+import logging
+import os
 import pathlib
 import shutil
 import socket
@@ -13,7 +16,8 @@ import threading
 import time
 
 import pytest
-from partcad_client.client import DaemonClient, DaemonError
+from partcad_client import client as client_module
+from partcad_client.client import DaemonClient, DaemonError, DaemonStalled
 from partcad_service_json_rpc.core import events
 from partcad_service_json_rpc.core.session import Session
 from partcad_service_json_rpc.transport.socket_server import SocketServer
@@ -124,3 +128,148 @@ def test_client_raises_daemon_error_on_error_response(socket_dir):
         client.close()
     finally:
         server.stop()
+
+
+def _stalling_client(path, timeout):
+    """A client bounded like the real socket one: a timeout on the socket."""
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(path)
+    sock.settimeout(timeout)
+    stream = sock.makefile("rwb")
+    return DaemonClient(
+        stream,
+        stream,
+        closer=lambda: (stream.close(), sock.close()),
+        timeout=timeout,
+        endpoint=path,
+    )
+
+
+def test_client_gives_up_on_a_service_that_stops_answering(socket_dir):
+    """A handler that never returns must not hold the client forever.
+
+    Regression: 'pc test' deadlocked inside the daemon, and because the client
+    waited on the response with no bound, the CLI sat in 'framing.read_message'
+    until CI's own watchdog killed the job 40 minutes later.
+    """
+    release = threading.Event()
+
+    def wedged(session, params):
+        release.wait(30)  # bounded so a failure here cannot hang the suite
+        return "eventually"
+
+    server, path = _serve(socket_dir, {"wedged": wedged})
+    try:
+        client = _stalling_client(path, 0.5)
+        started = time.monotonic()
+        with pytest.raises(DaemonStalled) as caught:
+            client.call("wedged")
+        waited = time.monotonic() - started
+        assert waited < 15, "gave up after %.1fs, which is not the bound it was given" % waited
+        # Says what stopped and what it was doing, so the report is actionable
+        # without the caller already knowing which command it was running.
+        assert "stopped responding" in str(caught.value)
+        assert "wedged" in str(caught.value)
+        client.close()
+    finally:
+        release.set()
+        server.stop()
+
+
+def test_the_stall_report_names_where_to_look(socket_dir, caplog):
+    """The loud half: the endpoint, the logs and the pid reach the log."""
+    release = threading.Event()
+    (socket_dir / "pid").write_text("4242", encoding="utf-8")
+
+    server, path = _serve(socket_dir, {"wedged": lambda s, p: release.wait(30)})
+    try:
+        client = _stalling_client(path, 0.5)
+        with caplog.at_level(logging.ERROR, logger="partcad_client.client"):
+            with pytest.raises(DaemonStalled):
+                client.call("wedged")
+        report = "\n".join(r.getMessage() for r in caplog.records)
+        assert path in report
+        assert str(socket_dir) in report
+        assert "4242" in report
+        assert "PC_DAEMON_IDLE_TIMEOUT" in report
+        client.close()
+    finally:
+        release.set()
+        server.stop()
+
+
+def test_a_long_but_talkative_call_is_not_cut_off(socket_dir):
+    """The bound is on silence, not on how long the operation takes.
+
+    A recursive render runs for minutes and streams an event per action while
+    it does. Every one of those pushes the deadline out, or the bound would be
+    a limit on how much work a command may do.
+    """
+
+    def slow(session, params):
+        for _ in range(6):
+            time.sleep(0.1)
+            session.emitter.emit(events.INFO, "still here")
+        return "done"
+
+    server, path = _serve(socket_dir, {"slow": slow})
+    try:
+        client = _stalling_client(path, 0.35)  # shorter than the whole call
+        seen = []
+        assert client.call("slow", {}, on_event=lambda m, p: seen.append(m)) == "done"
+        assert len(seen) == 6
+        client.close()
+    finally:
+        server.stop()
+
+
+def test_no_bound_is_applied_when_the_timeout_is_disabled(socket_dir, monkeypatch):
+    monkeypatch.setenv("PC_DAEMON_IDLE_TIMEOUT", "0")
+    assert client_module.idle_timeout() == 0.0
+
+
+def test_the_default_bound_is_used_when_the_setting_is_not_a_number(socket_dir, monkeypatch):
+    monkeypatch.setenv("PC_DAEMON_IDLE_TIMEOUT", "soon")
+    assert client_module.idle_timeout() == client_module.DEFAULT_IDLE_TIMEOUT
+
+
+def test_the_bound_can_be_set_from_the_environment(socket_dir, monkeypatch):
+    monkeypatch.setenv("PC_DAEMON_IDLE_TIMEOUT", "12.5")
+    assert client_module.idle_timeout() == 12.5
+
+
+def test_a_stalled_stdio_service_is_interrupted_rather_than_waited_on():
+    """The other half of the bound, for a channel that takes no timeout.
+
+    The stdio service is reached over pipes, which cannot carry a timeout the
+    way a socket can, so a watchdog ends the read instead. It is allowed to be
+    this blunt only because that service is a child of this process and serves
+    nobody else.
+    """
+    read_fd, write_fd = os.pipe()
+    read_stream = os.fdopen(read_fd, "rb")
+    killed = threading.Event()
+
+    def interrupt():
+        killed.set()
+        os.close(write_fd)  # what 'proc.kill()' amounts to for the read
+
+    client = DaemonClient(
+        read_stream,
+        io.BytesIO(),
+        timeout=0.2,
+        endpoint="stdio, pid 4242",
+        interrupt=interrupt,
+    )
+    try:
+        started = time.monotonic()
+        with pytest.raises(DaemonStalled) as caught:
+            client.call("wedged")
+        assert time.monotonic() - started < 15
+        assert killed.is_set(), "the watchdog never interrupted the read"
+        # Not reported as the service closing the connection: it did not, this
+        # client closed it, and saying otherwise sends the reader looking for a
+        # crash that never happened.
+        assert "stopped responding" in str(caught.value)
+    finally:
+        read_stream.close()


### PR DESCRIPTION
## Copilot Summary

`Examples (PartCAD)` on `ubuntu-24.04-arm` has been hanging since 0.8.19: `pc test -r` stops producing output, the job is killed at `timeout-minutes`, and the whole CI run is reported as *cancelled*. This fixes the deadlock behind it, and separately stops the CLI from waiting forever whenever the service stalls for any other reason.

### What was actually happening

`client.py:111` is the symptom, not the cause. The CLI was waiting on a `test.run` response the daemon was never going to send.

The artifact `dev-tools/ci/bounded.sh` captured (job `100499608371`, run `33707458906`) pins it down:

* the fault-handler dump shows a **single-threaded** client blocked in `recv`;
* job cleanup reports exactly **one** orphan python — so the daemon was alive and idle, with no children;
* the last thing it logged is `INFO:partcad:Git operations: 28`, which is `core/operations.py:908` — the line immediately before `asyncio.run(_test_async(...))`.

The daemon entered the test run and never came back. Both arm cells failed, 3.11 and 3.14, so it was never sandbox-Python-specific.

The deadlock:

* `Test.test_cached` is wrapped by `semaphore_wrapper`, which admits at most `MAX_CONCURRENT_TESTS` callers through one process-wide `asyncio.Semaphore`.
* `CamTest.test` (`test/cam.py:312`) runs the **whole suite over every object the assembly under test is procured from** — from inside the call that semaphore has already admitted.
* The semaphore counts each nested run as a new arrival. Once as many callers as the limit are each waiting on one, every permit is held by somebody waiting for a permit. Nothing completes, the loop stops, the daemon never answers.

Which callers end up admitted is a matter of scheduling, which is why one runner loses this consistently and another never does.

### The fix (commit 1)

Admission moves to a new `partcad/concurrency.py::ReentrantGate`:

* **Re-entrant** — nested work is charged to the permit its caller already holds. Admission is a `ContextVar`, so it reaches the tasks a caller creates and no further; a task started elsewhere on the same loop still queues. The heavy CAD work was never bounded by this semaphore anyway — `ThreadPoolManager`'s executors and `process_slots` bound that.
* **Per event loop** — `asyncio.Semaphore` binds to the loop it first blocks on and is not thread-safe, while PartCAD runs an `asyncio.run()` per worker thread and the daemon one per request. A semaphore kept in a class attribute belongs to whichever request created it. `tests/partcad/unit/test_test_cache.py` had been resetting `Test.semaphore` by hand between two `asyncio.run()` calls to work around exactly this; that workaround is gone.

`lint/lint.py` had the identical gate written the same way and gets the same treatment. Nothing there is re-entrant today, but the per-loop half applies as it stands: a warm daemon's second `pc lint` was being admitted by a primitive belonging to the first one's closed loop.

The `KNOWN OPEN` note in `test.yml` is replaced with what it turned out to be; the `bounded.sh` wrapper stays, because it is the bound that turns a hang into a reported failure with a traceback instead of a cancelled run.

### Not waiting forever (commit 2)

The deadlock is fixed, but nothing stopped the next stall costing the same 40 minutes, and the report named only the client — the service's half was in another process nobody had been told to look at.

`DaemonClient.call` now bounds how long the service may say **nothing**. Not how long the operation may take: a recursive render runs for many minutes and streams a log event per action while it does, so every notification pushes the deadline out. Five minutes by default (the quiet stretch to beat is one large shape being built in a sandbox); `PC_DAEMON_IDLE_TIMEOUT` sets it, or waits forever at `0`.

Bounded differently per channel because the channels differ: a socket takes a timeout, so `_connect_socket` gives it one; a pipe does not (`select` takes none on Windows, which is the platform the stdio channel exists for), so a watchdog ends the read by killing the service. That is acceptable only there — the stdio service is a child of this process serving nobody else, while the socket daemon is shared per workspace.

The report is written twice on purpose: to the log at the moment it happens, where in CI it lands directly under the last thing the service managed to say, naming the endpoint, the directory it logs into and its pid — so the next occurrence can be answered with that process's stacks. And carried by a new `DaemonStalled`, which `partcad_cli.click.service` renders as a `ClickException` (one line, exit 1) rather than a traceback that would read as a fault in the CLI. It is deliberately neither `DaemonError` (the service answering with an error) nor the closed-connection error (it going away) — this is it still being there and no longer talking.

### Verification

* `tests/partcad/unit/test_concurrency.py` covers nested admission, the cap that still applies to unrelated callers, a sibling task that must not inherit an admission, reuse across loops, and the real `Test.test_cached` nested the way `CamTest` nests it. Each is driven through `asyncio.wait_for()`, because a regression here does not make them slow — it makes them never return. `test_recursive_test_cached_completes` **times out against the unfixed tree** and passes with the fix.
* `tests/partcad_client/test_client.py` covers a handler that never returns being given up on, the report naming endpoint/logs/pid, the stdio watchdog, and the case the bound must not break — a call that runs longer than the timeout while streaming events, which completes.
* Full `tests/partcad/unit`: **1702 passed** vs **1695** on `devel` (the seven new cases), with the **same 36 failures on both** — all pre-existing environmental ones (CAD sandbox, git network, docker) that the dev environment used here cannot run. The baseline was run explicitly to confirm no new failures.
* `partcad_client` 230, `partcad_cli` 129, `partcad_service_json_rpc` 250, `partcad_utils` 70 — all pass. `black` clean on every file touched. A real `pc list parts` still makes its round trip through a live daemon.

One caveat worth stating: `pre-commit` could not run here (no Docker for the dev container), so the equivalent checks were run by hand. `src/partcad/lint/lint.py` fails `black`/`isort` both before and after this change, so its pre-existing formatting was left alone rather than adding unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cpuPFRhcrnmcBzrgBJkTg

---
_Generated by [Claude Code](https://claude.ai/code/session_015cpuPFRhcrnmcBzrgBJkTg)_