### PR TITLE
Stop the IDE and its daemon before uninstalling it

### DIFF
--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -912,6 +912,65 @@ jobs:
       - name: Uninstall with install.sh
         shell: bash
         run: |
+          # Nothing may still be running out of the tree about to be removed.
+          # The editor and the `pc` daemon it starts both live in it and both
+          # keep writing into it -- logs, workspace state, the directory the
+          # frozen bundle unpacks itself into -- and a file appearing under a
+          # directory while `rm -rf` walks it is how the removal ends in
+          # "Directory not empty" with the directory still there.
+          #
+          # "Start it once" above already signals the editor, from the `trap
+          # diagnose EXIT` in it. That is not enough here for two reasons:
+          # `pkill` returns when the signal has been sent rather than when the
+          # process is gone, so the uninstall starts while Electron is still
+          # shutting down and still writing; and the pattern matches the editor
+          # only, leaving the daemon behind it running. The Windows half of this
+          # workflow has had the shape this needs from the start -- it stops the
+          # editor in a `finally` and then waits for the directory to go -- and
+          # this is the same idea for the half that has an extra process to
+          # stop.
+          #
+          # `pc daemon stop` is per workspace, so it has to run in the one the
+          # IDE opened on its first start rather than in the checkout; from here
+          # it would stop a daemon for this repository, which is not the one
+          # holding the tree open. Asking nicely first, signalling after: a
+          # daemon told to stop closes its socket and removes its own state,
+          # which a signal in the middle of a write does not.
+          #
+          # It is bounded rather than instant -- against a daemon that has itself
+          # stopped answering, this is the CLI's own timeout rather than a hang,
+          # which is what makes it safe to run here at all. The signals below are
+          # sent either way, so a stop that times out still ends with both
+          # processes gone.
+          starter="${HOME}/.partcad/projects/start"
+          if [ -x "${HOME}/partcad-bin/pc" ] && [ -d "${starter}" ]; then
+            (cd "${starter}" && "${HOME}/partcad-bin/pc" --no-ansi daemon stop) || true
+          fi
+          pkill -if "partcad.ide" || true
+          # And the daemon by name, exactly: it is `pc`, as the "Terminate
+          # orphan process: pid (NNNN) (pc)" line at the end of a failed run
+          # says. Whatever `pc daemon stop` did or did not manage, this is what
+          # makes the wait below terminate.
+          pkill -x pc || true
+
+          # Then wait for both to actually be gone. Thirty seconds is far more
+          # than either needs; the point is to fail with something legible if
+          # one of them will not go, rather than to let the removal below fail
+          # on a directory that is still being written to.
+          gone=""
+          for _ in $(seq 30); do
+            if ! pgrep -if "partcad.ide" >/dev/null 2>&1 &&
+               ! pgrep -x pc >/dev/null 2>&1; then
+              gone="yes"
+              break
+            fi
+            sleep 1
+          done
+          if [ -z "${gone}" ]; then
+            echo "::warning::the editor or its daemon was still running 30s after being asked to stop"
+            ps ax | grep -i -e "partcad.ide" -e "[/ ]pc\b" | grep -v grep || true
+          fi
+
           sh install.sh --uninstall \
             --install-dir "${HOME}/partcad-standalone" \
             --bin-dir "${HOME}/partcad-bin" \

--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -954,21 +954,36 @@ jobs:
           pkill -x pc || true
 
           # Then wait for both to actually be gone. Thirty seconds is far more
-          # than either needs; the point is to fail with something legible if
-          # one of them will not go, rather than to let the removal below fail
-          # on a directory that is still being written to.
-          gone=""
-          for _ in $(seq 30); do
-            if ! pgrep -if "partcad.ide" >/dev/null 2>&1 &&
-               ! pgrep -x pc >/dev/null 2>&1; then
-              gone="yes"
-              break
-            fi
-            sleep 1
-          done
-          if [ -z "${gone}" ]; then
-            echo "::warning::the editor or its daemon was still running 30s after being asked to stop"
+          # than either needs, and reaching the end of it is not a reason to
+          # start removing the tree anyway: something still writing into it is
+          # the entire failure this step exists to avoid, so warning and then
+          # removing regardless would reproduce that failure with its diagnosis
+          # one step further away than it is now.
+          wait_gone() {
+            for _ in $(seq "$1"); do
+              if ! pgrep -if "partcad.ide" >/dev/null 2>&1 &&
+                 ! pgrep -x pc >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 1
+            done
+            return 1
+          }
+          if ! wait_gone 30; then
+            # SIGTERM was not enough. Nothing here has to shut down cleanly at
+            # this point: the daemon's state lives under `~/.partcad/workspaces`,
+            # outside every tree the uninstall removes, and a socket left behind
+            # by a killed daemon is one the next client probes and replaces
+            # rather than hangs on. So escalate, and wait again.
+            echo "::warning::the editor or its daemon was still running 30s after being asked to stop; killing it"
             ps ax | grep -i -e "partcad.ide" -e "[/ ]pc\b" | grep -v grep || true
+            pkill -9 -if "partcad.ide" || true
+            pkill -9 -x pc || true
+            if ! wait_gone 10; then
+              echo "::error::the editor or its daemon is still running after SIGKILL; refusing to remove a tree that is still being written to"
+              ps ax | grep -i -e "partcad.ide" -e "[/ ]pc\b" | grep -v grep || true
+              exit 1
+            fi
           fi
 
           sh install.sh --uninstall \


### PR DESCRIPTION
## Copilot Summary

`Install (linux-x86_64)` in the `IDE` workflow fails intermittently, in the uninstall step:

```
Removed /home/runner/partcad-bin/partcad-ide
rm: cannot remove '/home/runner/partcad-standalone/0.8.49-ide': Directory not empty
##[error]Process completed with exit code 1.
...
Cleaning up orphan processes
Terminate orphan process: pid (2362) (pc)
Terminate orphan process: pid (2744) (Xvfb)
Terminate orphan process: pid (2765) (partcad-ide)
```

Seen on `devel` at `330e488` ([IDE run 194](https://github.com/partcad/partcad/actions/runs/33828823852)) and again on #605, which is where it was diagnosed. It passed in run 193, so it is a race rather than a standing breakage.

### What is racing

The editor and the `pc` daemon it starts both run out of the tree `install.sh --uninstall` removes, and both keep writing into it — logs, workspace state, the directory the frozen bundle unpacks itself into. A file appearing under a directory while `rm -rf` walks it is how a removal ends in `ENOTEMPTY` with the directory still there.

`Start it once` does signal the editor already, from its `trap diagnose EXIT`. That is not enough, twice over:

1. **`pkill` returns when the signal is sent**, not when the process is gone, so the uninstall begins while Electron is still shutting down and still writing.
2. **The pattern matches the editor only** — `pkill -if "partcad.ide"` — leaving the daemon behind it running. That is the `pid (2362) (pc)` in the orphan list, and it is the one that outlives the editor.

### The fix

Stop both, then wait for them, at the top of `Uninstall with install.sh`.

`pc daemon stop` first, **run in the workspace the IDE opened** rather than in the checkout. That detail matters and is easy to get wrong: `pc daemon stop` is per workspace ("Stop the PartCAD daemon serving this workspace"), so from the checkout it would stop a daemon for this repository — not the one holding the tree open. It is bounded rather than instant against an unresponsive daemon, which is the CLI's own timeout from #603 rather than a hang, and that is what makes it safe to run here.

Then signal both by name, so a stop that timed out still ends with the process gone, and wait up to thirty seconds. If they will not go, the step says so and lists them — a legible failure, where a removal failing on a directory still being written to is not.

### Why this shape

The Windows half of this workflow has had it from the start: `Stop-Process -Name partcad-ide` in a `finally`, under the comment "the uninstaller below cannot remove an application that is running", followed by a poll for the directory to disappear. This is the same idea for the half that has a second process to stop.

macOS was never affected — all four macOS `Install` legs pass their uninstall step. Only the Linux leg starts the editor under `Xvfb` and gets far enough to leave a daemon behind.

### Validation

The changed step is shell in a workflow, so what can be checked without a runner was:

* `check-jsonschema --builtin-schema vendor.github-workflows` passes — the same check the `check-github-workflows` pre-commit hook runs.
* The step's script, extracted from the parsed YAML, passes `bash -n` and runs clean under `bash -eo pipefail` with the loop shortened: it finds nothing running, breaks on the first iteration, and does not trip the warning path.

Whether it closes the race can only be shown by the job itself, over a few runs — it is a timing bug that reproduces once in several.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZ3YceWNwRWCVDmvJGDpqp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZ3YceWNwRWCVDmvJGDpqp)_