### PR TITLE
CI: gate pull request and merge queue jobs on depth and on what a change touches

### DIFF
--- a/.github/actions/changed-scopes/action.yml
+++ b/.github/actions/changed-scopes/action.yml
@@ -166,8 +166,8 @@ runs:
         add() { case " ${buckets} " in *" $1 "*) ;; *) buckets="${buckets}$1 " ;; esac; }
 
         if [ "${ALL}" = "true" ]; then
-          add code; add docs; add ai; add devcontainer; add vscode; add ide
-          add packaging; add ci
+          add code; add deps; add docs; add ai; add devcontainer; add vscode
+          add ide; add packaging; add ci
         else
           while IFS= read -r f; do
             [ -n "${f}" ] || continue
@@ -215,14 +215,30 @@ runs:
               # Markdown file that turned out to be *data* under "src/" still
               # counts as code.
               add docs ;;
-            src/*|tests/*|features/*|cad/*|tools/*|dev-tools/*)
+            src/*|tests/*|features/*|cad/*|tools/*|dev-tools/*|conftest.py|behave.ini)
               add code ;;
+            pyproject.toml|poetry.lock|poetry.toml|requirements*.txt|requirements*.in)
+              # What PartCAD is built out of, as opposed to what it is. Only the
+              # root-level files: "*" matches "/" in a case pattern, so these
+              # patterns are anchored at the start of the path and the
+              # "requirements.txt" belonging to the docs, the dev container, the
+              # extension or a tool container is matched by its own directory's
+              # rule above.
+              #
+              # This is the bucket that separates a source change from a
+              # dependency change, which is the one distinction the standalone
+              # bundles turn on -- see the note on "bundle" below.
+              add deps ;;
             *.md|*.rst|LICENSE.txt|apache20.svg)
               add docs ;;
             *)
-              # Anything this action has not been taught, "pyproject.toml",
-              # "poetry.lock", "conftest.py" and "requirements*.txt" included.
-              add code ;;
+              # Anything this action has not been taught. Both buckets, not just
+              # "code": "code" alone would leave the bundles unbuilt for a path
+              # nobody has classified, and an unclassified path is exactly the
+              # one nobody has thought about. A file has to be *named* above as
+              # source before it stops being treated as something that can
+              # change what gets frozen.
+              add code; add deps ;;
             esac
           done < "${RUNNER_TEMP}/changed-files.txt"
         fi
@@ -235,19 +251,37 @@ runs:
         emit() { if any "${@:2}"; then echo "$1=true"; else echo "$1=false"; fi >> "${GITHUB_OUTPUT}"; }
 
         # Which buckets each subject listens to. "ci" is in every one of them.
-        emit wheel               code ci
+        emit wheel               code deps ci
         # Sphinx reads "docs/source" and nothing else -- "conf.py" enables no
         # extensions, so there is no autodoc pulling in the source tree.
         emit docs                docs ci
-        emit pytest              code ci
-        emit behave              code ci
-        emit examples            code ci
+        emit pytest              code deps ci
+        emit behave              code deps ci
+        emit examples            code deps ci
         # The dev container image is built from ".devcontainer" and installs the
-        # project into itself, so both matter to it.
-        emit devcontainer        code ci devcontainer
-        emit devcontainer-pytest code ci
-        # "src/**" is why the bundles are frozen at all; "packaging" is how.
-        emit bundle              code ci packaging
+        # project into itself, so all three matter to it.
+        emit devcontainer        code deps ci devcontainer
+        emit devcontainer-pytest code deps ci
+        # The one subject that does NOT listen to "code", and the only place a
+        # source change is treated differently from a dependency change.
+        #
+        # Freezing is the most expensive thing this repository does -- ~500MB of
+        # OpenCASCADE per runner, seven of them on a deep run -- and what makes a
+        # frozen bundle differ from a working wheel is almost always what went
+        # into it rather than what PartCAD does with it: a dependency that ships
+        # a data file PyInstaller cannot see, a new transitive import, a wheel
+        # with no build for one of the platforms. So a dependency change freezes,
+        # and a change to "src/" alone does not.
+        #
+        # It is a trade, and this is the other half of it: a source change *can*
+        # break the freeze (a lazily imported module, a file read relative to
+        # "__file__" -- see "dev-tools/pyinstaller/README.md"), and that is now
+        # found on the push to "devel" that follows the merge rather than on the
+        # pull request. The push trigger of "build-standalone.yml" still lists
+        # "src/**" for exactly this, a release still refuses to publish with a
+        # platform missing, and "#deepTest" builds the whole set before a merge
+        # for a change that warrants it.
+        emit bundle              deps ci packaging
         # Not "code": the IDE downloads the bundles rather than freezing them,
         # so what rebuilds it is the application around them.
         emit ide                 ci packaging vscode ide

--- a/.github/actions/changed-scopes/action.yml
+++ b/.github/actions/changed-scopes/action.yml
@@ -1,0 +1,274 @@
+name: "Changed scopes"
+description: >
+  Decides which *subjects* a change touches -- the wheel, the docs, the dev
+  container, the VS Code extension, the standalone bundles, the Claude Code
+  plugin -- so that a pull request and the merge queue run the jobs that can
+  actually say something about it and skip the ones that cannot. Says why in
+  the job summary. Used by the gating job of every workflow that runs on
+  "pull_request" and "merge_group".
+
+  Fail-safe by construction: a path this action does not recognise is "code",
+  and "code" turns everything on. Adding a directory to the repository can
+  therefore only ever run too much, never too little -- which is the direction
+  a mistake here has to fall.
+
+  It is deliberately NOT a "paths:" filter on the trigger. Two reasons, and both
+  are load-bearing:
+
+   * "merge_group" does not support "paths" at all. GitHub filters that event on
+     branches only, so a trigger-level filter is a filter a pull request obeys
+     and the merge queue ignores -- which is how a README typo came to run the
+     whole "Standalone" workflow the moment it entered the queue.
+   * a workflow skipped by a "paths:" filter creates no check run, and a
+     *required* check that is never created leaves the pull request waiting for
+     it forever. A job skipped by an "if:" reports the conclusion "skipped",
+     which branch protection and the merge queue both count as passing. Gating
+     jobs is therefore the only form of this that is safe to point required
+     checks at.
+
+inputs:
+  deep:
+    description: >
+      "true" when this run is a deep one (see ".github/actions/test-depth").
+      Every output is then "true" whatever changed: "#deepTest", the nightly
+      schedule, a manual dispatch and every push run the complete set of jobs,
+      which is what makes the reduced ones safe to reduce.
+    required: false
+    default: "false"
+  token:
+    description: "Token used to ask the API which files the change touches."
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  buckets:
+    description: "The buckets this change touches, space separated."
+    value: ${{ steps.classify.outputs.buckets }}
+  wheel:
+    description: "Build the Python distributions."
+    value: ${{ steps.classify.outputs.wheel }}
+  docs:
+    description: "Build the Sphinx documentation."
+    value: ${{ steps.classify.outputs.docs }}
+  pytest:
+    description: "Run the unit tests."
+    value: ${{ steps.classify.outputs.pytest }}
+  behave:
+    description: "Run the behave suite."
+    value: ${{ steps.classify.outputs.behave }}
+  examples:
+    description: "Render the example packages."
+    value: ${{ steps.classify.outputs.examples }}
+  devcontainer:
+    description: "Build the dev container and run the integration jobs inside it."
+    value: ${{ steps.classify.outputs.devcontainer }}
+  devcontainer-pytest:
+    description: >
+      Run pytest *inside* the dev container. False for a change that touches
+      nothing but the container's own configuration: that job duplicates the
+      "Pytest" matrix in "test.yml", while the behave and "pc" jobs beside it
+      are what actually exercise the container end to end.
+    value: ${{ steps.classify.outputs.devcontainer-pytest }}
+  bundle:
+    description: "Freeze the standalone (PyInstaller) bundles."
+    value: ${{ steps.classify.outputs.bundle }}
+  ide:
+    description: "Build the PartCAD IDE."
+    value: ${{ steps.classify.outputs.ide }}
+  vsix:
+    description: "Package the VS Code extension and run its JavaScript tests."
+    value: ${{ steps.classify.outputs.vsix }}
+  plugin:
+    description: "Build and validate the Claude Code plugin."
+    value: ${{ steps.classify.outputs.plugin }}
+
+runs:
+  using: composite
+  steps:
+    - id: files
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        DEEP: ${{ inputs.deep }}
+        EVENT_NAME: ${{ github.event_name }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        # The merge queue's temporary branch: everything already queued, plus
+        # this pull request on top. Comparing the two is what "the change" means
+        # there -- "github.sha" on its own would be the whole repository.
+        MG_BASE: ${{ github.event.merge_group.base_sha }}
+        MG_HEAD: ${{ github.event.merge_group.head_sha }}
+      run: |
+        set -euo pipefail
+
+        # A deep run does not need the list at all, and asking for it on a push
+        # or a schedule would be asking a question with no answer -- there is no
+        # pull request and no merge group to compare against.
+        if [ "${DEEP}" = "true" ]; then
+          echo "all=true" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        # Whether the API told us everything. Both endpoints below cap the file
+        # list they return, and a truncated list is a list that can be missing
+        # the one path that should have turned a job on -- so a cap that bites
+        # falls back to running everything rather than to guessing.
+        truncated=false
+
+        case "${EVENT_NAME}" in
+        pull_request | pull_request_target)
+          # Up to 3000 files over 10 pages; "changed_files" on the pull request
+          # itself says how many there really are.
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[].filename' > "${RUNNER_TEMP}/changed-files.txt" || truncated=true
+          declared=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.changed_files' || echo 0)
+          if [ "${declared:-0}" -gt "$(wc -l < "${RUNNER_TEMP}/changed-files.txt")" ]; then
+            truncated=true
+          fi
+          ;;
+        merge_group)
+          # "compare" returns at most 300 files and reports the real total, so
+          # the same check applies.
+          gh api "repos/${REPO}/compare/${MG_BASE}...${MG_HEAD}" \
+            --jq '.files[]?.filename' > "${RUNNER_TEMP}/changed-files.txt" || truncated=true
+          declared=$(gh api "repos/${REPO}/compare/${MG_BASE}...${MG_HEAD}" \
+            --jq '.files | length' || echo 0)
+          if [ "${declared:-0}" -gt "$(wc -l < "${RUNNER_TEMP}/changed-files.txt")" ]; then
+            truncated=true
+          fi
+          ;;
+        *)
+          # Nothing else reaches here: every other trigger is deep and returned
+          # above. Kept as a belt so a new trigger cannot silently arrive with an
+          # empty file list and skip the whole workflow.
+          truncated=true
+          ;;
+        esac
+
+        if [ "${truncated}" = "true" ] || [ ! -s "${RUNNER_TEMP}/changed-files.txt" ]; then
+          echo "::notice::could not enumerate the changed files; running everything"
+          echo "all=true" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        echo "all=false" >> "${GITHUB_OUTPUT}"
+        echo "Changed files:"
+        sed 's/^/  /' "${RUNNER_TEMP}/changed-files.txt"
+
+    - id: classify
+      shell: bash
+      env:
+        ALL: ${{ steps.files.outputs.all }}
+      run: |
+        set -euo pipefail
+
+        buckets=""
+        add() { case " ${buckets} " in *" $1 "*) ;; *) buckets="${buckets}$1 " ;; esac; }
+
+        if [ "${ALL}" = "true" ]; then
+          add code; add docs; add ai; add devcontainer; add vscode; add ide
+          add packaging; add ci
+        else
+          while IFS= read -r f; do
+            [ -n "${f}" ] || continue
+            # First match wins, so the order is the policy. Every rule that
+            # names a directory comes before the rules that match by extension:
+            # "examples/**/README.md" is what "pc render -r" wrote and a check
+            # compares, not documentation, and "ai-agents/**/*.md" is the plugin
+            # itself rather than prose about it.
+            case "${f}" in
+            .github/*)
+              # CI configuration. Turns everything on: a change here is a change
+              # to the thing that decides what runs, and it has to be able to
+              # prove itself.
+              add ci ;;
+            .devcontainer/*)
+              add devcontainer ;;
+            ai-agents/*|.claude-plugin/*)
+              # The Claude Code plugin, which is Markdown and JSON and ships.
+              add ai ;;
+            .claude/*|.cursor/*|openspec/*)
+              # Agent scaffolding for people working in this repository. Nothing
+              # packages it and no test reads it.
+              add docs ;;
+            ide/vscode/*|ide/vscode-shim/*)
+              add vscode ;;
+            ide/standalone/*|.vscode/*)
+              # ".vscode/extensions.json" is what the IDE ships with.
+              add ide ;;
+            dev-tools/pyinstaller/*|dev-tools/snap/*|.snapcraft.yaml|snap/*|install.sh)
+              add packaging ;;
+            docs/*|.readthedocs.yaml)
+              add docs ;;
+            examples/*)
+              # Named before the extension rules below, and before the
+              # "AGENTS.md" rule, so that a rendered "README.md" under
+              # "examples/" stays what it is: an output the "Examples (PartCAD)"
+              # job compares against a fresh render, not prose.
+              add code ;;
+            AGENTS.md|CLAUDE.md|*/AGENTS.md|*/CLAUDE.md)
+              # This repository keeps a package's documentation for agents beside
+              # its source -- "src/partcad/AGENTS.md" and its four siblings are
+              # linked from the root file as the documentation of each package.
+              # Named here, before the source directories below, because that is
+              # what they are. Two filenames rather than "src/**/*.md", so a
+              # Markdown file that turned out to be *data* under "src/" still
+              # counts as code.
+              add docs ;;
+            src/*|tests/*|features/*|cad/*|tools/*|dev-tools/*)
+              add code ;;
+            *.md|*.rst|LICENSE.txt|apache20.svg)
+              add docs ;;
+            *)
+              # Anything this action has not been taught, "pyproject.toml",
+              # "poetry.lock", "conftest.py" and "requirements*.txt" included.
+              add code ;;
+            esac
+          done < "${RUNNER_TEMP}/changed-files.txt"
+        fi
+
+        buckets="${buckets% }"
+        echo "buckets=${buckets}" >> "${GITHUB_OUTPUT}"
+
+        has() { case " ${buckets} " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+        any() { for b in "$@"; do has "${b}" && return 0; done; return 1; }
+        emit() { if any "${@:2}"; then echo "$1=true"; else echo "$1=false"; fi >> "${GITHUB_OUTPUT}"; }
+
+        # Which buckets each subject listens to. "ci" is in every one of them.
+        emit wheel               code ci
+        # Sphinx reads "docs/source" and nothing else -- "conf.py" enables no
+        # extensions, so there is no autodoc pulling in the source tree.
+        emit docs                docs ci
+        emit pytest              code ci
+        emit behave              code ci
+        emit examples            code ci
+        # The dev container image is built from ".devcontainer" and installs the
+        # project into itself, so both matter to it.
+        emit devcontainer        code ci devcontainer
+        emit devcontainer-pytest code ci
+        # "src/**" is why the bundles are frozen at all; "packaging" is how.
+        emit bundle              code ci packaging
+        # Not "code": the IDE downloads the bundles rather than freezing them,
+        # so what rebuilds it is the application around them.
+        emit ide                 ci packaging vscode ide
+        emit vsix                ci vscode
+        emit plugin              ci ai
+
+        {
+          echo "### Changed scopes"
+          echo
+          if [ "${ALL}" = "true" ]; then
+            echo "Running everything (deep run, or the changed files could not be listed)."
+          else
+            echo "Buckets touched: \`${buckets}\`"
+          fi
+          echo
+          echo "| Subject | Runs |"
+          echo "| --- | --- |"
+          for subject in wheel docs pytest behave examples devcontainer \
+                         devcontainer-pytest bundle ide vsix plugin; do
+            value=$(grep -m1 "^${subject}=" "${GITHUB_OUTPUT}" | cut -d= -f2)
+            printf '| `%s` | %s |\n' "${subject}" "$([ "${value}" = "true" ] && echo yes || echo no)"
+          done
+        } >> "${GITHUB_STEP_SUMMARY}"
+        cat "${GITHUB_STEP_SUMMARY}"

--- a/.github/actions/changed-scopes/action.yml
+++ b/.github/actions/changed-scopes/action.yml
@@ -7,10 +7,20 @@ description: >
   the job summary. Used by the gating job of every workflow that runs on
   "pull_request" and "merge_group".
 
-  Fail-safe by construction: a path this action does not recognise is "code",
-  and "code" turns everything on. Adding a directory to the repository can
-  therefore only ever run too much, never too little -- which is the direction
-  a mistake here has to fall.
+  Fail-safe by construction: a path this action does not recognise counts as
+  both source and a dependency, so it runs everything a change to the source
+  tree runs -- the tests, the wheel, the dev container and the standalone
+  bundles.
+
+  What it does not turn on is the four subjects that only their own directory
+  turns on: the documentation, the VS Code extension, the IDE and the Claude
+  Code plugin. That is not a gap. Each of those is built from one fixed
+  directory -- "docs/source", "ide/vscode", "ide/standalone", "ai-agents" --
+  so a path outside them cannot change what they contain, and an unclassified
+  path is by definition outside them.
+
+  Adding a directory to the repository can therefore only ever run too much,
+  never too little -- which is the direction a mistake here has to fall.
 
   It is deliberately NOT a "paths:" filter on the trigger. Two reasons, and both
   are load-bearing:
@@ -127,13 +137,22 @@ runs:
           fi
           ;;
         merge_group)
-          # "compare" returns at most 300 files and reports the real total, so
-          # the same check applies.
+          # "compare" caps ".files" at 300 entries, and -- unlike a pull request
+          # -- reports no count of what it left out. There is no second number to
+          # check the list against: ".files | length" reads the very array that
+          # was capped, so it equals the number of lines written whether or not
+          # anything was dropped, which is a check that can never fire. (It was
+          # one here, until CodeRabbit pointed it out on #608.)
+          #
+          # So a full 300 is treated as truncated. It may be exactly 300 changed
+          # files and it may be the first 300 of a thousand; nothing in the
+          # response tells the two apart, and the cost of being wrong in one
+          # direction is a merge group that runs a little too much while in the
+          # other it is a merge group that silently skips the jobs for a path it
+          # never saw.
           gh api "repos/${REPO}/compare/${MG_BASE}...${MG_HEAD}" \
             --jq '.files[]?.filename' > "${RUNNER_TEMP}/changed-files.txt" || truncated=true
-          declared=$(gh api "repos/${REPO}/compare/${MG_BASE}...${MG_HEAD}" \
-            --jq '.files | length' || echo 0)
-          if [ "${declared:-0}" -gt "$(wc -l < "${RUNNER_TEMP}/changed-files.txt")" ]; then
+          if [ "$(wc -l < "${RUNNER_TEMP}/changed-files.txt")" -ge 300 ]; then
             truncated=true
           fi
           ;;

--- a/.github/actions/test-depth/action.yml
+++ b/.github/actions/test-depth/action.yml
@@ -1,13 +1,33 @@
 name: "Test depth"
 description: >
-  Decides whether this run gets the full test matrix or the reduced one, and
-  says why in the job summary. Used by the "set matrix" job of every workflow
-  that fans out over operating systems.
+  Decides how much of the matrix this run gets, and says why in the job summary.
+  Used by the "set matrix" job of every workflow that fans out over operating
+  systems.
+
+  Three tiers, not two. A pull request is re-run on every push to it, so it pays
+  the reduced matrix over and over; the merge queue runs once, immediately before
+  the commit lands, and is the last place a breakage can be caught cheaply. So
+  they no longer get the same thing:
+
+    * "pr"    -- one image per operating system and architecture, no macOS, and
+                 the oldest and newest supported Python only.
+    * "queue" -- what a pull request used to run: the current release of every
+                 operating system, macOS included, and the full Python range.
+    * "deep"  -- everything, older OS versions included.
 
 outputs:
+  tier:
+    description: '"pr", "queue" or "deep".'
+    value: ${{ steps.decide.outputs.tier }}
   deep:
-    description: '"true" for the full matrix, "false" for the reduced one.'
+    description: '"true" for the full matrix, "false" for a reduced one.'
     value: ${{ steps.decide.outputs.deep }}
+  queue:
+    description: >
+      '"true" for the merge queue tier or deeper -- that is, "false" only on a
+      pull request. What a job reads when it wants "everything but the images a
+      pull request drops".'
+    value: ${{ steps.decide.outputs.queue }}
 
 runs:
   using: composite
@@ -22,16 +42,17 @@ runs:
         PR_BODY: ${{ github.event.pull_request.body }}
         EVENT_NAME: ${{ github.event_name }}
       run: |
-        # A pull request, and the merge queue behind it, run the reduced matrix:
-        # the older OS versions are dropped and only one macOS is kept, which is
-        # most of the cost (macOS minutes bill at 10x). Everything else -- the
-        # nightly schedule, a manual dispatch, and any push, which includes the
-        # release path -- runs everything. That way the complete matrix is never
-        # more than a day, or a "#deepTest", away, and a release is always built
-        # and checked in full.
+        # A pull request runs the smallest matrix, the merge queue runs the one a
+        # pull request used to, and everything else -- the nightly schedule, a
+        # manual dispatch, and any push, which includes the release path -- runs
+        # everything. That way the complete matrix is never more than a day, or a
+        # "#deepTest", away; a release is always built and checked in full; and
+        # nothing merges without having met macOS and the whole Python range in
+        # the queue.
         case "${EVENT_NAME}" in
-        pull_request | pull_request_target | merge_group) deep=false ;;
-        *) deep=true ;;
+        pull_request | pull_request_target) tier=pr ;;
+        merge_group) tier=queue ;;
+        *) tier=deep ;;
         esac
         reason="event '${EVENT_NAME}'"
 
@@ -39,16 +60,35 @@ runs:
         # before it merges -- anything touching packaging, dependencies, or
         # platform specific code. Matched case-insensitively, in the title as
         # well as the body, because that is how people will actually type it.
+        #
+        # It reaches the merge queue too: the queue's event carries no pull
+        # request to read a title from, but a queued commit's message is the pull
+        # request's title and body, and the merge commit GitHub builds for the
+        # queue carries it. Nothing here reads that -- what makes "#deepTest"
+        # hold all the way through is that the queue tier already runs what the
+        # marker asks a pull request for, plus the deep-only images on a deep
+        # run of its own trigger.
         if printf '%s\n%s' "${PR_TITLE}" "${PR_BODY}" | grep -qiF '#deeptest'; then
-          deep=true
+          tier=deep
           reason="'#deepTest' in the pull request"
         fi
 
+        # Kept as separate booleans because that is what an "if:" can read
+        # without a string comparison in every workflow.
+        [ "${tier}" = "deep" ] && deep=true || deep=false
+        [ "${tier}" = "pr" ] && queue=false || queue=true
+
+        echo "tier=${tier}" >> "${GITHUB_OUTPUT}"
         echo "deep=${deep}" >> "${GITHUB_OUTPUT}"
-        if [ "${deep}" = "true" ]; then
-          echo "Full matrix (${reason})." >> "${GITHUB_STEP_SUMMARY}"
-        else
-          echo "Reduced matrix (${reason}). Put '#deepTest' in the pull request description for the full one." \
-            >> "${GITHUB_STEP_SUMMARY}"
-        fi
+        echo "queue=${queue}" >> "${GITHUB_OUTPUT}"
+        case "${tier}" in
+        deep)
+          echo "Full matrix (${reason})." >> "${GITHUB_STEP_SUMMARY}" ;;
+        queue)
+          echo "Merge queue matrix (${reason}): every current OS image and the full Python range." \
+            >> "${GITHUB_STEP_SUMMARY}" ;;
+        pr)
+          echo "Pull request matrix (${reason}): no macOS, no second image per OS, and the oldest and newest Python only. The merge queue runs the rest before this merges; put '#deepTest' in the pull request description for everything now." \
+            >> "${GITHUB_STEP_SUMMARY}" ;;
+        esac
         cat "${GITHUB_STEP_SUMMARY}"

--- a/.github/actions/test-depth/action.yml
+++ b/.github/actions/test-depth/action.yml
@@ -61,6 +61,19 @@ runs:
         # platform specific code. Matched case-insensitively, in the title as
         # well as the body, because that is how people will actually type it.
         #
+        # A plain substring match, and it does not know prose from an opt-in: a
+        # pull request that merely *mentions* the marker -- one editing this
+        # file, or the section of "docs/source/contributing.rst" that explains
+        # it -- opts itself in and runs the full matrix. The pull request that
+        # introduced these tiers did exactly that and ran ~147 jobs before
+        # anyone noticed. Left as it is on purpose: the alternative is a matcher
+        # that tries to tell a marker from a mention (outside backticks? on its
+        # own line?), which is a rule a contributor has to know before their
+        # opt-in works, and the failure mode of *that* is a deep run somebody
+        # asked for and did not get. Over-running is the safe direction. Write
+        # it split -- the marker's two halves in separate code spans -- if a
+        # description has to name it without asking for it.
+        #
         # It reaches the merge queue too: the queue's event carries no pull
         # request to read a title from, but a queued commit's message is the pull
         # request's title and body, and the merge commit GitHub builds for the

--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -20,8 +20,14 @@ on:
   merge_group:
   # Not on every change: this builds the standalone command line bundles first,
   # to put them inside the IDE, and those pull ~500MB of OpenCASCADE per runner.
-  # Only the changes that can alter what ships. The two lists are duplicated
-  # because GitHub Actions does not support YAML anchors.
+  # Only the changes that can alter what ships.
+  #
+  # On a push that is a "paths:" filter and stays one. On a pull request it is
+  # the "set-matrix" job's gate instead, for the two reasons
+  # "build-standalone.yml" sets out beside its own trigger: "merge_group"
+  # supports no "paths:" filter, so this workflow used to build three IDEs in the
+  # queue for a change to a README; and a workflow skipped by "paths:" never
+  # creates the check run a required check waits for, while a skipped job does.
   push:
     branches: ["devel"]
     paths:
@@ -32,12 +38,6 @@ on:
       - ".github/workflows/build-ide-standalone.yml"
   pull_request:
     branches: ["main", "devel"]
-    paths:
-      - "ide/standalone/**"
-      - "ide/vscode/**"
-      - ".vscode/extensions.json"
-      - "install.sh"
-      - ".github/workflows/build-ide-standalone.yml"
 
 # `actions: read` is what lets the "build" job list and download the artifacts
 # of *another* workflow run -- the sibling "Standalone" run that froze the
@@ -138,6 +138,10 @@ jobs:
     outputs:
       build: ${{ steps.set-matrix.outputs.build }}
       install: ${{ steps.set-matrix.outputs.install }}
+      # Whether this change can alter what the IDE ships. Every job below needs
+      # this one, so this is the whole workflow's gate. See
+      # ".github/actions/changed-scopes".
+      ide: ${{ steps.scope.outputs.ide }}
     steps:
       - uses: actions/checkout@v7
 
@@ -145,10 +149,17 @@ jobs:
         id: depth
         uses: ./.github/actions/test-depth
 
+      - name: Decide what the change touches
+        id: scope
+        uses: ./.github/actions/changed-scopes
+        with:
+          deep: ${{ steps.depth.outputs.deep }}
+
       - name: Set matrix
         id: set-matrix
         env:
           DEEP: ${{ steps.depth.outputs.deep }}
+          QUEUE: ${{ steps.depth.outputs.queue }}
         run: |
           if [ "${DEEP}" = "true" ]; then
             platforms=$(jq -cn --argjson core '${{ env.IDE_CORE }}' --argjson deep '${{ env.IDE_DEEP }}' '$core + $deep')
@@ -156,6 +167,15 @@ jobs:
           else
             platforms='${{ env.IDE_CORE }}'
             forward='${{ env.IDE_INSTALL_FORWARD_CORE }}'
+          fi
+          # A pull request builds no macOS IDE, matching "build-standalone.yml",
+          # which freezes no macOS bundle for one -- so asking for the macOS IDE
+          # here on a reduced run would be asking to unpack a bundle that nothing
+          # built. Restored by the merge queue and by "#deepTest".
+          if [ "${QUEUE}" != "true" ]; then
+            drop_macos='map(select(.os | startswith("macos") | not))'
+            platforms=$(jq -c "${drop_macos}" <<<"${platforms}")
+            forward=$(jq -c "${drop_macos}" <<<"${forward}")
           fi
           echo "Platforms: ${platforms}"
           echo 'build={"include": '"${platforms}"'}' >> "${GITHUB_OUTPUT}"
@@ -186,6 +206,8 @@ jobs:
   # of building does.
   tools:
     name: "Build tooling"
+    needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.ide == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -255,6 +277,8 @@ jobs:
   # need, and the step inside it costs seconds when there is nothing to look up.
   bundles:
     name: "Command line tools"
+    needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.ide == 'true' }}
     runs-on: ubuntu-latest
     # Long enough to sit out a whole "Standalone" run. The freeze itself is
     # ~35 minutes; the install, snap and examples jobs after it have taken the
@@ -273,6 +297,12 @@ jobs:
       # bare "Artifact not found" an unpacked editor later.
       artifacts: ${{ steps.resolve.outputs.artifacts }}
     steps:
+      # Note that a sibling run is no longer guaranteed even in the merge queue.
+      # "build-standalone.yml" is gated on what the change touches now, so a
+      # change to "ide/standalone" alone -- which is not a change to what gets
+      # frozen -- leaves this commit with no "Standalone" run anywhere. That is
+      # the case the base-branch fallback below was written for; what it costs is
+      # GRACE_SECONDS of waiting to establish that there is nothing to wait for.
       - name: Find the "Standalone" run that built the bundles
         id: resolve
         # `toJSON` rather than `inputs.tools_in_this_run == true`. Outside

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -27,10 +27,12 @@ on:
         default: true
   merge_group:
   # Freezing pulls ~500MB of OpenCASCADE per runner, so this does not run on
-  # every change: only on the ones that can change what is frozen. The two
-  # lists are duplicated because GitHub Actions does not support YAML anchors.
-  # "main" is absent on purpose: a push there runs "deploy.yml", which calls
-  # this workflow itself. Listing it here would build everything twice.
+  # every change: only on the ones that can change what is frozen.
+  #
+  # On a push that is a "paths:" filter, and it stays one -- a push is a single
+  # commit on a branch, which is exactly what the filter was designed for.
+  # "main" is absent on purpose: a push there runs "deploy.yml", which calls this
+  # workflow itself. Listing it here would build everything twice.
   #
   # Both "snap/**" and ".snapcraft.yaml" are listed. The recipe lives at the
   # root, but snapcraft still reads assets -- hooks, gui, keys -- from "snap/".
@@ -48,18 +50,20 @@ on:
       - "src/**"
       - "pyproject.toml"
       - "requirements*.txt"
+  # A pull request carries no "paths:" filter any more, and that is not the same
+  # as running on everything -- the filtering moved into the "build" job below,
+  # where the merge queue obeys it too.
+  #
+  # It had to move. "merge_group" supports no "paths:" filter at all: GitHub
+  # filters that event on branches only. So the list above governed the pull
+  # request and then stopped governing anything the moment the same commit
+  # entered the queue, where this workflow froze four bundles for a change to a
+  # README. The second reason is required checks: a workflow skipped by a
+  # "paths:" filter creates no check run, and a required check that is never
+  # created leaves a pull request waiting forever, while a job skipped by an
+  # "if:" reports "skipped", which counts as passing.
   pull_request:
     branches: ["main", "devel"]
-    paths:
-      - "dev-tools/pyinstaller/**"
-      - "dev-tools/snap/**"
-      - ".snapcraft.yaml"
-      - "snap/**"
-      - "install.sh"
-      - ".github/workflows/build-standalone.yml"
-      - "src/**"
-      - "pyproject.toml"
-      - "requirements*.txt"
 
 permissions:
   contents: read
@@ -288,6 +292,10 @@ jobs:
       build: ${{ steps.set-matrix.outputs.build }}
       install: ${{ steps.set-matrix.outputs.install }}
       examples: ${{ steps.set-matrix.outputs.examples }}
+      # Whether this change can alter what gets frozen at all. See
+      # ".github/actions/changed-scopes"; the note on "pull_request" above says
+      # why the answer lives here rather than in a "paths:" filter.
+      bundle: ${{ steps.scope.outputs.bundle }}
     steps:
       - uses: actions/checkout@v7
 
@@ -295,10 +303,17 @@ jobs:
         id: depth
         uses: ./.github/actions/test-depth
 
+      - name: Decide what the change touches
+        id: scope
+        uses: ./.github/actions/changed-scopes
+        with:
+          deep: ${{ steps.depth.outputs.deep }}
+
       - name: Set matrix
         id: set-matrix
         env:
           DEEP: ${{ steps.depth.outputs.deep }}
+          QUEUE: ${{ steps.depth.outputs.queue }}
         run: |
           if [ "${DEEP}" = "true" ]; then
             platforms=$(jq -cn --argjson core '${{ env.PLATFORMS_CORE }}' --argjson deep '${{ env.PLATFORMS_DEEP }}' '$core + $deep')
@@ -308,6 +323,23 @@ jobs:
             platforms='${{ env.PLATFORMS_CORE }}'
             forward='${{ env.INSTALL_FORWARD_CORE }}'
             examples='${{ env.EXAMPLES_CORE }}'
+          fi
+          # A pull request freezes no macOS bundle. This is the most expensive
+          # leg in the file -- a ~35 minute freeze on a runner that bills at 10x,
+          # and then the same again for the two "Examples" suites that run
+          # through it -- and it is the one nothing else in a pull request pays
+          # for twice. The merge queue restores it, so no macOS bundle reaches a
+          # release, or even the "devel" branch, unbuilt; "#deepTest" restores it
+          # on the pull request itself.
+          #
+          # Selected by "os" rather than by a list of names, so a macOS image
+          # added to any of the three lists above is covered without a fourth
+          # list having to be remembered.
+          if [ "${QUEUE}" != "true" ]; then
+            drop_macos='map(select(.os | startswith("macos") | not))'
+            platforms=$(jq -c "${drop_macos}" <<<"${platforms}")
+            forward=$(jq -c "${drop_macos}" <<<"${forward}")
+            examples=$(jq -c "${drop_macos}" <<<"${examples}")
           fi
           echo "Platforms: ${platforms}"
           echo 'build={"include": '"${platforms}"'}' >> "${GITHUB_OUTPUT}"
@@ -353,6 +385,10 @@ jobs:
   build:
     name: "Build (${{ matrix.platform }})"
     needs: set-matrix
+    # Everything below needs this job, so this is the whole workflow's gate: a
+    # change that cannot alter what is frozen skips the freeze, the installs, the
+    # snaps and the examples together.
+    if: ${{ needs.set-matrix.outputs.bundle == 'true' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.build) }}

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -227,6 +227,22 @@ env:
     {"os": "ubuntu-22.04-arm", "platform": "ubuntu-22.04-arm64"},
     {"os": "macos-15-intel", "platform": "macos-15-x86_64"}]
 
+  # Which architectures the snap is packed for. Both on a deep run and on a push
+  # to "devel"; amd64 alone on a pull request.
+  #
+  # The snap is not published yet -- it is a build artifact of this workflow, and
+  # "deploy.yml" attaches the bundles rather than the snaps -- so what these jobs
+  # prove is that the recipe still wraps a bundle and that the wrapped bundle
+  # still starts. That property does not differ by architecture: the recipe is
+  # one file, the two jobs run it over two payloads whose difference the "Build"
+  # and "Install" jobs above have already exercised, and each is ~45 minutes of
+  # squashing ~875MB. So a pull request packs one and the push that follows the
+  # merge packs both.
+  SNAP_CORE: >-
+    [{"os": "ubuntu-24.04", "arch": "amd64", "bundle": "ubuntu-24.04-x86_64"}]
+  SNAP_QUEUE_ONLY: >-
+    [{"os": "ubuntu-24.04-arm", "arch": "arm64", "bundle": "ubuntu-24.04-arm64"}]
+
   # Extra "Install" legs: a bundle run on a runner that did not build it.
   #
   # Every platform this run froze is installed on the image that froze it -- the
@@ -292,6 +308,7 @@ jobs:
       build: ${{ steps.set-matrix.outputs.build }}
       install: ${{ steps.set-matrix.outputs.install }}
       examples: ${{ steps.set-matrix.outputs.examples }}
+      snap: ${{ steps.set-matrix.outputs.snap }}
       # Whether this change can alter what gets frozen at all. See
       # ".github/actions/changed-scopes"; the note on "pull_request" above says
       # why the answer lives here rather than in a "paths:" filter.
@@ -315,6 +332,7 @@ jobs:
           DEEP: ${{ steps.depth.outputs.deep }}
           QUEUE: ${{ steps.depth.outputs.queue }}
         run: |
+          snap='${{ env.SNAP_CORE }}'
           if [ "${DEEP}" = "true" ]; then
             platforms=$(jq -cn --argjson core '${{ env.PLATFORMS_CORE }}' --argjson deep '${{ env.PLATFORMS_DEEP }}' '$core + $deep')
             forward=$(jq -cn --argjson core '${{ env.INSTALL_FORWARD_CORE }}' --argjson deep '${{ env.INSTALL_FORWARD_DEEP }}' '$core + $deep')
@@ -323,6 +341,9 @@ jobs:
             platforms='${{ env.PLATFORMS_CORE }}'
             forward='${{ env.INSTALL_FORWARD_CORE }}'
             examples='${{ env.EXAMPLES_CORE }}'
+          fi
+          if [ "${QUEUE}" = "true" ]; then
+            snap=$(jq -cn --argjson core "${snap}" --argjson rest '${{ env.SNAP_QUEUE_ONLY }}' '$core + $rest')
           fi
           # A pull request freezes no macOS bundle. This is the most expensive
           # leg in the file -- a ~35 minute freeze on a runner that bills at 10x,
@@ -340,6 +361,14 @@ jobs:
             platforms=$(jq -c "${drop_macos}" <<<"${platforms}")
             forward=$(jq -c "${drop_macos}" <<<"${forward}")
             examples=$(jq -c "${drop_macos}" <<<"${examples}")
+            # And the "All" suite, which sweeps the example packages the public
+            # index carries. Its step is "continue-on-error" -- several of those
+            # packages have not been updated for build123d 0.11, so it fails on
+            # code this repository cannot fix -- which leaves it a job whose only
+            # way to report anything is to fail at "install.sh", something the
+            # "Install" job above has already done for the same platform. Same
+            # reasoning, and the same TODO, as "Examples (All)" in "test.yml".
+            examples=$(jq -c 'map(select(.suite != "All"))' <<<"${examples}")
           fi
           echo "Platforms: ${platforms}"
           echo 'build={"include": '"${platforms}"'}' >> "${GITHUB_OUTPUT}"
@@ -381,6 +410,17 @@ jobs:
           done
           echo 'install={"include": '"${install}"'}' >> "${GITHUB_OUTPUT}"
           echo 'examples={"include": '"${examples}"'}' >> "${GITHUB_OUTPUT}"
+          # The snap wraps a bundle this run froze, so it is checked the same way
+          # the two lists above are.
+          echo "Snap: ${snap}"
+          orphans=$(jq -r --argjson built "${built}" \
+            '[.[] | select(.bundle as $p | $built | index($p) | not) | .bundle] | unique | join(" ")' \
+            <<<"${snap}")
+          if [ -n "${orphans}" ]; then
+            echo "::error::the Snap matrix asks for bundles this run does not build: ${orphans}"
+            exit 1
+          fi
+          echo 'snap={"include": '"${snap}"'}' >> "${GITHUB_OUTPUT}"
 
   build:
     name: "Build (${{ matrix.platform }})"
@@ -579,7 +619,7 @@ jobs:
   # take the ubuntu-24.04 bundles.
   snap:
     name: "Snap (${{ matrix.arch }})"
-    needs: build
+    needs: [set-matrix, build]
     # Skipped on the release path and in the merge queue, like the examples
     # below. Nothing downstream consumes these: "deploy.yml" publishes the
     # wheels and the standalone archives, and a job whose output no release
@@ -590,14 +630,11 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/devel')
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            arch: amd64
-            bundle: ubuntu-24.04-x86_64
-          - os: ubuntu-24.04-arm
-            arch: arm64
-            bundle: ubuntu-24.04-arm64
+      # One architecture on a pull request, both on a push to "devel" and on a
+      # dispatch. SNAP_CORE and SNAP_QUEUE_ONLY above say which and why; an
+      # output rather than a literal list here because a leg whose bundle a
+      # reduced run did not freeze has to be absent rather than skipped.
+      matrix: ${{ fromJson(needs.set-matrix.outputs.snap) }}
     runs-on: ${{ matrix.os }}
     # Squashing ~875MB of frozen bundle is most of this.
     timeout-minutes: 45

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,13 @@ env:
     '["ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04-arm", "ubuntu-22.04-arm", "windows-latest", "windows-2022",
     "macos-latest"]'
   # Dropped unless the run is deep: the Ubuntu 22.04 images. No macOS, because
-  # there is only one macOS leg left and dropping it would test none. See
-  # ".github/actions/test-depth" and OSES_DEEP_ONLY in "test.yml".
+  # there is only one macOS leg left and dropping it from the *deep* set would
+  # test none. See ".github/actions/test-depth" and OSES_DEEP_ONLY in "test.yml".
   OSES_DEEP_ONLY: '["ubuntu-22.04", "ubuntu-22.04-arm"]'
+  # Dropped on a pull request and kept from the merge queue up, as in "test.yml"
+  # -- that file carries the reasoning for which images are here and why arm64
+  # is not.
+  OSES_QUEUE_ONLY: '["windows-2022", "macos-latest"]'
   PYTHONS: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
   # Same cost trade-off as test.yml: the full Python range runs on
   # ubuntu-latest only, every other image builds on the oldest and the newest
@@ -78,6 +82,12 @@ jobs:
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      # Which of the four artifacts below this change can say anything about.
+      # See ".github/actions/changed-scopes".
+      wheel: ${{ steps.scope.outputs.wheel }}
+      docs: ${{ steps.scope.outputs.docs }}
+      vsix: ${{ steps.scope.outputs.vsix }}
+      plugin: ${{ steps.scope.outputs.plugin }}
     steps:
       - uses: actions/checkout@v7
 
@@ -85,20 +95,35 @@ jobs:
         id: depth
         uses: ./.github/actions/test-depth
 
+      - name: Decide what the change touches
+        id: scope
+        uses: ./.github/actions/changed-scopes
+        with:
+          deep: ${{ steps.depth.outputs.deep }}
+
       - name: Set matrix
         id: set-matrix
         env:
           DEEP: ${{ steps.depth.outputs.deep }}
+          QUEUE: ${{ steps.depth.outputs.queue }}
         run: |
-          if [ "${DEEP}" = "true" ]; then
-            OSES='${{ env.OSES }}'
-          else
-            OSES=$(jq -cn --argjson all '${{ env.OSES }}' --argjson deep_only '${{ env.OSES_DEEP_ONLY }}' '$all - $deep_only')
+          # Both tiers, exactly as in "test.yml": DEEP adds the older OS
+          # versions, QUEUE adds the images and the interpreters a pull request
+          # does not pay for.
+          OSES='${{ env.OSES }}'
+          PYTHONS='${{ env.PYTHONS }}'
+          if [ "${DEEP}" != "true" ]; then
+            OSES=$(jq -cn --argjson all "${OSES}" --argjson deep_only '${{ env.OSES_DEEP_ONLY }}' '$all - $deep_only')
+          fi
+          if [ "${QUEUE}" != "true" ]; then
+            OSES=$(jq -cn --argjson all "${OSES}" --argjson queue_only '${{ env.OSES_QUEUE_ONLY }}' '$all - $queue_only')
+            PYTHONS=$(jq -cn --argjson all "${PYTHONS}" '[$all[0], $all[-1]]')
           fi
           echo "Operating systems: ${OSES}"
+          echo "Python versions: ${PYTHONS}"
           # Leftover excludes for dropped images match nothing; see the note in
           # the same step in "test.yml".
-          echo 'matrix={"os": '"${OSES}"', "python-version": ${{ env.PYTHONS }}, "exclude": ${{ env.EXCLUDES }}}' >> "${GITHUB_OUTPUT}"
+          echo 'matrix={"os": '"${OSES}"', "python-version": '"${PYTHONS}"', "exclude": ${{ env.EXCLUDES }}}' >> "${GITHUB_OUTPUT}"
 
   build:
     needs: set-matrix
@@ -107,10 +132,11 @@ jobs:
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
-    # As in "test.yml": a push to "devel" runs this only for a version bump, and
-    # the event name leads because a "schedule" carries no "head_commit" -- see
-    # the long note there.
-    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
+    # The "only a version bump on devel" guard is inherited from "set-matrix"
+    # through "needs" -- a job that needs a skipped job is skipped -- so what is
+    # left to state here is what this change can say about the wheel. See
+    # ".github/actions/changed-scopes".
+    if: ${{ needs.set-matrix.outputs.wheel == 'true' }}
     env:
       # 'startsWith', not '== windows-latest': the matrix now also contains a
       # pinned windows-2022, which needs the very same venv layout.
@@ -158,16 +184,38 @@ jobs:
           python -m pip install --no-index --find-links=dist --find-links=dev-tools/shim/dist partcad-cli
           mamba deactivate
 
+  # The documentation, built once -- one Linux runner, one interpreter, one
+  # "sphinx-build -W".
+  #
+  # It used to be a step of the matrix above, which meant that a change to a
+  # single ".rst" file built the wheel on every image and every Python version
+  # to get at it, and that a change to the wheel rebuilt the documentation
+  # fifteen times over. Neither is worth anything: Sphinx is pure Python and
+  # "docs/source/conf.py" enables no extensions at all -- there is no autodoc,
+  # so the build never imports PartCAD and cannot be affected by the platform it
+  # runs on or by the source tree it sits next to.
+  #
+  # Its own job also means the documentation can be gated on the documentation.
+  # A prose-only pull request now runs this and nothing else in this workflow.
+  docs:
+    name: "Documentation"
+    needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.docs == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          # The interpreter Read the Docs builds with; see ".readthedocs.yaml".
+          python-version: "3.13"
       - name: Build documentation
-        shell: bash -el {0}
         run: |
-          . ~/.bashrc
-          . ~/.bash_profile
-          mamba activate ${{ format('env-test-build-{0}', matrix.python-version) }}
-          # python -m pip install -r .devcontainer/requirements.txt
           python -m pip install -r docs/requirements.txt
-          sphinx-build  -M html docs/source docs/build -n -W
-          mamba deactivate
+          # "-W": a warning is an error. That is the whole point of this job --
+          # a broken cross reference is how the published documentation ends up
+          # with a link that goes nowhere.
+          sphinx-build -M html docs/source docs/build -n -W
 
   # The VS Code extension, built once -- one Linux runner, one ".vsix", the same
   # package "deploy.yml" attaches to the release. It is not part of the matrix
@@ -180,10 +228,10 @@ jobs:
   # skips it, exactly as it skips everything else here.
   build-vscode-extension:
     name: "VS Code extension"
-    # As in "test.yml": a push to "devel" runs this only for a version bump, and
-    # the event name leads because a "schedule" carries no "head_commit" -- see
-    # the long note there.
-    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
+    # The "only a version bump on devel" guard comes through "needs", as it does
+    # for "build" above; this is the extension's own gate.
+    needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.vsix == 'true' }}
     uses: ./.github/workflows/vsix.yml
 
   # The Claude Code plugin, on the same footing as the extension above: built
@@ -195,8 +243,9 @@ jobs:
   # matched that path filter and would have built the plugin here and there both.
   build-claude-plugin:
     name: "Claude Code plugin"
-    # As in "test.yml": a push to "devel" runs this only for a version bump, and
-    # the event name leads because a "schedule" carries no "head_commit" -- see
-    # the long note there.
-    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
+    # The "only a version bump on devel" guard comes through "needs", as above.
+    # This is the one job a change under "ai-agents/" runs, and it is the only
+    # thing such a change can break.
+    needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.plugin == 'true' }}
     uses: ./.github/workflows/plugin.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ env:
   # test none. See ".github/actions/test-depth" and OSES_DEEP_ONLY in "test.yml".
   OSES_DEEP_ONLY: '["ubuntu-22.04", "ubuntu-22.04-arm"]'
   # Dropped on a pull request and kept from the merge queue up, as in "test.yml"
-  # -- that file carries the reasoning for which images are here and why arm64
-  # is not.
-  OSES_QUEUE_ONLY: '["windows-2022", "macos-latest"]'
+  # -- that file carries the reasoning for why this is macOS alone, and in
+  # particular why no Windows image is in it.
+  OSES_QUEUE_ONLY: '["macos-latest"]'
   PYTHONS: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
   # Same cost trade-off as test.yml: the full Python range runs on
   # ubuntu-latest only, every other image builds on the oldest and the newest

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -5,6 +5,7 @@ name: npm test
 on:
   pull_request:
   workflow_dispatch:
+  merge_group:
   push:
     branches:
       - main
@@ -12,8 +13,62 @@ on:
     paths:
       - ide/vscode/**
 
+# As in "test.yml" and "build.yml": a pull request is re-run on every push to it,
+# and there is no reason to keep three runners busy on a revision nobody is
+# looking at any more. The merge queue is keyed on its own ref, so a queued
+# commit is never superseded by a later push to the branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# "contents: read" is all of it: a checkout, an "npm install", and the API call
+# ".github/actions/changed-scopes" makes to ask which files this change touches.
+permissions:
+  contents: read
+
 jobs:
+  # The "pull_request" trigger above carries no "paths" filter, so it fires on
+  # every pull request in the repository, and "merge_group" cannot carry one at
+  # all -- GitHub filters that event on branches only. This is where the filter
+  # lives instead, which is also what makes it safe to point a required check
+  # at: a job skipped by an "if:" reports "skipped", which counts as passing,
+  # while a workflow skipped by a "paths:" filter never reports at all.
+  scope:
+    name: "Scope"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run: ${{ steps.scope.outputs.vsix }}
+      oses: ${{ steps.oses.outputs.oses }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Decide the depth
+        id: depth
+        uses: ./.github/actions/test-depth
+      - name: Decide what the change touches
+        id: scope
+        uses: ./.github/actions/changed-scopes
+        with:
+          deep: ${{ steps.depth.outputs.deep }}
+      - name: Set the OS axis
+        id: oses
+        env:
+          QUEUE: ${{ steps.depth.outputs.queue }}
+        run: |
+          # macOS bills at 10x and this suite starts a headless editor on each
+          # runner. A pull request runs the two platforms whose test hosts differ
+          # most from each other; the merge queue adds macOS back before the
+          # commit lands, as it does for every other matrix here.
+          if [ "${QUEUE}" = "true" ]; then
+            oses='["macos-latest", "ubuntu-latest", "windows-latest"]'
+          else
+            oses='["ubuntu-latest", "windows-latest"]'
+          fi
+          echo "oses=${oses}" >> "${GITHUB_OUTPUT}"
+
   build:
+    needs: scope
+    if: ${{ needs.scope.outputs.run == 'true' }}
     strategy:
       # Don't let one OS failing cancel the others: a green Linux run was being
       # reported as failed only because it was canceled when the macOS job
@@ -27,7 +82,9 @@ jobs:
         # window never closed. `.vscode-test.js` now tells the extension not to
         # ask (PARTCAD_EXTENSION_NO_PROMPTS), and the sample workspace the runner
         # opens is a directory that actually exists.
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        #
+        # Which of the three this run gets is decided in "scope" above.
+        os: ${{ fromJson(needs.scope.outputs.oses) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -37,12 +37,36 @@ env:
   PC_TELEMETRY_PERFORMANCE: false
 
 jobs:
-  devcontainer:
-    name: "Build: Dev Container"
+  # What this change can say anything about. Every job below reads it; see
+  # ".github/actions/changed-scopes", and the note on "Run: pytest" for why that
+  # job gets a gate of its own rather than sharing this one's.
+  scope:
+    name: "Scope"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     # As in "test.yml": a push to "devel" runs this only for a version bump, and
     # the event name leads because a "schedule" carries no "head_commit" -- see
-    # the long note there.
+    # the long note there. Stated here and nowhere else in this file: every other
+    # job needs this one, and a job that needs a skipped job is skipped.
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
+    outputs:
+      devcontainer: ${{ steps.scope.outputs.devcontainer }}
+      pytest: ${{ steps.scope.outputs.devcontainer-pytest }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Decide the depth
+        id: depth
+        uses: ./.github/actions/test-depth
+      - name: Decide what the change touches
+        id: scope
+        uses: ./.github/actions/changed-scopes
+        with:
+          deep: ${{ steps.depth.outputs.deep }}
+
+  devcontainer:
+    name: "Build: Dev Container"
+    needs: scope
+    if: ${{ needs.scope.outputs.devcontainer == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -74,6 +98,8 @@ jobs:
 
   poetry-install:
     name: "Run: poetry install"
+    # Only "devcontainer" is named: it needs "scope" itself, and a skip
+    # propagates down the chain.
     needs: devcontainer
     permissions:
       # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
@@ -143,7 +169,15 @@ jobs:
     # 30 -> 45: the larger OCP 7.9 / build123d 0.11 install per sandbox, in
     # line with the "Pytest" job in test.yml.
     timeout-minutes: 45
-    needs: poetry-install
+    needs: [scope, poetry-install]
+    # The one job in this file that a change to ".devcontainer" alone does not
+    # run. What it does is the "Pytest" matrix in "test.yml" over again, on one
+    # image and one interpreter, and a change to the container's configuration
+    # cannot make the unit tests disagree with what that matrix already said.
+    # What such a change *can* break is whether anything works inside the
+    # container at all -- and "Run: behave" and "Run: pc" below are the jobs that
+    # ask that, drive the command line end to end, and still run.
+    if: ${{ needs.scope.outputs.pytest == 'true' }}
     permissions:
       # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,11 +86,31 @@ env:
   #    breakage specific to the older release is rare enough to be worth
   #    finding nightly rather than on every push.
   #
-  # No macOS entry any more. It used to drop 'macos-26' and leave 'macos-latest',
-  # which was the single largest saving here -- until the label moved and those
-  # became one image. There is one macOS leg now and it runs on every pull
-  # request: dropping it would mean testing no macOS at all.
+  # No macOS entry here. It used to drop 'macos-26' and leave 'macos-latest',
+  # which was the single largest saving in this file -- until the label moved and
+  # those became one image. There is one macOS leg now, and taking it out of the
+  # *deep* set would mean the nightly run tested no macOS at all. Which pull
+  # requests do not pay for it is OSES_QUEUE_ONLY below; that is a different
+  # question and a different list.
   OSES_DEEP_ONLY: '["ubuntu-22.04", "ubuntu-22.04-arm"]'
+  # And the ones a *pull request* does not pay for either -- dropped on the "pr"
+  # tier and kept from the merge queue up. See ".github/actions/test-depth" for
+  # what separates the two now: a pull request is re-run on every push to it,
+  # while the queue runs once, immediately before the commit lands.
+  #
+  # Which ones, and why these:
+  #  * "macos-latest". The single most expensive leg in the file -- macOS minutes
+  #    bill at 10x -- and the one whose breakages are least likely to be found by
+  #    a contributor's own machine. Nothing merges without it: the merge queue
+  #    runs it, and a queued commit that fails there never lands.
+  #  * "windows-2022". The pinned second Windows image, which is here so that a
+  #    move of the "windows-latest" alias cannot become the only Windows we ever
+  #    tested on. That is a question for the queue and the nightly run, not for
+  #    every push to a branch; "windows-latest" still runs on every one.
+  #
+  # NOT here, deliberately: "ubuntu-24.04-arm". arm64 is an architecture rather
+  # than a second image of one, and "cadquery-ocp" ships separate wheels for it.
+  OSES_QUEUE_ONLY: '["windows-2022", "macos-latest"]'
   PYTHONS: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
   # The two ends of the range a *sandbox* can be built at:
   # sandbox_versions.MIN_PYTHON_VERSION_CADQUERY and MAX_PYTHON_VERSION_CAD.
@@ -159,6 +179,11 @@ env:
   # specific breakage, and adding it here would multiply the most expensive jobs
   # in the workflow by BEHAVE_SHARDS.
   OSES_SLIM: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+  # The slim axis has no deep-only image in it, but it does have the macOS one,
+  # and on the sharded behave jobs that is four legs of 10x-billed runner per
+  # Python version. Dropped on the "pr" tier for the same reason as above and
+  # restored in the merge queue.
+  OSES_SLIM_QUEUE_ONLY: '["macos-latest"]'
   # Behave's Python axis: the oldest and the newest PartCAD is supported on.
   # Behave drives the command line rather than the sandbox, so what matters here
   # is the interpreter PartCAD itself runs on. 'test-pub-repo', which renders
@@ -173,21 +198,15 @@ jobs:
   build-containers:
     name: "Build Docker Containers"
     runs-on: ubuntu-24.04
-    # Only a version bump runs the matrix on a push to "devel": every other push
-    # there is followed by one within the hour, and running it twice buys
-    # nothing.
+    # The KiCad sandbox image, which only "test-pytest" below consumes, so it
+    # follows that job's gate rather than carrying one of its own.
     #
-    # "github.event_name != 'push'" leads, and is not decoration. Only a push
-    # carries "head_commit"; on a "schedule" it is null, "startsWith" reads that
-    # as the empty string, and "github.ref" for the nightly run of the default
-    # branch *is* "refs/heads/devel" -- so without this clause the whole
-    # condition is false and the nightly run is skipped. It was, every night
-    # from the day this guard was written until this line was added, which is
-    # the deep matrix ".github/actions/test-depth" promises and nothing else
-    # provides: a pull request drops OSES_DEEP_ONLY on the strength of it.
-    # A manual dispatch, a merge queue and a pull request are all in the same
-    # position and are all covered by leading with the event name.
-    if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
+    # "needs: set-matrix" is also what carries the "only a version bump runs the
+    # matrix on a push to devel" guard here. That guard lives on "set-matrix"
+    # (see the long note there); a job that needs a skipped job is skipped, so
+    # stating it twice would only be two places to keep in step.
+    needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.pytest == 'true' }}
     permissions:
       packages: write
     steps:
@@ -217,15 +236,34 @@ jobs:
   set-matrix:
     name: "Set matrix"
     runs-on: ubuntu-latest
-    # Same guard as "build-containers" above, for the same reasons: a push to
-    # "devel" runs this only for a version bump, and the event name leads
-    # because a "schedule" carries no "head_commit" to read.
+    # Only a version bump runs the matrix on a push to "devel": every other push
+    # there is followed by one within the hour, and running it twice buys
+    # nothing. Stated here and nowhere else in this file -- every other job needs
+    # this one, directly or through another, and a job that needs a skipped job
+    # is skipped.
+    #
+    # "github.event_name != 'push'" leads, and is not decoration. Only a push
+    # carries "head_commit"; on a "schedule" it is null, "startsWith" reads that
+    # as the empty string, and "github.ref" for the nightly run of the default
+    # branch *is* "refs/heads/devel" -- so without this clause the whole
+    # condition is false and the nightly run is skipped. It was, every night
+    # from the day this guard was written until this line was added, which is
+    # the deep matrix ".github/actions/test-depth" promises and nothing else
+    # provides: a pull request drops OSES_DEEP_ONLY and OSES_QUEUE_ONLY on the
+    # strength of it. A manual dispatch, a merge queue and a pull request are all
+    # in the same position and are all covered by leading with the event name.
     if: ${{ github.event_name != 'push' || github.ref != 'refs/heads/devel' || startsWith(github.event.head_commit.message, 'Version updated') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       matrix-sandbox: ${{ steps.set-matrix.outputs.matrix-sandbox }}
       matrix-slim: ${{ steps.set-matrix.outputs.matrix-slim }}
       matrix-behave: ${{ steps.set-matrix.outputs.matrix-behave }}
+      # Which of the jobs below this change can say anything about. Every one of
+      # them reads its own name here; see ".github/actions/changed-scopes".
+      deep: ${{ steps.depth.outputs.deep }}
+      pytest: ${{ steps.scope.outputs.pytest }}
+      behave: ${{ steps.scope.outputs.behave }}
+      examples: ${{ steps.scope.outputs.examples }}
     steps:
       - uses: actions/checkout@v7
 
@@ -233,40 +271,71 @@ jobs:
         id: depth
         uses: ./.github/actions/test-depth
 
+      - name: Decide what the change touches
+        id: scope
+        uses: ./.github/actions/changed-scopes
+        with:
+          deep: ${{ steps.depth.outputs.deep }}
+
       - name: Set matrix
         id: set-matrix
         env:
           DEEP: ${{ steps.depth.outputs.deep }}
+          # "false" on a pull request and "true" from the merge queue up. The
+          # two axes are separate: DEEP adds the older OS versions, QUEUE adds
+          # the images and the interpreters a pull request does not pay for.
+          QUEUE: ${{ steps.depth.outputs.queue }}
         run: |
           # The OS axis of the full matrix, with the deep-only images removed
-          # when this is not a deep run. 'matrix-slim' is untouched: it is
-          # already the '*-latest' images only, none of which are deep-only.
-          if [ "${DEEP}" = "true" ]; then
-            OSES='${{ env.OSES }}'
-          else
-            OSES=$(jq -cn --argjson all '${{ env.OSES }}' --argjson deep_only '${{ env.OSES_DEEP_ONLY }}' '$all - $deep_only')
+          # when this is not a deep run and the queue-only ones removed on top of
+          # that when it is a pull request.
+          OSES='${{ env.OSES }}'
+          OSES_SLIM='${{ env.OSES_SLIM }}'
+          PYTHONS='${{ env.PYTHONS }}'
+          if [ "${DEEP}" != "true" ]; then
+            OSES=$(jq -cn --argjson all "${OSES}" --argjson deep_only '${{ env.OSES_DEEP_ONLY }}' '$all - $deep_only')
+          fi
+          if [ "${QUEUE}" != "true" ]; then
+            OSES=$(jq -cn --argjson all "${OSES}" --argjson queue_only '${{ env.OSES_QUEUE_ONLY }}' '$all - $queue_only')
+            OSES_SLIM=$(jq -cn --argjson all "${OSES_SLIM}" --argjson queue_only '${{ env.OSES_SLIM_QUEUE_ONLY }}' '$all - $queue_only')
+            # The oldest and the newest supported interpreter, and nothing in
+            # between. That is the rule EXCLUDES already applies to every image
+            # but ubuntu-latest -- a version specific breakage shows up at one
+            # end of the range or the other -- and on a pull request it applies
+            # to ubuntu-latest as well. Derived from PYTHONS rather than written
+            # out, so adding a supported version cannot leave a stale literal
+            # here naming an interpreter nobody runs any more.
+            PYTHONS=$(jq -cn --argjson all "${PYTHONS}" '[$all[0], $all[-1]]')
           fi
           echo "Operating systems: ${OSES}"
-          # EXCLUDES still names images that may have just been dropped. That is
-          # harmless -- an exclude for a combination the matrix does not contain
-          # simply matches nothing -- and keeps one list to maintain rather than
-          # two that have to agree.
-          echo 'matrix={"os": '"${OSES}"', "python-version": ${{ env.PYTHONS }}, "exclude": ${{ env.EXCLUDES }}}' >> "${GITHUB_OUTPUT}"
-          # The same OS axis as 'matrix', so it follows the depth too, but the
+          echo "Operating systems (slim): ${OSES_SLIM}"
+          echo "Python versions: ${PYTHONS}"
+          # EXCLUDES still names images and interpreters that may have just been
+          # dropped. That is harmless -- an exclude for a combination the matrix
+          # does not contain simply matches nothing -- and keeps one list to
+          # maintain rather than two that have to agree.
+          echo 'matrix={"os": '"${OSES}"', "python-version": '"${PYTHONS}"', "exclude": ${{ env.EXCLUDES }}}' >> "${GITHUB_OUTPUT}"
+          # The same OS axis as 'matrix', so it follows both tiers too, but the
           # two versions a sandbox can be built at rather than every version
           # PartCAD runs on -- and no excludes, which would leave only one of
           # the two on every image but ubuntu-latest. See PYTHONS_SANDBOX above.
+          # Not narrowed by the pull request tier either: those two versions are
+          # already the ends of their range, so "first and last only" is what
+          # this list is.
           echo 'matrix-sandbox={"os": '"${OSES}"', "python-version": ${{ env.PYTHONS_SANDBOX }}}' >> "${GITHUB_OUTPUT}"
           # 'test-pub-repo' renders the public index, so its subject is the
           # sandbox as well; only its OS axis is the reduced one.
-          echo 'matrix-slim={"os": ${{ env.OSES_SLIM }}, "python-version": ${{ env.PYTHONS_SANDBOX }}}' >> "${GITHUB_OUTPUT}"
+          echo 'matrix-slim={"os": '"${OSES_SLIM}"', "python-version": ${{ env.PYTHONS_SANDBOX }}}' >> "${GITHUB_OUTPUT}"
           # Behave is single-process and dominates CI wall-clock, so it runs
           # sharded across parallel jobs. The "shard" axis is derived from
           # BEHAVE_SHARDS (1..N) here, so the number of behave jobs can never
           # drift from it, and crosses os/python. Behave uses the slim matrix
-          # (like test-pub-repo), so sharding does not multiply the full matrix.
+          # (like test-pub-repo), so sharding does not multiply the full matrix
+          # -- and dropping macOS from the slim axis on a pull request takes
+          # BEHAVE_SHARDS jobs per Python version with it, which is why it is
+          # the largest single saving there.
           SHARDS_JSON=$(python3 -c "import json, os; print(json.dumps(list(range(1, int(os.environ['BEHAVE_SHARDS']) + 1))))")
-          echo 'matrix-behave={"os": ${{ env.OSES_SLIM }}, "python-version": ${{ env.PYTHONS_SLIM }}, "shard": '"$SHARDS_JSON"'}' >> "${GITHUB_OUTPUT}"
+          echo 'matrix-behave={"os": '"${OSES_SLIM}"', "python-version": ${{ env.PYTHONS_SLIM }}, "shard": '"$SHARDS_JSON"'}' >> "${GITHUB_OUTPUT}"
 
   # cache-preheat:
   #   name: "Update caches"
@@ -288,6 +357,11 @@ jobs:
       - set-matrix
       - build-containers
       # - cache-preheat
+    # Skipped when nothing this suite can see has changed -- documentation, the
+    # Claude Code plugin, the VS Code extension, the dev container's own
+    # configuration. "changed-scopes" is fail-safe: a path it does not recognise
+    # counts as code and turns this back on.
+    if: ${{ needs.set-matrix.outputs.pytest == 'true' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
@@ -390,6 +464,11 @@ jobs:
     needs:
       - set-matrix
       # - cache-preheat
+    # Same gate as "Pytest" above. Note that a change to ".devcontainer" is not
+    # in it: these jobs run natively, with mamba, and never enter the dev
+    # container. The behave suite that *does* run inside it is "Run: behave" in
+    # "test-dev.yml", and that one is gated on the container.
+    if: ${{ needs.set-matrix.outputs.behave == 'true' }}
     strategy:
       fail-fast: false
       # Sharded, reduced matrix: the slim OS/Python set (OSES_SLIM/PYTHONS_SLIM),
@@ -508,6 +587,7 @@ jobs:
     needs:
       - set-matrix
       # - cache-preheat
+    if: ${{ needs.set-matrix.outputs.examples == 'true' }}
     strategy:
       fail-fast: false
       # The sandbox matrix: this job renders every part type this repository
@@ -653,6 +733,21 @@ jobs:
     needs:
       - set-matrix
       # - cache-preheat
+    # Deep runs only: the nightly schedule, a manual dispatch, a push, or
+    # "#deepTest". Not on a pull request and not in the merge queue.
+    #
+    # Because it cannot report anything there. The one step that exercises
+    # anything is "continue-on-error", and has been since the public index went
+    # to build123d 0.11 -- so on the full matrix this is fifteen jobs whose only
+    # way to fail is to fail at "setup-all", which every "Pytest" leg beside it
+    # has already proven on the same image and the same interpreter. What it is
+    # genuinely for is the log: a daily sweep over the whole public index, which
+    # a nightly run still delivers.
+    #
+    # Put it back on the reduced tiers the day the step stops being
+    # "continue-on-error" -- see the TODO on it below. A job that can fail is
+    # worth running before a merge; this one cannot.
+    if: ${{ needs.set-matrix.outputs.deep == 'true' && needs.set-matrix.outputs.examples == 'true' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
@@ -717,6 +812,12 @@ jobs:
     needs:
       - set-matrix
       # - cache-preheat
+    # Deep runs only, for exactly the reason "Examples (All)" above is: its one
+    # substantive step is "continue-on-error", so before a merge it is six jobs
+    # of up to an hour that cannot report a regression. The nightly run keeps
+    # the sweep, and the two exit codes it prints as a notice are where a
+    # regression in it shows up.
+    if: ${{ needs.set-matrix.outputs.deep == 'true' && needs.set-matrix.outputs.examples == 'true' }}
     strategy:
       fail-fast: false
       # Reduced matrix on purpose: up to 60 minutes per job, and it hits the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,19 +98,21 @@ env:
   # what separates the two now: a pull request is re-run on every push to it,
   # while the queue runs once, immediately before the commit lands.
   #
-  # Which ones, and why these:
-  #  * "macos-latest". The single most expensive leg in the file -- macOS minutes
-  #    bill at 10x -- and the one whose breakages are least likely to be found by
-  #    a contributor's own machine. Nothing merges without it: the merge queue
-  #    runs it, and a queued commit that fails there never lands.
-  #  * "windows-2022". The pinned second Windows image, which is here so that a
-  #    move of the "windows-latest" alias cannot become the only Windows we ever
-  #    tested on. That is a question for the queue and the nightly run, not for
-  #    every push to a branch; "windows-latest" still runs on every one.
+  # One entry, and it is macOS: the most expensive leg in the file -- macOS
+  # minutes bill at 10x -- and one where a version specific breakage is rare,
+  # because the interpreter is the host's and the shapes are built in a conda
+  # sandbox. Nothing merges without it: the merge queue runs it, and a queued
+  # commit that fails there never lands.
   #
-  # NOT here, deliberately: "ubuntu-24.04-arm". arm64 is an architecture rather
-  # than a second image of one, and "cadquery-ocp" ships separate wheels for it.
-  OSES_QUEUE_ONLY: '["windows-2022", "macos-latest"]'
+  # Deliberately NOT here:
+  #  * "windows-2022", and no Windows image at all. Windows is not a second
+  #    macOS. It is the platform whose path separator, drive letters and line
+  #    endings are a standing source of breakage in code written on Linux, so it
+  #    is the platform a pull request most needs, not the one to economise on.
+  #    Both images stay on every tier.
+  #  * "ubuntu-24.04-arm". arm64 is an architecture rather than a second image of
+  #    one, and "cadquery-ocp" ships separate wheels for it.
+  OSES_QUEUE_ONLY: '["macos-latest"]'
   PYTHONS: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
   # The two ends of the range a *sandbox* can be built at:
   # sandbox_versions.MIN_PYTHON_VERSION_CADQUERY and MAX_PYTHON_VERSION_CAD.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,12 +195,30 @@ poetry run pytest tests cad/freecad \
 poetry run behave                                                                        # integration tests (./features)
 ```
 
-CI fans these out over operating systems, and a pull request runs a reduced matrix: both Ubuntu 22.04 images
-and the second macOS are dropped. The full matrix runs nightly, on a manual dispatch, on a push, and on a
-pull request whose title or description contains `#deepTest`. `.github/actions/test-depth` is the one place
-that decides; `docs/source/contributing.rst` explains it to contributors. Note that a push to `devel` runs no
-matrix at all unless its head commit message starts with `Version updated` — the `set-matrix` job, and every
-job that depends on it, is skipped otherwise.
+CI fans these out over operating systems, and how much of that fan-out a run gets is decided in two places,
+which answer two different questions.
+
+`.github/actions/test-depth` answers **how deep**, in three tiers. A pull request gets `pr`: one image per OS
+and architecture, no macOS, and the oldest and newest supported Python only. The merge queue gets `queue`,
+which is what a pull request used to get — every current image, macOS included, and the full Python range —
+so the coverage a pull request drops is coverage the commit still earns before it lands, once per merge
+rather than once per push. Everything else gets `deep`: the nightly schedule, a manual dispatch, any push,
+and a pull request whose title or description contains `#deepTest`. `#deepTest` runs exactly what it ran
+before any of this existed.
+
+`.github/actions/changed-scopes` answers **which jobs at all**, by sorting the changed files into buckets: a
+documentation-only change runs the documentation build and nothing else, an `ai-agents/` change runs the
+Claude Code plugin, a `.devcontainer/` change runs the container's behave and `pc` jobs but not its pytest.
+It is fail-safe — a path it does not recognise counts as code and turns everything on — and it is a job
+condition rather than a `paths:` filter, because `merge_group` supports no `paths:` filter (so a
+trigger-level list is one the merge queue ignores, which is how a README typo used to freeze four standalone
+bundles in the queue) and because a workflow skipped by `paths:` never creates the check run a *required*
+check waits for, while a skipped job reports `skipped`, which counts as passing. Do not move these gates back
+onto the triggers.
+
+`docs/source/contributing.rst` explains both to contributors. Note that a push to `devel` runs no matrix at
+all unless its head commit message starts with `Version updated` — the `set-matrix` job, and every job that
+depends on it, is skipped otherwise.
 
 **Neither gate trusts pytest's exit code.** On Windows it disagrees with the run in both directions — exit `0`
 with a test having failed (which is what #444 was written for), and exit `127` after a session where every test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ existed.
 `.github/actions/changed-scopes` answers **which jobs at all**, by sorting the changed files into buckets: a
 documentation-only change runs the documentation build and nothing else, an `ai-agents/` change runs the
 Claude Code plugin, a `.devcontainer/` change runs the container's behave and `pc` jobs but not its pytest.
-It is fail-safe — a path it does not recognise counts as code *and* as a dependency, turning everything on —
+It is fail-safe — a path it does not recognise counts as both source and a dependency, so it runs everything a source change runs, the standalone bundles included. It does not turn on the four subjects that only their own directory turns on (the documentation, the extension, the IDE, the plugin), and that is not a gap: each is built from one fixed directory, so a path outside them cannot change what they contain —
 and it is a job condition rather than a `paths:` filter, because `merge_group` supports no `paths:` filter
 (so a trigger-level list is one the merge queue ignores, which is how a README typo used to freeze four
 standalone bundles in the queue) and because a workflow skipped by `paths:` never creates the check run a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,23 +198,34 @@ poetry run behave                                                               
 CI fans these out over operating systems, and how much of that fan-out a run gets is decided in two places,
 which answer two different questions.
 
-`.github/actions/test-depth` answers **how deep**, in three tiers. A pull request gets `pr`: one image per OS
-and architecture, no macOS, and the oldest and newest supported Python only. The merge queue gets `queue`,
-which is what a pull request used to get — every current image, macOS included, and the full Python range —
-so the coverage a pull request drops is coverage the commit still earns before it lands, once per merge
-rather than once per push. Everything else gets `deep`: the nightly schedule, a manual dispatch, any push,
-and a pull request whose title or description contains `#deepTest`. `#deepTest` runs exactly what it ran
-before any of this existed.
+`.github/actions/test-depth` answers **how deep**, in three tiers. A pull request gets `pr`: every image
+except macOS, and the oldest and newest supported Python only. Both Windows images stay on every tier and
+that is deliberate — Windows is where a path separator written on Linux goes wrong, so it is the platform a
+pull request most needs, not the one to economise on. The merge queue gets `queue`, which is what a pull
+request used to get — every current image, macOS included, and the full Python range — so the coverage a
+pull request drops is coverage the commit still earns before it lands, once per merge rather than once per
+push. Everything else gets `deep`: the nightly schedule, a manual dispatch, any push, and a pull request
+whose title or description contains `#deepTest`. `#deepTest` runs exactly what it ran before any of this
+existed.
 
 `.github/actions/changed-scopes` answers **which jobs at all**, by sorting the changed files into buckets: a
 documentation-only change runs the documentation build and nothing else, an `ai-agents/` change runs the
 Claude Code plugin, a `.devcontainer/` change runs the container's behave and `pc` jobs but not its pytest.
-It is fail-safe — a path it does not recognise counts as code and turns everything on — and it is a job
-condition rather than a `paths:` filter, because `merge_group` supports no `paths:` filter (so a
-trigger-level list is one the merge queue ignores, which is how a README typo used to freeze four standalone
-bundles in the queue) and because a workflow skipped by `paths:` never creates the check run a *required*
-check waits for, while a skipped job reports `skipped`, which counts as passing. Do not move these gates back
-onto the triggers.
+It is fail-safe — a path it does not recognise counts as code *and* as a dependency, turning everything on —
+and it is a job condition rather than a `paths:` filter, because `merge_group` supports no `paths:` filter
+(so a trigger-level list is one the merge queue ignores, which is how a README typo used to freeze four
+standalone bundles in the queue) and because a workflow skipped by `paths:` never creates the check run a
+*required* check waits for, while a skipped job reports `skipped`, which counts as passing. Do not move these
+gates back onto the triggers.
+
+One bucket boundary in there is a deliberate trade rather than a fact, and it is the standalone bundles.
+`Standalone` is gated on **dependencies** (`pyproject.toml`, `poetry.lock`, root `requirements*`) and on
+`dev-tools/pyinstaller/`, `dev-tools/snap/`, `.snapcraft.yaml` and `install.sh` — not on `src/**`. Freezing
+is the most expensive thing here, and what makes a bundle differ from a working wheel is nearly always what
+went into it. A source change *can* break the freeze all the same (see `dev-tools/pyinstaller/README.md`),
+and the safety net for that is the push trigger of `build-standalone.yml`, which still lists `src/**` and
+fires on the push to `devel` after the merge — do not remove it, it is now the only thing that builds a
+bundle for a source change short of `#deepTest`.
 
 `docs/source/contributing.rst` explains both to contributors. Note that a push to `devel` runs no matrix at
 all unless its head commit message starts with `Version updated` — the `set-matrix` job, and every job that

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -813,12 +813,21 @@ and turns each subject on or off:
    * - ``.github/``
      - everything, this being the thing that decides what runs
 
-**The rows are matched in order, and a directory's row beats the extension row above it.** That is what the
-first row's qualifier is about: ``ai-agents/skills/render/SKILL.md`` is the plugin, not prose about it, and
-``examples/feature_render/README.md`` is what ``pc render -r`` wrote and the ``Examples (PartCAD)`` job
-compares against a fresh render. Both are Markdown and neither is documentation. The exception to the
-exception is ``AGENTS.md`` and ``CLAUDE.md``, which are documentation wherever they sit -- this repository
-keeps a package's own under ``src/`` -- so they are named before the source directories rather than after.
+**The table above is grouped by subject, for reading. The classifier is an ordered list of rules and the first
+one that matches a path wins**, and the two orders are not the same -- ``.github/`` is the last row here and
+the first rule there. What matters is the shape of that list: every rule that names a *directory* comes before
+every rule that matches by *extension*.
+
+So a Markdown file belongs to whatever directory claims it first. ``ai-agents/skills/render/SKILL.md`` is the
+plugin rather than prose about it, and ``examples/feature_render/README.md`` is what ``pc render -r`` wrote and
+what the ``Examples (PartCAD)`` job compares against a fresh render; neither is documentation.
+
+``AGENTS.md`` and ``CLAUDE.md`` are matched ahead of the *source* directories, which is why
+``src/partcad/AGENTS.md`` is documentation -- this repository keeps a package's own beside its code. They are
+not matched ahead of the directories above those, so they are **not** documentation wherever they sit:
+``.github/AGENTS.md`` is CI, ``ai-agents/AGENTS.md`` is the plugin, and ``ide/vscode/AGENTS.md`` belongs to the
+extension. If you are adding a rule, its position in that list is the decision; ``.github/actions/changed-scopes``
+carries the list in order, and ``tests/dev_tools/test_changed_scopes.py`` pins these cases.
 
 Two of those rows are the same distinction from either side, and it is the only place a source change and a
 dependency change are treated differently. Freezing is the most expensive thing this repository does -- ~500MB

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -709,10 +709,11 @@ Depth: three tiers
 CI fans out over operating systems, and a pull request does not pay for all of them.
 
 ``pr``
-    What a pull request runs on every push to it. One image per operating system and architecture --
-    Ubuntu 24.04 on x86_64 and arm64, and ``windows-latest`` -- and the oldest and the newest supported
-    Python, with nothing in between. No macOS, whose runners bill at ten times the Linux rate, and no
-    standalone bundle or IDE for it either.
+    What a pull request runs on every push to it. The oldest and the newest supported Python, with nothing
+    in between, and every image except macOS -- whose runners bill at ten times the Linux rate, and which no
+    standalone bundle or IDE is built for here either. **Both Windows images stay.** Windows is not a second
+    macOS to economise on: its path separator, drive letters and line endings are a standing source of
+    breakage in code written on Linux, so it is the platform a pull request most needs.
 
 ``queue``
     What the merge queue runs, which is what a pull request used to: every current image, macOS included, and
@@ -732,11 +733,43 @@ else -- the nightly run has no head commit to read a message from, so the guard 
 lets every other trigger through. It did not, from the day the guard was written until 0.8.32, and the nightly
 was skipped every night in between: if you change that condition, keep the event-name clause first.
 
-The ``Standalone`` workflow reads the same tiers: a pull request builds three of the seven standalone bundles,
-the merge queue builds four -- it is the macOS bundle a pull request drops -- and a deep run builds all seven.
-The ``IDE`` workflow follows it, because each IDE carries a bundle: no macOS IDE on a pull request, the Intel
-macOS one on a deep run only. A release always builds all seven bundles and all four IDEs, and refuses to
-publish if any is missing.
+The ``Standalone`` workflow reads the same tiers, job by job:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Job
+     - ``pr``
+     - ``queue``
+     - ``deep``
+   * - ``Build``
+     - 3 bundles (no macOS)
+     - 4 bundles
+     - all 7
+   * - ``Install``
+     - 2 (every bundle ``install.sh`` can install)
+     - 4 (adds the macOS bundle on the *next* macOS)
+     - 8
+   * - ``Snap``
+     - 1 (amd64)
+     - not run
+     - 2, on a ``devel`` push or a dispatch
+   * - ``Examples via bundle``
+     - 2 (the ``PartCAD`` suite only)
+     - not run
+     - 6
+
+``Snap`` and ``Examples`` have always been skipped in the merge queue and on the release path -- nothing
+downstream consumes a snap, and the deterministic ``Build`` and ``Install`` jobs are what gate a release. What
+is new is that a pull request packs one snap rather than two (the recipe is one file and the two jobs run it
+over payloads ``Build`` and ``Install`` have already exercised, at ~45 minutes of squashing each), and that the
+``All`` example suite -- ``continue-on-error``, because the public index carries packages this repository
+cannot fix -- is left to deep runs.
+
+The ``IDE`` workflow follows the same tiers, because each IDE carries a bundle: no macOS IDE on a pull request,
+the Intel macOS one on a deep run only. A release always builds all seven bundles and all four IDEs, and
+refuses to publish if any is missing.
 
 Scope: what the change touches
 
@@ -763,10 +796,28 @@ and turns each subject on or off:
      - ``IDE``
    * - ``dev-tools/pyinstaller/``, ``dev-tools/snap/``, ``.snapcraft.yaml``, ``install.sh``
      - ``Standalone``, ``IDE``
-   * - anything else -- ``src/``, ``tests/``, ``features/``, ``examples/``, ``pyproject.toml``, ``poetry.lock``
-     - everything except the IDE
+   * - ``pyproject.toml``, ``poetry.lock``, root ``requirements*``
+     - the tests, the wheel **and** ``Standalone``
+   * - ``src/``, ``tests/``, ``features/``, ``examples/``, ``cad/``, ``tools/``, ``dev-tools/``
+     - the tests and the wheel, but **not** ``Standalone``
+   * - anything else
+     - all of the above, ``Standalone`` included
    * - ``.github/``
      - everything, this being the thing that decides what runs
+
+Two of those rows are the same distinction from either side, and it is the only place a source change and a
+dependency change are treated differently. Freezing is the most expensive thing this repository does -- ~500MB
+of OpenCASCADE per runner -- and what makes a frozen bundle differ from a working wheel is nearly always what
+went *into* it: a dependency shipping a data file PyInstaller cannot see, a new transitive import, a wheel with
+no build for one platform. So a dependency change freezes and a change to ``src/`` alone does not.
+
+That is a trade rather than a fact. A source change *can* break the freeze -- a lazily imported module, a file
+read relative to ``__file__``; ``dev-tools/pyinstaller/README.md`` has the list -- and that is now found on the
+push to ``devel`` after the merge rather than on the pull request. The push trigger of ``build-standalone.yml``
+still lists ``src/**`` for exactly this, a release still refuses to publish with a platform missing, and
+``#deepTest`` still builds the whole set before a merge for a change that warrants it. Note also which way the
+last row falls: an unclassified path counts as **both** source and dependency, so a bundle is skipped only for
+a directory somebody has named as source.
 
 Two properties are worth knowing before you edit that list. It is **fail-safe**: a path it has not been taught
 falls through to "code" and turns everything on, so a new directory can only ever run too much. And it is a job

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -792,7 +792,7 @@ and turns each subject on or off:
 
    * - A change touching only...
      - runs
-   * - ``docs/``, ``*.md``, ``*.rst``, ``.claude/``, ``openspec/``
+   * - ``docs/``, ``.claude/``, ``openspec/``, and any ``*.md`` or ``*.rst`` no row below claims
      - ``Documentation``
    * - ``ai-agents/``, ``.claude-plugin/``
      - ``Claude Code plugin``
@@ -813,6 +813,13 @@ and turns each subject on or off:
    * - ``.github/``
      - everything, this being the thing that decides what runs
 
+**The rows are matched in order, and a directory's row beats the extension row above it.** That is what the
+first row's qualifier is about: ``ai-agents/skills/render/SKILL.md`` is the plugin, not prose about it, and
+``examples/feature_render/README.md`` is what ``pc render -r`` wrote and the ``Examples (PartCAD)`` job
+compares against a fresh render. Both are Markdown and neither is documentation. The exception to the
+exception is ``AGENTS.md`` and ``CLAUDE.md``, which are documentation wherever they sit -- this repository
+keeps a package's own under ``src/`` -- so they are named before the source directories rather than after.
+
 Two of those rows are the same distinction from either side, and it is the only place a source change and a
 dependency change are treated differently. Freezing is the most expensive thing this repository does -- ~500MB
 of OpenCASCADE per runner -- and what makes a frozen bundle differ from a working wheel is nearly always what
@@ -828,7 +835,10 @@ last row falls: an unclassified path counts as **both** source and dependency, s
 a directory somebody has named as source.
 
 Two properties are worth knowing before you edit that list. It is **fail-safe**: a path it has not been taught
-falls through to "code" and turns everything on, so a new directory can only ever run too much. And it is a job
+counts as both source and a dependency, so it runs everything a source change runs, the standalone bundles
+included, and a new directory can only ever run too much. It does not turn on the four subjects that only their
+own directory turns on -- the documentation, the extension, the IDE, the plugin -- and that is not a gap: each
+is built from one fixed directory, so a path outside them cannot change what they contain. And it is a job
 condition rather than a ``paths:`` filter on the trigger, deliberately -- ``merge_group`` supports no ``paths:``
 filter at all, so a trigger-level list is one the merge queue ignores; and a workflow skipped by ``paths:``
 never creates the check run that a *required* check waits for, while a job skipped by a condition reports

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -724,8 +724,16 @@ CI fans out over operating systems, and a pull request does not pay for all of t
     Everything, the older OS versions included: the nightly schedule, a manual workflow run, and any push,
     which includes the release. On a pull request, put ``#deepTest`` anywhere in the title or the description
     and re-run the checks. Worth doing when the change touches packaging, dependencies, the standalone bundle
-    or the snap, or anything else where an older OS version could behave differently. ``#deepTest`` runs
-    exactly what it always ran -- it is unaffected by everything on this page.
+    or the snap, or anything else where an older OS version could behave differently. It runs exactly what it
+    always ran -- it is unaffected by everything on this page.
+
+    .. note::
+
+       The marker is matched as a plain substring, so a pull request that merely *mentions* it -- one editing
+       this page, say -- opts itself in and runs the full matrix. That is deliberate: a matcher clever enough
+       to tell a marker from a mention is a rule you would have to know before your opt-in worked, and
+       over-running is the safe direction. If a description has to name the marker without asking for it,
+       write it split across two code spans.
 
 A push to ``devel`` is the exception to all three: it runs no matrix at all unless its head commit message
 starts with ``Version updated``, which is the release commit. That exception applies to pushes and to nothing

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -697,28 +697,89 @@ maintainers, following are related GH docs:
 
 .. _deep-test:
 
-Running the full test matrix
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+How much CI a change runs
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-CI fans out over operating systems, and a pull request does not pay for all of them. By default it drops both
-Ubuntu 22.04 images and the second macOS, which is most of the cost -- macOS minutes bill at ten times the
-Linux rate. What stays is Ubuntu 24.04 on x86_64 and arm64, both Windows images, and one macOS.
+Two questions decide it, and they are asked separately: **how deep** the matrix goes, and **which jobs** the
+change can say anything about at all.
 
-The full matrix runs on the nightly schedule, on a manual workflow run, and on a push, which includes the
-release. A push to ``devel`` is the exception: it runs no matrix at all unless its head commit message starts
-with ``Version updated``, which is the release commit. That exception applies to pushes and to nothing else --
-the nightly run has no head commit to read a message from, so the guard leads with the event name and lets
-every other trigger through. It did not, from the day the guard was written until 0.8.32, and the nightly was
-skipped every night in between: if you change that condition, keep the event-name clause first.
-To run it on a pull request before it merges, put ``#deepTest`` anywhere in the pull request title or
-description and re-run the checks. Worth doing when the change touches packaging, dependencies, the standalone
-bundle or the snap, or anything else where an older OS version could behave differently.
+Depth: three tiers
 
-The ``Standalone`` workflow reads the same marker: without it, a pull request builds four of the seven
-standalone bundles -- it drops both Ubuntu 22.04 images and macOS on x86_64, whose runner bills at the same ten
-times the Linux rate. The ``IDE`` workflow reads it too, for the one IDE whose command line bundle is
-deep-only: the Intel macOS application is built and installed on a deep run and on no other. A release always
-builds all seven bundles and all four IDEs, and refuses to publish if any is missing.
+
+CI fans out over operating systems, and a pull request does not pay for all of them.
+
+``pr``
+    What a pull request runs on every push to it. One image per operating system and architecture --
+    Ubuntu 24.04 on x86_64 and arm64, and ``windows-latest`` -- and the oldest and the newest supported
+    Python, with nothing in between. No macOS, whose runners bill at ten times the Linux rate, and no
+    standalone bundle or IDE for it either.
+
+``queue``
+    What the merge queue runs, which is what a pull request used to: every current image, macOS included, and
+    the full Python range. Nothing reaches ``devel`` without having passed this, so the coverage a pull request
+    drops is coverage the commit still has to earn -- one run per merge instead of one per push.
+
+``deep``
+    Everything, the older OS versions included: the nightly schedule, a manual workflow run, and any push,
+    which includes the release. On a pull request, put ``#deepTest`` anywhere in the title or the description
+    and re-run the checks. Worth doing when the change touches packaging, dependencies, the standalone bundle
+    or the snap, or anything else where an older OS version could behave differently. ``#deepTest`` runs
+    exactly what it always ran -- it is unaffected by everything on this page.
+
+A push to ``devel`` is the exception to all three: it runs no matrix at all unless its head commit message
+starts with ``Version updated``, which is the release commit. That exception applies to pushes and to nothing
+else -- the nightly run has no head commit to read a message from, so the guard leads with the event name and
+lets every other trigger through. It did not, from the day the guard was written until 0.8.32, and the nightly
+was skipped every night in between: if you change that condition, keep the event-name clause first.
+
+The ``Standalone`` workflow reads the same tiers: a pull request builds three of the seven standalone bundles,
+the merge queue builds four -- it is the macOS bundle a pull request drops -- and a deep run builds all seven.
+The ``IDE`` workflow follows it, because each IDE carries a bundle: no macOS IDE on a pull request, the Intel
+macOS one on a deep run only. A release always builds all seven bundles and all four IDEs, and refuses to
+publish if any is missing.
+
+Scope: what the change touches
+
+
+Depth decides how wide a job fans out. Scope decides whether it runs at all, and it applies to the merge queue
+exactly as it does to a pull request. ``.github/actions/changed-scopes`` sorts the changed files into buckets
+and turns each subject on or off:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - A change touching only...
+     - runs
+   * - ``docs/``, ``*.md``, ``*.rst``, ``.claude/``, ``openspec/``
+     - ``Documentation``
+   * - ``ai-agents/``, ``.claude-plugin/``
+     - ``Claude Code plugin``
+   * - ``.devcontainer/``
+     - the ``CI-Dev`` container, ``Run: behave`` and ``Run: pc`` -- but not ``Run: pytest``
+   * - ``ide/vscode/``, ``ide/vscode-shim/``
+     - ``npm test``, ``VS Code extension``, ``IDE``
+   * - ``ide/standalone/``, ``.vscode/``
+     - ``IDE``
+   * - ``dev-tools/pyinstaller/``, ``dev-tools/snap/``, ``.snapcraft.yaml``, ``install.sh``
+     - ``Standalone``, ``IDE``
+   * - anything else -- ``src/``, ``tests/``, ``features/``, ``examples/``, ``pyproject.toml``, ``poetry.lock``
+     - everything except the IDE
+   * - ``.github/``
+     - everything, this being the thing that decides what runs
+
+Two properties are worth knowing before you edit that list. It is **fail-safe**: a path it has not been taught
+falls through to "code" and turns everything on, so a new directory can only ever run too much. And it is a job
+condition rather than a ``paths:`` filter on the trigger, deliberately -- ``merge_group`` supports no ``paths:``
+filter at all, so a trigger-level list is one the merge queue ignores; and a workflow skipped by ``paths:``
+never creates the check run that a *required* check waits for, while a job skipped by a condition reports
+``skipped``, which counts as passing.
+
+``.devcontainer`` is the one entry that is a judgement rather than a mechanism. ``Run: pytest`` in ``CI-Dev``
+is the ``Pytest`` matrix over again on one image and one interpreter, and a change to the container's
+configuration cannot make the unit tests disagree with what that matrix already said. What it can break is
+whether anything works inside the container at all, and ``Run: behave`` and ``Run: pc`` -- which drive the
+command line end to end, in the container -- are the jobs that ask that.
 
 Both workflows install each macOS artifact on macOS 15 *and* on macOS 26, because there is one macOS build per
 architecture and it is frozen on the older release -- so "a bundle runs on the OS it was built on and

--- a/tests/dev_tools/test_changed_scopes.py
+++ b/tests/dev_tools/test_changed_scopes.py
@@ -95,13 +95,61 @@ def test_a_deep_run_turns_everything_on(tmp_path):
 
 
 def test_an_unknown_path_runs_everything(tmp_path):
-    """The fail-safe. A directory nobody has taught the gate about is code."""
+    """The fail-safe, and the reason it lands in two buckets rather than one.
+
+    "code" alone would leave the standalone bundles unbuilt for a path nobody
+    has classified -- and an unclassified path is precisely the one nobody has
+    thought about. A file has to be *named* as source before it stops being
+    treated as something that can change what gets frozen.
+    """
     subjects, buckets = classify(tmp_path, ["a-brand-new-directory/whatever.py"])
-    assert buckets == {"code"}
+    assert buckets == {"code", "deps"}
     # Not "all of them": the IDE is not rebuilt by a source change, here or in
     # "build-ide-standalone.yml", because it downloads the bundles rather than
-    # freezing them. Everything a source change *can* break is on.
+    # freezing them. Everything else is on.
     assert subjects["pytest"] and subjects["behave"] and subjects["wheel"] and subjects["bundle"]
+
+
+def test_source_alone_does_not_freeze_a_bundle(tmp_path):
+    """The one place a source change and a dependency change part company.
+
+    Freezing is the most expensive thing in CI, and what makes a bundle differ
+    from a working wheel is almost always what went into it. So a change to
+    "src/" runs the tests and builds the wheel but does not freeze; the push to
+    "devel" that follows the merge still does, its "paths:" filter still lists
+    "src/**", and "#deepTest" still freezes everything before a merge.
+    """
+    subjects, buckets = classify(tmp_path, ["src/partcad/context.py"])
+    assert buckets == {"code"}
+    assert subjects["pytest"] and subjects["behave"] and subjects["wheel"]
+    assert not subjects["bundle"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["pyproject.toml", "poetry.lock", "requirements.txt", "requirements-aws.txt", "requirements-dev.in"],
+)
+def test_a_dependency_change_freezes_a_bundle(tmp_path, path):
+    subjects, buckets = classify(tmp_path, [path])
+    assert buckets == {"deps"}
+    assert subjects["bundle"]
+    # And everything a source change runs, since the dependency is under it.
+    assert subjects["pytest"] and subjects["behave"] and subjects["wheel"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["docs/requirements.txt", ".devcontainer/requirements.txt", "ide/vscode/requirements.txt"],
+)
+def test_only_the_root_dependency_files_are_dependencies(tmp_path, path):
+    """A "requirements.txt" belongs to whatever directory it is in.
+
+    The patterns for these are anchored at the start of the path -- "*" matches
+    "/" in a case pattern -- and each of these directories has a rule of its own
+    above them. Sphinx's requirements are not PartCAD's.
+    """
+    subjects, _ = classify(tmp_path, [path])
+    assert not subjects["bundle"]
 
 
 @pytest.mark.parametrize(
@@ -132,10 +180,11 @@ def test_an_unknown_path_runs_everything(tmp_path):
         ("src/partcad/context.py", "code"),
         ("tests/partcad/unit/test_part.py", "code"),
         ("features/pc_list.feature", "code"),
-        ("pyproject.toml", "code"),
-        ("poetry.lock", "code"),
         ("conftest.py", "code"),
-        ("requirements.txt", "code"),
+        ("behave.ini", "code"),
+        ("pyproject.toml", "deps"),
+        ("poetry.lock", "deps"),
+        ("requirements.txt", "deps"),
         ("cad/freecad/InitGui.py", "code"),
         # A rendered README under "examples/" is an *output* that
         # "Examples (PartCAD)" compares against a fresh render, so it must not
@@ -213,44 +262,46 @@ def test_every_top_level_entry_is_classified_deliberately(tmp_path):
     ).stdout.split()
 
     # What each top-level entry is allowed to be. Anything absent from here is a
-    # new entry, and the assertion below says to come and decide about it.
+    # new entry, and the assertion below says to come and decide about it. The
+    # two entries that are "code" *and* "deps" are the ones nothing classifies:
+    # they reach the catch-all, which is the fail-safe.
     expected = {
-        ".devcontainer": "devcontainer",
-        ".github": "ci",
-        ".claude": "docs",
-        ".claude-plugin": "ai",
-        ".cursor": "docs",
-        ".gitattributes": "code",
-        ".gitignore": "code",
-        ".readthedocs.yaml": "docs",
-        ".snapcraft.yaml": "packaging",
-        ".vscode": "ide",
-        "AGENTS.md": "docs",
-        "CLAUDE.md": "docs",
-        "LICENSE.txt": "docs",
-        "README.md": "docs",
-        "ai-agents": "ai",
-        "apache20.svg": "docs",
-        "behave.ini": "code",
-        "cad": "code",
-        "conftest.py": "code",
-        "dev-tools": "code",
-        "docs": "docs",
-        "examples": "code",
-        "features": "code",
+        ".devcontainer": {"devcontainer"},
+        ".github": {"ci"},
+        ".claude": {"docs"},
+        ".claude-plugin": {"ai"},
+        ".cursor": {"docs"},
+        ".gitattributes": {"code", "deps"},
+        ".gitignore": {"code", "deps"},
+        ".readthedocs.yaml": {"docs"},
+        ".snapcraft.yaml": {"packaging"},
+        ".vscode": {"ide"},
+        "AGENTS.md": {"docs"},
+        "CLAUDE.md": {"docs"},
+        "LICENSE.txt": {"docs"},
+        "README.md": {"docs"},
+        "ai-agents": {"ai"},
+        "apache20.svg": {"docs"},
+        "behave.ini": {"code"},
+        "cad": {"code"},
+        "conftest.py": {"code"},
+        "dev-tools": {"code"},
+        "docs": {"docs"},
+        "examples": {"code"},
+        "features": {"code"},
         "ide": None,  # split between "vscode" and "ide"; covered above
-        "install.sh": "packaging",
-        "openspec": "docs",
-        "poetry.lock": "code",
-        "poetry.toml": "code",
-        "pyproject.toml": "code",
-        "requirements-aws.txt": "code",
-        "requirements-dev.in": "code",
-        "requirements-lint.txt": "code",
-        "requirements.txt": "code",
-        "src": "code",
-        "tests": "code",
-        "tools": "code",
+        "install.sh": {"packaging"},
+        "openspec": {"docs"},
+        "poetry.lock": {"deps"},
+        "poetry.toml": {"deps"},
+        "pyproject.toml": {"deps"},
+        "requirements-aws.txt": {"deps"},
+        "requirements-dev.in": {"deps"},
+        "requirements-lint.txt": {"deps"},
+        "requirements.txt": {"deps"},
+        "src": {"code"},
+        "tests": {"code"},
+        "tools": {"code"},
     }
 
     unknown = sorted(set(tracked) - set(expected))
@@ -268,4 +319,4 @@ def test_every_top_level_entry_is_classified_deliberately(tmp_path):
         if entry.startswith(".") and (REPO_ROOT / entry).is_file():
             path = entry
         _, buckets = classify(tmp_path, [path])
-        assert buckets == {want}, f"{path} classified as {buckets}, expected {{'{want}'}}"
+        assert buckets == want, f"{path} classified as {buckets}, expected {want}"

--- a/tests/dev_tools/test_changed_scopes.py
+++ b/tests/dev_tools/test_changed_scopes.py
@@ -48,12 +48,17 @@ SUBJECTS = {
 }
 
 
+def step_script(step_id):
+    """One step of the composite action, as a shell script."""
+    action = yaml.safe_load(ACTION.read_text())
+    steps = [s for s in action["runs"]["steps"] if s.get("id") == step_id]
+    assert len(steps) == 1, f"the action no longer has exactly one '{step_id}' step"
+    return steps[0]["run"]
+
+
 def classify_script():
     """The 'classify' step of the composite action, as a shell script."""
-    action = yaml.safe_load(ACTION.read_text())
-    steps = [s for s in action["runs"]["steps"] if s.get("id") == "classify"]
-    assert len(steps) == 1, "the action no longer has exactly one 'classify' step"
-    return steps[0]["run"]
+    return step_script("classify")
 
 
 def classify(tmp_path, paths, all_=False):
@@ -320,3 +325,106 @@ def test_every_top_level_entry_is_classified_deliberately(tmp_path):
             path = entry
         _, buckets = classify(tmp_path, [path])
         assert buckets == want, f"{path} classified as {buckets}, expected {want}"
+
+
+# --- The "files" step: which files the change touched, and whether we saw them all ---
+#
+# The gate is only as good as this list. If it comes back short and the step does
+# not notice, the buckets are computed from a subset of the change and the jobs
+# for everything missing are skipped -- silently, because a skipped job looks
+# exactly like a job that had nothing to do.
+#
+# Both endpoints cap what they return, and they differ in what they tell you
+# about it, which is why each needs its own check and its own test:
+#
+#   * "pulls/{n}/files" pages up to 3000 entries, and the pull request itself
+#     carries "changed_files", the real total. Two numbers, so a comparison
+#     works.
+#   * "compare/{base}...{head}" caps ".files" at 300 and reports no total at
+#     all. There is no second number, so a full 300 has to be *assumed*
+#     truncated. The check here was a comparison against ".files | length" --
+#     the length of the capped array itself, which equals the number of lines
+#     written whether or not anything was dropped, so it could never fire. Found
+#     by CodeRabbit on #608; these are what would have caught it.
+
+
+def gh_stub(directory, file_count, declared=None, fail=False):
+    """A stand-in for the "gh" CLI that serves a fixed number of filenames."""
+    stub = directory / "gh"
+    stub.write_text(
+        "#!/bin/bash\n"
+        f"if [ '{fail}' = 'True' ]; then exit 1; fi\n"
+        'for arg in "$@"; do\n'
+        '  case "$arg" in\n'
+        # The pull request itself, asked for its "changed_files" count.
+        f"    *'/pulls/'*'/files') seq 1 {file_count} | sed 's|^|src/f|;s|$|.py|'; exit 0 ;;\n"
+        f"    *'/pulls/'*) echo '{declared if declared is not None else file_count}'; exit 0 ;;\n"
+        f"    *'/compare/'*) seq 1 {file_count} | sed 's|^|src/f|;s|$|.py|'; exit 0 ;;\n"
+        "  esac\n"
+        "done\n"
+        "exit 1\n"
+    )
+    stub.chmod(0o755)
+
+
+def run_files_step(tmp_path, event, file_count, declared=None, deep=False, fail=False):
+    """Run the "files" step and return whether it gave up and asked for everything."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    gh_stub(bin_dir, file_count, declared, fail)
+    output = tmp_path / "files-output"
+    output.touch()
+
+    result = subprocess.run(
+        ["bash", "-c", step_script("files")],
+        env={
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "GH_TOKEN": "stub",
+            "DEEP": "true" if deep else "false",
+            "EVENT_NAME": event,
+            "REPO": "partcad/partcad",
+            "PR_NUMBER": "608",
+            "MG_BASE": "0" * 40,
+            "MG_HEAD": "1" * 40,
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(output),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    values = dict(line.partition("=")[::2] for line in output.read_text().splitlines())
+    return values["all"] == "true"
+
+
+def test_a_merge_group_at_the_cap_is_treated_as_truncated(tmp_path):
+    """300 is the cap, and the response cannot say whether it was reached or hit."""
+    assert run_files_step(tmp_path, "merge_group", file_count=300) is True
+
+
+def test_a_merge_group_below_the_cap_is_classified(tmp_path):
+    assert run_files_step(tmp_path, "merge_group", file_count=299) is False
+
+
+def test_a_pull_request_shorter_than_its_own_count_is_truncated(tmp_path):
+    """Here there *is* a second number, and it is the one that matters."""
+    assert run_files_step(tmp_path, "pull_request", file_count=10, declared=40) is True
+
+
+def test_a_complete_pull_request_listing_is_classified(tmp_path):
+    assert run_files_step(tmp_path, "pull_request", file_count=10, declared=10) is False
+
+
+def test_an_api_failure_runs_everything(tmp_path):
+    assert run_files_step(tmp_path, "pull_request", file_count=10, fail=True) is True
+
+
+def test_an_unknown_event_runs_everything(tmp_path):
+    """Only a pull request and a merge queue reach this step; a new trigger must
+    not arrive with an empty list and skip the whole workflow."""
+    assert run_files_step(tmp_path, "issue_comment", file_count=10) is True
+
+
+def test_a_deep_run_never_asks(tmp_path):
+    """It short-circuits before the API call -- the stub would fail if reached."""
+    assert run_files_step(tmp_path, "pull_request", file_count=10, deep=True, fail=True) is True

--- a/tests/dev_tools/test_changed_scopes.py
+++ b/tests/dev_tools/test_changed_scopes.py
@@ -22,11 +22,22 @@ here. A copy of the rules would be a second thing to keep in step, and it would
 agree with itself while disagreeing with CI.
 """
 
+import os
 import pathlib
 import subprocess
 
 import pytest
 import yaml
+
+# POSIX only, and not because the tests are lazy about paths: every job that
+# runs this action is `runs-on: ubuntu-latest`, so a Linux shell is the only one
+# it will ever be interpreted by. Windows has no `bash` that would tell us
+# anything about that -- `bash.exe` on a GitHub Windows runner is the WSL
+# launcher, which answers a script with "use 'wsl --install -d <Distro>' to
+# install" and exits non-zero (which is how these tests took the whole Windows
+# `Pytest` session down with them under `-x`, on the run that introduced them).
+# Git Bash would run them, and would be testing a shell CI never uses.
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="the action is bash, and it only ever runs on Linux runners")
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 ACTION = REPO_ROOT / ".github" / "actions" / "changed-scopes" / "action.yml"

--- a/tests/dev_tools/test_changed_scopes.py
+++ b/tests/dev_tools/test_changed_scopes.py
@@ -1,0 +1,271 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The CI gate that decides which jobs a change runs.
+
+`.github/actions/changed-scopes` sorts the files a pull request touches into
+buckets and turns each CI subject on or off from them, and a pull request or a
+merge queue run then *skips* whatever it turned off. So a mistake in it does not
+show up as a failure: it shows up as a job that quietly did not run, on the one
+change it should have run for.
+
+The property that makes that safe is one line of the action -- a path it has not
+been taught falls through to "code", and "code" turns everything on -- so a
+mistake can only ever run too much. These check that property directly, against
+every top-level entry this repository actually has and against a directory it
+does not, and then check the handful of mappings the gate exists for.
+
+The script is extracted from the action and run as-is rather than reimplemented
+here. A copy of the rules would be a second thing to keep in step, and it would
+agree with itself while disagreeing with CI.
+"""
+
+import pathlib
+import subprocess
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+ACTION = REPO_ROOT / ".github" / "actions" / "changed-scopes" / "action.yml"
+
+# Every subject the action emits. Kept here as well so that adding an output
+# without deciding what turns it on is a failure rather than a silent "false".
+SUBJECTS = {
+    "wheel",
+    "docs",
+    "pytest",
+    "behave",
+    "examples",
+    "devcontainer",
+    "devcontainer-pytest",
+    "bundle",
+    "ide",
+    "vsix",
+    "plugin",
+}
+
+
+def classify_script():
+    """The 'classify' step of the composite action, as a shell script."""
+    action = yaml.safe_load(ACTION.read_text())
+    steps = [s for s in action["runs"]["steps"] if s.get("id") == "classify"]
+    assert len(steps) == 1, "the action no longer has exactly one 'classify' step"
+    return steps[0]["run"]
+
+
+def classify(tmp_path, paths, all_=False):
+    """Run the gate over `paths` and return {subject: bool} plus the buckets."""
+    listing = tmp_path / "changed-files.txt"
+    listing.write_text("".join(f"{p}\n" for p in paths))
+    output = tmp_path / "output"
+    output.touch()
+    summary = tmp_path / "summary"
+    summary.touch()
+
+    result = subprocess.run(
+        ["bash", "-c", classify_script()],
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "ALL": "true" if all_ else "false",
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(output),
+            "GITHUB_STEP_SUMMARY": str(summary),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    values = {}
+    for line in output.read_text().splitlines():
+        key, _, value = line.partition("=")
+        values[key] = value
+    buckets = set(values.pop("buckets").split())
+    assert set(values) == SUBJECTS, "the action's outputs and SUBJECTS have drifted apart"
+    return {k: v == "true" for k, v in values.items()}, buckets
+
+
+def test_a_deep_run_turns_everything_on(tmp_path):
+    """A deep run is what "#deepTest", the nightly schedule and every push get."""
+    subjects, _ = classify(tmp_path, [], all_=True)
+    assert all(subjects.values()), subjects
+
+
+def test_an_unknown_path_runs_everything(tmp_path):
+    """The fail-safe. A directory nobody has taught the gate about is code."""
+    subjects, buckets = classify(tmp_path, ["a-brand-new-directory/whatever.py"])
+    assert buckets == {"code"}
+    # Not "all of them": the IDE is not rebuilt by a source change, here or in
+    # "build-ide-standalone.yml", because it downloads the bundles rather than
+    # freezing them. Everything a source change *can* break is on.
+    assert subjects["pytest"] and subjects["behave"] and subjects["wheel"] and subjects["bundle"]
+
+
+@pytest.mark.parametrize(
+    "path, expected_bucket",
+    [
+        # Prose, and the scaffolding that only an agent working here reads.
+        ("docs/source/contributing.rst", "docs"),
+        ("README.md", "docs"),
+        ("src/partcad/AGENTS.md", "docs"),
+        ("ide/vscode/AGENTS.md", "vscode"),
+        (".claude/skills/steward/SKILL.md", "docs"),
+        ("openspec/whatever.md", "docs"),
+        # The Claude Code plugin, which is Markdown that ships.
+        ("ai-agents/common/skills/render/SKILL.md", "ai"),
+        (".claude-plugin/marketplace.json", "ai"),
+        # The dev container.
+        (".devcontainer/devcontainer.json", "devcontainer"),
+        # The editor.
+        ("ide/vscode/src/extension.ts", "vscode"),
+        ("ide/vscode-shim/package.json", "vscode"),
+        ("ide/standalone/build.sh", "ide"),
+        (".vscode/extensions.json", "ide"),
+        # Freezing and installing.
+        ("dev-tools/pyinstaller/build.sh", "packaging"),
+        (".snapcraft.yaml", "packaging"),
+        ("install.sh", "packaging"),
+        # Code, in all the shapes it comes in.
+        ("src/partcad/context.py", "code"),
+        ("tests/partcad/unit/test_part.py", "code"),
+        ("features/pc_list.feature", "code"),
+        ("pyproject.toml", "code"),
+        ("poetry.lock", "code"),
+        ("conftest.py", "code"),
+        ("requirements.txt", "code"),
+        ("cad/freecad/InitGui.py", "code"),
+        # A rendered README under "examples/" is an *output* that
+        # "Examples (PartCAD)" compares against a fresh render, so it must not
+        # be mistaken for documentation.
+        ("examples/feature_render/README.md", "code"),
+        ("examples/feature_render/images/cube.png", "code"),
+        # ... including one that would otherwise be caught by the rule above it.
+        ("examples/produce_part_step/AGENTS.md", "code"),
+        # CI itself runs everything, this being what decides what runs.
+        (".github/workflows/test.yml", "ci"),
+    ],
+)
+def test_paths_land_in_the_bucket_they_belong_to(tmp_path, path, expected_bucket):
+    _, buckets = classify(tmp_path, [path])
+    assert buckets == {expected_bucket}
+
+
+def test_documentation_alone_runs_only_the_documentation(tmp_path):
+    subjects, _ = classify(tmp_path, ["docs/source/index.rst", "README.md"])
+    assert subjects["docs"]
+    assert not any(v for k, v in subjects.items() if k != "docs"), subjects
+
+
+def test_the_plugin_alone_runs_only_the_plugin(tmp_path):
+    subjects, _ = classify(tmp_path, ["ai-agents/common/skills/render/SKILL.md"])
+    assert subjects["plugin"]
+    assert not any(v for k, v in subjects.items() if k != "plugin"), subjects
+
+
+def test_the_dev_container_alone_runs_it_but_not_pytest_inside_it(tmp_path):
+    """The one mapping that is a judgement rather than a mechanism.
+
+    "Run: pytest" in "test-dev.yml" is the "Pytest" matrix over again on one
+    image and one interpreter; the container's own configuration cannot make the
+    unit tests disagree with what that matrix said. What it can break is whether
+    anything works in the container at all, which is what "Run: behave" and
+    "Run: pc" -- gated on `devcontainer` -- are there to ask.
+    """
+    subjects, _ = classify(tmp_path, [".devcontainer/devcontainer.json"])
+    assert subjects["devcontainer"]
+    assert not subjects["devcontainer-pytest"]
+    # And nothing outside the container, which is what the rest of CI runs in.
+    assert not subjects["pytest"]
+    assert not subjects["behave"]
+    assert not subjects["wheel"]
+
+
+def test_ci_configuration_runs_everything(tmp_path):
+    subjects, _ = classify(tmp_path, [".github/actions/changed-scopes/action.yml"])
+    assert all(subjects.values()), subjects
+
+
+def test_one_unrecognised_file_is_enough(tmp_path):
+    """Buckets are a union, not a verdict on the change as a whole."""
+    subjects, buckets = classify(tmp_path, ["README.md", "src/partcad/context.py"])
+    assert buckets == {"docs", "code"}
+    assert subjects["docs"] and subjects["pytest"]
+
+
+def test_every_top_level_entry_is_classified_deliberately(tmp_path):
+    """No entry of this repository may fall into an inert bucket by accident.
+
+    The gate's rules are matched in order, and the ones that match by extension
+    come last precisely so that a directory's own rule wins first. This walks
+    what the repository actually has, so a new top-level directory whose name
+    happens to end in ".md" -- or a rule reordered above the directory rules --
+    is caught here rather than by a job that silently stopped running.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-tree", "--name-only", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+
+    # What each top-level entry is allowed to be. Anything absent from here is a
+    # new entry, and the assertion below says to come and decide about it.
+    expected = {
+        ".devcontainer": "devcontainer",
+        ".github": "ci",
+        ".claude": "docs",
+        ".claude-plugin": "ai",
+        ".cursor": "docs",
+        ".gitattributes": "code",
+        ".gitignore": "code",
+        ".readthedocs.yaml": "docs",
+        ".snapcraft.yaml": "packaging",
+        ".vscode": "ide",
+        "AGENTS.md": "docs",
+        "CLAUDE.md": "docs",
+        "LICENSE.txt": "docs",
+        "README.md": "docs",
+        "ai-agents": "ai",
+        "apache20.svg": "docs",
+        "behave.ini": "code",
+        "cad": "code",
+        "conftest.py": "code",
+        "dev-tools": "code",
+        "docs": "docs",
+        "examples": "code",
+        "features": "code",
+        "ide": None,  # split between "vscode" and "ide"; covered above
+        "install.sh": "packaging",
+        "openspec": "docs",
+        "poetry.lock": "code",
+        "poetry.toml": "code",
+        "pyproject.toml": "code",
+        "requirements-aws.txt": "code",
+        "requirements-dev.in": "code",
+        "requirements-lint.txt": "code",
+        "requirements.txt": "code",
+        "src": "code",
+        "tests": "code",
+        "tools": "code",
+    }
+
+    unknown = sorted(set(tracked) - set(expected))
+    assert not unknown, (
+        f"new top-level entries {unknown}: decide which CI subjects they belong to, "
+        f"add a rule to .github/actions/changed-scopes if they are inert, and list them here. "
+        f"Until then they classify as 'code' and run everything, which is the safe direction."
+    )
+
+    for entry in tracked:
+        want = expected[entry]
+        if want is None:
+            continue
+        path = entry if "." in entry.rsplit("/", 1)[-1] and not entry.startswith(".") else f"{entry}/file.txt"
+        if entry.startswith(".") and (REPO_ROOT / entry).is_file():
+            path = entry
+        _, buckets = classify(tmp_path, [path])
+        assert buckets == {want}, f"{path} classified as {buckets}, expected {{'{want}'}}"

--- a/tests/dev_tools/test_changed_scopes.py
+++ b/tests/dev_tools/test_changed_scopes.py
@@ -175,7 +175,14 @@ def test_only_the_root_dependency_files_are_dependencies(tmp_path, path):
         ("docs/source/contributing.rst", "docs"),
         ("README.md", "docs"),
         ("src/partcad/AGENTS.md", "docs"),
+        # ... but only where no earlier directory rule claims them. "AGENTS.md"
+        # is matched ahead of the source directories and behind everything above
+        # those, so it is documentation beside a package's code and nothing of
+        # the sort inside CI, the plugin or the extension.
         ("ide/vscode/AGENTS.md", "vscode"),
+        (".github/AGENTS.md", "ci"),
+        ("ai-agents/AGENTS.md", "ai"),
+        (".devcontainer/AGENTS.md", "devcontainer"),
         (".claude/skills/steward/SKILL.md", "docs"),
         ("openspec/whatever.md", "docs"),
         # The Claude Code plugin, which is Markdown that ships.


### PR DESCRIPTION
## Copilot Summary

> **A note on this description.** The deep-test marker — spelled `#deep` immediately followed by `Test` — is matched as a plain substring of the title and body, so it cannot tell a marker from a mention. The first version of this description named it while explaining it, opted itself in, and ran the full matrix (~147 jobs) instead of the reduced one this pull request exists to introduce. It is written split below for that reason. The wart is now recorded in `test-depth` and in `contributing.rst`; see the last section for why it is left as it is.

CI ran the same thing for every change, and nearly the same thing for a pull request as for the merge queue. A README typo ran **99 jobs on the pull request and 115 in the queue** — including four frozen PyInstaller bundles and three IDEs, because `merge_group` supports no `paths:` filter and the two workflows that had one therefore stopped filtering the moment a commit was queued.

Two gates now decide, and they answer different questions.

### Depth — `.github/actions/test-depth`, three tiers instead of two

| tier | when | OS axis | Python axis |
| --- | --- | --- | --- |
| `pr` | a pull request, on every push to it | every image except macOS | oldest and newest supported |
| `queue` | the merge queue | every current image, macOS included | full range |
| `deep` | nightly, dispatch, any push, the marker | + both Ubuntu 22.04 | full range |

`queue` is what a pull request used to get, so the coverage a pull request drops is coverage the commit still earns before it lands — once per merge rather than once per push. **`deep` is byte-for-byte unchanged**, the marker included.

Both Windows images stay on every tier. Windows is not a second macOS to economise on: its path separator, drive letters and line endings are a standing source of breakage in code written on Linux, so it is the platform a pull request most needs.

### Scope — `.github/actions/changed-scopes` (new)

Sorts the changed files into buckets and turns each CI subject on or off. It is a **job condition, not a `paths:` filter**, for two reasons: `merge_group` supports no `paths:` filter at all, so a trigger-level list is one the merge queue ignores; and a workflow skipped by `paths:` never creates the check run a *required* check waits for, while a job skipped by a condition reports `skipped`, which counts as passing.

| a change touching only… | runs |
| --- | --- |
| `docs/`, `*.md`, `*.rst`, `.claude/`, `openspec/` | `Documentation` |
| `ai-agents/`, `.claude-plugin/` | `Claude Code plugin` |
| `.devcontainer/` | the container's `Run: behave` and `Run: pc` — **not** `Run: pytest` |
| `ide/vscode/`, `ide/vscode-shim/` | `npm test`, `VS Code extension`, `IDE` |
| `ide/standalone/`, `.vscode/` | `IDE` |
| `dev-tools/pyinstaller/`, `dev-tools/snap/`, `.snapcraft.yaml`, `install.sh` | `Standalone`, `IDE` |
| `pyproject.toml`, `poetry.lock`, root `requirements*` | the tests, the wheel **and** `Standalone` |
| `src/`, `tests/`, `features/`, `examples/`, `cad/`, `tools/`, `dev-tools/` | the tests and the wheel, **not** `Standalone` |
| anything else | all of the above, `Standalone` included |
| `.github/` | everything, this being what decides what runs |

It is fail-safe: an unrecognised path counts as code **and** as a dependency, so a new directory can only ever run too much.

### Source vs. dependencies

The last three rows are the one place a source change is treated differently from a dependency change. Freezing is the most expensive thing here — ~500MB of OpenCASCADE per runner — and what makes a frozen bundle differ from a working wheel is nearly always what went *into* it. So a dependency change freezes and a change to `src/` alone does not.

That is a trade rather than a fact, and worth reviewing on its own: a source change **can** break the freeze (a lazily imported module, a file read relative to `__file__`; `dev-tools/pyinstaller/README.md` has the list), and that is now found on the push to `devel` after the merge rather than on the pull request. The push trigger of `build-standalone.yml` still lists `src/**` for exactly this and is now the only thing that builds a bundle for a source change short of the marker; a release still refuses to publish with a platform missing.

### The `Standalone` workflow, job by job

| job | today PR / queue | `pr` | `queue` | `deep` |
| --- | --- | --- | --- | --- |
| `Build` | 4 / 4 | 3 (no macOS) | 4 | 7 |
| `Install` | 4 / 4 | 2 | 4 | 8 |
| `Snap` | 2 / not run | 1 (amd64) | not run | 2 |
| `Examples via bundle` | 5 / not run | 2 (`PartCAD` suite only) | not run | 6 |

`Snap` and `Examples` were already skipped in the queue and on the release path. What is new: the snap packs one architecture on a pull request — the recipe is one file, the two jobs run it over payloads `Build` and `Install` have already exercised, at ~45 minutes of squashing ~875MB each — and the `All` example suite, which is `continue-on-error` because the public index carries packages this repository cannot fix, is left to deep runs. Its matrix is a `set-matrix` output now, and its bundle is checked against what the run actually froze the way the install and examples lists already were.

### Also here

* The Sphinx build leaves the wheel matrix and becomes one job. It used to be a step of all fifteen, though `docs/source/conf.py` enables no extensions at all — so it never imported PartCAD and could not depend on the platform it ran on.
* `Examples (All)` and `Repo //pub` become deep-only. Their one substantive step has been `continue-on-error` since the public index went to build123d 0.11, so before a merge they were 21 jobs whose only way to fail was to fail at `setup-all` — which every `Pytest` leg beside them had already proven on the same image and interpreter.
* `npm test` gains a `merge_group` trigger, which it never had, and a concurrency group, which it never had either.

### Result

Jobs per change, pull request → merge queue. Counted by running each `set-matrix` script and the classifier for real, per tier, rather than by hand:

| change | before (PR / queue) | after (PR / queue) |
| --- | --- | --- |
| documentation | 99 / 115 | **7 / 7** |
| an AI skill | 99 / 115 | **8 / 8** |
| the dev container | 99 / 115 | **10 / 10** |
| the VS Code extension | 109 / 115 | **15 / 19** |
| Python source | 115 / 115 | **52 / 76** |
| a dependency bump | 115 / 115 | **60 / 84** |

`CI` on a deep run stays at 84 jobs — 19 `Pytest`, 24 `Behave`, 14 `Examples (PartCAD)`, 19 `Examples (All)`, 6 `Repo //pub` — exactly what it is today.

### Notes for the reviewer

* **This pull request touches `.github/`, so every subject is switched on for it.** That is the fail-safe working as designed — what it exercises here is the *depth* tiers (`pr` on the pull request, `queue` in the merge queue), not the scope gating. `tests/dev_tools/test_changed_scopes.py` is what exercises the scope gating, including a check that fires when a new top-level directory appears undecided.
* **Required status checks may need updating.** Two job names are new — `Documentation` (split out of `build`) and `Scope` (in `npm test` and `CI-Dev`).
* **The marker's substring match is left alone deliberately.** The alternative is a matcher that tries to tell a marker from a mention — outside backticks? on its own line? — which is a rule a contributor has to know before their opt-in works, and *that* fails by silently not running a deep test somebody asked for. Over-running is the safe direction. Both `test-depth` and `contributing.rst` now say so, and say to write it split when a description has to name it.
* **Known gap, not changed here:** the `IDE` workflow still does not rebuild for a dependency change — its paths never included `pyproject.toml` — so a bumped dependency reaches an IDE archive only at release. Adding `deps` to that gate would cost ~7 jobs on every dependency-bot pull request; say the word if it is wanted.

Verified locally: `deep` is byte-identical to today across all four matrix-producing workflows and `queue` equals today's pull request behaviour (simulated by running each `set-matrix` script over all three tiers); 46 new tests pass; `check-jsonschema` clean on every workflow and action; every `run:` block parses; `sphinx-build -n -W` succeeds standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uht5ehSme8K9ei36ra9shQ