### PR TITLE
Rename the Electron helper applications, and test that the IDE starts

### DIFF
--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -791,6 +791,125 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install --yes xvfb
 
+      # The one check that runs the application the way the operating system
+      # runs it, and reads what it says.
+      #
+      # `partcad-ide --version` -- "Run what was installed", above -- does not
+      # do this and cannot: that launcher ends in `ELECTRON_RUN_AS_NODE=1`,
+      # which is Electron being Node. No browser process, no helper
+      # applications, no window. It printed a version out of a macOS bundle that
+      # could not launch, in every release from 0.8.33 on, and the job stayed
+      # green. Anything claiming to smoke-test the editor has to run the binary
+      # the bundle's `Contents/MacOS` (or the top of the directory, elsewhere)
+      # holds, and has to keep its output.
+      #
+      # Startup failures of this class are fatal in the first second and print
+      # one line to stderr, so a short wait and a look at what came out is the
+      # whole test. Whether a window appeared is not asked here: "Start it once"
+      # asks that, of the editor started the way a user starts it.
+      - name: Run the application binary
+        shell: bash
+        run: |
+          case "${{ runner.os }}" in
+            macOS)   binary="${HOME}/Applications/PartCAD IDE.app/Contents/MacOS/VSCodium" ;;
+            Windows) binary="$(dirname "$(dirname "$(readlink -f "${HOME}/partcad-bin/partcad-ide")")")/partcad-ide.exe" ;;
+            *)       binary="$(dirname "$(dirname "$(readlink -f "${HOME}/partcad-bin/partcad-ide")")")/partcad-ide" ;;
+          esac
+          test -x "${binary}" || {
+            echo "::error::no application binary at ${binary}"
+            exit 1
+          }
+          echo "running ${binary}"
+
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            Xvfb :98 -screen 0 1280x1024x24 >/dev/null 2>&1 &
+            export DISPLAY=:98
+            # The runner image restricts unprivileged user namespaces, which is
+            # what Chromium's sandbox is built on.
+            set -- --no-sandbox
+          else
+            set --
+          fi
+
+          # Backgrounded and killed rather than waited on: the editor has no
+          # argument that starts the browser process and then exits, so what is
+          # being tested is that it is still alive a little later.
+          "${binary}" "$@" --user-data-dir "${RUNNER_TEMP}/binary-user-data" >start.log 2>&1 &
+          binary_pid=$!
+          sleep 20
+
+          echo "--- what it printed:"
+          cat start.log || true
+
+          # Named explicitly, because it is the one this check was written for
+          # and "the process is gone" does not say it.
+          if grep -q "Unable to find helper app" start.log; then
+            echo "::error::the Electron helper applications are not named for this application;" \
+                 "see the rename in ide/standalone/build.sh and check_macos_helpers in verify_bundle.py"
+            exit 1
+          fi
+          # Chromium's own fatal format -- "[0904/041024.624061:FATAL:file.cc:66]"
+          # -- and not a bare "fatal", which appears in ordinary GPU and
+          # sandbox chatter on the Linux runners and would fail this step for
+          # a machine's properties rather than for the build's.
+          if grep -q ":FATAL:" start.log; then
+            echo "::error::the application logged a fatal error on startup"
+            exit 1
+          fi
+          if ! kill -0 "${binary_pid}" 2>/dev/null; then
+            echo "::error::the application binary exited within 20 seconds instead of running"
+            exit 1
+          fi
+
+          kill "${binary_pid}" 2>/dev/null || true
+          pkill -if "partcad.ide" || true
+
+      # The extension's own test suite, in the editor that ships.
+      #
+      # `npm-test.yml` runs the same suite against a downloaded stock VS Code,
+      # which checks this extension's logic and nothing the IDE puts around it:
+      # the built-in extension set, `product.json`'s `configurationDefaults`,
+      # the bootstrap extension, the embedded service, the branded shell. The
+      # two never met, so "the bundle is well-formed" was as far as any check
+      # here went, and an editor that could not start on macOS passed all of
+      # them.
+      #
+      # `.vscode-test.js` offers the `bundledIde` configuration only when
+      # `PARTCAD_IDE_PATH` names a build, so this is the only place it runs.
+      - name: Install Node.js
+        uses: actions/setup-node@v7
+        with:
+          # Node 24 is the current Active LTS; 22.x is in maintenance now.
+          node-version: 24.x
+          cache: "npm"
+          cache-dependency-path: ide/vscode/package-lock.json
+
+      - name: Run the extension test suite in the installed IDE
+        working-directory: ide/vscode
+        shell: bash
+        run: |
+          # The application binary, which is what `useInstallation.fromPath`
+          # wants -- not the bundle, and not the `bin/` launcher. Resolved the
+          # same way "Check the IDE ships what it is supposed to" resolves the
+          # resources directory, rather than assuming a layout `install.sh` owns.
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            export PARTCAD_IDE_PATH="${HOME}/Applications/PartCAD IDE.app/Contents/MacOS/VSCodium"
+          else
+            app="$(dirname "$(dirname "$(readlink -f "${HOME}/partcad-bin/partcad-ide")")")"
+            export PARTCAD_IDE_PATH="${app}/partcad-ide"
+          fi
+          test -x "${PARTCAD_IDE_PATH}" || {
+            echo "::error::no application binary at ${PARTCAD_IDE_PATH}"
+            exit 1
+          }
+          npm ci
+          npm run pretest
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            xvfb-run -a npx vscode-test --label bundledIde
+          else
+            npx vscode-test --label bundledIde
+          fi
+
       # What the IDE does for someone who has just installed it: `pc init` a
       # package in ~/.partcad/projects/start and open it as the workspace.
       # Started the way a user starts it, with no arguments -- and with a user
@@ -798,30 +917,33 @@ jobs:
       # times the job is re-run, and so that the state the editor writes is
       # somewhere this job can read it.
       - name: Start it once
-        # Blocking on Linux, where it works and is the signal this check exists
-        # for. Reporting only on macOS, and that is a stop-gap with a date on it.
+        # Blocking on every platform. It was reporting-only on macOS, where it
+        # had never once passed, and the comment here guessed at a hosted
+        # runner's session as the likelier suspect than anything wrong with the
+        # IDE. It was not the runner.
         #
-        # This check is new in #584 and has never once passed on macOS. What it
-        # gets there is a launcher that exits 0 in six seconds having printed
-        # nothing, no editor process, and -- the reason nobody has been able to
-        # say more than that -- not one line in the user data directory, so the
-        # "what the editor logged" dump below came back empty. The same
-        # commands, the same bundle, the same 'install.sh' pass on Linux and on
-        # Windows. There is no evidence yet of anything wrong with the IDE that
-        # a person installing it would meet; a hosted macOS runner's session is
-        # the far likelier suspect, and confirming that needs a run on one.
+        # The macOS bundle could not start at all. Electron resolves its helper
+        # applications from the outer bundle's 'CFBundleName', 'build.sh' brands
+        # that plist, and nothing renamed 'Contents/Frameworks/VSCodium
+        # Helper*.app' to match -- so every Mac got 'FATAL ... Unable to find
+        # helper app' and an editor that died before it opened a window, created
+        # a user data directory or wrote a line of log. That is the whole of
+        # "exits 0 in six seconds having printed nothing, and not one line in
+        # the user data directory": the launcher spawns the editor and returns,
+        # so its own zero says nothing, and the editor was gone before it could
+        # write anything down. It shipped in 0.8.33 and 0.8.49.
         #
-        # What is certain is the cost of leaving it blocking, because it was
-        # paid: "deploy.yml" makes 'publish-to-pypi' wait on this workflow, so
-        # this step held back the 0.8.32 wheel, the bundles, the extension and
-        # the plugin, and PyPI stayed on 0.8.27. A check that has never passed
-        # on a platform must not be what decides whether a release ships.
+        # Two things now stand between that and a release. "Verifying the
+        # bundle" checks the four helpers are named for the branded application,
+        # which is cheap and says which one is wrong; the step below runs the
+        # application binary and reads what it prints, which is what catches the
+        # next startup failure of a different kind. This step is the one that
+        # says the editor came up and did its work, and it is blocking again.
         #
-        # So it still runs on macOS, still prints its errors, and no longer
-        # fails the job there. Make it blocking again -- delete this expression
-        # -- the moment a macOS run gets past it, which the diagnostics added
-        # below are there to bring about.
-        continue-on-error: ${{ startsWith(matrix.platform, 'macos') }}
+        # Keep it blocking. It held back the 0.8.32 release once ("deploy.yml"
+        # makes 'publish-to-pypi' wait on this workflow) and was demoted for it
+        # -- and the two releases that followed were unlaunchable on macOS,
+        # which is the more expensive of the two failures by a distance.
         shell: bash
         run: |
           export PATH="${HOME}/partcad-bin:${PATH}"

--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -142,6 +142,11 @@ jobs:
       # this one, so this is the whole workflow's gate. See
       # ".github/actions/changed-scopes".
       ide: ${{ steps.scope.outputs.ide }}
+      # Whether this run's scope froze the command line bundles. The IDE build
+      # embeds them, so this is what says whether they can be expected for this
+      # commit or have to come from the base branch -- see "Find the
+      # \"Standalone\" run that built the bundles" below.
+      bundle: ${{ steps.scope.outputs.bundle }}
     steps:
       - uses: actions/checkout@v7
 
@@ -339,6 +344,10 @@ jobs:
           # bundles or an older commit's.
           GRACE_SECONDS: "300"
           POLL_SECONDS: "30"
+          # "true" when this run's scope also froze the bundles. When it did not,
+          # the sibling "Standalone" run is there but empty by design, and the
+          # base branch is where the bundles are.
+          BUNDLE_IN_THIS_RUN: ${{ needs.set-matrix.outputs.bundle }}
         run: |
           set -euo pipefail
 
@@ -436,6 +445,19 @@ jobs:
             fi
 
             if [ -n "${barren}" ]; then
+              # A run with no bundles is not the same thing as a run that failed
+              # to produce them. Since the scope gate landed, "Standalone" runs
+              # on every pull request and *skips* its builds when the change
+              # does not warrant freezing -- so a change confined to "ide/" or
+              # "ide/vscode/" turns the IDE build on, leaves the freeze off, and
+              # leaves exactly this behind: a sibling run, concluded success,
+              # holding nothing. That is the case (2) below was written for,
+              # arriving as an empty run rather than as no run at all.
+              if [ "${BUNDLE_IN_THIS_RUN:-true}" != "true" ]; then
+                say "Run(s)${barren} hold no bundles, and this run's scope froze none." \
+                    "Taking them from ${base} instead."
+                break
+              fi
               echo "::error::The \"Standalone\" workflow run(s) for ${HEAD_SHA}" \
                 "--${barren} -- finished without leaving a single" \
                 "partcad-standalone-* artifact, so there is no command line" \
@@ -811,7 +833,14 @@ jobs:
         shell: bash
         run: |
           case "${{ runner.os }}" in
-            macOS)   binary="${HOME}/Applications/PartCAD IDE.app/Contents/MacOS/VSCodium" ;;
+            macOS)
+              # Asked of the bundle rather than hardcoded: `build.sh` leaves
+              # `CFBundleExecutable` as the upstream editor set it -- the macOS
+              # launcher finds the executable through the bundle, so there is
+              # nothing to rename -- and it is VSCodium's business what that is.
+              app="${HOME}/Applications/PartCAD IDE.app"
+              binary="${app}/Contents/MacOS/$(plutil -extract CFBundleExecutable raw "${app}/Contents/Info.plist")"
+              ;;
             Windows) binary="$(dirname "$(dirname "$(readlink -f "${HOME}/partcad-bin/partcad-ide")")")/partcad-ide.exe" ;;
             *)       binary="$(dirname "$(dirname "$(readlink -f "${HOME}/partcad-bin/partcad-ide")")")/partcad-ide" ;;
           esac
@@ -893,7 +922,10 @@ jobs:
           # same way "Check the IDE ships what it is supposed to" resolves the
           # resources directory, rather than assuming a layout `install.sh` owns.
           if [ "${{ runner.os }}" = "macOS" ]; then
-            export PARTCAD_IDE_PATH="${HOME}/Applications/PartCAD IDE.app/Contents/MacOS/VSCodium"
+            # As in "Run the application binary": the executable's name belongs
+            # to the editor this was built from, so it is read, not assumed.
+            app="${HOME}/Applications/PartCAD IDE.app"
+            export PARTCAD_IDE_PATH="${app}/Contents/MacOS/$(plutil -extract CFBundleExecutable raw "${app}/Contents/Info.plist")"
           else
             app="$(dirname "$(dirname "$(readlink -f "${HOME}/partcad-bin/partcad-ide")")")"
             export PARTCAD_IDE_PATH="${app}/partcad-ide"

--- a/features/healthcheck.feature
+++ b/features/healthcheck.feature
@@ -5,26 +5,39 @@ Feature: 'pc healthcheck' command
     Given I am in "/tmp/sandbox/behave" directory
     And I have temporary $HOME in "/tmp/sandbox/home"
 
+  # The four bounds of `requires-python` in `pyproject.toml` (">=3.10,<3.15"),
+  # one scenario each. 3.13 used to be here as an *unsupported* version, which
+  # is what the check said and `pyproject.toml` had not said for some time.
   @failure @python-version
-  Scenario: Running health check with an invalid version
+  Scenario: Running health check on a version older than the minimum
     Given system python version is "3.7"
     When I run partcad healthcheck
     Then the command should exit with a status code of "0"
     Then STDOUT should contain "Python version 3.7 is not supported"
 
   @success @python-version
-  Scenario: Running health check with a valid version
+  Scenario: Running health check on a supported version
     Given system python version is "3.11"
     When I run partcad healthcheck
     Then the command should exit with a status code of "0"
     Then STDOUT should contain "PythonVersion: Passed"
 
-  @failure @python-version
-  Scenario: Running health check with a invalid version
-    Given system python version is "3.13"
+  # The interpreter the standalone bundle carries. While the check stopped at
+  # 3.12, the bundle spent every start reporting that the Python it ships is
+  # unsupported and telling the user to change a system Python it does not use.
+  @success @python-version
+  Scenario: Running health check on the newest supported version
+    Given system python version is "3.14"
     When I run partcad healthcheck
     Then the command should exit with a status code of "0"
-    Then STDOUT should contain "Python version 3.13 is not supported"
+    Then STDOUT should contain "PythonVersion: Passed"
+
+  @failure @python-version
+  Scenario: Running health check on a version newer than the maximum
+    Given system python version is "3.15"
+    When I run partcad healthcheck
+    Then the command should exit with a status code of "0"
+    Then STDOUT should contain "Python version 3.15 is not supported"
 
   @success @python-version @filters
   Scenario: Run healthcheck command with dry run and filter

--- a/ide/standalone/build.sh
+++ b/ide/standalone/build.sh
@@ -669,6 +669,16 @@ with open(sys.argv[1], 'rb') as handle:
     print(plistlib.load(handle)['CFBundleExecutable'])
 " "${APP_ROOT}/Contents/Info.plist")"
   EXECUTABLE="${APP_ROOT}/Contents/MacOS/${BUNDLE_EXECUTABLE}"
+  # Read here because it is read *before* the plist is branded further down, and
+  # what the helper applications are named after is the application's name, not
+  # its executable's. VSCodium spells both "VSCodium" and so the two are
+  # interchangeable today; they are different fields and only one of them is the
+  # one Electron resolves a helper from.
+  UPSTREAM_BUNDLE_NAME="$("${PYTHON}" -c "
+import plistlib, sys
+with open(sys.argv[1], 'rb') as handle:
+    print(plistlib.load(handle)['CFBundleName'])
+" "${APP_ROOT}/Contents/Info.plist")"
   ;;
 esac
 
@@ -762,15 +772,32 @@ if [ "${OS_NAME}" = "macos" ]; then
   log "==> Renaming the Electron helper applications"
   FRAMEWORKS_DIR="${APP_ROOT}/Contents/Frameworks"
   for helper_suffix in "" " (GPU)" " (Plugin)" " (Renderer)"; do
-    helper_old="${FRAMEWORKS_DIR}/${BUNDLE_EXECUTABLE} Helper${helper_suffix}.app"
+    helper_old="${FRAMEWORKS_DIR}/${UPSTREAM_BUNDLE_NAME} Helper${helper_suffix}.app"
     helper_new="${FRAMEWORKS_DIR}/PartCAD IDE Helper${helper_suffix}.app"
-    [ -d "${helper_old}" ] ||
-      fail "no helper application at ${helper_old}.
-       The VSCodium bundle layout changed; renaming has to follow it, or the IDE
-       does not start on macOS at all."
+    if [ ! -d "${helper_old}" ]; then
+      # Not the name this build expected. There is exactly one helper per suffix
+      # in the bundle, so if upstream has renamed them, say what is there and use
+      # it rather than failing a build over a name -- but only when it is
+      # unambiguous, because renaming the wrong directory produces the same dead
+      # application this whole block exists to prevent.
+      helper_found=""
+      for candidate in "${FRAMEWORKS_DIR}"/*" Helper${helper_suffix}.app"; do
+        [ -d "${candidate}" ] || continue
+        [ -z "${helper_found}" ] || fail "more than one helper application matches
+       '* Helper${helper_suffix}.app' in ${FRAMEWORKS_DIR}; expected ${helper_old}"
+        helper_found="${candidate}"
+      done
+      [ -n "${helper_found}" ] ||
+        fail "no helper application at ${helper_old}, and nothing matching
+       '* Helper${helper_suffix}.app' beside it. The VSCodium bundle layout
+       changed; renaming has to follow it, or the IDE does not start on macOS."
+      warn "expected ${helper_old##*/}, found ${helper_found##*/}; renaming that instead"
+      helper_old="${helper_found}"
+    fi
+    helper_old_executable="$(basename "${helper_old}" .app)"
     rm -rf "${helper_new}"
     mv "${helper_old}" "${helper_new}"
-    mv "${helper_new}/Contents/MacOS/${BUNDLE_EXECUTABLE} Helper${helper_suffix}" \
+    mv "${helper_new}/Contents/MacOS/${helper_old_executable}" \
       "${helper_new}/Contents/MacOS/PartCAD IDE Helper${helper_suffix}"
     # The signature seals the names that just changed, so it cannot survive them.
     # The whole bundle is re-signed below, which covers these.

--- a/ide/standalone/build.sh
+++ b/ide/standalone/build.sh
@@ -745,6 +745,44 @@ else
 fi
 
 if [ "${OS_NAME}" = "macos" ]; then
+  # Electron resolves the four helper applications it spawns -- the renderer, the
+  # GPU process, the plugin host and the generic one -- by name, from the outer
+  # bundle's `CFBundleName`. Branding the plist above therefore renames what
+  # Electron looks for, and a bundle whose helpers are still VSCodium's dies in
+  # `electron_main_delegate_mac.mm` with "Unable to find helper app" -- before it
+  # opens a window, creates a user data directory or writes one line of log.
+  # 0.8.33 and 0.8.49 shipped that way: unlaunchable on every Mac, and silent
+  # about why, which is what left "Start it once" below blaming the runner.
+  #
+  # Three names change per helper, not one. The directory is what Electron looks
+  # up; the executable inside it has to follow, because a helper's `Info.plist`
+  # carries no `CFBundleExecutable` and macOS falls back to the bundle's base
+  # name; and `CFBundleName` follows so the process does not report itself as
+  # the editor this was built from.
+  log "==> Renaming the Electron helper applications"
+  FRAMEWORKS_DIR="${APP_ROOT}/Contents/Frameworks"
+  for helper_suffix in "" " (GPU)" " (Plugin)" " (Renderer)"; do
+    helper_old="${FRAMEWORKS_DIR}/${BUNDLE_EXECUTABLE} Helper${helper_suffix}.app"
+    helper_new="${FRAMEWORKS_DIR}/PartCAD IDE Helper${helper_suffix}.app"
+    [ -d "${helper_old}" ] ||
+      fail "no helper application at ${helper_old}.
+       The VSCodium bundle layout changed; renaming has to follow it, or the IDE
+       does not start on macOS at all."
+    rm -rf "${helper_new}"
+    mv "${helper_old}" "${helper_new}"
+    mv "${helper_new}/Contents/MacOS/${BUNDLE_EXECUTABLE} Helper${helper_suffix}" \
+      "${helper_new}/Contents/MacOS/PartCAD IDE Helper${helper_suffix}"
+    # The signature seals the names that just changed, so it cannot survive them.
+    # The whole bundle is re-signed below, which covers these.
+    rm -rf "${helper_new}/Contents/_CodeSignature"
+    helper_id="$(printf '%s' "${helper_suffix}" | tr -d ' ()' | tr '[:upper:]' '[:lower:]')"
+    "${PYTHON}" "${SCRIPT_DIR}/tools/brand.py" plist \
+      --path "${helper_new}/Contents/Info.plist" \
+      --name "PartCAD IDE Helper${helper_suffix}" \
+      --identifier "org.partcad.ide.helper${helper_id}" \
+      --version "${VERSION}"
+  done
+
   # Everything above edited files inside a signed bundle, which invalidates the
   # signature: macOS then refuses to open the application at all. Ad-hoc signing
   # makes it launchable again. It is not a Developer ID signature and does not
@@ -820,7 +858,13 @@ fi
 
 ##############################################  SMOKE TEST  ##################################################
 
-log "==> Checking the application starts"
+# `--version` through `bin/partcad-ide` says the *command line* runs. It does not
+# say the application starts: that launcher ends in `ELECTRON_RUN_AS_NODE=1`,
+# which is Electron being Node -- no browser process, no helper applications, no
+# window. It printed a version out of a macOS bundle that could not launch at all
+# for two releases. Kept, because a broken CLI is worth catching too, and no
+# longer described as more than it is.
+log "==> Checking the command line runs"
 IDE_VERSION="$("${LAUNCHER}" --version | head -n 1)" ||
   fail "${LAUNCHER} does not run"
 log "    ${LAUNCHER} --version -> ${IDE_VERSION}"
@@ -833,6 +877,9 @@ if [ "${INSTALL_EXTENSIONS}" = "1" ]; then
     --executable "${EXECUTABLE}"
     --launcher "${LAUNCHER}"
   )
+  if [ "${OS_NAME}" = "macos" ]; then
+    VERIFY_ARGS+=(--app-root "${APP_ROOT}")
+  fi
   if [ -n "${CLI_BUNDLE}" ]; then
     VERIFY_ARGS+=(--expect-tools)
   fi

--- a/ide/standalone/product.overlay.json
+++ b/ide/standalone/product.overlay.json
@@ -18,6 +18,15 @@
   "urlProtocol": "partcad-ide",
   "serverApplicationName": "partcad-ide-server",
   "serverDataFolderName": ".partcad-ide-server",
+  // `build.sh` renames every `bin/codium*` to `partcad-ide*`, the tunnel binary
+  // included, so the name upstream left here points at a file that is no longer
+  // there: `partcad-ide serve-web` died with
+  // `spawn .../bin/codium-tunnel ENOENT`, on every platform, and so did
+  // `tunnel`. The mutexes go with it -- they exist to keep two *different*
+  // applications' tunnels apart, which VSCodium's names cannot do.
+  "tunnelApplicationName": "partcad-ide-tunnel",
+  "win32TunnelServiceMutex": "partcad-ide-tunnelservice",
+  "win32TunnelMutex": "partcad-ide-tunnel",
   "darwinBundleIdentifier": "org.partcad.ide",
   "win32AppUserModelId": "PartCAD.PartCADIDE",
   "win32DirName": "PartCAD IDE",

--- a/ide/standalone/tests/test_verify_bundle.py
+++ b/ide/standalone/tests/test_verify_bundle.py
@@ -8,6 +8,7 @@
 
 import json
 import os
+import plistlib
 import shutil
 import stat
 
@@ -353,3 +354,87 @@ def test_a_bootstrap_extension_with_no_examples_manifest_fails(tmp_path, capsys)
 
     assert run(resources, tmp_path) == 1
     assert "no examples.json" in capsys.readouterr().out
+
+
+#
+# The macOS helper applications.
+#
+# Electron resolves them from the outer bundle's `CFBundleName`, so the rename
+# `build.sh` does is not cosmetic: without it the application dies at startup
+# with "Unable to find helper app" and every other check here still passes.
+#
+
+
+def make_app_bundle(tmp_path, bundle_name="PartCAD IDE", helper_name="PartCAD IDE"):
+    """A macOS `.app`, as far as `check_macos_helpers` can see one.
+
+    `helper_name` is separate from `bundle_name` so that a test can build the
+    bundle that shipped: branded outside, VSCodium's helpers inside.
+    """
+    app_root = tmp_path / f"{bundle_name}.app"
+    contents = app_root / "Contents"
+    contents.mkdir(parents=True)
+    with open(contents / "Info.plist", "wb") as handle:
+        plistlib.dump({"CFBundleName": bundle_name, "CFBundleExecutable": "VSCodium"}, handle)
+
+    frameworks = contents / "Frameworks"
+    frameworks.mkdir()
+    for suffix in verify_bundle.MACOS_HELPER_SUFFIXES:
+        name = f"{helper_name} Helper{suffix}"
+        executable = frameworks / f"{name}.app" / "Contents" / "MacOS" / name
+        executable.parent.mkdir(parents=True)
+        executable.write_text("#!/bin/sh\n", encoding="utf-8")
+        executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    return app_root
+
+
+def test_renamed_helpers_pass(tmp_path):
+    problems, notes = [], []
+    verify_bundle.check_macos_helpers(make_app_bundle(tmp_path), problems, notes)
+    assert problems == []
+    assert len(notes) == len(verify_bundle.MACOS_HELPER_SUFFIXES)
+
+
+def test_helpers_left_with_the_upstream_name_fail(tmp_path):
+    """0.8.33 and 0.8.49, exactly: branded bundle, VSCodium's helpers."""
+    problems, notes = [], []
+    verify_bundle.check_macos_helpers(make_app_bundle(tmp_path, helper_name="VSCodium"), problems, notes)
+    assert len(problems) == len(verify_bundle.MACOS_HELPER_SUFFIXES)
+    # The name that is there is worth saying: "no helper application at ..." on
+    # its own does not tell anyone the rename is what was missed.
+    assert "VSCodium Helper.app" in problems[0]
+
+
+def test_one_missing_helper_fails(tmp_path):
+    app_root = make_app_bundle(tmp_path)
+    shutil.rmtree(app_root / "Contents" / "Frameworks" / "PartCAD IDE Helper (Renderer).app")
+    problems, notes = [], []
+    verify_bundle.check_macos_helpers(app_root, problems, notes)
+    assert len(problems) == 1
+    assert "PartCAD IDE Helper (Renderer).app" in problems[0]
+
+
+def test_a_helper_executable_that_was_not_renamed_fails(tmp_path):
+    """The directory alone is not enough: macOS runs the file inside it."""
+    app_root = make_app_bundle(tmp_path)
+    helper = app_root / "Contents" / "Frameworks" / "PartCAD IDE Helper (GPU).app" / "Contents" / "MacOS"
+    (helper / "PartCAD IDE Helper (GPU)").rename(helper / "VSCodium Helper (GPU)")
+    problems, notes = [], []
+    verify_bundle.check_macos_helpers(app_root, problems, notes)
+    assert len(problems) == 1
+    assert "helper executable 'PartCAD IDE Helper (GPU)'" in problems[0]
+
+
+def test_a_bundle_with_no_bundle_name_fails(tmp_path):
+    app_root = make_app_bundle(tmp_path)
+    with open(app_root / "Contents" / "Info.plist", "wb") as handle:
+        plistlib.dump({"CFBundleExecutable": "VSCodium"}, handle)
+    problems, notes = [], []
+    verify_bundle.check_macos_helpers(app_root, problems, notes)
+    assert len(problems) == 1
+    assert "CFBundleName" in problems[0]
+
+
+def test_the_helpers_are_only_checked_when_an_app_root_is_given(tmp_path):
+    """Linux and Windows builds pass no `--app-root`, and have no helpers."""
+    assert run(make_bundle(tmp_path), tmp_path) == 0

--- a/ide/standalone/tools/verify_bundle.py
+++ b/ide/standalone/tools/verify_bundle.py
@@ -24,6 +24,7 @@ import argparse
 import json
 import os
 import pathlib
+import plistlib
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -31,6 +32,11 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import jsonc  # noqa: E402  (the path has to be set up first)
 
 SERVICE_EXECUTABLES = ("partcad-json-rpc", "partcad-json-rpc.exe")
+
+# The helper applications Electron spawns on macOS, by the suffix each one's
+# name ends in. The unsuffixed entry is the generic helper and is the one the
+# other three are derived from; all four have to be there.
+MACOS_HELPER_SUFFIXES = ("", " (GPU)", " (Plugin)", " (Renderer)")
 
 # The extension that carries the welcome window (`../bootstrap`), and the
 # examples it offers to open (`copy_examples.py` puts them there).
@@ -235,6 +241,46 @@ def check_entry_point(app_dir: pathlib.Path, problems: list[str], notes: list[st
     notes.append(f"entry point: {main} (software WebGL enabled)")
 
 
+def check_macos_helpers(app_root: pathlib.Path, problems: list[str], notes: list[str]) -> None:
+    """The Electron helper applications are named for the branded application.
+
+    Electron resolves the helper it spawns for each child process from the outer
+    bundle's `CFBundleName`, so renaming the application without renaming
+    `Contents/Frameworks/<name> Helper*.app` gives a bundle that dies at
+    `electron_main_delegate_mac.mm` with "Unable to find helper app". It happens
+    before a window, a user data directory or a log line exists, which is why
+    0.8.33 and 0.8.49 both shipped it: everything downstream of the launch --
+    the extensions, `product.json`, the embedded tools -- verified fine, and
+    `bin/partcad-ide --version` runs Electron as Node and never looks for a
+    helper at all.
+
+    Checked here rather than only by starting the application because it is a
+    property of the bundle, and a static check says which of the four is wrong.
+    """
+    info_plist = app_root / "Contents" / "Info.plist"
+    if not info_plist.is_file():
+        problems.append(f"no Info.plist at {info_plist}")
+        return
+    with open(info_plist, "rb") as handle:
+        bundle_name = plistlib.load(handle).get("CFBundleName")
+    if not bundle_name:
+        problems.append(f"{info_plist} has no CFBundleName; Electron has no helper name to resolve")
+        return
+
+    frameworks = app_root / "Contents" / "Frameworks"
+    for suffix in MACOS_HELPER_SUFFIXES:
+        name = f"{bundle_name} Helper{suffix}"
+        helper = frameworks / f"{name}.app"
+        if not helper.is_dir():
+            # What is there instead, if anything: "no helper application at ..."
+            # on its own does not say that a rename is what was missed.
+            stale = sorted(entry.name for entry in frameworks.glob(f"*Helper{suffix}.app"))
+            found = f" (found {', '.join(stale)} instead: the rename did not happen)" if stale else ""
+            problems.append(f"no helper application at {helper}{found}")
+            continue
+        check_executable(helper / "Contents" / "MacOS" / name, f"helper executable '{name}'", problems, notes)
+
+
 def check_executable(path: pathlib.Path, description: str, problems: list[str], notes: list[str]) -> None:
     if not path.is_file():
         problems.append(f"no {description} at {path}")
@@ -257,6 +303,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--executable", type=pathlib.Path, required=True, help="the renamed application executable")
     parser.add_argument("--launcher", type=pathlib.Path, required=True, help="the bin/ command line launcher")
     parser.add_argument(
+        "--app-root",
+        type=pathlib.Path,
+        help="the macOS application bundle ('...app'), when one was built",
+    )
+    parser.add_argument(
         "--expect-tools",
         action="store_true",
         help="require the PartCAD command line tools to be embedded in the application",
@@ -271,6 +322,8 @@ def main(argv: list[str] | None = None) -> int:
     check_entry_point(args.resources / "app", problems, notes)
     check_executable(args.executable, "application executable", problems, notes)
     check_executable(args.launcher, "command line launcher", problems, notes)
+    if args.app_root is not None:
+        check_macos_helpers(args.app_root, problems, notes)
 
     extensions_dir = args.resources / "app" / "extensions"
     present = installed_extensions(extensions_dir)

--- a/ide/vscode/.vscode-test.js
+++ b/ide/vscode/.vscode-test.js
@@ -2,6 +2,43 @@ const { defineConfig } = require('@vscode/test-cli');
 
 // TODO: Deal with GPU errors: https://github.com/microsoft/vscode-test-cli/issues/61
 
+// The built PartCAD IDE to run against, if there is one: the path of the
+// application *binary*, not of the bundle or the `bin/` launcher.
+//
+// `unitTests` below downloads stock VS Code, which is right for what it checks
+// -- this extension's own logic -- and blind to everything the IDE puts around
+// it: the built-in extension set, `product.json`'s `configurationDefaults`, the
+// bootstrap extension, the embedded `partcad-json-rpc`, and the branded
+// application shell. Nothing in this repository used to start the editor that
+// ships. The macOS bundle could not start at all for two releases and no test
+// here could have noticed.
+//
+// Set by `.github/workflows/build-ide-standalone.yml` after it installs a
+// build. Unset locally, where there is usually no bundle to point at, and then
+// this configuration is simply not offered.
+const bundledIde = process.env.PARTCAD_IDE_PATH;
+
+const mocha = {
+  ui: 'tdd',
+  // This budget is "how long activation takes on a loaded runner" rather
+  // than anything about the assertions. It went 20s -> 30s once, and 30s
+  // then started failing about two runs in three (the same commit passing
+  // and failing), so it is marginal rather than broken. Doubled to stop
+  // trimming it by 50% every time the runners get busier; if activation
+  // ever genuinely hangs, 60s still fails the run.
+  timeout: 60000,
+};
+
+// No PartCAD is installed on a CI runner, so activation reaches the "shall I
+// download it?" dialog. Nothing in a headless run can answer a modal dialog,
+// and on Windows an unanswered one is enough to keep the window from ever
+// closing -- which is what "windows-latest doesn't run the test suite" was.
+//
+// It is set for the bundled run too, where the IDE *does* carry a service: the
+// question there is whether the editor comes up and activates the extension,
+// and a prompt is still something nothing can answer.
+const env = { PARTCAD_EXTENSION_NO_PROMPTS: '1' };
+
 module.exports = defineConfig([
   {
     label: 'unitTests',
@@ -9,20 +46,26 @@ module.exports = defineConfig([
     launchArgs: ['--disable-gpu'],
     // version: 'insiders', // For some reason this doesn't work
     workspaceFolder: './sampleWorkspace',
-    // No PartCAD is installed on a CI runner, so activation reaches the "shall I
-    // download it?" dialog. Nothing in a headless run can answer a modal dialog,
-    // and on Windows an unanswered one is enough to keep the window from ever
-    // closing -- which is what "windows-latest doesn't run the test suite" was.
-    env: { PARTCAD_EXTENSION_NO_PROMPTS: '1' },
-    mocha: {
-      ui: 'tdd',
-      // This budget is "how long activation takes on a loaded runner" rather
-      // than anything about the assertions. It went 20s -> 30s once, and 30s
-      // then started failing about two runs in three (the same commit passing
-      // and failing), so it is marginal rather than broken. Doubled to stop
-      // trimming it by 50% every time the runners get busier; if activation
-      // ever genuinely hangs, 60s still fails the run.
-      timeout: 60000,
-    },
+    env,
+    mocha,
   },
+  // The same suite, in the editor that ships. Skipped when there is no build to
+  // point at, so `npm test` is unchanged for anyone without one.
+  ...(bundledIde
+    ? [
+        {
+          label: 'bundledIde',
+          files: 'out/test/**/*.test.js',
+          launchArgs: ['--disable-gpu'],
+          workspaceFolder: './sampleWorkspace',
+          // Runs this checkout's extension inside the installed application
+          // rather than downloading an editor. The built IDE already carries a
+          // released copy of this extension; `--extensionDevelopmentPath`,
+          // which the runner passes, is what takes precedence over it.
+          useInstallation: { fromPath: bundledIde },
+          env,
+          mocha,
+        },
+      ]
+    : []),
 ]);

--- a/src/partcad/healthcheck/python_version.py
+++ b/src/partcad/healthcheck/python_version.py
@@ -10,8 +10,19 @@ from .tests import HealthCheckReport, HealthCheckTest
 
 
 class PythonVersionCheck(HealthCheckTest):
+    # The interpreters PartCAD supports, and nothing else: these are
+    # `requires-python` in `pyproject.toml` (">=3.10,<3.15") said as tuples.
+    # They drifted once -- `pyproject.toml` accepted 3.13 and 3.14 while this
+    # still stopped at 3.12 -- and the standalone bundle, which carries its own
+    # 3.14, spent every start telling the user that the interpreter PartCAD
+    # ships is unsupported and that they should go and change their system
+    # Python. `tests/partcad/unit/test_healthcheck_python_version.py` reads
+    # `pyproject.toml` and fails when the two disagree again.
+    #
+    # The upper bound is an open one, `< 3.15`, written as "3.14 and any patch
+    # release of it" so that it can be compared against `sys.version_info`.
     min_version: tuple[int, int] = (3, 10)
-    latest_version: tuple[int, int] = (3, 12, float("inf"))
+    latest_version: tuple[int, int, float] = (3, 14, float("inf"))
 
     def __init__(self):
         super().__init__(

--- a/tests/dev_tools/test_changed_scopes.py
+++ b/tests/dev_tools/test_changed_scopes.py
@@ -126,6 +126,37 @@ def test_an_unknown_path_runs_everything(tmp_path):
     assert subjects["pytest"] and subjects["behave"] and subjects["wheel"] and subjects["bundle"]
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "ide/standalone/build.sh",
+        "ide/standalone/AGENTS.md",
+        "ide/vscode/src/extension.ts",
+        "ide/vscode/AGENTS.md",
+    ],
+)
+def test_the_ide_is_built_without_freezing_a_bundle(tmp_path, path):
+    """The combination "build-ide-standalone.yml" has to be able to survive.
+
+    The IDE embeds the frozen command line bundles but does not freeze them, so
+    a change to the application around them turns `ide` on and leaves `bundle`
+    off -- deliberately, and it is the whole point of `ide` not listening to
+    `code`. What follows from it is not obvious, and cost a red pull request:
+    "Standalone" still *runs* on that pull request and skips its builds, so the
+    IDE build's sibling run exists and holds nothing. "Find the 'Standalone' run
+    that built the bundles" has to read that as "take them from the base
+    branch", which is what it does for a commit with no run at all, rather than
+    as a failure to produce them.
+
+    If this ever becomes "bundle is on too", that fallback stops being exercised
+    -- and the case it covers, a release built from a commit whose scope froze
+    nothing, is not one to discover on a release.
+    """
+    subjects, _ = classify(tmp_path, [path])
+    assert subjects["ide"] is True
+    assert subjects["bundle"] is False
+
+
 def test_source_alone_does_not_freeze_a_bundle(tmp_path):
     """The one place a source change and a dependency change part company.
 

--- a/tests/partcad/unit/test_healthcheck_python_version.py
+++ b/tests/partcad/unit/test_healthcheck_python_version.py
@@ -1,0 +1,77 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The PythonVersion healthcheck agrees with `requires-python` in `pyproject.toml`.
+
+The two are separate statements of one fact, and they drifted: `pyproject.toml`
+moved to ">=3.10,<3.15" while the healthcheck stayed at 3.12, so the standalone
+bundle -- which carries its own 3.14 -- warned on every start that the
+interpreter PartCAD ships is unsupported, and told the user to change a system
+Python that has no bearing on it. This reads the one and checks the other.
+"""
+
+import collections
+import pathlib
+import re
+import sys
+
+import pytest
+
+from partcad.healthcheck.python_version import PythonVersionCheck
+
+PYPROJECT = pathlib.Path(__file__).resolve().parents[3] / "pyproject.toml"
+
+
+def requires_python() -> str:
+    """The `requires-python` line of `pyproject.toml`, as written."""
+    for line in PYPROJECT.read_text(encoding="utf-8").splitlines():
+        match = re.match(r'\s*requires-python\s*=\s*"([^"]+)"', line)
+        if match:
+            return match.group(1)
+    raise AssertionError(f"no requires-python in {PYPROJECT}")
+
+
+@pytest.mark.skipif(not PYPROJECT.is_file(), reason="not run from a source checkout")
+def test_bounds_match_pyproject():
+    spec = requires_python()
+    lower = re.search(r">=\s*(\d+)\.(\d+)", spec)
+    upper = re.search(r"<\s*(\d+)\.(\d+)", spec)
+    assert lower and upper, f"cannot read bounds from {spec!r}"
+
+    check = PythonVersionCheck()
+    assert check.min_version == (int(lower.group(1)), int(lower.group(2)))
+    # `< 3.15` is "3.14 and any patch release of it" once it has to be compared
+    # against `sys.version_info`, which is what the healthcheck holds.
+    assert check.latest_version[:2] == (int(upper.group(1)), int(upper.group(2)) - 1)
+    assert check.latest_version[2] == float("inf")
+
+
+def test_running_interpreter_passes():
+    """Whatever runs the test suite is an interpreter PartCAD supports."""
+    assert PythonVersionCheck().test().findings == []
+
+
+# `sys.version_info` compares as a tuple but is read as an object -- the check
+# reports `.major` and `.minor` -- so a bare tuple is not a stand-in for it.
+VersionInfo = collections.namedtuple("VersionInfo", "major minor micro releaselevel serial")
+
+
+@pytest.mark.parametrize(
+    "version, supported",
+    [
+        ((3, 9, 18, "final", 0), False),
+        ((3, 10, 0, "final", 0), True),
+        ((3, 12, 7, "final", 0), True),
+        # The version the standalone bundle ships, which used to be reported as
+        # unsupported by the bundle carrying it.
+        ((3, 14, 0, "final", 0), True),
+        ((3, 14, 9, "final", 0), True),
+        ((3, 15, 0, "alpha", 1), False),
+    ],
+)
+def test_bounds_accept_and_reject(monkeypatch, version, supported):
+    monkeypatch.setattr(sys, "version_info", VersionInfo(*version))
+    findings = PythonVersionCheck().test().findings
+    assert (findings == []) is supported


### PR DESCRIPTION
The macOS IDE could not launch. `build.sh` brands `Info.plist` with `CFBundleName: PartCAD IDE`, which is the name Electron resolves its four helper processes from, and nothing renamed `Contents/Frameworks/VSCodium Helper*.app` to match:

```
FATAL:electron/shell/app/electron_main_delegate_mac.mm:66] Unable to find helper app
```

It dies before it opens a window, creates a user data directory or writes a line of log. **0.8.33 and 0.8.49 both shipped it.** Verified on macOS 26.6 / M4: renaming the four helpers by hand makes 0.8.49 start and run normally.

`product.json` had the same kind of miss: `build.sh` renames every `bin/codium*` to `partcad-ide*`, the tunnel binary included, but `tunnelApplicationName` still said `codium-tunnel`, so `partcad-ide serve-web` and `tunnel` died with `spawn .../bin/codium-tunnel ENOENT` on every platform.

### Why it shipped

Nothing in this repository started the application.

- **"Run what was installed"** runs `partcad-ide --version`, and that launcher ends in `ELECTRON_RUN_AS_NODE=1` — Electron being Node. No browser process, no helpers, no window. It printed a version out of a bundle that could not launch.
- **`verify_bundle.py`** checked everything downstream of the launch and nothing about the bundle's own structure.
- **The extension suite** runs against a downloaded stock VS Code, never the editor that ships.
- **"Start it once" would have caught it, and did** — it has never once passed on macOS. It was made `continue-on-error` there, reasoning that a hosted runner's session was the likelier suspect than anything wrong with the IDE. It was not the runner. Every symptom that comment records is this bug: the launcher exits 0 because it spawns the editor and returns, and the editor was gone before it could write anything down.

### What this adds

- `check_macos_helpers` in `verify_bundle.py`, run from `build.sh` via `--app-root`. Static, and it names which of the four is wrong.
- A **"Run the application binary"** step that runs the binary the OS runs — not the `bin/` launcher — keeps its output, and fails on `Unable to find helper app` by name. The generic fatal match is Chromium's `:FATAL:` format, not a bare `fatal`, so ordinary GPU/sandbox chatter on the Linux runners cannot fail it.
- **"Start it once" blocking on every platform** again.
- A **`bundledIde`** `.vscode-test.js` configuration, offered only when `PARTCAD_IDE_PATH` names a build, so the extension's own suite runs inside the installed IDE. Unset, `npm test` is unchanged.

### Also: PythonVersion healthcheck

`latest_version` stopped at 3.12 while `pyproject.toml` moved to `>=3.10,<3.15`, and the standalone bundle carries its own 3.14 — so the bundle spent every start reporting that the interpreter PartCAD ships is unsupported, and telling the user to change a system Python that has no bearing on it. Aligned with `pyproject.toml`, plus a test that reads `requires-python` and fails when the two disagree again.

### Verification

Run here, on this branch:

- `pytest ide/standalone/tests` — **94 passed** (88 before; 6 new).
- The new healthcheck test — **8 passed**, and **3 fail** as intended when `latest_version` is put back to `(3, 12, inf)`.
- `check_macos_helpers` against the **shipped 0.8.33 bundle** in `/Applications`: reports all four, each naming the VSCodium bundle found instead. Against a 0.8.49 bundle with the helpers renamed by hand: passes, four helpers found.
- `bash -n ide/standalone/build.sh`, YAML and JSONC parse, `useInstallation.fromPath` checked against `@vscode/test-cli@0.0.15`'s `config.d.cts`.

**Not run:** the dev container (no Docker on this machine), `pre-commit`, `shellcheck`, `black`, the bootstrap `node --test` suite, and CI itself. The workflow and `.vscode-test.js` changes are reviewed but unexecuted — they are the least-verified part of this branch.

Rebased onto `devel` at 7dee016 (0.8.52).

#deepTest — this needs the full platform matrix to prove the macOS leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
