### PR TITLE
AGENTS.md: the macOS bundle, and testing against the IDE that ships

### DIFF
--- a/ide/standalone/AGENTS.md
+++ b/ide/standalone/AGENTS.md
@@ -52,6 +52,41 @@ Three things about how it is done:
 `tools/verify_bundle.py` fails the build if the wrapper is missing, if `main` does not point at it, or if it
 does not contain the switch -- each of which leaves an IDE that either has no software WebGL or does not start.
 
+## The macOS bundle
+
+**Electron resolves the four helper applications it spawns from the outer bundle's `CFBundleName`.** Renaming
+the application without renaming `Contents/Frameworks/<name> Helper*.app` gives a bundle that dies at
+`electron_main_delegate_mac.mm` with "Unable to find helper app". It happens before a window, a user data
+directory or a single line of log exists, so the bundle leaves nothing behind to explain itself. 0.8.33 and
+0.8.49 shipped that way: unlaunchable on every Mac.
+
+Three names change per helper, not one -- the directory Electron looks up, the executable inside it (a helper's
+`Info.plist` carries no `CFBundleExecutable`, so macOS falls back to the bundle's base name), and
+`CFBundleName`. The rename runs **before** `codesign --force --deep`, which seals the names it is given.
+`check_macos_helpers` in `tools/verify_bundle.py` fails the build when any of the four is missing or still
+carries the upstream name, and says which.
+
+**Two plist fields, and only one of them is the helper's.** VSCodium spells `CFBundleName` and
+`CFBundleExecutable` the same -- both "VSCodium" -- so they look interchangeable and are not: the executable in
+`Contents/MacOS` is `CFBundleExecutable`, and what a helper is named after is `CFBundleName`. `build.sh` reads
+the latter into `UPSTREAM_BUNDLE_NAME` *before* `brand.py plist` overwrites it, and keeps `BUNDLE_EXECUTABLE`
+for the main executable. Where the expected name is not there, a unique `* Helper<suffix>.app` beside it is
+renamed instead and said out loud, so an upstream rename does not fail a build over a name -- but two matches
+fail, because renaming the wrong directory produces the same dead application the rename exists to prevent.
+
+**`bin/partcad-ide --version` does not test that the application starts, and never could.** That launcher ends
+in `ELECTRON_RUN_AS_NODE=1` -- Electron being Node: no browser process, no helper applications, no window. It
+printed a version out of a macOS bundle that could not launch, for two releases, while the job stayed green.
+Anything claiming to smoke-test the *editor* has to run the binary in `Contents/MacOS` (the top of the
+directory, on Linux and Windows), keep its output, and assert the process is still alive -- which is what
+"Run the application binary" in `.github/workflows/build-ide-standalone.yml` does.
+
+**A check that fails on one platform is evidence about that platform, not a reason to stop asking.** "Start it
+once" had never passed on macOS and was made `continue-on-error` there, reasoning that a hosted runner's
+session was the likelier suspect. It was not the runner; it was the helpers, and the demotion is what let the
+two releases after it ship unlaunchable. It is blocking on every platform again, and it passes. If a start
+check fails on one platform, get the application's own stderr before concluding anything about the runner.
+
 ## Test
 
 ```bash

--- a/ide/vscode/AGENTS.md
+++ b/ide/vscode/AGENTS.md
@@ -419,6 +419,67 @@ belongs in a pure function that takes the platform (`pathKey`, `listenOptions`, 
 `resolveServicePath`'s `searched` list) so a test can ask what it would do somewhere else. Everything in this
 file that starts "on Windows" was shipped broken at some point precisely because nothing asked.
 
+### Testing against the IDE, not against VS Code
+
+**`npm test` downloads stock VS Code, so it says nothing about the editor that ships.** That is the right
+default -- what it checks is this extension's logic -- but it is blind to everything the PartCAD IDE puts
+around it: the built-in extension set, `product.json`'s `configurationDefaults` (`partcad.backend`,
+`partcad.serviceChannel`), the bootstrap extension and the first-start workspace it creates, the embedded
+`partcad-json-rpc` the extension is meant to find without a dialog, and the branded application shell itself.
+Nothing here started that editor until #609, and it could not start at all on macOS for two releases without a
+single test in this repository noticing.
+
+So a change to any of those is tested against a **built** IDE. `.vscode-test.js` offers a second
+configuration, `bundledIde`, when `PARTCAD_IDE_PATH` names one. What it wants is the application *binary* --
+not the bundle, and not the `bin/` launcher:
+
+```bash
+# macOS. The executable's name belongs to the editor this was built from --
+# VSCodium's, today -- so it is read rather than written down here.
+app="$HOME/Applications/PartCAD IDE.app"
+export PARTCAD_IDE_PATH="$app/Contents/MacOS/$(plutil -extract CFBundleExecutable raw "$app/Contents/Info.plist")"
+
+# Linux. Resolved through the launcher `install.sh` symlinks, rather than
+# assuming the layout it owns.
+app="$(dirname "$(dirname "$(readlink -f "$HOME/partcad-bin/partcad-ide")")")"
+export PARTCAD_IDE_PATH="$app/partcad-ide"
+
+npm run pretest && npx vscode-test --label bundledIde        # xvfb-run -a ... on Linux
+```
+
+```powershell
+# Windows. There is no `install.sh` there -- the setup program puts the
+# application here -- and `fromPath` is read by Node, so it wants a native path.
+$env:PARTCAD_IDE_PATH = Join-Path $env:LOCALAPPDATA "Programs\PartCAD IDE\partcad-ide.exe"
+npm run pretest; npx vscode-test --label bundledIde
+```
+
+The first two are the ones `build-ide-standalone.yml` uses, and neither hardcodes a name it can ask for. The
+first version of that step wrote `Contents/MacOS/VSCodium` and was right about today's bundle and wrong in
+principle; `ide/standalone/AGENTS.md` has which plist field means what.
+
+**CI runs this on macOS and Linux only.** The `install` job drops Windows from its matrix -- there is no shell
+installer there, and `install-windows` runs the setup program instead -- so the Windows form above is the one
+to use by hand and the one nothing checks. Do not reach it by running the Bash recipe under Git Bash: there is
+no `~/partcad-bin/partcad-ide` to resolve, and if there were, `readlink -f` answers with an MSYS path
+(`/c/...`) that `useInstallation.fromPath` cannot use.
+
+Unset, the configuration is not offered and `npm test` is unchanged, so nobody needs a bundle to work here.
+`.github/workflows/build-ide-standalone.yml` sets it after installing a build, which is the only place it runs
+in CI -- `ide/standalone/AGENTS.md` has how that bundle is made.
+
+Three things the bundled run needs, all of which have already cost a debugging session:
+
+- **`PARTCAD_EXTENSION_NO_PROMPTS=1` still applies.** The IDE *does* carry a service, so the download dialog is
+  not the risk it is under stock VS Code -- but a prompt of any kind is still something a headless run cannot
+  answer, and on Windows an unanswered modal keeps the window from ever closing.
+- **The built IDE already contains a released copy of this extension.** `--extensionDevelopmentPath`, which the
+  runner passes, is what makes the checkout win. A test asserting on extension *version* rather than behaviour
+  will read whichever copy it happened to get.
+- **A first `Display` provisions a conda environment**, which takes about three minutes on a clean machine
+  against roughly two seconds warm. A test that exercises geometry needs a warmed `~/.partcad/conda` or a
+  budget that admits the cold path; the 60s Mocha timeout is sized for activation, not for that.
+
 ## Build / package
 
 ```bash


### PR DESCRIPTION
Two things that were not written down anywhere, and cost two unlaunchable releases between them.

### `ide/standalone/AGENTS.md` — "The macOS bundle"

- Electron resolves its four helper applications from the outer bundle's `CFBundleName`, so branding the plist without renaming `Contents/Frameworks/<name> Helper*.app` produces a bundle that dies at `electron_main_delegate_mac.mm` — before a window, a user data directory or a line of log exists, so it leaves nothing behind to explain itself.
- Three names change per helper, and the rename has to precede `codesign --force --deep`, which seals the names it is given.
- **`CFBundleName` and `CFBundleExecutable` hold the same string in VSCodium and are not interchangeable** — only the first is what a helper is named after. This is the distinction the review of #609 turned on, and the one a future rebrand will meet again.
- **`bin/partcad-ide --version` cannot test that the application starts**, because that launcher runs Electron as Node. Anything claiming to smoke-test the editor has to run the real binary and keep its output.
- The lesson from "Start it once": a start check that fails on one platform is evidence about that platform, not a reason to stop asking. It is blocking again, and it passes.

### `ide/vscode/AGENTS.md` — "Testing against the IDE, not against VS Code"

- `npm test` downloads stock VS Code, which is right for what it checks and blind to everything the IDE puts around the extension: the built-in extension set, `product.json`'s `configurationDefaults`, the bootstrap extension, the embedded service, the branded shell.
- How to run the same suite in a built IDE — the `bundledIde` configuration and `PARTCAD_IDE_PATH`, with the resolution for each platform.
- The three things that run needs, each of which has already cost a debugging session: the no-prompts flag still applies; the built IDE already carries a released copy of the extension, so `--extensionDevelopmentPath` is what makes the checkout win; and a first `Display` provisions a conda environment in about three minutes against roughly two seconds warm, which the 60s Mocha timeout is not sized for.

### Rebased onto #609

Documentation only — no code changes. Rebased onto `devel` at 813583e, after #609 merged, and corrected against what actually landed rather than what the branch was written beside:

- Both `PARTCAD_IDE_PATH` examples now match the merged workflow. The first draft hardcoded `Contents/MacOS/VSCodium` — right about today's bundle, wrong in principle, and the very thing the merged step was corrected for. macOS reads `CFBundleExecutable` with `plutil -extract`; Linux and Windows resolve through the launcher `install.sh` symlinks.
- The helper section now describes `UPSTREAM_BUNDLE_NAME` and the unique-match fallback that the review added, not the earlier `BUNDLE_EXECUTABLE` form.

Every file, function, step, setting and environment variable named in these two files was checked to resolve against merged `devel` — `check_macos_helpers`, `UPSTREAM_BUNDLE_NAME`, `BUNDLE_EXECUTABLE`, "Run the application binary", `bundledIde`, `PARTCAD_IDE_PATH`, `useInstallation.fromPath`, `PARTCAD_EXTENSION_NO_PROMPTS`, the 60s timeout, `ELECTRON_RUN_AS_NODE`, `codesign --force --deep`, `plutil -extract`, and that "Start it once" no longer carries `continue-on-error`.

The `Command line tools` failure on the previous push should be gone: #609 taught that job to treat a barren same-commit `Standalone` run the way it already treats no run at all, which is exactly what a documentation-only change produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)