### PR TITLE
Retry the standalone bundle upload, which has blocked two releases

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -461,7 +461,36 @@ jobs:
         shell: bash
         run: dev-tools/pyinstaller/build.sh --platform=${{ matrix.platform }}
 
+      # Three attempts, because losing this one costs the whole build.
+      #
+      # `upload-artifact` reaches the artifact service over the network, and on
+      # the `macos-15-intel` runners that request has twice resolved to nothing:
+      #
+      #     ##[error]Failed to CreateArtifact: Unable to make request: ENOTFOUND
+      #
+      # It blocked the 0.8.47 and 0.8.54 releases, both on `macos-15-x86_64`,
+      # and both times *after* the bundle was built -- the log says "there will
+      # be 2 files uploaded" and "Artifact name is valid!" and then fails a DNS
+      # lookup. What that throws away is the most expensive thing this
+      # repository does, ~500MB of OpenCASCADE frozen over the better part of an
+      # hour, and "deploy.yml" makes `publish-to-pypi` wait on this workflow, so
+      # it takes the wheel, the bundles, the extension and the plugin with it.
+      #
+      # Spelled out rather than looped. A step that `uses:` an action cannot be
+      # wrapped in a shell loop, a composite action cannot help either
+      # (`continue-on-error` is not supported on a composite's steps), and the
+      # repository has no retry action to reach for -- `version-bump.yml` writes
+      # its own loop for the same reason. Only the last attempt is allowed to
+      # fail the job.
+      #
+      # `overwrite: true` on the retries: a first attempt that got far enough to
+      # create the artifact and then died would otherwise make every retry fail
+      # with "an artifact with this name already exists", turning one transient
+      # error into a permanent one. It is not needed on the first attempt, and
+      # not set there, so a genuine duplicate name is still an error.
       - name: Upload the bundle
+        id: upload
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: partcad-standalone-${{ matrix.platform }}
@@ -471,6 +500,47 @@ jobs:
             dist/standalone/*.sha256
           if-no-files-found: error
           retention-days: 14
+
+      # Long enough for a failed DNS lookup to be worth repeating, short enough
+      # that it is noise against the build that just ran.
+      - name: Wait before retrying the upload
+        if: steps.upload.outcome == 'failure'
+        shell: bash
+        run: sleep 30
+
+      - name: Upload the bundle (second attempt)
+        id: upload-retry
+        if: steps.upload.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: partcad-standalone-${{ matrix.platform }}
+          path: |
+            dist/standalone/*.tar.xz
+            dist/standalone/*.zip
+            dist/standalone/*.sha256
+          if-no-files-found: error
+          retention-days: 14
+          overwrite: true
+
+      - name: Wait before the last upload attempt
+        if: steps.upload.outcome == 'failure' && steps.upload-retry.outcome == 'failure'
+        shell: bash
+        run: sleep 60
+
+      # The one that is allowed to fail the job.
+      - name: Upload the bundle (final attempt)
+        if: steps.upload.outcome == 'failure' && steps.upload-retry.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: partcad-standalone-${{ matrix.platform }}
+          path: |
+            dist/standalone/*.tar.xz
+            dist/standalone/*.zip
+            dist/standalone/*.sha256
+          if-no-files-found: error
+          retention-days: 14
+          overwrite: true
 
   # Every platform this run built that "install.sh" can install, which is every
   # one except Windows -- there is no shell installer there -- plus the macOS


### PR DESCRIPTION
`upload-artifact` reaches the artifact service over the network, and on the `macos-15-intel` runners that request has twice resolved to nothing:

```
##[error]Failed to CreateArtifact: Unable to make request: ENOTFOUND
```

| Release | Job | Step | Outcome |
| --- | --- | --- | --- |
| 0.8.47 (Sep 3) | `Build (macos-15-x86_64)` | Upload the bundle | release blocked |
| 0.8.54 (Sep 5) | `Build (macos-15-x86_64)` | Upload the bundle | release blocked, manual re-run |

Both times the bundle had already been **built**. The log reads `there will be 2 files uploaded`, `Artifact name is valid!`, `Root directory input is valid!` — and then fails a DNS lookup. What that throws away is the most expensive thing this repository does: ~500MB of OpenCASCADE frozen over the better part of an hour. And `deploy.yml` makes `publish-to-pypi` wait on this workflow, so one failed lookup on one Intel macOS runner holds back the wheel, the bundles, the extension and the plugin.

### What this does

Three attempts, with 30s and 60s between them. Only the last can fail the job — so a bundle that genuinely cannot be uploaded (`if-no-files-found: error` because the build produced nothing, say) still fails, ninety seconds later than before rather than never.

**Spelled out rather than looped**, which is not a style choice:

- a step that `uses:` an action cannot be wrapped in a shell loop;
- a composite action cannot help either — `continue-on-error` is not supported on a composite's steps;
- and this repository has no retry action to reach for. `version-bump.yml` writes its own loop for the same reason.

**`overwrite: true` on the retries only.** A first attempt that got far enough to create the artifact and then died would otherwise make every retry fail with "an artifact with this name already exists" — turning one transient error into a permanent one. The first attempt does not set it, so a genuine duplicate name is still an error.

### Scope

Only this upload. It is the one with observed failures, and at ~20 lines per site the same treatment across all eleven `upload-artifact` steps would be a large change for a hypothetical benefit. `Upload the IDE` and `Upload the snap` are the two that would matter next if this turns out to be broader — happy to extend if you'd rather do it once.

### Verified

- The workflow parses; all 21 bash `run:` blocks still parse with their GitHub expressions stubbed.
- The four outcome combinations were simulated:

  | case | steps that run | job |
  | --- | --- | --- |
  | first works | attempt1 | PASS |
  | first flakes, second ok | attempt1, sleep30, attempt2 | PASS |
  | two flake, third ok | attempt1, sleep30, attempt2, sleep60, attempt3 | PASS |
  | all three flake | attempt1, sleep30, attempt2, sleep60, attempt3 | **FAIL** |

- `steps.upload-retry.outcome` — a hyphen in a step id is what `steps.set-matrix.outputs.*` already relies on throughout these workflows.
- `overwrite` is a real input of `actions/upload-artifact@v7`, checked against its `action.yml`.
- `shell: bash` on the two wait steps, because this job also runs on `windows-2022`.

Not run: CI itself. The retry path only executes when the upload fails, so it will sit unexercised until the next blip — the simulation above is what stands in for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
