### PR TITLE
Do not crash 'pc healthcheck --fix' on a Mac without Homebrew

### DIFF
--- a/src/partcad/healthcheck/openscad.py
+++ b/src/partcad/healthcheck/openscad.py
@@ -164,6 +164,26 @@ class MacOpenSCADCheck(OpenSCADCheck):
         macOS -- so on Apple Silicon it was the wrong build to reach for even
         while it installed.
         """
+        # Homebrew is not on every Mac, and this used to find that out by
+        # execing it: `subprocess.run(["brew", ...])` raises `FileNotFoundError`
+        # rather than returning non-zero, that is not a
+        # `subprocess.CalledProcessError`, and the `except` below did not catch
+        # it. The exception left `fix`, left `run_healthchecks`, and reached the
+        # user as a PyInstaller traceback -- taking every *later* fix with it, so
+        # `pc healthcheck --fix` on a Mac without Homebrew repaired nothing at
+        # all, not even the stale git locks it knows how to clear.
+        #
+        # Asked rather than caught, so the answer is a sentence about what to do
+        # instead: an auto-fix that cannot run is a normal outcome here, not an
+        # error.
+        if shutil.which("brew") is None:
+            pc_logging.error(
+                "Cannot install OpenSCAD automatically: Homebrew is not installed. "
+                "Install OpenSCAD yourself (https://openscad.org/downloads.html), or install "
+                "Homebrew and run 'brew install --cask openscad@snapshot'."
+            )
+            return False
+
         env = os.environ.copy()
         env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
 
@@ -190,6 +210,12 @@ class MacOpenSCADCheck(OpenSCADCheck):
             return True
         except subprocess.CalledProcessError as error:
             pc_logging.error("OpenSCAD installation failed.")
+            pc_logging.debug(error)
+        except OSError as error:
+            # Homebrew disappearing between the check above and the exec, or
+            # being there and not executable. The Linux fixer already ends in a
+            # catch-all for the same reason.
+            pc_logging.error("OpenSCAD installation failed: could not run Homebrew.")
             pc_logging.debug(error)
         return False
 

--- a/src/partcad/healthcheck/tests.py
+++ b/src/partcad/healthcheck/tests.py
@@ -107,7 +107,21 @@ def run_healthchecks(filters: str = None, fix: bool = False, dry_run: bool = Fal
                     report.warning(test.findings)
                     if fix and test.auto_fixable():
                         report.debug("Attempting to fix issues...")
-                        report.fixed = test.fix()
+                        # A fix that raises is a failed fix, not the end of the
+                        # run. It was the end of the run: the macOS OpenSCAD fix
+                        # exec'd a Homebrew that was not installed, the
+                        # `FileNotFoundError` came out here, and `--fix` died
+                        # before reaching any of the checks after it -- so a Mac
+                        # with no Homebrew could not clear its stale git locks
+                        # either, for a reason that had nothing to do with them.
+                        # Each fix is independent and the caller asked for all of
+                        # them.
+                        try:
+                            report.fixed = test.fix()
+                        except Exception as error:
+                            report.fixed = False
+                            report.error(f"Auto fix raised: {error}")
+                            pc_logging.exception(f"Healthcheck '{test.name}' failed while fixing")
                         if report.fixed:
                             report.info(f"Auto fix successful")
                         else:

--- a/tests/partcad/unit/test_openscad.py
+++ b/tests/partcad/unit/test_openscad.py
@@ -114,6 +114,12 @@ def homebrew(tmp_path, monkeypatch):
     installing, ``fix`` deletes cached ``*openscad*.dmg`` files out of the real
     Homebrew download directory, which is not something a unit test may do to
     the machine running it.
+
+    ``shutil.which`` is answered as well, because ``fix`` now asks whether
+    Homebrew is there before reaching for it -- and the machines this suite runs
+    on, the Linux CI runners included, mostly do not have it. Without this the
+    fixture would describe a Mac that cannot install anything, which is what the
+    two tests below are specifically not about.
     """
     calls = []
 
@@ -127,6 +133,7 @@ def homebrew(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pc_openscad.subprocess, "run", _run)
     monkeypatch.setattr(pc_openscad.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(pc_openscad.shutil, "which", lambda name: "/opt/homebrew/bin/brew")
     return calls
 
 
@@ -141,3 +148,41 @@ def test_macos_install_does_not_let_homebrew_update_itself(homebrew):
     pc_openscad.MacOpenSCADCheck().fix()
     _, kwargs = homebrew[0]
     assert kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"] == "1"
+
+
+# What the fix does when Homebrew is not there at all.
+#
+# The tests above replace `subprocess.run`, so they never exec anything and
+# never noticed that the real call raises `FileNotFoundError` on a Mac without
+# Homebrew -- which is most Macs that have just installed the standalone IDE.
+# `pc healthcheck --fix` ended in a PyInstaller traceback, and took every fix
+# after it down with it.
+
+
+def test_macos_says_what_to_do_when_homebrew_is_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(pc_openscad.shutil, "which", lambda name: None)
+    monkeypatch.setattr(pc_openscad.Path, "home", staticmethod(lambda: tmp_path))
+
+    def _never(*args, **kwargs):
+        raise AssertionError("Homebrew is absent; nothing should have been executed")
+
+    monkeypatch.setattr(pc_openscad.subprocess, "run", _never)
+    assert pc_openscad.MacOpenSCADCheck().fix() is False
+
+
+def test_macos_fix_does_not_raise_when_brew_cannot_be_executed(monkeypatch, tmp_path):
+    """`which` found it and the exec still failed -- a race, or a bad +x bit."""
+    monkeypatch.setattr(pc_openscad.shutil, "which", lambda name: "/opt/homebrew/bin/brew")
+    monkeypatch.setattr(pc_openscad.Path, "home", staticmethod(lambda: tmp_path))
+
+    def _missing(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory: 'brew'")
+
+    monkeypatch.setattr(pc_openscad.subprocess, "run", _missing)
+    assert pc_openscad.MacOpenSCADCheck().fix() is False
+
+
+def test_macos_still_installs_when_homebrew_is_present(homebrew):
+    """The guard does not get in the way of the machines that can install."""
+    assert pc_openscad.MacOpenSCADCheck().fix() is True
+    assert [command for command, _ in homebrew] == [["brew", "install", "--cask", "openscad@snapshot"]]


### PR DESCRIPTION
Found while trying the 0.8.55 IDE on a Mac that has no Homebrew. `pc healthcheck --fix`:

```
File "partcad/healthcheck/openscad.py", line 183, in fix
FileNotFoundError: [Errno 2] No such file or directory: 'brew'
[PYI-32103:ERROR] Failed to execute script 'entrypoint' due to unhandled exception!
```

`MacOpenSCADCheck.fix` execs `brew install --cask openscad@snapshot`. With Homebrew absent, `subprocess.run` **raises** `FileNotFoundError` rather than returning non-zero — that is not a `subprocess.CalledProcessError`, and the only `except` there did not catch it.

### Two consequences, both fixed

**The user gets a traceback instead of a sentence.** `fix` now asks `shutil.which("brew")` first and says what to do instead — install OpenSCAD directly, or install Homebrew and run the command by hand. An auto-fix that cannot run is a normal outcome here, not an error. `OSError` is caught around the exec too, for a Homebrew that vanishes between the check and the call or is present and not executable. The Linux fixer already ends in a catch-all for exactly this reason; the macOS one did not.

**Every later fix was abandoned.** The exception left `fix`, left `run_healthchecks`, and ended the process — so on this machine `--fix` also never cleared the **29 stale git locks** in `~/.partcad/git`, which have a perfectly good fixer, for a reason with nothing to do with them. A fix that raises is now a failed fix, not the end of the run. Each check is independent and the caller asked for all of them.

That second change is why this PR touches `tests.py` as well as `openscad.py`. The user-visible damage was as much the runner's contract as the fixer's bug, and without it the next fixer that raises does the same thing.

### Why the tests missed it

The existing macOS tests replace `subprocess.run`, so they never exec anything and could not have seen this. They also do not stub `shutil.which` — so the new guard would have started failing them on every machine without Homebrew, the Linux CI runners included. The `homebrew` fixture now answers `which` too, which is what a fixture called `homebrew` is for.

Three new tests: Homebrew missing (and nothing is executed), Homebrew found but the exec still fails, and the ordinary install still working.

### Verification

On the Mac that produced the traceback, with no stubs at all:

```
brew on this Mac: (none)
ERROR:root:Cannot install OpenSCAD automatically: Homebrew is not installed. Install OpenSCAD
yourself (https://openscad.org/downloads.html), or install Homebrew and run
'brew install --cask openscad@snapshot'.
  returned False (no exception)
```

And the runner guard, with a two-check run where the first raises:

```
Healthcheck: Boom: Auto fix raised: [Errno 2] No such file or directory: 'brew'
Healthcheck: Boom: Auto fix failed
run_healthchecks completed without raising
the check after the crashing one ran: True
```

26 healthcheck unit tests pass (`test_openscad.py` 11 → 14, plus the stale-git-locks and python-version suites). Not run here: the dev container, `pre-commit`, `black`.

### Not in scope

`OpenSCAD executable not found, neither bundled nor in PATH` is still the finding on macOS — the bundles ship no OpenSCAD there, so the `produce_part_openscad` example the welcome window offers remains a dead end on this platform. This PR only stops the *fixer* from crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
