### PR TITLE
Carry one OpenSCAD build in every bundle, macOS included #deepTest

### DIFF
--- a/.github/actions/setup-test/action.yml
+++ b/.github/actions/setup-test/action.yml
@@ -36,10 +36,14 @@ runs:
         #
         # The snapshot cask is the maintained one, and on these runners it is
         # the only candidate: they are arm64, and 2021.01 ships an x86_64-only
-        # .dmg. "dev-tools/pyinstaller/build.sh" says so, and declines to
-        # bundle OpenSCAD on macOS for exactly that reason -- so fetching that
-        # release directly would quietly require Rosetta 2 rather than fix
-        # anything.
+        # .dmg, so fetching that release directly would quietly require Rosetta 2
+        # rather than fix anything. "dev-tools/pyinstaller/build.sh" carries the
+        # same snapshot into the macOS bundles, for the same two reasons.
+        #
+        # These are the wheel-based jobs, which have no bundle and so need an
+        # OpenSCAD on the host. The bundle-based jobs in "build-standalone.yml"
+        # deliberately install none on macOS any more: the payload is what they
+        # are there to exercise.
         set -euo pipefail
 
         if ! command -v openscad >/dev/null 2>&1; then

--- a/.github/actions/setup-test/action.yml
+++ b/.github/actions/setup-test/action.yml
@@ -37,8 +37,9 @@ runs:
         # The snapshot cask is the maintained one, and on these runners it is
         # the only candidate: they are arm64, and 2021.01 ships an x86_64-only
         # .dmg, so fetching that release directly would quietly require Rosetta 2
-        # rather than fix anything. "dev-tools/pyinstaller/build.sh" carries the
-        # same snapshot into the macOS bundles, for the same two reasons.
+        # rather than fix anything. "dev-tools/pyinstaller/build.sh" carries that
+        # same snapshot into every bundle, on every platform, for the same two
+        # reasons -- one OpenSCAD version everywhere.
         #
         # These are the wheel-based jobs, which have no bundle and so need an
         # OpenSCAD on the host. The bundle-based jobs in "build-standalone.yml"

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -556,17 +556,34 @@ jobs:
 
       # The bundled OpenSCAD has to survive being packed, downloaded and
       # unpacked with its executable bit intact, which the build's own smoke
-      # test cannot show: it runs against the bundle before it is archived.
+      # test cannot show: it runs against the bundle before it is archived. On
+      # macOS it also has to survive `.app` -> ditto -> tar.xz -> curl -> untar
+      # with enough of its signed bundle intact to still launch, which is the
+      # half of this that only a runner can answer.
+      #
+      # Linux arm64 is excluded because it carries no payload -- upstream
+      # publishes the pinned release for x86_64 only. Windows does carry one and
+      # is still not covered here; that predates this step growing a macOS leg,
+      # and the build's own smoke test is what exercises it there.
       - name: Run the bundled OpenSCAD after installation
-        if: endsWith(matrix.platform, '-x86_64') && startsWith(matrix.platform, 'ubuntu-')
+        if: runner.os == 'macOS' || (startsWith(matrix.platform, 'ubuntu-') && endsWith(matrix.platform, '-x86_64'))
         shell: bash
         run: |
+          set -euo pipefail
           export PATH="${HOME}/partcad-bin:${PATH}"
           cd "${HOME}"
-          test -x "$(readlink -f "${HOME}/partcad-bin/pc" | xargs dirname)/_internal/openscad/AppRun"
+          # By the installed path rather than by resolving the `pc` symlink, for
+          # the reason the conda step below gives: `readlink -f` is not portable
+          # to macOS, and only one version is installed.
+          internal="$(ls -d "${HOME}"/partcad-standalone/*/_internal)"
+          if [ "${RUNNER_OS}" = "macOS" ]; then
+            openscad="${internal}/openscad/OpenSCAD.app/Contents/MacOS/OpenSCAD"
+          else
+            openscad="${internal}/openscad/AppRun"
+          fi
+          test -x "${openscad}"
           printf 'cube(10);\n' > smoke.scad
-          "$(readlink -f "${HOME}/partcad-bin/pc" | xargs dirname)/_internal/openscad/AppRun" \
-            --export-format binstl -o smoke.stl smoke.scad
+          "${openscad}" --export-format binstl -o smoke.stl smoke.scad
           test -s smoke.stl
           pc --no-ansi healthcheck --filters openscad 2>&1 | tee healthcheck.log
           grep -q "OpenSCAD: Passed" healthcheck.log
@@ -859,59 +876,20 @@ jobs:
           sudo apt-get install --yes --no-install-recommends \
             libgl1 libx11-6 libxcb1 libfontconfig1 libfreetype6 libglib2.0-0 libharfbuzz0b
 
-      # The macOS bundles carry no OpenSCAD, and neither does the Linux arm64 one
-      # -- upstream publishes the pinned release for x86_64 only (see build.sh).
-      # Both fall back to a host OpenSCAD, exactly as the wheels do.
+      # Linux arm64 is the one bundle that carries no OpenSCAD -- upstream
+      # publishes the pinned release for x86_64 only (see build.sh) -- so it
+      # falls back to a host one, exactly as the wheels do.
       - name: Install OpenSCAD (Linux arm64)
         if: matrix.platform == 'ubuntu-24.04-arm64'
         run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends openscad
 
-      # Same install as the wheel-based jobs' setup-test action.
-      - name: Install OpenSCAD (macOS)
-        if: runner.os == 'macOS'
-        shell: bash -el {0}
-        run: |
-          # Homebrew disabled the "openscad" cask on 2026-09-01: the pinned
-          # 2021.01 release does not pass the macOS Gatekeeper check. That makes
-          # `brew install openscad` fail outright, and the retry beneath it --
-          # which existed for a *corrupted cached* .dmg -- fail with it, so the
-          # step could not succeed on any macOS runner.
-          #
-          # The snapshot cask is the maintained one, and it is what gets
-          # installed on either architecture. On the arm64 runners it is also the
-          # only candidate: 2021.01 ships an x86_64-only .dmg, so fetching that
-          # release directly would quietly require Rosetta 2 rather than fix
-          # anything -- "dev-tools/pyinstaller/build.sh" says so, and declines to
-          # bundle OpenSCAD on macOS for exactly that reason. On macos-15-intel
-          # that release would run, but Homebrew disabled the cask for everyone,
-          # so there is nothing to gain from a second code path here.
-          set -euo pipefail
-
-          if ! command -v openscad >/dev/null 2>&1; then
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask openscad@snapshot
-          fi
-
-          # A cask need not put a binary on PATH, and the .app it installs is not
-          # named identically across versions, so look for the executable rather
-          # than assuming either. `-iname`, because the binary inside the bundle
-          # is "OpenSCAD" while what the tests invoke is "openscad".
-          if ! command -v openscad >/dev/null 2>&1; then
-            binary="$(find /Applications -maxdepth 4 -path '*/Contents/MacOS/*' \
-              -type f -perm -111 -iname 'openscad' 2>/dev/null | head -n 1)"
-            if [ -z "${binary}" ]; then
-              echo "::error::openscad@snapshot installed but no OpenSCAD executable was found under /Applications"
-              exit 1
-            fi
-            mkdir -p "${HOME}/.local/bin"
-            ln -sf "${binary}" "${HOME}/.local/bin/openscad"
-            echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-            export PATH="${HOME}/.local/bin:${PATH}"
-          fi
-
-          # Proves the thing runs on this architecture, rather than that a file
-          # of the right name exists. An x86_64 build on an arm64 runner with no
-          # Rosetta fails here, which is the failure worth seeing.
-          openscad --version
+      # macOS installs nothing here on purpose, and used to install the
+      # "openscad@snapshot" cask. The bundle now carries that same snapshot, and
+      # `find_executable` prefers the bundled copy, so a host install would leave
+      # this job green whether or not the payload works -- exactly what the
+      # Linux x86_64 leg avoids by installing the AppImage's libraries and not
+      # OpenSCAD itself. The wheel-based jobs still install it: they have no
+      # bundle to carry one. See ".github/actions/setup-test/action.yml".
 
       - name: Download the bundle
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -561,10 +561,10 @@ jobs:
       # with enough of its signed bundle intact to still launch, which is the
       # half of this that only a runner can answer.
       #
-      # Linux arm64 is excluded because it carries no payload -- upstream
-      # publishes the pinned release for x86_64 only. Windows does carry one and
-      # is still not covered here; that predates this step growing a macOS leg,
-      # and the build's own smoke test is what exercises it there.
+      # Linux arm64 is excluded because it carries no payload -- upstream builds
+      # no current arm64 snapshot. Windows does carry one and is still not
+      # covered here; that predates this step growing a macOS leg, and the
+      # build's own smoke test is what exercises it there.
       - name: Run the bundled OpenSCAD after installation
         if: runner.os == 'macOS' || (startsWith(matrix.platform, 'ubuntu-') && endsWith(matrix.platform, '-x86_64'))
         shell: bash
@@ -876,15 +876,15 @@ jobs:
           sudo apt-get install --yes --no-install-recommends \
             libgl1 libx11-6 libxcb1 libfontconfig1 libfreetype6 libglib2.0-0 libharfbuzz0b
 
-      # Linux arm64 is the one bundle that carries no OpenSCAD -- upstream
-      # publishes the pinned release for x86_64 only (see build.sh) -- so it
-      # falls back to a host one, exactly as the wheels do.
+      # Linux arm64 is the one bundle that carries no OpenSCAD -- upstream builds
+      # no current arm64 snapshot (see build.sh) -- so it falls back to a host
+      # one, exactly as the wheels do.
       - name: Install OpenSCAD (Linux arm64)
         if: matrix.platform == 'ubuntu-24.04-arm64'
         run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends openscad
 
       # macOS installs nothing here on purpose, and used to install the
-      # "openscad@snapshot" cask. The bundle now carries that same snapshot, and
+      # "openscad@snapshot" cask. Every bundle now carries that same snapshot, and
       # `find_executable` prefers the bundled copy, so a host install would leave
       # this job green whether or not the payload works -- exactly what the
       # Linux x86_64 leg avoids by installing the AppImage's libraries and not

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -199,6 +199,22 @@ concurrency:
 # embeds. If Windows ever does need two, the host-to-build mapping has to exist
 # first, or the choice is a guess with a version number on it.
 env:
+  # The libraries the bundled OpenSCAD AppImage resolves from the host. It is not
+  # fully self-contained -- see dev-tools/pyinstaller/build.sh -- and every job
+  # that runs the Linux x86_64 payload needs these: the freeze (its own smoke
+  # test runs it), the install (it runs it after unpacking), and the examples.
+  # Defined once here because three copies of a list like this drift.
+  #
+  # libegl1 and libopengl0 are the two the Qt5 release never wanted and the Qt6
+  # snapshot does. They were not guessed: the build's smoke test runs `ldd` over
+  # the payload when it will not start, and named exactly `libEGL.so.1` and
+  # `libOpenGL.so.0` as unresolvable while everything else resolved through the
+  # AppImage's own `usr/lib`. Add to this list the same way rather than by
+  # reasoning about what Qt "should" need.
+  OPENSCAD_HOST_LIBRARIES: >-
+    libgl1 libx11-6 libxcb1 libfontconfig1 libfreetype6 libglib2.0-0 libharfbuzz0b
+    libegl1 libopengl0
+
   # Built on every run.
   PLATFORMS_CORE: >-
     [{"os": "ubuntu-24.04", "platform": "ubuntu-24.04-x86_64"},
@@ -468,8 +484,7 @@ jobs:
       - name: Install the bundled OpenSCAD's host libraries (Linux x86_64)
         if: matrix.platform == 'ubuntu-22.04-x86_64' || matrix.platform == 'ubuntu-24.04-x86_64'
         run: |
-          sudo apt-get install --yes --no-install-recommends \
-            libgl1 libx11-6 libxcb1 libfontconfig1 libfreetype6 libglib2.0-0 libharfbuzz0b
+          sudo apt-get install --yes --no-install-recommends ${{ env.OPENSCAD_HOST_LIBRARIES }}
 
       # The platform id is passed rather than detected: the runner image label is
       # the authoritative answer to which OS version this is, and recovering it
@@ -640,6 +655,15 @@ jobs:
           partcad --help
           pc init
           pc list
+
+      # Same libraries as the freeze and the examples: this job runs the payload
+      # too, and had no step for them because the older OpenSCAD release found
+      # what it needed on the runner unaided.
+      - name: Install the bundled OpenSCAD's host libraries (Linux x86_64)
+        if: startsWith(matrix.platform, 'ubuntu-') && endsWith(matrix.platform, '-x86_64')
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends ${{ env.OPENSCAD_HOST_LIBRARIES }}
 
       # The bundled OpenSCAD has to survive being packed, downloaded and
       # unpacked with its executable bit intact, which the build's own smoke
@@ -960,8 +984,7 @@ jobs:
         if: matrix.platform == 'ubuntu-24.04-x86_64'
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            libgl1 libx11-6 libxcb1 libfontconfig1 libfreetype6 libglib2.0-0 libharfbuzz0b
+          sudo apt-get install --yes --no-install-recommends ${{ env.OPENSCAD_HOST_LIBRARIES }}
 
       # Linux arm64 is the one bundle that carries no OpenSCAD -- upstream builds
       # no current arm64 snapshot (see build.sh) -- so it falls back to a host

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -454,6 +454,23 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install --yes libcairo2-dev
 
+      # The libraries the bundled OpenSCAD AppImage resolves from the host: it is
+      # not fully self-contained (see dev-tools/pyinstaller/build.sh). The
+      # "Examples" job below has installed these for a while; this job needs them
+      # too, because `build.sh` runs the payload as part of its own smoke test.
+      #
+      # It went without until the payload moved from the 2021.01 release to a
+      # snapshot. The older, smaller build happened to find everything it needed
+      # on the runner; the current one does not, and the loader's answer to that
+      # is exit 127 -- which reads like a missing file and is not one.
+      #
+      # x86_64 only, because Linux arm64 carries no OpenSCAD to run.
+      - name: Install the bundled OpenSCAD's host libraries (Linux x86_64)
+        if: matrix.platform == 'ubuntu-22.04-x86_64' || matrix.platform == 'ubuntu-24.04-x86_64'
+        run: |
+          sudo apt-get install --yes --no-install-recommends \
+            libgl1 libx11-6 libxcb1 libfontconfig1 libfreetype6 libglib2.0-0 libharfbuzz0b
+
       # The platform id is passed rather than detected: the runner image label is
       # the authoritative answer to which OS version this is, and recovering it
       # from the running system is guesswork on Windows in particular.

--- a/dev-tools/pyinstaller/README.md
+++ b/dev-tools/pyinstaller/README.md
@@ -427,8 +427,8 @@ Three things, at three levels:
 
 ## OpenSCAD
 
-The Linux and Windows bundles carry OpenSCAD, pinned to the version in `build.sh` and downloaded from
-`files.openscad.org` at build time (checksum-verified). `partcad.healthcheck.openscad.find_executable()` prefers it over
+Every bundle but Linux arm64 carries OpenSCAD, pinned in `build.sh` and downloaded at build time from
+`files.openscad.org` (checksum-verified). `partcad.healthcheck.openscad.find_executable()` prefers it over
 any OpenSCAD on the host, and falls back to `shutil.which` when there is no bundled copy — which is what the
 wheels always do. A user can opt out of the bundled copy with `--ignore-bundled-openscad` /
 `IGNORE_BUNDLED_OPENSCAD=1` (`user_config.ignore_bundled_openscad`), which makes the resolver skip the
@@ -437,14 +437,62 @@ where the AppImage's library dependencies are absent.
 
 | | what ships | self-contained |
 | --- | --- | --- |
-| Linux x86_64 | the AppImage, unpacked | no — needs `libGL`, `libX11`, `libxcb`, fontconfig, freetype, glib, harfbuzz from the host |
+| Linux x86_64 | the AppImage, unpacked | no — needs `libGL`, `libX11`, `libxcb`, fontconfig, freetype, glib and harfbuzz from the host |
 | Linux arm64 | nothing | — |
 | Windows | the portable build | yes — one statically linked `openscad.exe`, no DLLs |
-| macOS, both architectures | nothing | — |
+| macOS, both architectures | `OpenSCAD.app` out of the `.dmg` | yes — its Qt frameworks are inside the `.app` |
 
 Linux arm64 carries nothing because upstream publishes the pinned 2021.01 AppImage for x86_64 only; running it
 under emulation is not something a bundle should quietly require. `pc` there uses the host's OpenSCAD, exactly
 as the wheels do.
+
+### macOS carries a snapshot, not the release
+
+**macOS is the one platform that does not carry `OPENSCAD_VERSION`.** It carries `OPENSCAD_MACOS_VERSION`, a
+development snapshot, and both architectures carry the same one. Two things rule the 2021.01 release out, and
+either would be enough:
+
+* It is **x86_64 only**. On Apple silicon it would need Rosetta 2, which a clean machine does not have.
+  Homebrew's `openscad` cask states this in the open, with a `requires_rosetta` caveat.
+* Homebrew **disabled that cask outright** on 2026-09-01, `because: :fails_gatekeeper_check`. The release does
+  not pass Gatekeeper any more, which is also what took every macOS CI job down until #583 moved them to the
+  snapshot.
+
+The snapshot is a better artifact here than a fallback: one `.dmg` under one checksum, with no `requires_rosetta`
+caveat, so a single payload serves both architectures — which is why there is one macOS OpenSCAD and not one per
+architecture, matching the one-build-per-architecture shape of the macOS bundles themselves.
+
+Two consequences worth knowing:
+
+* **macOS renders with a different OpenSCAD than Linux and Windows.** That is already true of every macOS CI
+  job — #583 put the host ones on this same cask — and the check that would notice a rendering difference
+  ("The rendered examples must match what is checked in", in `test.yml`) runs on one Linux cell on purpose.
+  Moving the other platforms to a snapshot to match is a separate and much larger decision: it changes what
+  every Linux and Windows user renders with.
+* **The pin is by content, not just by name.** `OPENSCAD_MACOS_SHA256` is compared against a literal in
+  `build.sh` rather than against a `.sha256` fetched beside the artifact, which is what the other two payloads
+  do. Snapshots live in a rolling `snapshots/` directory upstream prunes, so pinning the bytes is what stops a
+  rebuild from picking up something else republished under the version it asked for. When the pinned snapshot
+  is pruned the fetch 404s — deliberately not retried — and the fix is to bump the version and the hash
+  together from [Homebrew's cask](https://raw.githubusercontent.com/Homebrew/homebrew-cask/master/Casks/o/openscad%40snapshot.rb),
+  which is the easiest place to read a known-good pair.
+
+Staging it means mounting the `.dmg`: `build.sh` attaches it read-only at an explicit mount point under
+`build/` (not `/Volumes`, where two builds sharing a workspace would collide and hdiutil silently suffixes the
+name), copies `OpenSCAD.app` out with `ditto`, and detaches — on the failure path too, and without a trap,
+since `set -e` unwinding a function does not reliably run a `RETURN` trap and an `EXIT` trap would displace the
+smoke test's. `ditto` rather than `cp -R` because this app is signed and notarized, and that is macOS's own
+bundle copier.
+
+The `.app` is carried entire rather than reduced to the binary inside it: that binary resolves its Qt
+frameworks through `@executable_path/../Frameworks`, so the layout around it is what makes it runnable — the
+same reason Linux keeps the whole AppImage tree. `BUNDLED_SUBPATH` in `partcad.healthcheck.openscad` and the
+staging in `build.sh` have to agree on that path; a unit test pins all three platforms' layouts, since the one
+being described is never the one the test run is on.
+
+What only a runner can answer is whether the signed `.app` survives `ditto` → `tar.xz` → download → untar and
+still launches. The `Run the bundled OpenSCAD after installation` step in `build-standalone.yml` is that check,
+and it runs on macOS as well as Linux x86_64.
 
 The AppImage ships *unpacked* because running it as an image needs FUSE, which a minimal host may not have.
 
@@ -455,21 +503,11 @@ and glib beside the ones Python needs, on the frozen application's own library s
 ~100MB. That means a bare `pyinstaller partcad.spec` produces a bundle without OpenSCAD; `build.sh` is the
 supported way to build one, as it already is for the dependency pre-flight.
 
-macOS is excluded because the 2021.01 release predates Apple silicon and ships an x86_64-only `.dmg`, which
-on the arm64 bundle would require Rosetta 2 — absent from a clean machine. Development snapshots may be
-universal binaries, but they are snapshots and their architecture has not been confirmed; `lipo -archs` on a
-mounted snapshot `.dmg` would settle it.
-
-The `macos-15-x86_64` bundle is the one where that argument does not apply — the pinned `.dmg` is for exactly
-that architecture — and it still carries nothing, deliberately. Two macOS bundles that differ in what is inside
-them are two behaviours to explain, to health-check and to support, on the architecture that is being retired;
-and `build.sh` would have to learn to mount and copy out of a `.dmg` to gain it. `pc` on an Intel Mac uses the
-host's OpenSCAD, exactly as the wheels do. If that changes, it is a one-architecture payload and this paragraph
-is where to say so.
-
-To move to a different OpenSCAD, change `OPENSCAD_VERSION` in `build.sh`. Upstream publishes a `.sha256` next
-to each artifact and the build verifies it, so nothing else needs updating — but note the published checksum
-files name a `releases/` path rather than the bare file, which is why the build compares the hash alone.
+To move Linux and Windows to a different OpenSCAD, change `OPENSCAD_VERSION` in `build.sh`. Upstream publishes
+a `.sha256` next to each release artifact and the build verifies it, so nothing else needs updating — but note
+the published checksum files name a `releases/` path rather than the bare file, which is why the build compares
+the hash alone. macOS is the pair `OPENSCAD_MACOS_VERSION` and `OPENSCAD_MACOS_SHA256`, bumped together, as
+above.
 
 That sandbox is also why `partcad/wrappers/*.py` are bundled as *data* rather than frozen as modules: they are
 handed to that other interpreter as a file path.

--- a/dev-tools/pyinstaller/README.md
+++ b/dev-tools/pyinstaller/README.md
@@ -427,7 +427,8 @@ Three things, at three levels:
 
 ## OpenSCAD
 
-Every bundle but Linux arm64 carries OpenSCAD, pinned in `build.sh` and downloaded at build time from
+Every bundle but Linux arm64 carries OpenSCAD, and they all carry **the same version** — that is what makes a
+`.scad` part render the same wherever `pc` runs. It is pinned in `build.sh` and downloaded at build time from
 `files.openscad.org` (checksum-verified). `partcad.healthcheck.openscad.find_executable()` prefers it over
 any OpenSCAD on the host, and falls back to `shutil.which` when there is no bundled copy — which is what the
 wheels always do. A user can opt out of the bundled copy with `--ignore-bundled-openscad` /
@@ -439,50 +440,66 @@ where the AppImage's library dependencies are absent.
 | --- | --- | --- |
 | Linux x86_64 | the AppImage, unpacked | no — needs `libGL`, `libX11`, `libxcb`, fontconfig, freetype, glib and harfbuzz from the host |
 | Linux arm64 | nothing | — |
-| Windows | the portable build | yes — one statically linked `openscad.exe`, no DLLs |
+| Windows | the portable zip | yes — `openscad.exe` and `openscad.com`, no DLLs |
 | macOS, both architectures | `OpenSCAD.app` out of the `.dmg` | yes — its Qt frameworks are inside the `.app` |
 
-Linux arm64 carries nothing because upstream publishes the pinned 2021.01 AppImage for x86_64 only; running it
-under emulation is not something a bundle should quietly require. `pc` there uses the host's OpenSCAD, exactly
-as the wheels do.
+Linux arm64 carries nothing because upstream builds no current arm64 snapshot. The only two aarch64 artifacts
+in the whole directory are one-offs from 2021 and 2023, under a naming scheme (`...ai-aarch64`) it no longer
+uses. `pc` there uses the host's OpenSCAD, exactly as the wheels do.
 
-### macOS carries a snapshot, not the release
+### It is a development snapshot, and the pin expires
 
-**macOS is the one platform that does not carry `OPENSCAD_VERSION`.** It carries `OPENSCAD_MACOS_VERSION`, a
-development snapshot, and both architectures carry the same one. Two things rule the 2021.01 release out, and
-either would be enough:
+**The version is a snapshot, not a release.** That is forced, not preferred. The last release, 2021.01, cannot
+be the one version every platform shares:
 
-* It is **x86_64 only**. On Apple silicon it would need Rosetta 2, which a clean machine does not have.
-  Homebrew's `openscad` cask states this in the open, with a `requires_rosetta` caveat.
-* Homebrew **disabled that cask outright** on 2026-09-01, `because: :fails_gatekeeper_check`. The release does
-  not pass Gatekeeper any more, which is also what took every macOS CI job down until #583 moved them to the
-  snapshot.
+* It is **x86_64 only**, so an arm64 Mac would need Rosetta 2, which a clean machine does not have. Homebrew's
+  `openscad` cask states this with a `requires_rosetta` caveat.
+* Homebrew **disabled that cask outright** on 2026-09-01, `because: :fails_gatekeeper_check`. It is also what
+  took every macOS CI job down until #583.
 
-The snapshot is a better artifact here than a fallback: one `.dmg` under one checksum, with no `requires_rosetta`
-caveat, so a single payload serves both architectures — which is why there is one macOS OpenSCAD and not one per
-architecture, matching the one-build-per-architecture shape of the macOS bundles themselves.
+So one version across platforms has to be a snapshot. Three consequences follow, and all three are the reason
+this section is long:
 
-Two consequences worth knowing:
+1. **The pin expires.** Upstream prunes `snapshots/` on a rolling window of about a year — measured at 143
+   Linux and Windows builds spanning 368 days and 119 macOS builds spanning 365. A pin left alone for a year
+   stops resolving, and then **no bundle builds on any platform**, the release included. It fails loudly: the
+   fetch 404s, `fetch_and_verify` does not retry a 4xx, and `stage_openscad` prints what to do. This is the
+   single biggest maintenance liability in this file. The durable fix, not done here, is to mirror the three
+   artifacts somewhere the project controls.
+2. **A bump picks a date from the listing rather than constructing one.** Builds are not nightly — roughly one
+   every 2.6 days — and a given date can be missing a platform, with gaps up to 35 days on Linux and Windows
+   and 76 on macOS. The date has to be one where all three artifacts exist.
+3. **Checksums are pinned as literals, not read from the sidecars.** Upstream does publish a correct `.sha256`
+   (and `.sha512`) beside every snapshot, and the build could read those — but a snapshot directory is
+   rolling, and pinning the bytes rather than the name is what stops a rebuild of a given PartCAD version
+   picking up something republished under the date it asked for. So a bump moves four values together:
+   `OPENSCAD_VERSION` and the three `OPENSCAD_SHA256_*`. The conda payload still reads its sidecar; its
+   upstream is a tagged release, which does not move.
 
-* **macOS renders with a different OpenSCAD than Linux and Windows.** That is already true of every macOS CI
-  job — #583 put the host ones on this same cask — and the check that would notice a rendering difference
-  ("The rendered examples must match what is checked in", in `test.yml`) runs on one Linux cell on purpose.
-  Moving the other platforms to a snapshot to match is a separate and much larger decision: it changes what
-  every Linux and Windows user renders with.
-* **The pin is by content, not just by name.** `OPENSCAD_MACOS_SHA256` is compared against a literal in
-  `build.sh` rather than against a `.sha256` fetched beside the artifact, which is what the other two payloads
-  do. Snapshots live in a rolling `snapshots/` directory upstream prunes, so pinning the bytes is what stops a
-  rebuild from picking up something else republished under the version it asked for. When the pinned snapshot
-  is pruned the fetch 404s — deliberately not retried — and the fix is to bump the version and the hash
-  together from [Homebrew's cask](https://raw.githubusercontent.com/Homebrew/homebrew-cask/master/Casks/o/openscad%40snapshot.rb),
-  which is the easiest place to read a known-good pair.
+The three artifact names have almost nothing in common — `-x86_64` on Linux, `-x86-64` on Windows, and no
+architecture token at all on macOS — and the Windows zip sits beside an `-x86-64-Installer.exe` that differs
+from it only by a suffix. They are spelled out in the `case` rather than composed, for that reason.
 
-Staging it means mounting the `.dmg`: `build.sh` attaches it read-only at an explicit mount point under
-`build/` (not `/Volumes`, where two builds sharing a workspace would collide and hdiutil silently suffixes the
-name), copies `OpenSCAD.app` out with `ditto`, and detaches — on the failure path too, and without a trap,
-since `set -e` unwinding a function does not reliably run a `RETURN` trap and an `EXIT` trap would displace the
-smoke test's. `ditto` rather than `cp -R` because this app is signed and notarized, and that is macOS's own
-bundle copier.
+### Per-platform staging
+
+**Windows** takes the portable zip. Its single top-level directory is named after the zip itself
+(`OpenSCAD-<version>-x86-64`), and `build.sh` derives it from the artifact name rather than hardcoding it.
+Worth knowing that the *release* zips did not follow this rule — 2021.01's inner directory was the lowercase
+`openscad-2021.01` — so a hardcoded name carried over from the release era would have moved nothing at all,
+silently.
+
+**macOS** takes the `.dmg`. `build.sh` attaches it read-only at an explicit mount point under `build/`, copies
+`OpenSCAD.app` out with `ditto`, and detaches — on the failure path too, and without a trap, since `set -e`
+unwinding a function does not reliably run a `RETURN` trap and an `EXIT` trap would displace the smoke test's.
+The explicit mount point is not fastidiousness: the volume is named `OpenSCAD` with no date in it, so every
+snapshot mounts at the same `/Volumes/OpenSCAD`, and a name already taken is silently suffixed
+(`/Volumes/OpenSCAD 1`) rather than refused — so a second build, or a stale mount from an interrupted one,
+would have the copy read whichever image got there first. `ditto` rather than `cp -R` because this app is
+signed and notarized, and that is macOS's own bundle copier.
+
+One `.dmg` serves both Mac architectures because it is a **Universal 2** binary: `lipo -archs` on
+`OpenSCAD.app/Contents/MacOS/OpenSCAD` prints `x86_64 arm64`. That was an open question in this file for a
+while and it is now measured, not inferred.
 
 The `.app` is carried entire rather than reduced to the binary inside it: that binary resolves its Qt
 frameworks through `@executable_path/../Frameworks`, so the layout around it is what makes it runnable — the
@@ -503,11 +520,9 @@ and glib beside the ones Python needs, on the frozen application's own library s
 ~100MB. That means a bare `pyinstaller partcad.spec` produces a bundle without OpenSCAD; `build.sh` is the
 supported way to build one, as it already is for the dependency pre-flight.
 
-To move Linux and Windows to a different OpenSCAD, change `OPENSCAD_VERSION` in `build.sh`. Upstream publishes
-a `.sha256` next to each release artifact and the build verifies it, so nothing else needs updating — but note
-the published checksum files name a `releases/` path rather than the bare file, which is why the build compares
-the hash alone. macOS is the pair `OPENSCAD_MACOS_VERSION` and `OPENSCAD_MACOS_SHA256`, bumped together, as
-above.
+To move to a different OpenSCAD, change `OPENSCAD_VERSION` and the three `OPENSCAD_SHA256_*` values in
+`build.sh` together, as described above — one date that carries all three artifacts, and the hash of each read
+from the `.sha256` beside it.
 
 That sandbox is also why `partcad/wrappers/*.py` are bundled as *data* rather than frozen as modules: they are
 handed to that other interpreter as a file path.

--- a/dev-tools/pyinstaller/README.md
+++ b/dev-tools/pyinstaller/README.md
@@ -427,9 +427,10 @@ Three things, at three levels:
 
 ## OpenSCAD
 
-Every bundle but Linux arm64 carries OpenSCAD, and they all carry **the same version** — that is what makes a
-`.scad` part render the same wherever `pc` runs. It is pinned in `build.sh` and downloaded at build time from
-`files.openscad.org` (checksum-verified). `partcad.healthcheck.openscad.find_executable()` prefers it over
+Every bundle but Linux arm64 carries OpenSCAD, and they all carry **the same build** — that is what makes a
+`.scad` part render the same wherever `pc` runs. The three download URLs, their checksums and the version live
+in one block, `OPENSCAD BUILDS` at the top of `build.sh`, which is also where the reasoning below is written
+down for whoever bumps it next; nothing else in the build composes a URL of its own. `partcad.healthcheck.openscad.find_executable()` prefers it over
 any OpenSCAD on the host, and falls back to `shutil.which` when there is no bundled copy — which is what the
 wheels always do. A user can opt out of the bundled copy with `--ignore-bundled-openscad` /
 `IGNORE_BUNDLED_OPENSCAD=1` (`user_config.ignore_bundled_openscad`), which makes the resolver skip the
@@ -446,6 +447,16 @@ where the AppImage's library dependencies are absent.
 Linux arm64 carries nothing because upstream builds no current arm64 snapshot. The only two aarch64 artifacts
 in the whole directory are one-offs from 2021 and 2023, under a naming scheme (`...ai-aarch64`) it no longer
 uses. `pc` there uses the host's OpenSCAD, exactly as the wheels do.
+
+### One build for every platform
+
+The requirement is stronger than "the same version number": every platform carries OpenSCAD built from the
+**same upstream source**, which the snapshot date in the filenames is what identifies. OpenSCAD's language and
+its exports both move between builds, so bundles built from different sources disagree about what a `.scad`
+file means — a part that renders on one machine could fail to parse, or render differently, on another. An
+older date that all three platforms share therefore beats a newer one that they do not, and no platform is
+ever bumped alone. `build.sh` carries the command that finds the newest date with all three artifacts, which
+is not the same as the newest date in the directory.
 
 ### It is a development snapshot, and the pin expires
 
@@ -520,9 +531,10 @@ and glib beside the ones Python needs, on the frozen application's own library s
 ~100MB. That means a bare `pyinstaller partcad.spec` produces a bundle without OpenSCAD; `build.sh` is the
 supported way to build one, as it already is for the dependency pre-flight.
 
-To move to a different OpenSCAD, change `OPENSCAD_VERSION` and the three `OPENSCAD_SHA256_*` values in
-`build.sh` together, as described above — one date that carries all three artifacts, and the hash of each read
-from the `.sha256` beside it.
+To move to a different OpenSCAD, replace the `OPENSCAD BUILDS` block at the top of `build.sh` wholesale — the
+version, the three URLs and the three checksums, all naming one date. That block documents how to find a date
+that qualifies and how the three filenames differ; a startup check refuses a bump that moved the version but
+left a URL behind.
 
 That sandbox is also why `partcad/wrappers/*.py` are bundled as *data* rather than frozen as modules: they are
 handed to that other interpreter as a file path.

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -51,12 +51,38 @@ PYTHON="${PYTHON:-python3}"
 # rebuild of a given PartCAD version produces the same bundle, and matching the
 # version `partcad.healthcheck.openscad` installs on Windows hosts.
 OPENSCAD_VERSION="2021.01"
-# The staged payload is keyed by version, so that bumping OPENSCAD_VERSION and
-# rebuilding in a tree that still holds an old `build/` fetches the new version
-# rather than silently reusing the stale one (`build/` is not wiped between
-# builds, and CI aside, nobody wipes it by hand). Stale siblings are harmless:
-# `build/` is gitignored, and only the matching directory is ever read.
-OPENSCAD_PAYLOAD_DIR="${OPENSCAD_STAGE_DIR}/payload-${OPENSCAD_VERSION}"
+
+# macOS cannot have that one, and takes a development snapshot instead.
+#
+# 2021.01 ships an x86_64-only `.dmg` -- Homebrew's `openscad` cask says so in
+# the open, with a `requires_rosetta` caveat -- so on Apple silicon it is the
+# wrong build to carry, and Rosetta 2 is absent from a clean machine. Homebrew
+# then `disable!`d that cask outright on 2026-09-01, `because:
+# :fails_gatekeeper_check`, which is what took every macOS CI job down with it
+# (see #583). The snapshot is what is left, and it is a better artifact than the
+# release on this platform: one `.dmg` with one checksum and no Rosetta caveat,
+# so it serves both architectures from a single payload.
+#
+# The cost of a snapshot is that macOS renders with a different OpenSCAD than
+# Linux and Windows do. That is already true of every macOS CI job -- #583 put
+# the host ones on this same cask -- and the check that would notice a rendering
+# difference ("The rendered examples must match what is checked in", in
+# test.yml) runs on one Linux cell on purpose. Moving the other platforms onto a
+# snapshot to match is a separate decision, and a bigger one: it would change
+# what every Linux and Windows user renders with.
+OPENSCAD_MACOS_VERSION="2026.09.03"
+# Verified against this literal rather than against a `.sha256` fetched beside
+# the artifact, which is what `fetch_and_verify` does for the other two payloads.
+# Snapshots live in a rolling directory upstream prunes, so pinning the bytes --
+# not just the name -- is what stops a rebuild from silently picking up a
+# different build republished under the version it asked for.
+#
+# Both values are the ones Homebrew ships, which is the easiest place to read a
+# known-good pair:
+#   https://raw.githubusercontent.com/Homebrew/homebrew-cask/master/Casks/o/openscad%40snapshot.rb
+# When the pinned snapshot is pruned the fetch below 404s, which `fetch_and_verify`
+# deliberately does not retry; bump both fields together from that file.
+OPENSCAD_MACOS_SHA256="0bb3511507c19d01dfd17c94777c7d55e27cdba21e6d2eb60127f20bce7a3f0a"
 
 # The conda the bundle carries, as the tag of a `micromamba-releases` release --
 # "<micromamba version>-<build>", where `micromamba --version` prints only the
@@ -214,6 +240,37 @@ fi
 # is a confusing way to find out about a one-line key.
 CONDA_PAYLOAD_DIR="${CONDA_STAGE_DIR}/payload-${MICROMAMBA_VERSION}-${OS_NAME}-${ARCH_NAME}"
 
+# Which OpenSCAD this platform carries, and where it is staged. Also set here
+# rather than beside the version pins, for the same reason: macOS takes a
+# different build from the other two, and OS_NAME is what the block above
+# settles.
+#
+# `OPENSCAD_EXPECTED_SHA256` is empty for the platforms whose upstream publishes
+# a `.sha256` next to the artifact; `fetch_and_verify` fetches that one when it
+# is given nothing to compare against.
+if [ "${OS_NAME}" = "macos" ]; then
+  OPENSCAD_BUILD_VERSION="${OPENSCAD_MACOS_VERSION}"
+  OPENSCAD_EXPECTED_SHA256="${OPENSCAD_MACOS_SHA256}"
+else
+  OPENSCAD_BUILD_VERSION="${OPENSCAD_VERSION}"
+  OPENSCAD_EXPECTED_SHA256=""
+fi
+
+# Keyed by version, so that bumping a pin above and rebuilding in a tree that
+# still holds an old `build/` fetches the new version rather than silently
+# reusing the stale one (`build/` is not wiped between builds, and CI aside,
+# nobody wipes it by hand). Stale siblings are harmless: `build/` is gitignored,
+# and only the matching directory is ever read.
+#
+# Unlike conda's, not keyed by platform. The two macOS bundles want the very same
+# payload -- the snapshot `.dmg` is one artifact serving both architectures -- so
+# an Apple silicon Mac building the Intel bundle under `arch -x86_64` out of one
+# workspace should share it rather than fetch it twice. Linux and Windows share a
+# key without sharing a payload, but they stage different entry points
+# (`AppRun` against `openscad.exe`), so the staged-already check below tells them
+# apart and simply refetches.
+OPENSCAD_PAYLOAD_DIR="${OPENSCAD_STAGE_DIR}/payload-${OPENSCAD_BUILD_VERSION}"
+
 VERSION="$("${PYTHON}" -c "
 import re, pathlib
 source = pathlib.Path('${REPO_ROOT}/src/partcad/__init__.py').read_text()
@@ -282,6 +339,13 @@ fi
 # and conda -- so that neither can be staged from a truncated or substituted
 # download.
 #
+# A third argument overrides that: the expected hash as a literal, for an
+# upstream that publishes no `.sha256` beside the artifact, or one whose artifact
+# can be replaced under a name it already used. The macOS OpenSCAD snapshot is
+# both -- see the pin beside OPENSCAD_MACOS_SHA256 -- and a literal is the
+# stronger check there anyway, since it pins the bytes rather than trusting
+# whatever the same host serves for the checksum.
+#
 # Fetched and verified with the Python this script already depends on, rather
 # than with curl and sha256sum, whose presence and flags differ across the three
 # platforms this runs on. The two upstreams do not publish the checksum in the
@@ -316,9 +380,9 @@ fi
 # way through `copyfileobj` is raised bare, and an 18 MB payload is a lot of
 # transfer to leave unguarded.
 fetch_and_verify() {
-  local url="$1" destination="$2"
+  local url="$1" destination="$2" expected="${3:-}"
 
-  "${PYTHON}" - "${url}" "${destination}" <<'FETCH'
+  "${PYTHON}" - "${url}" "${destination}" "${expected}" <<'FETCH'
 import http.client
 import shutil
 import ssl
@@ -365,17 +429,26 @@ def fetch(url, destination):
         time.sleep(delay)
 
 
-for url, destination in ((sys.argv[1], sys.argv[2]), (sys.argv[1] + ".sha256", sys.argv[2] + ".sha256")):
+downloads = [(sys.argv[1], sys.argv[2])]
+# The sidecar is fetched only when no hash was pinned on the command line. An
+# upstream that publishes none would 404 here, which is not retried and would
+# fail the build after the artifact itself had already arrived intact.
+if not sys.argv[3]:
+    downloads.append((sys.argv[1] + ".sha256", sys.argv[2] + ".sha256"))
+
+for url, destination in downloads:
     fetch(url, destination)
 FETCH
 
-  "${PYTHON}" - "${destination}" <<'VERIFY'
+  "${PYTHON}" - "${destination}" "${expected}" <<'VERIFY'
 import hashlib
 import pathlib
 import sys
 
 artifact = pathlib.Path(sys.argv[1])
-expected = pathlib.Path(str(artifact) + ".sha256").read_text().split()[0]
+# A hash pinned in `build.sh` is already the bare field; a fetched sidecar may
+# carry a file name after it, which the split below is what drops.
+expected = (sys.argv[2] or pathlib.Path(str(artifact) + ".sha256").read_text()).split()[0]
 actual = hashlib.sha256(artifact.read_bytes()).hexdigest()
 if actual != expected:
     sys.exit(f"error: checksum mismatch for {artifact.name}: expected {expected}, got {actual}")
@@ -397,21 +470,25 @@ VERIFY
 # bundled OpenSCAD still needs those present. Windows takes the upstream portable
 # build, a single statically linked executable that needs nothing at all.
 #
-# Linux arm64 carries none either: upstream publishes the 2021.01 AppImage for
-# x86_64 only, and running an x86_64 AppImage under emulation is not something
-# a bundle should be quietly requiring. `pc` there uses the host's OpenSCAD,
-# exactly as the wheels do.
+# Linux arm64 is the one platform that carries nothing: upstream publishes the
+# 2021.01 AppImage for x86_64 only, and running an x86_64 AppImage under
+# emulation is not something a bundle should be quietly requiring. `pc` there
+# uses the host's OpenSCAD, exactly as the wheels do.
 #
-# macOS is deliberately excluded for the same shape of reason. The 2021.01
-# release predates Apple Silicon and ships an x86_64-only .dmg, which on the
-# arm64 bundle would require Rosetta 2 -- absent from a clean machine, and not
-# something an installer should be quietly requiring. The current development snapshots may well be
-# universal binaries, but they are snapshots, and their architecture has not
-# been confirmed. Until that is settled, `pc` on macOS uses the host's
-# OpenSCAD, exactly as the wheels do.
+# macOS takes the development snapshot, as a `.dmg` mounted at build time and
+# the `OpenSCAD.app` inside it copied out whole. Both architectures carry it and
+# both carry the same one: the snapshot is a single artifact under a single
+# checksum, where the 2021.01 release is x86_64 only. See OPENSCAD_MACOS_VERSION
+# for why the release is not an option on either architecture any more.
+#
+# The `.app` is copied entire rather than reduced to the executable inside it:
+# the binary at `Contents/MacOS/OpenSCAD` resolves its Qt frameworks through
+# `@executable_path/../Frameworks`, so the layout around it is what makes it
+# runnable. That is also the path Homebrew's cask links onto PATH as `openscad`,
+# and it is what `partcad.healthcheck.openscad.BUNDLED_SUBPATH` expects to find.
 stage_openscad() {
-  local artifact download_dir payload_dir entry_point
-  download_dir="${OPENSCAD_STAGE_DIR}/download-${OPENSCAD_VERSION}"
+  local artifact url download_dir payload_dir entry_point mount_point
+  download_dir="${OPENSCAD_STAGE_DIR}/download-${OPENSCAD_BUILD_VERSION}"
   payload_dir="${OPENSCAD_PAYLOAD_DIR}"
 
   # Keyed on the operating system and architecture rather than on PLATFORM,
@@ -420,11 +497,20 @@ stage_openscad() {
   case "${OS_NAME}-${ARCH_NAME}" in
   linux-x86_64)
     artifact="OpenSCAD-${OPENSCAD_VERSION}-x86_64.AppImage"
+    url="https://files.openscad.org/${artifact}"
     entry_point="${payload_dir}/AppRun"
     ;;
   windows-x86_64)
     artifact="OpenSCAD-${OPENSCAD_VERSION}-x86-64.zip"
+    url="https://files.openscad.org/${artifact}"
     entry_point="${payload_dir}/openscad.exe"
+    ;;
+  macos-x86_64 | macos-arm64)
+    artifact="OpenSCAD-${OPENSCAD_MACOS_VERSION}.dmg"
+    # A different directory from the releases: snapshots are published under
+    # "snapshots/", which is also the directory upstream prunes.
+    url="https://files.openscad.org/snapshots/${artifact}"
+    entry_point="${payload_dir}/OpenSCAD.app/Contents/MacOS/OpenSCAD"
     ;;
   *)
     echo "==> Not bundling OpenSCAD on ${PLATFORM} (see the comment in build.sh)"
@@ -434,15 +520,15 @@ stage_openscad() {
   esac
 
   if [ -e "${entry_point}" ]; then
-    echo "==> OpenSCAD ${OPENSCAD_VERSION} already staged"
+    echo "==> OpenSCAD ${OPENSCAD_BUILD_VERSION} already staged"
     return 0
   fi
 
-  echo "==> Fetching OpenSCAD ${OPENSCAD_VERSION} for ${PLATFORM}"
+  echo "==> Fetching OpenSCAD ${OPENSCAD_BUILD_VERSION} for ${PLATFORM}"
   rm -rf "${payload_dir}"
   mkdir -p "${download_dir}" "${payload_dir}"
 
-  fetch_and_verify "https://files.openscad.org/${artifact}" "${download_dir}/${artifact}"
+  fetch_and_verify "${url}" "${download_dir}/${artifact}" "${OPENSCAD_EXPECTED_SHA256}"
 
   case "${artifact}" in
   *.AppImage)
@@ -459,6 +545,41 @@ stage_openscad() {
     # needs its sibling data directories, so the contents move up together.
     mv "${download_dir}/unpacked/openscad-${OPENSCAD_VERSION}"/* "${payload_dir}/"
     rm -rf "${download_dir}/unpacked"
+    ;;
+  *.dmg)
+    # An explicit mount point under `build/`, rather than letting hdiutil pick
+    # one under /Volumes: two macOS builds sharing a workspace would collide
+    # there, and a name already taken is silently suffixed rather than refused,
+    # so the copy below would read whichever image got there first.
+    mount_point="${download_dir}/mnt"
+    rm -rf "${mount_point}"
+    mkdir -p "${mount_point}"
+
+    # `-nobrowse` keeps it out of the Finder, `-noautoopen` stops it opening a
+    # window on a runner that has a session.
+    hdiutil attach -quiet -readonly -nobrowse -noautoopen \
+      -mountpoint "${mount_point}" "${download_dir}/${artifact}"
+
+    # `ditto` rather than `cp -R`: it is macOS's own bundle copier and preserves
+    # the symlinks, permissions and extended attributes of a signed `.app`
+    # exactly. `cp` would do for the bits that matter today, but this app is
+    # signed and notarized -- that is why it passes the Gatekeeper check the
+    # 2021.01 release fails -- and a copy that quietly rewrites its metadata is
+    # not a thing to discover later.
+    #
+    # Detached either way, and not through a trap: `set -e` unwinding a function
+    # does not reliably run a RETURN trap, and an EXIT trap here would displace
+    # the one the smoke test installs further down. An image left attached fails
+    # the *next* build's attach on this mount point, which is a confusing way to
+    # find out that a copy failed.
+    if ! ditto "${mount_point}/OpenSCAD.app" "${payload_dir}/OpenSCAD.app"; then
+      hdiutil detach -quiet -force "${mount_point}" 2>/dev/null || true
+      echo "error: could not copy OpenSCAD.app out of ${artifact}" >&2
+      exit 1
+    fi
+
+    hdiutil detach -quiet "${mount_point}"
+    rmdir "${mount_point}" 2>/dev/null || true
     ;;
   esac
 
@@ -758,18 +879,23 @@ if [ -d "${OPENSCAD_BUNDLED_DIR}" ]; then
   # First that the payload itself runs, and that it is the version we pinned:
   # this catches a data file that shipped without its executable bit, an
   # AppImage tree that lost a piece on the way in, and a stale payload left in
-  # `build/` from a different OPENSCAD_VERSION. OpenSCAD prints its version to
-  # stderr.
-  if [ "${OS_NAME}" = "windows" ]; then
-    openscad_version_output="$(cd "${SMOKE_DIR}" && "${OPENSCAD_BUNDLED_DIR}/openscad.exe" --version 2>&1)"
-  else
-    openscad_version_output="$(cd "${SMOKE_DIR}" && "${OPENSCAD_BUNDLED_DIR}/AppRun" --version 2>&1)"
-  fi
+  # `build/` from a different pin. OpenSCAD prints its version to stderr.
+  #
+  # On macOS it is the architecture check too. A universal or arm64 `.app` runs
+  # here; an x86_64-only one on Apple silicon needs Rosetta 2, which a runner
+  # does not have, so it fails the build rather than shipping a bundle whose
+  # OpenSCAD starts on only some Macs.
+  case "${OS_NAME}" in
+  windows) openscad_entry_point="${OPENSCAD_BUNDLED_DIR}/openscad.exe" ;;
+  macos) openscad_entry_point="${OPENSCAD_BUNDLED_DIR}/OpenSCAD.app/Contents/MacOS/OpenSCAD" ;;
+  *) openscad_entry_point="${OPENSCAD_BUNDLED_DIR}/AppRun" ;;
+  esac
+  openscad_version_output="$(cd "${SMOKE_DIR}" && "${openscad_entry_point}" --version 2>&1)"
   echo "    ${openscad_version_output}"
   case "${openscad_version_output}" in
-  *"OpenSCAD version ${OPENSCAD_VERSION}"*) ;;
+  *"OpenSCAD version ${OPENSCAD_BUILD_VERSION}"*) ;;
   *)
-    echo "error: bundled OpenSCAD is not ${OPENSCAD_VERSION}: '${openscad_version_output}'" >&2
+    echo "error: bundled OpenSCAD is not ${OPENSCAD_BUILD_VERSION}: '${openscad_version_output}'" >&2
     exit 1
     ;;
   esac

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -47,42 +47,48 @@ OPENSCAD_STAGE_DIR="${REPO_ROOT}/build/openscad"
 CONDA_STAGE_DIR="${REPO_ROOT}/build/conda"
 PYTHON="${PYTHON:-python3}"
 
-# The OpenSCAD the bundle carries. Pinned rather than tracking the latest, so a
-# rebuild of a given PartCAD version produces the same bundle, and matching the
-# version `partcad.healthcheck.openscad` installs on Windows hosts.
-OPENSCAD_VERSION="2021.01"
+# The OpenSCAD every bundle carries -- one version across all of them, which is
+# what makes a `.scad` part render the same wherever `pc` runs.
+#
+# A development snapshot rather than a release, because the last release cannot
+# be that one version. 2021.01 ships an x86_64-only `.dmg`, so an arm64 Mac
+# would need Rosetta 2 -- Homebrew's `openscad` cask says so in the open, with a
+# `requires_rosetta` caveat -- and Homebrew then `disable!`d that cask outright
+# on 2026-09-01, `because: :fails_gatekeeper_check`, which took every macOS CI
+# job down with it (see #583). One version everywhere therefore has to be a
+# snapshot; what that costs is the expiry note below.
+#
+# The date has to be one that every platform actually published on. That is not
+# automatic: upstream builds roughly every 2.6 days rather than nightly, and the
+# gaps run to 35 days on Linux and Windows and 76 on macOS, so a bump picks a
+# date from the listing rather than constructing one.
+OPENSCAD_VERSION="2026.09.05"
 
-# macOS cannot have that one, and takes a development snapshot instead.
+# **This pin expires.** Upstream prunes `snapshots/` on a rolling window of
+# about a year -- measured at 143 Linux and Windows builds spanning 368 days,
+# 119 macOS builds spanning 365 -- so a pin left alone for a year stops
+# resolving and every bundle stops building, on every platform, release
+# included. It fails loudly rather than quietly: the fetch 404s, which
+# `fetch_and_verify` deliberately does not retry, and `stage_openscad` says what
+# to do about it.
 #
-# 2021.01 ships an x86_64-only `.dmg` -- Homebrew's `openscad` cask says so in
-# the open, with a `requires_rosetta` caveat -- so on Apple silicon it is the
-# wrong build to carry, and Rosetta 2 is absent from a clean machine. Homebrew
-# then `disable!`d that cask outright on 2026-09-01, `because:
-# :fails_gatekeeper_check`, which is what took every macOS CI job down with it
-# (see #583). The snapshot is what is left, and it is a better artifact than the
-# release on this platform: one `.dmg` with one checksum and no Rosetta caveat,
-# so it serves both architectures from a single payload.
+# To bump: pick a date from https://files.openscad.org/snapshots/ that has all
+# three artifacts, and take the three hashes from the `.sha256` published beside
+# each one:
 #
-# The cost of a snapshot is that macOS renders with a different OpenSCAD than
-# Linux and Windows do. That is already true of every macOS CI job -- #583 put
-# the host ones on this same cask -- and the check that would notice a rendering
-# difference ("The rendered examples must match what is checked in", in
-# test.yml) runs on one Linux cell on purpose. Moving the other platforms onto a
-# snapshot to match is a separate decision, and a bigger one: it would change
-# what every Linux and Windows user renders with.
-OPENSCAD_MACOS_VERSION="2026.09.03"
-# Verified against this literal rather than against a `.sha256` fetched beside
-# the artifact, which is what `fetch_and_verify` does for the other two payloads.
-# Snapshots live in a rolling directory upstream prunes, so pinning the bytes --
-# not just the name -- is what stops a rebuild from silently picking up a
-# different build republished under the version it asked for.
+#   for f in OpenSCAD-<date>-x86_64.AppImage OpenSCAD-<date>-x86-64.zip OpenSCAD-<date>.dmg; do
+#     curl -s "https://files.openscad.org/snapshots/${f}.sha256"
+#   done
 #
-# Both values are the ones Homebrew ships, which is the easiest place to read a
-# known-good pair:
-#   https://raw.githubusercontent.com/Homebrew/homebrew-cask/master/Casks/o/openscad%40snapshot.rb
-# When the pinned snapshot is pruned the fetch below 404s, which `fetch_and_verify`
-# deliberately does not retry; bump both fields together from that file.
-OPENSCAD_MACOS_SHA256="0bb3511507c19d01dfd17c94777c7d55e27cdba21e6d2eb60127f20bce7a3f0a"
+# Verified against these literals rather than against the sidecars at build
+# time, even though the sidecars exist and are correct. A snapshot directory is
+# rolling: pinning the bytes rather than the name is what stops a rebuild of a
+# given PartCAD version picking up something republished under the date it asked
+# for. (The conda payload below still reads its sidecar -- its upstream is a
+# tagged release, which does not move.)
+OPENSCAD_SHA256_LINUX_X86_64="931c230683182e51c30f8e895f3e3e0b545be67f2e54e8ddba7de0e7df093513"
+OPENSCAD_SHA256_WINDOWS_X86_64="cc4e9ed6b515fab2ba095bf92a2215d9a7bc9fde90fa9653968c83d673caa35a"
+OPENSCAD_SHA256_MACOS="52829dc59f9e96f5154c7bdad01158acfc3dd97511611f43054ee918fda5e003"
 
 # The conda the bundle carries, as the tag of a `micromamba-releases` release --
 # "<micromamba version>-<build>", where `micromamba --version` prints only the
@@ -240,36 +246,22 @@ fi
 # is a confusing way to find out about a one-line key.
 CONDA_PAYLOAD_DIR="${CONDA_STAGE_DIR}/payload-${MICROMAMBA_VERSION}-${OS_NAME}-${ARCH_NAME}"
 
-# Which OpenSCAD this platform carries, and where it is staged. Also set here
-# rather than beside the version pins, for the same reason: macOS takes a
-# different build from the other two, and OS_NAME is what the block above
-# settles.
+# Where the OpenSCAD payload is staged. Set here rather than beside the version
+# pin because it needs OS_NAME, which the block above is what settles.
 #
-# `OPENSCAD_EXPECTED_SHA256` is empty for the platforms whose upstream publishes
-# a `.sha256` next to the artifact; `fetch_and_verify` fetches that one when it
-# is given nothing to compare against.
-if [ "${OS_NAME}" = "macos" ]; then
-  OPENSCAD_BUILD_VERSION="${OPENSCAD_MACOS_VERSION}"
-  OPENSCAD_EXPECTED_SHA256="${OPENSCAD_MACOS_SHA256}"
-else
-  OPENSCAD_BUILD_VERSION="${OPENSCAD_VERSION}"
-  OPENSCAD_EXPECTED_SHA256=""
-fi
-
-# Keyed by version, so that bumping a pin above and rebuilding in a tree that
-# still holds an old `build/` fetches the new version rather than silently
-# reusing the stale one (`build/` is not wiped between builds, and CI aside,
-# nobody wipes it by hand). Stale siblings are harmless: `build/` is gitignored,
-# and only the matching directory is ever read.
+# Keyed by version, so that bumping the pin and rebuilding in a tree that still
+# holds an old `build/` fetches the new version rather than silently reusing the
+# stale one (`build/` is not wiped between builds, and CI aside, nobody wipes it
+# by hand). Stale siblings are harmless: `build/` is gitignored, and only the
+# matching directory is ever read.
 #
-# Unlike conda's, not keyed by platform. The two macOS bundles want the very same
-# payload -- the snapshot `.dmg` is one artifact serving both architectures -- so
-# an Apple silicon Mac building the Intel bundle under `arch -x86_64` out of one
-# workspace should share it rather than fetch it twice. Linux and Windows share a
-# key without sharing a payload, but they stage different entry points
-# (`AppRun` against `openscad.exe`), so the staged-already check below tells them
-# apart and simply refetches.
-OPENSCAD_PAYLOAD_DIR="${OPENSCAD_STAGE_DIR}/payload-${OPENSCAD_BUILD_VERSION}"
+# Keyed by operating system as well, now that all three carry the same version
+# and would otherwise share one directory holding whichever payload was staged
+# last. Not by architecture, unlike conda: the two macOS bundles want the very
+# same payload -- the `.dmg` is a universal binary, x86_64 and arm64 in one
+# artifact -- so an Apple silicon Mac building the Intel bundle under
+# `arch -x86_64` out of one workspace shares it rather than fetching it twice.
+OPENSCAD_PAYLOAD_DIR="${OPENSCAD_STAGE_DIR}/payload-${OPENSCAD_VERSION}-${OS_NAME}"
 
 VERSION="$("${PYTHON}" -c "
 import re, pathlib
@@ -339,12 +331,13 @@ fi
 # and conda -- so that neither can be staged from a truncated or substituted
 # download.
 #
-# A third argument overrides that: the expected hash as a literal, for an
-# upstream that publishes no `.sha256` beside the artifact, or one whose artifact
-# can be replaced under a name it already used. The macOS OpenSCAD snapshot is
-# both -- see the pin beside OPENSCAD_MACOS_SHA256 -- and a literal is the
-# stronger check there anyway, since it pins the bytes rather than trusting
-# whatever the same host serves for the checksum.
+# A third argument overrides that: the expected hash as a literal, for an upstream
+# that publishes no `.sha256` beside the artifact, or one whose artifact can be
+# replaced under a name it already used. The OpenSCAD snapshots are the second
+# case -- see the pin beside OPENSCAD_SHA256_LINUX_X86_64 -- and a literal is the
+# stronger check for them anyway, since it pins the bytes rather than trusting
+# whatever the same host serves for the checksum. conda still takes the sidecar:
+# its upstream is a tagged release, which does not move.
 #
 # Fetched and verified with the Python this script already depends on, rather
 # than with curl and sha256sum, whose presence and flags differ across the three
@@ -468,18 +461,19 @@ VERIFY
 # self-contained -- it resolves libGL, libX11, libxcb, fontconfig, freetype,
 # glib and harfbuzz from the host -- so on a stripped-down Linux system the
 # bundled OpenSCAD still needs those present. Windows takes the upstream portable
-# build, a single statically linked executable that needs nothing at all.
+# zip, `openscad.exe` and `openscad.com` with no DLLs of their own.
 #
-# Linux arm64 is the one platform that carries nothing: upstream publishes the
-# 2021.01 AppImage for x86_64 only, and running an x86_64 AppImage under
-# emulation is not something a bundle should be quietly requiring. `pc` there
-# uses the host's OpenSCAD, exactly as the wheels do.
+# Linux arm64 is the one platform that carries nothing: upstream builds no
+# current arm64 snapshot -- the only two aarch64 artifacts in the directory are
+# one-offs from 2021 and 2023 -- and running the x86_64 AppImage under emulation
+# is not something a bundle should be quietly requiring. `pc` there uses the
+# host's OpenSCAD, exactly as the wheels do.
 #
-# macOS takes the development snapshot, as a `.dmg` mounted at build time and
-# the `OpenSCAD.app` inside it copied out whole. Both architectures carry it and
-# both carry the same one: the snapshot is a single artifact under a single
-# checksum, where the 2021.01 release is x86_64 only. See OPENSCAD_MACOS_VERSION
-# for why the release is not an option on either architecture any more.
+# macOS takes the `.dmg`, mounted at build time and the `OpenSCAD.app` inside it
+# copied out whole. Both architectures carry the identical payload: the `.dmg`
+# is a Universal 2 binary -- `lipo -archs` on the executable inside prints
+# "x86_64 arm64" -- which is why there is one macOS artifact rather than one per
+# architecture.
 #
 # The `.app` is copied entire rather than reduced to the executable inside it:
 # the binary at `Contents/MacOS/OpenSCAD` resolves its Qt frameworks through
@@ -487,32 +481,40 @@ VERIFY
 # runnable. That is also the path Homebrew's cask links onto PATH as `openscad`,
 # and it is what `partcad.healthcheck.openscad.BUNDLED_SUBPATH` expects to find.
 stage_openscad() {
-  local artifact url download_dir payload_dir entry_point mount_point
-  download_dir="${OPENSCAD_STAGE_DIR}/download-${OPENSCAD_BUILD_VERSION}"
+  local artifact expected download_dir payload_dir entry_point mount_point
+  download_dir="${OPENSCAD_STAGE_DIR}/download-${OPENSCAD_VERSION}"
   payload_dir="${OPENSCAD_PAYLOAD_DIR}"
 
   # Keyed on the operating system and architecture rather than on PLATFORM,
   # which now also carries the OS version: which OpenSCAD to fetch does not
   # depend on whether this is Ubuntu 22.04 or 24.04.
+  #
+  # Note how little the three names have in common -- a hyphen before the
+  # architecture on Linux, a differently spelled one on Windows, and no
+  # architecture token at all on macOS -- and that the Windows zip sits beside an
+  # "-x86-64-Installer.exe" that differs from it by a suffix. They are spelled
+  # out rather than composed for that reason.
   case "${OS_NAME}-${ARCH_NAME}" in
   linux-x86_64)
     artifact="OpenSCAD-${OPENSCAD_VERSION}-x86_64.AppImage"
-    url="https://files.openscad.org/${artifact}"
+    expected="${OPENSCAD_SHA256_LINUX_X86_64}"
     entry_point="${payload_dir}/AppRun"
     ;;
   windows-x86_64)
     artifact="OpenSCAD-${OPENSCAD_VERSION}-x86-64.zip"
-    url="https://files.openscad.org/${artifact}"
+    expected="${OPENSCAD_SHA256_WINDOWS_X86_64}"
     entry_point="${payload_dir}/openscad.exe"
     ;;
   macos-x86_64 | macos-arm64)
-    artifact="OpenSCAD-${OPENSCAD_MACOS_VERSION}.dmg"
-    # A different directory from the releases: snapshots are published under
-    # "snapshots/", which is also the directory upstream prunes.
-    url="https://files.openscad.org/snapshots/${artifact}"
+    artifact="OpenSCAD-${OPENSCAD_VERSION}.dmg"
+    expected="${OPENSCAD_SHA256_MACOS}"
     entry_point="${payload_dir}/OpenSCAD.app/Contents/MacOS/OpenSCAD"
     ;;
   *)
+    # Linux arm64, and nothing else today. Upstream publishes no current arm64
+    # snapshot: the only two aarch64 artifacts in the whole directory are one-offs
+    # from 2021 and 2023, under a naming scheme ("...ai-aarch64") it no longer
+    # uses. `pc` there uses the host's OpenSCAD, exactly as the wheels do.
     echo "==> Not bundling OpenSCAD on ${PLATFORM} (see the comment in build.sh)"
     rm -rf "${payload_dir}"
     return 0
@@ -520,15 +522,27 @@ stage_openscad() {
   esac
 
   if [ -e "${entry_point}" ]; then
-    echo "==> OpenSCAD ${OPENSCAD_BUILD_VERSION} already staged"
+    echo "==> OpenSCAD ${OPENSCAD_VERSION} already staged"
     return 0
   fi
 
-  echo "==> Fetching OpenSCAD ${OPENSCAD_BUILD_VERSION} for ${PLATFORM}"
+  echo "==> Fetching OpenSCAD ${OPENSCAD_VERSION} for ${PLATFORM}"
   rm -rf "${payload_dir}"
   mkdir -p "${download_dir}" "${payload_dir}"
 
-  fetch_and_verify "${url}" "${download_dir}/${artifact}" "${OPENSCAD_EXPECTED_SHA256}"
+  # The expiry the pin comment warns about surfaces here, as a 404 from a
+  # perfectly well-formed URL. Saying so beats leaving a reader to work out why
+  # a build that passed last year does not resolve today.
+  if ! fetch_and_verify "https://files.openscad.org/snapshots/${artifact}" \
+    "${download_dir}/${artifact}" "${expected}"; then
+    echo "error: could not fetch OpenSCAD ${OPENSCAD_VERSION} (${artifact})." >&2
+    echo "       If that was an HTTP 404, the pinned snapshot has been pruned:" >&2
+    echo "       upstream keeps roughly a year of them. Pick a date from" >&2
+    echo "       https://files.openscad.org/snapshots/ that carries all three" >&2
+    echo "       artifacts and bump OPENSCAD_VERSION and the three OPENSCAD_SHA256_*" >&2
+    echo "       values together -- see the comment beside them in build.sh." >&2
+    exit 1
+  fi
 
   case "${artifact}" in
   *.AppImage)
@@ -541,16 +555,25 @@ stage_openscad() {
     ;;
   *.zip)
     "${PYTHON}" -m zipfile -e "${download_dir}/${artifact}" "${download_dir}/unpacked"
-    # The zip holds a single "openscad-<version>" directory; the executable
-    # needs its sibling data directories, so the contents move up together.
-    mv "${download_dir}/unpacked/openscad-${OPENSCAD_VERSION}"/* "${payload_dir}/"
+    # The zip holds a single top-level directory, named after the zip itself
+    # ("OpenSCAD-<version>-x86-64"), holding openscad.exe and openscad.com at its
+    # root. Derived from the artifact name rather than spelled out, because the
+    # two agree by construction -- and note the release zips did NOT follow this
+    # rule: 2021.01's inner directory was the lowercase "openscad-2021.01", so
+    # anything hardcoded here would have quietly moved nothing.
+    #
+    # The executable needs its sibling data directories, so the contents move up
+    # together.
+    mv "${download_dir}/unpacked/${artifact%.zip}"/* "${payload_dir}/"
     rm -rf "${download_dir}/unpacked"
     ;;
   *.dmg)
     # An explicit mount point under `build/`, rather than letting hdiutil pick
-    # one under /Volumes: two macOS builds sharing a workspace would collide
-    # there, and a name already taken is silently suffixed rather than refused,
-    # so the copy below would read whichever image got there first.
+    # one under /Volumes. The volume is named "OpenSCAD" with no date in it, so
+    # every snapshot mounts at the same /Volumes/OpenSCAD -- and a name already
+    # taken is silently suffixed ("/Volumes/OpenSCAD 1") rather than refused, so
+    # a second build, or a stale mount left by an interrupted one, would have the
+    # copy below reading whichever image got there first.
     mount_point="${download_dir}/mnt"
     rm -rf "${mount_point}"
     mkdir -p "${mount_point}"
@@ -893,9 +916,9 @@ if [ -d "${OPENSCAD_BUNDLED_DIR}" ]; then
   openscad_version_output="$(cd "${SMOKE_DIR}" && "${openscad_entry_point}" --version 2>&1)"
   echo "    ${openscad_version_output}"
   case "${openscad_version_output}" in
-  *"OpenSCAD version ${OPENSCAD_BUILD_VERSION}"*) ;;
+  *"OpenSCAD version ${OPENSCAD_VERSION}"*) ;;
   *)
-    echo "error: bundled OpenSCAD is not ${OPENSCAD_BUILD_VERSION}: '${openscad_version_output}'" >&2
+    echo "error: bundled OpenSCAD is not ${OPENSCAD_VERSION}: '${openscad_version_output}'" >&2
     exit 1
     ;;
   esac

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -47,48 +47,136 @@ OPENSCAD_STAGE_DIR="${REPO_ROOT}/build/openscad"
 CONDA_STAGE_DIR="${REPO_ROOT}/build/conda"
 PYTHON="${PYTHON:-python3}"
 
-# The OpenSCAD every bundle carries -- one version across all of them, which is
-# what makes a `.scad` part render the same wherever `pc` runs.
+###########################################  OPENSCAD BUILDS  ################################################
 #
-# A development snapshot rather than a release, because the last release cannot
-# be that one version. 2021.01 ships an x86_64-only `.dmg`, so an arm64 Mac
-# would need Rosetta 2 -- Homebrew's `openscad` cask says so in the open, with a
-# `requires_rosetta` caveat -- and Homebrew then `disable!`d that cask outright
-# on 2026-09-01, `because: :fails_gatekeeper_check`, which took every macOS CI
-# job down with it (see #583). One version everywhere therefore has to be a
-# snapshot; what that costs is the expiry note below.
+# The OpenSCAD every bundle carries. This block is the ONE place the builds are
+# chosen: the URLs, their checksums and the version are here, and nothing below
+# constructs a download URL of its own. Bump all of it together.
 #
-# The date has to be one that every platform actually published on. That is not
-# automatic: upstream builds roughly every 2.6 days rather than nightly, and the
-# gaps run to 35 days on Linux and Windows and 76 on macOS, so a bump picks a
-# date from the listing rather than constructing one.
+# ---------------------------------------------------------------------------
+# WHY ONE VERSION EVERYWHERE
+# ---------------------------------------------------------------------------
+#
+# Every platform must carry OpenSCAD built from the SAME upstream source, and
+# the snapshot date in these filenames is what identifies that source. It is a
+# feature-parity requirement, not tidiness: OpenSCAD's language and its exports
+# both move between builds, so bundles built from different sources disagree
+# about what a `.scad` file means. A part that renders on one machine would fail
+# to parse, or render differently, on another -- and "the same part builds the
+# same everywhere" is the promise the bundle exists to keep. A user who reports
+# a rendering difference should never have to ask which platform they were on.
+#
+# So the three URLs below always name one date. Do not bump one platform alone,
+# and do not mix dates to get a newer build on some platform: an older date that
+# all platforms share beats a newer one that they do not.
+#
+# ---------------------------------------------------------------------------
+# HOW TO FIND THE LATEST BUILD THAT QUALIFIES
+# ---------------------------------------------------------------------------
+#
+# Not "yesterday", and not the newest date in the directory. Upstream builds
+# roughly every 2.6 days rather than nightly, a given date can be missing a
+# platform, and the gaps run to 35 days on Linux and Windows and 76 on macOS --
+# so the newest date overall very often has no `.dmg`. What is needed is the
+# newest date carrying all three artifacts, which this prints:
+#
+#   curl -s https://files.openscad.org/snapshots/ |
+#     grep -oE 'OpenSCAD-[0-9A-Za-z._-]+' |
+#     grep -E '^OpenSCAD-[0-9]{4}\.[0-9]{2}\.[0-9]{2}(-x86_64\.AppImage|-x86-64\.zip|\.dmg)$' |
+#     sort -u |
+#     sed -E 's/^OpenSCAD-([0-9]{4}\.[0-9]{2}\.[0-9]{2}).*/\1/' |
+#     uniq -c | awk '$1 == 3 { print $2 }' | tail -1
+#
+# (The two `grep`s are separate on purpose. Anchoring the match to the whole
+# filename is what rejects the `.sha256` and `.sha512` sidecars, and the
+# `-x86-64-Installer.exe` sitting next to the Windows zip; `sort -u` first is
+# what stops a listing that names each file twice counting it twice. Drop the
+# `tail -1` to see every qualifying date, oldest first.)
+#
+# ---------------------------------------------------------------------------
+# HOW TO CONSTRUCT THE URLS
+# ---------------------------------------------------------------------------
+#
+# Base: https://files.openscad.org/snapshots/ -- the development snapshots, not
+# the releases at the parent path. See "WHY A SNAPSHOT" below for why a release
+# is not an option, and note that this directory is the one upstream prunes.
+#
+# The three filenames share almost nothing, so read them off carefully:
+#
+#   Linux x86_64   OpenSCAD-<date>-x86_64.AppImage    underscore before 64
+#   Windows x86_64 OpenSCAD-<date>-x86-64.zip         hyphen before 64, and it
+#                                                     sits beside an
+#                                                     "-x86-64-Installer.exe"
+#                                                     that is NOT what we want
+#   macOS          OpenSCAD-<date>.dmg                no architecture token: the
+#                                                     .dmg is Universal 2 and
+#                                                     serves both Macs
+#
+# There is no Linux arm64 line. Upstream builds no current arm64 snapshot -- the
+# only two aarch64 artifacts in the directory are one-offs from 2021 and 2023,
+# under a naming scheme ("...ai-aarch64") it no longer uses -- so that bundle
+# carries no OpenSCAD and `pc` there uses the host's, exactly as the wheels do.
+#
+# Each checksum below is the `.sha256` upstream publishes beside its artifact:
+#
+#   curl -s "<url>.sha256"
+#
+# They are copied in here rather than fetched at build time, even though they
+# exist and are correct, because a snapshot directory is rolling: pinning the
+# bytes rather than the name is what stops a rebuild of a given PartCAD version
+# picking up something republished under the date it asked for. (The conda
+# payload further down still reads its sidecar -- its upstream is a tagged
+# release, which does not move.)
+#
+# ---------------------------------------------------------------------------
+# WHY A SNAPSHOT, AND WHAT IT COSTS
+# ---------------------------------------------------------------------------
+#
+# The last release, 2021.01, cannot be the shared version. It ships an
+# x86_64-only `.dmg`, so an arm64 Mac would need Rosetta 2 -- Homebrew's
+# `openscad` cask says so in the open, with a `requires_rosetta` caveat -- and
+# Homebrew then `disable!`d that cask outright on 2026-09-01, `because:
+# :fails_gatekeeper_check`, which took every macOS CI job down with it (#583).
+#
+# **The pin therefore expires.** Upstream prunes `snapshots/` on a rolling window
+# of about a year -- measured at 143 Linux and Windows builds spanning 368 days,
+# 119 macOS builds spanning 365 -- so a pin left alone for a year stops resolving
+# and NO bundle builds, on any platform, releases included. It fails loudly: the
+# fetch 404s, `fetch_and_verify` does not retry a 4xx, and `stage_openscad` prints
+# what happened and points back here. The durable fix is to mirror these three
+# artifacts somewhere the project controls.
+#
 OPENSCAD_VERSION="2026.09.05"
 
-# **This pin expires.** Upstream prunes `snapshots/` on a rolling window of
-# about a year -- measured at 143 Linux and Windows builds spanning 368 days,
-# 119 macOS builds spanning 365 -- so a pin left alone for a year stops
-# resolving and every bundle stops building, on every platform, release
-# included. It fails loudly rather than quietly: the fetch 404s, which
-# `fetch_and_verify` deliberately does not retry, and `stage_openscad` says what
-# to do about it.
-#
-# To bump: pick a date from https://files.openscad.org/snapshots/ that has all
-# three artifacts, and take the three hashes from the `.sha256` published beside
-# each one:
-#
-#   for f in OpenSCAD-<date>-x86_64.AppImage OpenSCAD-<date>-x86-64.zip OpenSCAD-<date>.dmg; do
-#     curl -s "https://files.openscad.org/snapshots/${f}.sha256"
-#   done
-#
-# Verified against these literals rather than against the sidecars at build
-# time, even though the sidecars exist and are correct. A snapshot directory is
-# rolling: pinning the bytes rather than the name is what stops a rebuild of a
-# given PartCAD version picking up something republished under the date it asked
-# for. (The conda payload below still reads its sidecar -- its upstream is a
-# tagged release, which does not move.)
+OPENSCAD_URL_LINUX_X86_64="https://files.openscad.org/snapshots/OpenSCAD-2026.09.05-x86_64.AppImage"
 OPENSCAD_SHA256_LINUX_X86_64="931c230683182e51c30f8e895f3e3e0b545be67f2e54e8ddba7de0e7df093513"
+
+OPENSCAD_URL_WINDOWS_X86_64="https://files.openscad.org/snapshots/OpenSCAD-2026.09.05-x86-64.zip"
 OPENSCAD_SHA256_WINDOWS_X86_64="cc4e9ed6b515fab2ba095bf92a2215d9a7bc9fde90fa9653968c83d673caa35a"
+
+OPENSCAD_URL_MACOS="https://files.openscad.org/snapshots/OpenSCAD-2026.09.05.dmg"
 OPENSCAD_SHA256_MACOS="52829dc59f9e96f5154c7bdad01158acfc3dd97511611f43054ee918fda5e003"
+
+# The URLs are written out in full rather than composed from OPENSCAD_VERSION,
+# so that what gets downloaded is readable and greppable without running the
+# script. This is the cost of that: a half-finished bump, where the version moved
+# and a URL did not, would otherwise be found only by the smoke test at the end
+# of a build -- or on the one platform nobody rebuilt.
+for openscad_url in \
+  "${OPENSCAD_URL_LINUX_X86_64}" \
+  "${OPENSCAD_URL_WINDOWS_X86_64}" \
+  "${OPENSCAD_URL_MACOS}"; do
+  case "${openscad_url}" in
+  *"OpenSCAD-${OPENSCAD_VERSION}"*) ;;
+  *)
+    echo "error: '${openscad_url}' is not OpenSCAD ${OPENSCAD_VERSION}." >&2
+    echo "       The URLs and OPENSCAD_VERSION are bumped together; see the" >&2
+    echo "       OPENSCAD BUILDS block in build.sh." >&2
+    exit 1
+    ;;
+  esac
+done
+unset openscad_url
 
 # The conda the bundle carries, as the tag of a `micromamba-releases` release --
 # "<micromamba version>-<build>", where `micromamba --version` prints only the
@@ -481,32 +569,30 @@ VERIFY
 # runnable. That is also the path Homebrew's cask links onto PATH as `openscad`,
 # and it is what `partcad.healthcheck.openscad.BUNDLED_SUBPATH` expects to find.
 stage_openscad() {
-  local artifact expected download_dir payload_dir entry_point mount_point
+  local artifact url expected download_dir payload_dir entry_point mount_point
   download_dir="${OPENSCAD_STAGE_DIR}/download-${OPENSCAD_VERSION}"
   payload_dir="${OPENSCAD_PAYLOAD_DIR}"
 
+  # Which of the builds chosen at the top of this file this platform takes. The
+  # URLs live there and nothing is composed here, so there is one place to look
+  # at, and to change, when the pin moves.
+  #
   # Keyed on the operating system and architecture rather than on PLATFORM,
   # which now also carries the OS version: which OpenSCAD to fetch does not
   # depend on whether this is Ubuntu 22.04 or 24.04.
-  #
-  # Note how little the three names have in common -- a hyphen before the
-  # architecture on Linux, a differently spelled one on Windows, and no
-  # architecture token at all on macOS -- and that the Windows zip sits beside an
-  # "-x86-64-Installer.exe" that differs from it by a suffix. They are spelled
-  # out rather than composed for that reason.
   case "${OS_NAME}-${ARCH_NAME}" in
   linux-x86_64)
-    artifact="OpenSCAD-${OPENSCAD_VERSION}-x86_64.AppImage"
+    url="${OPENSCAD_URL_LINUX_X86_64}"
     expected="${OPENSCAD_SHA256_LINUX_X86_64}"
     entry_point="${payload_dir}/AppRun"
     ;;
   windows-x86_64)
-    artifact="OpenSCAD-${OPENSCAD_VERSION}-x86-64.zip"
+    url="${OPENSCAD_URL_WINDOWS_X86_64}"
     expected="${OPENSCAD_SHA256_WINDOWS_X86_64}"
     entry_point="${payload_dir}/openscad.exe"
     ;;
   macos-x86_64 | macos-arm64)
-    artifact="OpenSCAD-${OPENSCAD_VERSION}.dmg"
+    url="${OPENSCAD_URL_MACOS}"
     expected="${OPENSCAD_SHA256_MACOS}"
     entry_point="${payload_dir}/OpenSCAD.app/Contents/MacOS/OpenSCAD"
     ;;
@@ -521,6 +607,11 @@ stage_openscad() {
     ;;
   esac
 
+  # The file name is the last path segment of the chosen URL rather than a
+  # second spelling of it. The unpackers below key off it -- the Windows zip's
+  # inner directory is its own basename -- so the two cannot drift apart.
+  artifact="${url##*/}"
+
   if [ -e "${entry_point}" ]; then
     echo "==> OpenSCAD ${OPENSCAD_VERSION} already staged"
     return 0
@@ -533,14 +624,14 @@ stage_openscad() {
   # The expiry the pin comment warns about surfaces here, as a 404 from a
   # perfectly well-formed URL. Saying so beats leaving a reader to work out why
   # a build that passed last year does not resolve today.
-  if ! fetch_and_verify "https://files.openscad.org/snapshots/${artifact}" \
-    "${download_dir}/${artifact}" "${expected}"; then
+  if ! fetch_and_verify "${url}" "${download_dir}/${artifact}" "${expected}"; then
     echo "error: could not fetch OpenSCAD ${OPENSCAD_VERSION} (${artifact})." >&2
     echo "       If that was an HTTP 404, the pinned snapshot has been pruned:" >&2
     echo "       upstream keeps roughly a year of them. Pick a date from" >&2
     echo "       https://files.openscad.org/snapshots/ that carries all three" >&2
-    echo "       artifacts and bump OPENSCAD_VERSION and the three OPENSCAD_SHA256_*" >&2
-    echo "       values together -- see the comment beside them in build.sh." >&2
+    echo "       artifacts and bump the whole OPENSCAD BUILDS block at the top" >&2
+    echo "       of build.sh -- version, URLs and checksums together. That block" >&2
+    echo "       carries the command that finds the newest qualifying date." >&2
     exit 1
   fi
 

--- a/dev-tools/pyinstaller/build.sh
+++ b/dev-tools/pyinstaller/build.sh
@@ -1004,7 +1004,35 @@ if [ -d "${OPENSCAD_BUNDLED_DIR}" ]; then
   macos) openscad_entry_point="${OPENSCAD_BUNDLED_DIR}/OpenSCAD.app/Contents/MacOS/OpenSCAD" ;;
   *) openscad_entry_point="${OPENSCAD_BUNDLED_DIR}/AppRun" ;;
   esac
-  openscad_version_output="$(cd "${SMOKE_DIR}" && "${openscad_entry_point}" --version 2>&1)"
+  # The status is captured rather than left to `set -e`, and the output is
+  # printed on failure. It has to be captured to match the version below, which
+  # means an unexplained abort here would take the one message that explains it
+  # down with it, still inside the variable -- which is exactly what happened
+  # when this payload moved to a Qt6 snapshot and the runner turned out to be
+  # short of a library.
+  openscad_smoke_status=0
+  openscad_version_output="$(cd "${SMOKE_DIR}" && "${openscad_entry_point}" --version 2>&1)" ||
+    openscad_smoke_status=$?
+  if [ "${openscad_smoke_status}" -ne 0 ]; then
+    echo "error: the bundled OpenSCAD did not run (exit ${openscad_smoke_status})" >&2
+    echo "       ${openscad_entry_point}" >&2
+    printf '       %s\n' "${openscad_version_output}" >&2
+    # 127 from a file that exists is the dynamic loader, not a missing path: the
+    # Linux payload is an AppImage and resolves several libraries from the host
+    # (see the note above `stage_openscad`). Name them rather than leaving the
+    # next reader to guess which one the machine is short of.
+    if command -v ldd >/dev/null 2>&1; then
+      for openscad_object in "${openscad_entry_point}" "${OPENSCAD_BUNDLED_DIR}/usr/bin/openscad"; do
+        [ -e "${openscad_object}" ] || continue
+        openscad_missing="$(ldd "${openscad_object}" 2>/dev/null | grep "not found" || true)"
+        if [ -n "${openscad_missing}" ]; then
+          echo "       ${openscad_object} cannot resolve:" >&2
+          printf '         %s\n' "${openscad_missing}" >&2
+        fi
+      done
+    fi
+    exit 1
+  fi
   echo "    ${openscad_version_output}"
   case "${openscad_version_output}" in
   *"OpenSCAD version ${OPENSCAD_VERSION}"*) ;;

--- a/dev-tools/pyinstaller/partcad.spec
+++ b/dev-tools/pyinstaller/partcad.spec
@@ -255,12 +255,15 @@ add_metadata("partcad")
 # OpenSCAD is deliberately NOT declared here, even though the bundle ships it:
 # `build.sh` copies it into the bundle after this spec has been built.
 #
-# Declaring the unpacked AppImage in `datas` does not keep PyInstaller's hands
-# off it. Shared libraries found among data files are reclassified as binaries
-# and collected into the top level of the bundle, so OpenSCAD's Qt, ICU and
-# glib end up beside the ones Python needs -- on the frozen application's own
-# library search path, and duplicated, at ~100MB. Copying the tree in
-# afterwards keeps OpenSCAD's libraries where only OpenSCAD will find them.
+# Declaring the payload in `datas` does not keep PyInstaller's hands off it --
+# the unpacked AppImage on Linux, the portable build on Windows, the
+# `OpenSCAD.app` on macOS. Shared libraries found among data files are
+# reclassified as binaries and collected into the top level of the bundle, so
+# OpenSCAD's Qt, ICU and glib end up beside the ones Python needs -- on the
+# frozen application's own library search path, and duplicated, at ~100MB.
+# Copying the tree in afterwards keeps OpenSCAD's libraries where only OpenSCAD
+# will find them, which on macOS is what `@executable_path/../Frameworks` inside
+# the `.app` resolves to.
 
 ############################################  COLLECTED TESTS  ###############################################
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -374,9 +374,9 @@ The exception is ``MAMBA_ROOT_PREFIX``: if you already have that set -- because 
 the bundled copy uses your prefix rather than making a second cache of its own, and then none of the sentence
 above applies to it. It is your cache, in your location, and PartCAD neither reports nor deletes it.
 
-On Linux x86_64 and on Windows it also carries **OpenSCAD**, which PartCAD runs as an external program to
+Every bundle but Linux arm64 also carries **OpenSCAD**, which PartCAD runs as an external program to
 build ``.scad`` parts. The bundled copy is used in preference to any OpenSCAD installed on the machine, so that the
-bundle behaves the same everywhere rather than depending on which version a given host happens to have. Two
+bundle behaves the same everywhere rather than depending on which version a given host happens to have. Three
 consequences worth knowing:
 
 * A newer OpenSCAD installed on the machine is *not* used by default. To use the host's OpenSCAD instead of
@@ -387,12 +387,15 @@ consequences worth knowing:
   installations have these; a stripped-down container or a minimal server may not, and there the bundled
   OpenSCAD will not start -- pass ``--ignore-bundled-openscad`` to fall back to a host OpenSCAD if you have
   one.
+* On macOS the bundled OpenSCAD is a development snapshot rather than the last release, on both
+  architectures. The release predates Apple silicon and ships an Intel-only build that would quietly
+  require Rosetta 2, and Homebrew disabled it in September 2026 for failing the macOS Gatekeeper check --
+  so the snapshot is both the only build that runs everywhere and the only one still installable. It is a
+  newer OpenSCAD than the Linux and Windows bundles carry, which can mean small differences in what a
+  ``.scad`` part renders to.
 
-The macOS bundles carry no OpenSCAD: the last OpenSCAD release predates Apple silicon and ships an
-Intel-only build, which would quietly require Rosetta 2. The Linux arm64 bundles carry none for the same
-reason -- upstream publishes that release for x86_64 only. The Intel macOS bundle carries none either, so
-that both macOS builds behave the same way. On all of them, install OpenSCAD yourself and PartCAD will use
-it.
+The Linux arm64 bundles carry no OpenSCAD: upstream publishes the pinned release for x86_64 only. Install
+OpenSCAD yourself there and PartCAD will use it.
 
 One thing is deliberately not in the bundle, because PartCAD runs it as an external program rather than
 importing it, exactly as the wheels do: **git**, used for your git configuration when packages are fetched

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -183,8 +183,8 @@ That downloads the bundle for the current operating system and architecture from
 Nothing else on the system is touched, and no ``sudo`` is asked for. If ``~/.local/bin`` is not on your
 ``PATH``, the installer says so and prints the line to add.
 
-The bundle is around 200MB unpacked and 63MB to download on Linux x86_64, and about half that on macOS and
-on Linux arm64, which carry no bundled OpenSCAD. It carries no CAD kernel: PartCAD builds every shape in a
+Most of the bundle is the OpenSCAD it carries, so that is what its size follows: the Linux arm64 build, which
+carries none, is roughly half the size of the others. It carries no CAD kernel: PartCAD builds every shape in a
 sandbox it provisions itself -- and it carries the conda that provisions it, so nothing has to be installed
 first, and the ``conda`` sandbox is what you get rather than the ``venv`` fallback the wheels use when there
 is no conda (see :ref:`python-sandbox`). ``pc healthcheck`` reports what this machine is missing.
@@ -598,8 +598,9 @@ What is inside
   Studio Code is built from, with its extensions coming from `Open VSX <https://open-vsx.org/>`_.
 * The PartCAD extension -- which carries the PartCAD Viewer itself -- and the extensions PartCAD works
   with: Python, YAML and the rest of the list in ``.vscode/extensions.json``.
-* The PartCAD command line tools, the same ones the standalone bundle installs, including OpenSCAD on
-  Linux and Windows.
+* The PartCAD command line tools, the same ones the standalone bundle installs, including the OpenSCAD they
+  bundle -- on every platform the IDE ships for, since the one build that carries none is Linux arm64 and
+  there is no Linux arm64 IDE.
 
 Pylance is not among them: it is proprietary and licensed for use only with Microsoft's products.
 Open-source type checking for Python is included in its place.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -387,15 +387,15 @@ consequences worth knowing:
   installations have these; a stripped-down container or a minimal server may not, and there the bundled
   OpenSCAD will not start -- pass ``--ignore-bundled-openscad`` to fall back to a host OpenSCAD if you have
   one.
-* On macOS the bundled OpenSCAD is a development snapshot rather than the last release, on both
-  architectures. The release predates Apple silicon and ships an Intel-only build that would quietly
-  require Rosetta 2, and Homebrew disabled it in September 2026 for failing the macOS Gatekeeper check --
-  so the snapshot is both the only build that runs everywhere and the only one still installable. It is a
-  newer OpenSCAD than the Linux and Windows bundles carry, which can mean small differences in what a
-  ``.scad`` part renders to.
+* The bundled OpenSCAD is a development snapshot rather than the last release, and it is the *same*
+  snapshot on every platform, so a ``.scad`` part renders the same wherever you run ``pc``. The last
+  release, 2021.01, could not be that shared version: it predates Apple silicon and ships an Intel-only
+  build that would quietly require Rosetta 2, and Homebrew disabled it in September 2026 for failing the
+  macOS Gatekeeper check. It is a considerably newer OpenSCAD than 2021.01, so a part may render
+  differently than it did with a 2021.01 you had installed.
 
-The Linux arm64 bundles carry no OpenSCAD: upstream publishes the pinned release for x86_64 only. Install
-OpenSCAD yourself there and PartCAD will use it.
+The Linux arm64 bundles carry no OpenSCAD: upstream builds no current arm64 snapshot. Install OpenSCAD
+yourself there and PartCAD will use it.
 
 One thing is deliberately not in the bundle, because PartCAD runs it as an external program rather than
 importing it, exactly as the wheels do: **git**, used for your git configuration when packages are fetched

--- a/src/partcad/healthcheck/openscad.py
+++ b/src/partcad/healthcheck/openscad.py
@@ -6,8 +6,10 @@ its own OpenSCAD and that copy is preferred over anything installed on the host,
 so the bundle behaves the same on every machine rather than depending on
 whatever version a host happens to have; everywhere else -- the wheels, a source
 checkout -- there is no bundled copy and this falls back to the host's, exactly
-as before. Only the Linux and Windows bundles carry OpenSCAD; see
-``dev-tools/pyinstaller/build.sh`` for why macOS does not.
+as before. Every bundle carries OpenSCAD except the Linux arm64 one, which has
+none to carry: upstream publishes the pinned release for x86_64 only. See
+``dev-tools/pyinstaller/build.sh``, which also says why macOS carries a
+development snapshot where the other platforms carry a release.
 """
 
 import os
@@ -39,15 +41,37 @@ from partcad.healthcheck.tests import HealthCheckReport, HealthCheckTest
 #
 # Windows ships the upstream portable build, a single statically linked
 # executable with no libraries of its own.
-BUNDLED_SUBPATH = ("openscad", "openscad.exe") if os.name == "nt" else ("openscad", "AppRun")
+#
+# macOS ships the ``OpenSCAD.app`` out of the upstream ``.dmg``, entire. The
+# binary within it resolves its Qt frameworks through
+# ``@executable_path/../Frameworks``, so it is the surrounding bundle that makes
+# it runnable -- the same reason Linux keeps the whole AppImage tree. This is the
+# path Homebrew's cask links onto PATH as ``openscad``, and ``build.sh`` asserts
+# the same one after staging.
+def bundled_subpath(os_name: str, platform_name: str) -> "tuple[str, ...]":
+    """Return the payload's path within a bundle for the platform named.
+
+    A function rather than three inline branches so that the two platforms this
+    process is not running on can still be asserted -- the layout is a fact about
+    an artifact built elsewhere, and a wrong one is only discovered by a user
+    whose bundle cannot find its OpenSCAD.
+    """
+    if os_name == "nt":
+        return ("openscad", "openscad.exe")
+    if platform_name == "darwin":
+        return ("openscad", "OpenSCAD.app", "Contents", "MacOS", "OpenSCAD")
+    return ("openscad", "AppRun")
+
+
+BUNDLED_SUBPATH = bundled_subpath(os.name, sys.platform)
 
 
 def find_bundled_executable() -> "str | None":
     """Return the OpenSCAD shipped inside the standalone bundle, or None.
 
     Returns None whenever PartCAD is not running from a bundle, and also when it
-    is running from a bundle built without OpenSCAD (macOS, or a bundle built by
-    hand without staging the payload).
+    is running from a bundle built without OpenSCAD (Linux arm64, or a bundle
+    built by hand without staging the payload).
     """
     if not getattr(sys, "frozen", False):
         return None
@@ -159,10 +183,15 @@ class MacOpenSCADCheck(OpenSCADCheck):
         The snapshot cask rather than the release one: Homebrew disabled
         ``openscad`` on 2026-09-01 because the pinned 2021.01 release does not
         pass the macOS Gatekeeper check, so ``brew install openscad`` cannot
-        succeed on any machine any more. 2021.01 is also x86_64 only -- the
-        reason ``dev-tools/pyinstaller/build.sh`` does not bundle OpenSCAD on
-        macOS -- so on Apple Silicon it was the wrong build to reach for even
-        while it installed.
+        succeed on any machine any more. 2021.01 is also x86_64 only, so on
+        Apple Silicon it was the wrong build to reach for even while it
+        installed. ``dev-tools/pyinstaller/build.sh`` carries the same snapshot
+        into the macOS bundles, for both of those reasons.
+
+        This is the wheel's path to an OpenSCAD, and it needs Homebrew. A
+        standalone bundle does not come here at all: it carries its own copy,
+        which ``test()`` above resolves first, so the check passes and never
+        offers this fix.
         """
         env = os.environ.copy()
         env["HOMEBREW_NO_AUTO_UPDATE"] = "1"

--- a/src/partcad/healthcheck/openscad.py
+++ b/src/partcad/healthcheck/openscad.py
@@ -7,9 +7,11 @@ so the bundle behaves the same on every machine rather than depending on
 whatever version a host happens to have; everywhere else -- the wheels, a source
 checkout -- there is no bundled copy and this falls back to the host's, exactly
 as before. Every bundle carries OpenSCAD except the Linux arm64 one, which has
-none to carry: upstream publishes the pinned release for x86_64 only. See
-``dev-tools/pyinstaller/build.sh``, which also says why macOS carries a
-development snapshot where the other platforms carry a release.
+none to carry: upstream builds no current arm64 snapshot. Every bundle that does
+carry one carries the same version, so a ``.scad`` part renders the same
+wherever ``pc`` runs; see ``dev-tools/pyinstaller/build.sh`` for why that shared
+version is a development snapshot rather than a release, and for the expiry that
+comes with it.
 """
 
 import os
@@ -185,8 +187,8 @@ class MacOpenSCADCheck(OpenSCADCheck):
         pass the macOS Gatekeeper check, so ``brew install openscad`` cannot
         succeed on any machine any more. 2021.01 is also x86_64 only, so on
         Apple Silicon it was the wrong build to reach for even while it
-        installed. ``dev-tools/pyinstaller/build.sh`` carries the same snapshot
-        into the macOS bundles, for both of those reasons.
+        installed. ``dev-tools/pyinstaller/build.sh`` carries that same snapshot
+        into every bundle, for both of those reasons.
 
         This is the wheel's path to an OpenSCAD, and it needs Homebrew. A
         standalone bundle does not come here at all: it carries its own copy,
@@ -224,6 +226,17 @@ class MacOpenSCADCheck(OpenSCADCheck):
 
 
 class WindowsOpenSCADCheck(OpenSCADCheck):
+    """Install OpenSCAD for a Windows host that has none.
+
+    Deliberately still the 2021.01 *release*, where the standalone bundle carries
+    a development snapshot: this installs onto a user's machine, and a stable
+    release is the right thing to put there. The two are pinned separately and
+    they do not have to agree -- this is the wheel's path to an OpenSCAD, and a
+    bundle never reaches it, because it carries its own and ``test()`` resolves
+    that one first. It used to be the same version as the bundle's only because
+    the bundle was on the release too.
+    """
+
     def __init__(self):
         super().__init__()
         self.installation_path = os.path.join(UserConfig.get_config_dir(), "OpenSCAD")

--- a/src/partcad_client/selfupdate.py
+++ b/src/partcad_client/selfupdate.py
@@ -885,12 +885,18 @@ def _extract(archive_path: str, dest: str, ext: str) -> None:
 def _reject_unsafe_links(members, dest: str) -> None:
     """Refuse an archive whose links would reach outside ``dest``.
 
-    The bundle carries two of them -- ``partcad`` and ``partcad-json-rpc`` are
-    relative symlinks to ``pc``, so that one ~38MB payload serves all three
-    names -- which is why link members are extracted rather than skipped. What
-    ``filter="data"`` enforces on a modern interpreter is enforced here too, for
-    the older ones this falls back to: a link target may be neither absolute nor
-    a path that climbs out of the archive.
+    The bundle carries these, which is why link members are extracted rather
+    than skipped: ``partcad`` and ``partcad-json-rpc`` are relative symlinks to
+    ``pc``, so that one ~38MB payload serves all three names, and on macOS the
+    bundled ``OpenSCAD.app`` brings the links a framework bundle is built from
+    (``Versions/Current`` -> ``A`` and the like). Those are relative and internal
+    too, and have to stay that way: an absolute one anywhere in that app would
+    fail ``pc upgrade`` on macOS here, while ``install.sh``, which unpacks with
+    the system ``tar``, would not notice.
+
+    What ``filter="data"`` enforces on a modern interpreter is enforced here too,
+    for the older ones this falls back to: a link target may be neither absolute
+    nor a path that climbs out of the archive.
     """
     for member in members:
         if not (member.issym() or member.islnk()):

--- a/tests/partcad/unit/test_openscad.py
+++ b/tests/partcad/unit/test_openscad.py
@@ -6,6 +6,7 @@
 
 import os
 import stat
+import sys
 
 import pytest
 
@@ -50,7 +51,7 @@ def test_bundled_executable_is_none_outside_a_bundle(tmp_path, monkeypatch):
 
 
 def test_bundled_executable_is_none_when_the_bundle_carries_no_payload(bundle):
-    """macOS bundles, and hand-made ones, are built without OpenSCAD."""
+    """Linux arm64 bundles, and hand-made ones, are built without OpenSCAD."""
     assert pc_openscad.find_bundled_executable() is None
 
 
@@ -141,3 +142,29 @@ def test_macos_install_does_not_let_homebrew_update_itself(homebrew):
     pc_openscad.MacOpenSCADCheck().fix()
     _, kwargs = homebrew[0]
     assert kwargs["env"]["HOMEBREW_NO_AUTO_UPDATE"] == "1"
+
+
+# Where each platform's payload sits inside the bundle. Every test above builds
+# its payload from BUNDLED_SUBPATH, so they would all agree with a wrong value;
+# what the layout *is* comes from an artifact none of them has, and on a platform
+# the test run is not on. So all three are pinned here, and `build.sh` stages and
+# asserts the same paths -- a change to one and not the other is a bundle whose
+# OpenSCAD PartCAD cannot find.
+
+
+@pytest.mark.parametrize(
+    "os_name, platform_name, expected",
+    [
+        ("nt", "win32", ("openscad", "openscad.exe")),
+        ("posix", "darwin", ("openscad", "OpenSCAD.app", "Contents", "MacOS", "OpenSCAD")),
+        ("posix", "linux", ("openscad", "AppRun")),
+    ],
+)
+def test_the_payload_layout_is_the_one_build_sh_stages(os_name, platform_name, expected):
+    """macOS keeps the whole '.app': the binary inside needs the bundle around it."""
+    assert pc_openscad.bundled_subpath(os_name, platform_name) == expected
+
+
+def test_the_layout_in_use_is_the_one_for_this_platform():
+    """The module-level constant is that function applied to this process."""
+    assert pc_openscad.BUNDLED_SUBPATH == pc_openscad.bundled_subpath(os.name, sys.platform)


### PR DESCRIPTION
## Copilot Summary

The macOS bundles carried no OpenSCAD, so `pc` there fell back to a host copy — on the platform whose bundle exists for machines with nothing set up. This adds it, on both architectures, and then makes **every** bundle carry the same build, because a bundle-dependent OpenSCAD is a `.scad` part that renders differently depending on where you installed from.

Three commits, each standing on its own.

### 1. macOS bundles carry OpenSCAD

`build.sh` declined macOS because the pinned 2021.01 release ships an x86_64-only `.dmg` (Rosetta 2 on Apple silicon) and left the snapshots as an open question — *"may well be universal binaries, but their architecture has not been confirmed"*.

It is confirmed now, by the check `dev-tools/pyinstaller/README.md` itself named: `lipo -archs` on the mounted `.dmg` prints **`x86_64 arm64`**. One Universal 2 payload serves both Macs.

Staging mounts the `.dmg` at an explicit mount point under `build/` and copies `OpenSCAD.app` out with `ditto`. Not `/Volumes`: the volume is always named `OpenSCAD` with no date in it, and a taken name is silently suffixed (`/Volumes/OpenSCAD 1`) rather than refused, so a second build or a stale mount would have the copy read the wrong image. Detach happens on the failure path too, and deliberately not through a trap — `set -e` unwinding a function does not reliably run a `RETURN` trap, and an `EXIT` trap would displace the smoke test's.

The `.app` is carried entire, not reduced to the binary: it resolves its Qt frameworks through `@executable_path/../Frameworks`, the same reason Linux keeps the whole AppImage tree.

### 2. One version everywhere

macOS on a 2026 snapshot while Linux and Windows sat on the 2021.01 release is the skew this removes. Convergence had to go upward — 2021.01 cannot be the shared version, being x86_64-only and disabled by Homebrew on 2026-09-01 for failing the Gatekeeper check. All bundles now carry **2026.09.05**.

Two facts here contradicted the obvious assumption:

- **The Windows snapshot zip's inner directory is `OpenSCAD-<version>-x86-64`**, named after the zip — where the *release* zips used lowercase `openscad-<version>`. The existing hardcoded name would have matched nothing and staged an empty payload. Now derived from the artifact name.
- **Linux arm64 still carries nothing**, for a new reason: upstream builds no current arm64 snapshot. The only two aarch64 artifacts in the directory are one-offs from 2021 and 2023 under a retired naming scheme.

### 3. One place to choose the builds

The three downloads were spread across the file — version and checksums at the top, artifact names composed in the `case`, base URL inline at the fetch. They are now one `OPENSCAD BUILDS` block carrying the URLs, checksums, version, and the reasoning a bump needs: why one build everywhere (same upstream source, or platforms disagree about what a `.scad` file means), how to find the next qualifying date, and how the three filenames differ. A startup check refuses a URL that does not name `OPENSCAD_VERSION`, so a half-finished bump fails at the top of the build rather than on the one platform nobody rebuilt.

## Known cost, stated deliberately

**This pin expires.** Upstream prunes `snapshots/` on a rolling ~1 year window (143 Linux/Windows builds over 368 days, 119 macOS over 365). Where an expired macOS pin used to break one bundle, it now breaks **every** bundle on every platform, releases included — around September 2027 on this pin.

It fails loudly: a 404, which `fetch_and_verify` does not retry, and `stage_openscad` prints what happened and points at the block. The durable fix is mirroring the three artifacts somewhere the project controls; that is an infrastructure decision and is **not** done here.

Bumping is four values, not one, and the date must be picked from the listing rather than constructed — builds run every ~2.6 days with gaps to 76 days on macOS, so the newest date often has no `.dmg`.

## Not changed

`WindowsOpenSCADCheck` still installs the 2021.01 release onto a Windows *host*. That is a wheel user's machine, where a stable release is the right thing to put, and no bundle reaches that path. The two pins are independent now and the class says so.

## Verification

Upstream is unreachable from the environment this was written in, so the artifact names, checksums, `lipo` output and retention figures were gathered against `files.openscad.org` from a machine that can reach it, rather than assumed.

Run locally:

- `stage_openscad`'s `.dmg` and `.zip` paths driven with stubbed `hdiutil`/`ditto` and a zip built to the real inner-directory layout — macOS stages the `.app` with its Frameworks, Windows lands `openscad.exe` with sibling data directories, Linux arm64 skips cleanly, re-runs no-op, both Macs share one payload
- failure modes: a `ditto` failure detaches and fails; a wrong checksum and a pruned (404) artifact both produce the bump guidance; the drift guard rejects a URL left behind by a partial bump
- the qualifying-date command, against a synthetic listing including the `-Installer.exe`, the `.sha256`/`.sha512` sidecars, a date missing its `.dmg`, and duplicate hrefs
- `fetch_and_verify` in both modes (pinned literal, and the sidecar path conda still uses)
- shellcheck 0.10.0 and check-jsonschema 0.37.4 (the versions `dev-tools/pre-commit-config.yaml` pins), `bash -n` on every workflow `run` block, 280 unit tests
- `black`/`flake8` findings are byte-identical to the pre-existing set on `devel`

**Only CI can answer** whether the signed `.app` survives `ditto` → `tar.xz` → download → untar and still launches, and whether the Linux and Windows snapshots print `OpenSCAD version <date>` for the smoke test's assertion. The `Run the bundled OpenSCAD after installation` step now runs on macOS as well as Linux x86_64 and is what checks the first.

`#deepTest` because this changes what every bundle freezes, and `macos-15-x86_64` is built only on a deep run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117abitj92Advi4z14XXk9q

---
_Generated by [Claude Code](https://claude.ai/code/session_0117abitj92Advi4z14XXk9q)_