### PR TITLE
Ship the agent skills in the wheel, and have `pc init` install them

### DIFF
--- a/.github/actions/changed-scopes/action.yml
+++ b/.github/actions/changed-scopes/action.yml
@@ -19,6 +19,11 @@ description: >
   so a path outside them cannot change what they contain, and an unclassified
   path is by definition outside them.
 
+  The plugin's own directory is the one that is *also* something else: the
+  wheel ships the skills under it, through symlinks in "src/partcad/ai_agents",
+  so "ai-agents/common" and the plugin manifest are source as well and turn on
+  the tests and the wheel too.
+
   Adding a directory to the repository can therefore only ever run too much,
   never too little -- which is the direction a mistake here has to fall.
 
@@ -203,8 +208,17 @@ runs:
               add ci ;;
             .devcontainer/*)
               add devcontainer ;;
+            ai-agents/common/*|ai-agents/claude/.claude-plugin/*)
+              # The library itself: the skills, and the plugin manifest. Two
+              # buckets, because these are the files "src/partcad/ai_agents"
+              # symlinks into the wheel -- a change here changes the plugin
+              # *and* what the wheel and the frozen bundles contain. Named
+              # before the rule below, which would stop at "ai".
+              add ai; add code ;;
             ai-agents/*|.claude-plugin/*)
-              # The Claude Code plugin, which is Markdown and JSON and ships.
+              # The rest of the Claude Code plugin -- the catalog, the
+              # materialization script, the README. Markdown and JSON that ships
+              # as the plugin and nothing else.
               add ai ;;
             .claude/*|.cursor/*|openspec/*)
               # Agent scaffolding for people working in this repository. Nothing

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -63,8 +63,9 @@ jobs:
       # warns that "skills" is a symlink, reads nothing through it, and passes.
       # What gets validated instead is the materialized copy below, whose files
       # are real -- and "tests/partcad_cli/unit/test_ai_agent_skills.py" checks
-      # the front matter of every "SKILL.md" in the pytest run, which is where
-      # a contributor sees it first.
+      # the front matter of every "SKILL.md", and that the two symlinks putting
+      # this library in the wheel still point at it, in the pytest run, which is
+      # where a contributor sees it first.
       - name: Validate the marketplace catalog
         run: claude plugin validate .
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,7 +355,15 @@ the same way, by `.github/workflows/plugin.yml`, and published two ways by `depl
 the release, and the `plugin-dist` branch, which is what `/plugin marketplace add partcad/partcad@plugin-dist`
 reads. It has no version of its own — `plugin.json` is in `dev-tools/bumpversion.toml` like everything else —
 and it must not get one back: it had one, and stayed at 0.1.0 for twenty-three releases because publishing it
-meant remembering a tag nobody pushed. See `ai-agents/README.md`. The snap carries whatever the bundle carries,
+meant remembering a tag nobody pushed. **The skills it is made of also ship in the wheel**, through two symlinks
+under `src/partcad/ai_agents` into `ai-agents/`, because `pc init` installs them into the repository it creates a
+package in and the wheel is what a user has: the plugin for Claude Code, `pc-`-prefixed copies for Cursor. The
+skills stay at the top of the repository where a visitor finds them, and there is one copy of each file.
+So `ai-agents/common` is *both* the plugin and the distribution, which is why `.github/actions/changed-scopes`
+classifies it into both buckets, why `pyproject.toml` and `dev-tools/pyinstaller/partcad.spec` both name it as
+data, and why a new file under a skill has to be covered by the `package-data` patterns or it is simply absent
+from what gets installed. See `ai-agents/README.md`. The snap
+carries whatever the bundle carries,
 so it needs nothing extra of its
 own; `dev-tools/snap/README.md` covers what is specific to it (confinement, aliases, the base, its state directory).
 Its build tooling lives beside that README, but the recipe, `.snapcraft.yaml`, stays at the repository root and

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Subscribe on [LinkedIn], [YouTube], [TikTok], [Facebook], [Instagram], [Threads]
     - [x] `SVG`
 - Tooling for AI agents doing mechanical design
   - [x] Agent Skills any `SKILL.md`-aware coding agent can load ([`ai-agents/`](./ai-agents/README.md)),
-        distributed as the `pc` plugin
+        installed by `pc init`, and distributed as the `pc` plugin
     - [x] Generate a part, an assembly or a 2D sketch (`/pc:gen`, `/pc:gen-part`, `/pc:gen-assembly`,
           `/pc:gen-sketch`) -- the agent authors the CAD script and validates it by rendering
     - [x] Describe an existing object (`/pc:describe`), search the catalog (`/pc:search`), add interfaces
@@ -245,7 +245,10 @@ symlinks, which on Windows means `git config core.symlinks true`), and every
 `claude --plugin-url <url>` loads for a single session, to try one version without installing it.
 
 The skills are plain [Agent Skills](https://code.claude.com/docs/en/skills), so any `SKILL.md`-aware agent can
-read them out of [`ai-agents/`](./ai-agents/README.md) without the plugin.
+read them out of [`ai-agents/`](./ai-agents/README.md) without the plugin. They also ship inside the `partcad`
+wheel, and `pc init` installs them into the repository it creates a package in: the plugin for Claude Code, and
+`pc-`-prefixed skills for Cursor. Pass `--no-skills` to skip it, or `--skills-only` to install them into a
+repository that has a package already.
 
 ### PartCAD IDE
 

--- a/ai-agents/README.md
+++ b/ai-agents/README.md
@@ -5,6 +5,14 @@ are vendor-neutral [Agent Skills](https://code.claude.com/docs/en/skills)
 (`SKILL.md` folders) so any `SKILL.md`-aware agent can consume them; the Claude
 plugin is a thin wrapper that ships the same files to Claude Code.
 
+**These files are also in the `partcad` wheel**, through two symlinks under
+[`src/partcad/ai_agents`](../src/partcad/ai_agents/). The wheel is what a user of
+PartCAD has, and `pc init` installs the skills out of it into the repository it
+just created a package in — so the agent already open in the editor knows how to
+drive PartCAD without anyone first finding this repository, a marketplace, or an
+install command. See *Installed by `pc init`* below. This directory stays the
+one place the skills are edited; nothing is copied.
+
 ## Install
 
 ```text
@@ -39,13 +47,69 @@ ai-agents/
     └── materialize.sh              # publish-time: deref the symlink into real files
 ```
 
-Two more files outside this directory tie it together:
+And, so that the same files reach a user through the wheel:
+
+```
+src/partcad/ai_agents/
+├── __init__.py                                              # what `pc init` calls
+├── skills      -> ../../../ai-agents/common/skills          # symlink
+└── plugin.json -> ../../../ai-agents/claude/.claude-plugin/plugin.json
+```
+
+Two symlinks and no copies. `setuptools` resolves a symlink that is a path
+*component* and stores what it finds as an ordinary file, so the wheel and the
+sdist carry real files and contain no symlinks at all —
+`[tool.setuptools.package-data]` in `pyproject.toml` says which patterns, and
+`dev-tools/pyinstaller/partcad.spec` names the same files again (from
+`ai-agents/`, since a frozen bundle does not read `package-data` and should not
+depend on a symlink having been materialized). The manifest lands flat, as
+`plugin.json`, so that the wheel carries no dot-directory; `pc init` writes it
+back into a `.claude-plugin/` when it installs.
+
+What this buys is that the plugin and the wheel cannot ship different skills,
+and that a skill is edited in exactly one place: here.
+
+Two more files outside these directories tie it together:
 
 - `../.claude-plugin/marketplace.json` — top-level catalog (for discoverability),
   lists `pc` with `source: ./ai-agents/claude`.
 - `../.claude/skills/pc -> ../../ai-agents/claude` — makes Claude auto-discover
   the plugin as `pc@skills-dir` when this repo is opened as the workspace, so
   `/pc:init` is available with no install step.
+
+## Installed by `pc init`
+
+`pc init` creates a package and then installs these skills into the repository
+holding it — the same root it writes `.vscode/launch.json` into, because that is
+what an editor opens as its workspace. `pc init --no-skills` skips it, and
+`pc init --skills-only` does this and nothing else, which is how a repository
+that already has a package gets them (or gets a newer PartCAD's).
+`src/partcad/ai_agents/__init__.py` is the whole of it, and it reads the files
+out of the *installed* PartCAD, not out of a checkout. The two agents do **not**
+get the same thing:
+
+- **Claude Code** gets the *plugin*: `.claude/skills/pc/`, a manifest plus every
+  skill under it. A directory there holding a `.claude-plugin/plugin.json` is
+  loaded as a plugin, which is what puts the skills in one namespace —
+  `/pc:init`, not `/init` — and it is the same `pc` a marketplace install
+  produces, so a project with both does not end up with two spellings of one
+  skill. The `SKILL.md` files are copied byte for byte.
+- **Cursor** gets loose skills, because it has no plugin to namespace anything:
+  `.cursor/skills/pc-init/`, `pc-gen/`, `pc-render/` and so on. Shipped as they
+  are, PartCAD would be claiming `init`, `gen`, `render`, `search` and `export`
+  in a user's skills directory. So the prefix is applied to the directory *and*
+  to the `name` in the front matter (which has to match it), and the
+  `pc:<skill>` cross-references in the text are rewritten to match — a skill
+  that tells the agent to run `/pc:setup` where that resolves to nothing is
+  worse than one that says nothing. Only names that are actually shipped are
+  rewritten, so the `pc render` and `pc adhoc convert` command lines these files
+  are full of are left alone.
+
+Neither destination is written through a symlink, and this repository is why:
+`.claude/skills/pc` here points at `ai-agents/claude`, so following it would
+have `pc init` overwrite the working tree with a copy of the installed PartCAD.
+Everything installed is namespaced, so a re-run updates PartCAD's own skills and
+touches nothing else in those directories.
 
 The plugin folder is named `claude`, but the command namespace comes from
 `plugin.json`'s `name` field (`pc`), so skills invoke as `/pc:<skill>`.
@@ -232,11 +296,22 @@ front matter, or with a `name` that does not match its directory, would get as
 far as whoever installed the plugin. The pytest run reads every one of them for
 real, on commit.
 
+It also covers the half no plugin tooling can see: that the symlinks under
+`src/partcad/ai_agents` still point here, and that every file in the library
+matches a `package-data` pattern. A pattern that misses one produces a wheel
+where `pc init` installs a skill that is not there — and nothing else would
+notice, since a test run from a checkout finds every file on disk whether it was
+packaged or not. `tests/partcad/unit/test_ai_agents.py` covers the installation
+itself.
+
 ## Windows contributors
 
 If local discovery or a build produces a `skills` file containing the text
 `../common/skills` instead of a directory, git did not materialize the symlink.
-Enable symlinks and re-checkout:
+The same goes for the two under `src/partcad/ai_agents`, and there it is a wheel
+built from that checkout that comes out short. (The frozen bundles do not care:
+`partcad.spec` names the files under `ai-agents/` directly.) Enable symlinks and
+re-checkout:
 
 ```bash
 git config core.symlinks true

--- a/ai-agents/scripts/materialize.sh
+++ b/ai-agents/scripts/materialize.sh
@@ -10,6 +10,11 @@
 # empty plugin. This script dereferences the symlink into real files so the
 # published artifact contains no symlinks at all.
 #
+# The same library is in the "partcad" wheel, which "pc init" installs it out
+# of: "src/partcad/ai_agents" symlinks into this directory. Nothing here needs
+# to know about that -- setuptools resolves those symlinks itself -- but it is
+# why a skill added here also changes the wheel.
+#
 # Requires no credentials. `claude plugin validate` runs fully offline.
 #
 # Usage:
@@ -99,6 +104,9 @@ claude plugin validate "$OUT_DIR"
 # directories are not read through symlinks, and "skills" there is one -- so it
 # warns and passes over a "SKILL.md" with no front matter. Here the files are
 # real, so this is the first time anything looks at them.
+#
+# (`pytest tests/partcad_cli/unit/test_ai_agent_skills.py` reads them for real
+# too, on every commit, which is where a contributor sees it first.)
 echo "==> Validating materialized plugin"
 claude plugin validate "$OUT_DIR/$PLUGIN_NAME"
 

--- a/dev-tools/bumpversion.toml
+++ b/dev-tools/bumpversion.toml
@@ -141,6 +141,12 @@ replace = "version\": \"{new_version}\""
 # at the 0.1.0 it was created with while everything around it moved, which is
 # exactly the failure the comment at the top of this file describes. It is one
 # artifact of one release now, and states that release.
+#
+# It ships twice over: this file is also what the wheel carries, through
+# `src/partcad/ai_agents/plugin.json`, so that `pc init` can install the plugin
+# out of an ordinary PartCAD installation. Named here at the path it really
+# lives at -- writing a version through a symlink is not something to depend on
+# a tool doing.
 [[tool.bumpversion.files]]
 filename = "ai-agents/claude/.claude-plugin/plugin.json"
 search = "\"version\": \"{current_version}\""

--- a/dev-tools/pyinstaller/partcad.spec
+++ b/dev-tools/pyinstaller/partcad.spec
@@ -141,6 +141,20 @@ datas += [
     (str(SRC / "partcad" / "builtin"), "partcad/builtin"),
     # Copied into new packages by `pc init`.
     (str(SRC / "partcad" / "template"), "partcad/template"),
+    # Also `pc init`: the AI agent skills and the Claude plugin manifest it
+    # installs into the repository around the new package. Markdown and JSON,
+    # copied out to disk, so they have to be files here too -- and the bundle is
+    # the install that needs them most, since it is the one whose user has no
+    # Python and therefore no other copy of them anywhere.
+    #
+    # Named at the paths the files really live at, under "ai-agents", rather
+    # than through the two symlinks in "src/partcad/ai_agents" that put them in
+    # the wheel. The destinations are what those symlinks are called, because
+    # that is where "partcad.ai_agents" reads them from. A checkout that did not
+    # materialize a symlink (Windows, without "core.symlinks") therefore still
+    # freezes a complete bundle.
+    (str(REPO_ROOT / "ai-agents" / "common" / "skills"), "partcad/ai_agents/skills"),
+    (str(REPO_ROOT / "ai-agents" / "claude" / ".claude-plugin" / "plugin.json"), "partcad/ai_agents"),
     # Read through `importlib.resources` by `pc lint`. Both schemas -- the ASSY
     # one and the `partcad.yaml` one -- are in `partcad_utils` because both ends
     # check both kinds of file: the daemon over a package, `pc lint --file` in

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -172,6 +172,16 @@ Package commands
   Create a new PartCAD package (a ``partcad.yaml`` file) in the current directory. Use ``-i`` for interactive
   mode, and options such as ``--desc``, ``--url``, and ``--manufacturable`` to prefill package metadata.
 
+  It also sets up the repository the package is in: a **Render** command in ``.vscode/launch.json``, and the
+  AI agent skills that teach a coding agent to drive PartCAD -- the ``pc`` plugin in
+  ``.claude/skills/`` for Claude Code, and ``pc-``-prefixed skills in ``.cursor/skills/`` for Cursor. Both come
+  out of the installed PartCAD, so they state the version that wrote them. Neither is a reason for the command
+  to fail.
+
+  ``--no-skills`` skips the skills. ``--skills-only`` installs *just* them and touches no package at all, which
+  is how a repository that has a package already gets them, or gets a newer PartCAD's -- there is nothing to
+  create, so an existing ``partcad.yaml`` is neither read nor replaced.
+
 ``pc install``
   Download everything the current package needs to be built - the PartCAD counterpart of ``npm install``.
   It fetches all imported packages, then prepares every sketch, part and assembly by computing its cache key:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -879,6 +879,8 @@ and turns each subject on or off:
      - ``Documentation``
    * - ``ai-agents/``, ``.claude-plugin/``
      - ``Claude Code plugin``
+   * - ``ai-agents/common/``, ``ai-agents/claude/.claude-plugin/``
+     - ``Claude Code plugin``, **and** the tests and the wheel -- the wheel ships the skills too
    * - ``.devcontainer/``
      - the ``CI-Dev`` container, ``Run: behave`` and ``Run: pc`` -- but not ``Run: pytest``
    * - ``ide/vscode/``, ``ide/vscode-shim/``
@@ -901,8 +903,9 @@ one that matches a path wins**, and the two orders are not the same -- ``.github
 the first rule there. What matters is the shape of that list: every rule that names a *directory* comes before
 every rule that matches by *extension*.
 
-So a Markdown file belongs to whatever directory claims it first. ``ai-agents/skills/render/SKILL.md`` is the
-plugin rather than prose about it, and ``examples/feature_render/README.md`` is what ``pc render -r`` wrote and
+So a Markdown file belongs to whatever directory claims it first. ``ai-agents/common/skills/render/SKILL.md``
+is the plugin -- and, since ``src/partcad/ai_agents`` symlinks it into the wheel, the wheel -- rather than prose
+about either, and ``examples/feature_render/README.md`` is what ``pc render -r`` wrote and
 what the ``Examples (PartCAD)`` job compares against a fresh render; neither is documentation.
 
 ``AGENTS.md`` and ``CLAUDE.md`` are matched ahead of the *source* directories, which is why

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -46,6 +46,8 @@ The plugin is versioned with everything else in the release that publishes it, s
   The skills are plain `Agent Skills <https://code.claude.com/docs/en/skills>`_ -- a directory of
   ``SKILL.md`` files -- and the plugin is a thin wrapper that ships them to Claude Code. Any other agent
   that reads ``SKILL.md`` can use the same library, from ``ai-agents/common/skills`` in the repository.
+  It also ships inside the ``partcad`` wheel, and ``pc init`` installs it into the repository it
+  creates a package in -- so there is nothing to install here if you have PartCAD already.
 
 ==================
 Command line tools

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -24,6 +24,14 @@ repository it is run in (next to the package, when there is no repository). It s
 it renders the package the same way ``pc render`` does from a terminal. An existing
 ``launch.json``, with commands and comments of your own in it, is added to rather than replaced.
 
+Into the same directory it installs the **AI agent skills** -- what teaches a coding agent to drive
+PartCAD rather than guess at it. Claude Code gets the ``pc`` plugin, in ``.claude/skills/``, so the
+skills are ``/pc:gen-part``, ``/pc:render`` and the rest; Cursor, which has no plugin to namespace
+them, gets the same skills in ``.cursor/skills/`` named ``pc-gen-part``, ``pc-render`` and so on.
+They come from the PartCAD you have installed, so they always match it. Pass ``--no-skills`` if you
+would rather not have them, and ``pc init --skills-only`` to install them into a package you created
+before this version -- that touches nothing else.
+
 Alternatively, manually create ``partcad.yaml`` with the following content:
 
   .. code-block:: yaml

--- a/features/init.feature
+++ b/features/init.feature
@@ -49,6 +49,59 @@ Feature: `pc init` command
     And the file ".vscode/launch.json" should hold the "Render" run command
     And STDERR should contain "Added the 'Render' command"
 
+  @pc-init @agent-skills
+  Scenario: Install the AI agent skills the repository's agent will need
+    Given a file named "partcad.yaml" does not exist
+    When I run "pc --no-ansi init"
+    Then the command should exit with a status code of "0"
+    # Claude Code gets the plugin, which is what puts the skills in one
+    # namespace: "/pc:init" rather than "/init".
+    And a file named ".claude/skills/pc/.claude-plugin/plugin.json" should be created
+    And a file named ".claude/skills/pc/skills/init/SKILL.md" should be created
+    # Cursor has no plugin, so the prefix is the namespace.
+    And a file named ".cursor/skills/pc-init/SKILL.md" should be created
+    And a file named ".cursor/skills/init/SKILL.md" should not exist
+    And the skill "pc-init" should be named after its directory
+    And STDERR should contain "Installed the 'pc' plugin"
+
+  @pc-init @agent-skills @skills-only
+  Scenario: Install the skills into a repository that has a package already
+    # The package this would have created exists, which is the usual reason to
+    # want this: the skills came from the "pc init" that created it, and a newer
+    # PartCAD has newer ones.
+    Given a file named "partcad.yaml" does not exist
+    When I run "pc --no-ansi init"
+    Then the command should exit with a status code of "0"
+    When I run "pc --no-ansi init --skills-only"
+    Then the command should exit with a status code of "0"
+    And STDERR should not contain "File already exists"
+    And a file named ".cursor/skills/pc-init/SKILL.md" should be created
+
+  @pc-init @agent-skills @skills-only
+  Scenario: Install the skills where there is no package at all
+    Given a file named "partcad.yaml" does not exist
+    When I run "pc --no-ansi init --skills-only"
+    Then the command should exit with a status code of "0"
+    And a file named ".claude/skills/pc/.claude-plugin/plugin.json" should be created
+    And a file named "partcad.yaml" should not exist
+    And a file named ".vscode/launch.json" should not exist
+
+  @pc-init @agent-skills @skills-only @failure
+  Scenario: Ask for the skills and for no skills at once
+    When I run "pc --no-ansi init --skills-only --no-skills"
+    Then the command should exit with a status code of "1"
+    And STDERR should contain "ask for opposite things"
+    And a directory named ".cursor" should not exist
+
+  @pc-init @agent-skills
+  Scenario: Create a package without them
+    Given a file named "partcad.yaml" does not exist
+    When I run "pc --no-ansi init --no-skills"
+    Then the command should exit with a status code of "0"
+    And a file named "partcad.yaml" should be created
+    And a directory named ".claude" should not exist
+    And a directory named ".cursor" should not exist
+
   @pc-init @option-private @failure
   Scenario: Fail initializing package when `partcad.yaml`already exists
     Given a file named "partcad.yaml" does not exist

--- a/features/steps/partcad-cli/commands/init.py
+++ b/features/steps/partcad-cli/commands/init.py
@@ -50,6 +50,31 @@ def step_impl(context, filename):
         raise Exception(f"File '{filename}' was created")
 
 
+@then('a directory named "{directory}" should not exist')
+def step_impl(context, directory):
+    path = os.path.join(context.test_dir, directory)
+    assert not os.path.exists(path), f"'{directory}' was created"
+
+
+@then('the skill "{name}" should be named after its directory')
+def step_impl(context, name):
+    """A skill answers to the name in its front matter, not to its directory.
+
+    The Cursor copies are installed under a `pc-` prefix -- unprefixed, PartCAD
+    would be claiming `init`, `gen` and `render` in a user's skills directory --
+    and the front matter has to be rewritten to match or the skill answers to a
+    command nobody typed.
+    """
+    path = os.path.join(context.test_dir, ".cursor", "skills", name, "SKILL.md")
+    assert os.path.isfile(path), f"'{name}' was not installed"
+
+    with open(path, "r", encoding="utf-8") as file:
+        text = file.read()
+    assert text.startswith("---\n"), f"'{name}' has no front matter"
+    front_matter = yaml.safe_load(text[4 : text.index("\n---", 3)])
+    assert front_matter.get("name") == name, f"'{name}' names itself {front_matter.get('name')!r}"
+
+
 @given('a file named "{filename}" does not exist')
 def step_impl(context, filename):
     file_path = os.path.join(context.test_dir, filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,24 @@ aws = {file = ["requirements-aws.txt"]}
 "partcad.builtin.export" = ["*.py", "*.yaml"]
 "partcad.builtin.render" = ["*.py", "*.yaml"]
 "partcad.template" = ["*.yaml"]
+# The AI agent skills and the Claude plugin manifest `pc init` installs into a
+# repository (see `src/partcad/ai_agents/__init__.py`). They are data rather
+# than code -- Markdown and JSON, read and copied -- and they have to be in the
+# wheel, because the wheel is what a user of PartCAD has.
+#
+# They are also the plugin Claude Code's marketplace publishes, and they stay at
+# the top of the repository where a visitor finds them: `ai-agents/`. What is
+# under `src/partcad/ai_agents/` is two symlinks into it -- `skills` and
+# `plugin.json` -- so there is one copy of each file and the wheel and the
+# plugin cannot ship different skills.
+#
+# The patterns below are matched with `glob`, which resolves a symlink that is a
+# path *component*: `skills/` is followed, and the directories inside it are
+# real, so `**` recurses through them normally. A `SKILL.md` and anything a
+# skill carries beside it are both picked up. `tests/partcad_cli/unit/
+# test_ai_agent_skills.py` checks that every file in the library matches one of
+# these, since a file that does not is simply absent from the install.
+"partcad.ai_agents" = ["skills/**/*", "plugin.json"]
 # The schemas `partcad_utils.assy_lint` validates against: the ASSY one and the
 # `partcad.yaml` one. Both live in `partcad_utils` because both ends check both
 # kinds of file -- the daemon over a package, every client over the one file

--- a/src/partcad/__init__.py
+++ b/src/partcad/__init__.py
@@ -99,6 +99,7 @@ from . import plugin  # noqa: F401
 # anyway because 'shape' imports it, and that is exactly the dependency the
 # 'plugin' line above exists not to have.
 from . import cae  # noqa: F401
+from .ai_agents import install_agent_skills
 from .assembly import Assembly
 from .assembly_connect import ConnectHold, ConnectHow
 from .consts import *
@@ -190,6 +191,7 @@ __all__ = [
     "get_scene_build123d",
     "healthcheck",
     "init",
+    "install_agent_skills",
     "logging",
     "part",
     "shape",

--- a/src/partcad/ai_agents/__init__.py
+++ b/src/partcad/ai_agents/__init__.py
@@ -1,0 +1,269 @@
+#
+# PartCAD, 2026
+#
+# Author: PartCAD (support@partcad.org)
+# Created: 2026-09-08
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""The AI agent skills PartCAD ships, and where `pc init` puts them.
+
+The skills live at the top of the repository, in `ai-agents/`, where a visitor
+finds them and where the Claude plugin is published from. `skills` and
+`plugin.json` in *this* directory are symlinks into it, and they are what puts
+the library in the wheel -- because the wheel is what a user of PartCAD has.
+`pc init` creates a package and then installs the skills beside it, so the agent
+already open in the editor knows how to drive PartCAD without anyone first
+finding a repository, a marketplace or an install command.
+
+Nothing is a second copy, in either direction. `setuptools` resolves a symlink
+that is a path component and stores what it finds as an ordinary file, so the
+wheel, the sdist and the frozen bundle all carry real files; `pyproject.toml`
+says which patterns, and a test fails if a file in the library matches none of
+them. What the plugin ships and what the wheel ships cannot drift, because they
+are the same files.
+
+Two consumers, and they are not given the same thing:
+
+  * **Claude Code** gets the *plugin*, written into `.claude/skills/pc/` as a
+    manifest plus the skills under it. A directory there holding a
+    `.claude-plugin/plugin.json` is loaded as a plugin, which is what puts every
+    skill in one namespace: `/pc:init`, not `/init`. The name comes from the
+    manifest, so it is the same `pc` a marketplace install produces, and a
+    project that has both does not end up with two spellings of one skill.
+
+  * **Cursor** has no plugin to namespace anything, so a skill is whatever its
+    directory is called. `init`, `gen`, `render`, `search`, `export` -- shipped
+    as they are, PartCAD would be claiming five of the most generic names in a
+    user's `.cursor/skills`. They are installed prefixed instead, as `pc-init`
+    and its siblings, and the `pc:<skill>` cross-references in the text are
+    rewritten to match: a skill that tells the agent to run `/pc:setup` in an
+    editor where that resolves to nothing is worse than one that says nothing.
+
+Neither destination is written through a symlink. `.claude/skills/pc` is a
+symlink in PartCAD's own repository -- to `ai-agents/claude`, so that a session
+opened here loads the plugin from the working tree -- and following it would
+have `pc init` overwrite the source tree with a copy of itself.
+"""
+
+import json
+import os
+import re
+import shutil
+from typing import Optional
+
+from .. import logging as pc_logging
+from ..launch_config import find_repository_root
+
+# Read out of this package rather than out of the repository, because in every
+# install except a checkout there is no repository: `pyproject.toml` lists these
+# two under `[tool.setuptools.package-data]`, and
+# `dev-tools/pyinstaller/partcad.spec` lists them again for the frozen bundle,
+# which does not read `package-data`. In a checkout they are the symlinks, which
+# resolve to the same files.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+SKILLS_DIR = os.path.join(_HERE, "skills")
+
+# The Claude plugin manifest. Flat here, and written into a `.claude-plugin/`
+# directory at install time, so that the wheel carries no dot-directory: in the
+# repository it is `ai-agents/claude/.claude-plugin/plugin.json`, which is where
+# `dev-tools/bumpversion.toml` moves its version with every other version.
+CLAUDE_PLUGIN_MANIFEST = os.path.join(_HERE, "plugin.json")
+
+# Where each editor looks. Relative to the repository the package was created
+# in, which is what an editor opens as its workspace -- the same root
+# `add_render_configuration` writes `.vscode/launch.json` into.
+CLAUDE_SKILLS_DIR = os.path.join(".claude", "skills")
+CURSOR_SKILLS_DIR = os.path.join(".cursor", "skills")
+
+# The manifest directory Claude Code identifies a plugin by.
+CLAUDE_PLUGIN_DIR = ".claude-plugin"
+
+# What a Cursor skill of ours is called, and what the plugin calls it. The
+# prefix is the plugin's name because they are the same skill: `/pc:init` in
+# Claude Code is `pc-init` in Cursor.
+CURSOR_PREFIX = "pc-"
+
+
+def plugin_manifest() -> dict:
+    """The Claude plugin manifest, as shipped."""
+    with open(CLAUDE_PLUGIN_MANIFEST, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def plugin_name() -> str:
+    """The name Claude Code loads the plugin under, and the `/<name>:` prefix."""
+    return plugin_manifest()["name"]
+
+
+def available_skills() -> list[str]:
+    """Every skill in the wheel, by directory name -- which is also its name."""
+    if not os.path.isdir(SKILLS_DIR):
+        return []
+    return sorted(name for name in os.listdir(SKILLS_DIR) if os.path.isfile(os.path.join(SKILLS_DIR, name, "SKILL.md")))
+
+
+def _front_matter_bounds(text: str) -> Optional[tuple[int, int]]:
+    """The offsets of the YAML front matter body, or None if there is none.
+
+    Front matter is the block between the first two `---` lines, and it has to
+    start at the very beginning of the file -- a `---` further down is a
+    horizontal rule.
+    """
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    return 4, end + 1
+
+
+def rename_skill(text: str, name: str, skills: list[str]) -> str:
+    """Return `text` as the skill `name`, for an agent with no plugin namespace.
+
+    Two things change, and only these two. The `name` in the front matter, which
+    has to match the directory the skill is installed in or it answers to a
+    command nobody typed. And every `pc:<skill>` in the text -- `/pc:setup` in
+    prose, `# pc:init` as a title -- which names a skill through the plugin
+    namespace that does not exist here.
+
+    `skills` is what makes the second one safe: only the names actually shipped
+    are rewritten, so a `pc:` that is something else, and the `pc render` and
+    `pc adhoc convert` command lines that fill these files, are left alone.
+    """
+    bounds = _front_matter_bounds(text)
+    if bounds is not None:
+        start, end = bounds
+        front_matter = re.sub(
+            r"^name:[ \t]*\S.*$",
+            "name: %s" % name,
+            text[start:end],
+            count=1,
+            flags=re.MULTILINE,
+        )
+        text = text[:start] + front_matter + text[end:]
+
+    if skills:
+        text = re.sub(
+            r"\bpc:(%s)\b" % "|".join(re.escape(skill) for skill in sorted(skills, key=len, reverse=True)),
+            lambda match: CURSOR_PREFIX + match.group(1),
+            text,
+        )
+
+    return text
+
+
+def _writable_destination(path: str, what: str) -> bool:
+    """Whether `path` is ours to write, reporting why when it is not.
+
+    A symlink is never followed. PartCAD's own repository has
+    `.claude/skills/pc -> ../../ai-agents/claude`, so `pc init` run in a
+    checkout would otherwise replace the working tree's plugin with a copy of
+    the installed one -- and any user who symlinked one of these at a shared
+    directory means it to stay a symlink.
+    """
+    if os.path.islink(path):
+        pc_logging.warning("Not installing %s: '%s' is a symbolic link" % (what, path))
+        return False
+    if os.path.exists(path) and not os.path.isdir(path):
+        pc_logging.warning("Not installing %s: '%s' is not a directory" % (what, path))
+        return False
+    return True
+
+
+def install_claude_plugin(root: str) -> bool:
+    """Install the skills into `root` as the Claude Code plugin.
+
+    Written as `.claude/skills/<plugin>/`, holding the manifest and a copy of
+    every skill. Returns True when the plugin was written.
+    """
+    name = plugin_name()
+    destination = os.path.join(root, CLAUDE_SKILLS_DIR, name)
+    if not _writable_destination(destination, "the Claude plugin"):
+        return False
+
+    skills = available_skills()
+    if not skills:
+        pc_logging.warning("Not installing the Claude plugin: no skills are installed with PartCAD")
+        return False
+
+    try:
+        os.makedirs(os.path.join(destination, CLAUDE_PLUGIN_DIR), exist_ok=True)
+        shutil.copyfile(CLAUDE_PLUGIN_MANIFEST, os.path.join(destination, CLAUDE_PLUGIN_DIR, "plugin.json"))
+        for skill in skills:
+            # Copied whole: a skill is a directory, and the ones that grow a
+            # `references/` or a script beside the `SKILL.md` have to keep them.
+            target = os.path.join(destination, "skills", skill)
+            shutil.rmtree(target, ignore_errors=True)
+            shutil.copytree(os.path.join(SKILLS_DIR, skill), target)
+    except OSError as e:
+        pc_logging.warning("Failed to install the Claude plugin into '%s': %s" % (destination, e))
+        return False
+
+    pc_logging.info("Installed the '%s' plugin (%d skills) into '%s'" % (name, len(skills), destination))
+    return True
+
+
+def install_cursor_skills(root: str) -> bool:
+    """Install the skills into `root` for Cursor, prefixed and renamed.
+
+    One directory per skill under `.cursor/skills`, named `pc-<skill>`. Returns
+    True when at least one skill was written.
+    """
+    destination = os.path.join(root, CURSOR_SKILLS_DIR)
+    if not _writable_destination(destination, "the Cursor skills"):
+        return False
+
+    skills = available_skills()
+    if not skills:
+        pc_logging.warning("Not installing the Cursor skills: no skills are installed with PartCAD")
+        return False
+
+    installed = 0
+    for skill in skills:
+        name = CURSOR_PREFIX + skill
+        target = os.path.join(destination, name)
+        if os.path.islink(target):
+            pc_logging.warning("Not installing '%s': '%s' is a symbolic link" % (name, target))
+            continue
+        try:
+            source = os.path.join(SKILLS_DIR, skill)
+            shutil.rmtree(target, ignore_errors=True)
+            # The whole directory, then the one file that has to be rewritten --
+            # so anything a skill carries beside its `SKILL.md` comes along.
+            shutil.copytree(source, target)
+            with open(os.path.join(source, "SKILL.md"), "r", encoding="utf-8") as f:
+                text = f.read()
+            with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8", newline="\n") as f:
+                f.write(rename_skill(text, name, skills))
+        except OSError as e:
+            pc_logging.warning("Failed to install '%s' into '%s': %s" % (name, target, e))
+            continue
+        installed += 1
+
+    if not installed:
+        return False
+
+    pc_logging.info("Installed %d skills into '%s' as '%s*'" % (installed, destination, CURSOR_PREFIX))
+    return True
+
+
+def install_agent_skills(package_dir: str = ".") -> bool:
+    """Install the skills for every agent, beside the package in `package_dir`.
+
+    The files go to the root of the git repository holding the package, because
+    that is what an editor opens as its workspace; when the package is not in a
+    repository, they go next to the package itself. This is the same root
+    `add_render_configuration` writes into, and for the same reason.
+
+    Returns True when anything was installed. Nothing here is a reason for
+    `pc init` to fail -- the package is created either way -- so every failure
+    is reported and returns False.
+    """
+    root = find_repository_root(package_dir) or os.path.abspath(package_dir)
+    # `or` short-circuits, and both of these have to run.
+    claude = install_claude_plugin(root)
+    cursor = install_cursor_skills(root)
+    return claude or cursor

--- a/src/partcad/ai_agents/plugin.json
+++ b/src/partcad/ai_agents/plugin.json
@@ -1,0 +1,1 @@
+../../../ai-agents/claude/.claude-plugin/plugin.json

--- a/src/partcad/ai_agents/skills
+++ b/src/partcad/ai_agents/skills
@@ -1,0 +1,1 @@
+../../../ai-agents/common/skills

--- a/src/partcad_cli/click/commands/init.py
+++ b/src/partcad_cli/click/commands/init.py
@@ -102,6 +102,21 @@ class DynamicPromptOption(click.Option):
     show_envvar=True,
 )
 @click.option(
+    "--skills/--no-skills",
+    "skills",
+    is_flag=True,
+    default=True,
+    show_envvar=True,
+    help="Install the PartCAD AI agent skills into this repository",
+)
+@click.option(
+    "--skills-only",
+    is_flag=True,
+    default=False,
+    show_envvar=True,
+    help="Install the AI agent skills only, leaving any package alone",
+)
+@click.option(
     "-p",
     "--private",
     is_flag=True,
@@ -125,6 +140,27 @@ def cli(cli_ctx: CliContext, click_ctx: click.rich_context.RichContext, **kwargs
         else:
             dst_path = "partcad.yaml"
 
+        # None of these is part of the package configuration: "interactive"
+        # decided how the options above were collected, and the other two are
+        # about the repository around the package rather than the package.
+        install_skills = kwargs.pop("skills")
+        skills_only = kwargs.pop("skills_only")
+
+        if skills_only:
+            # The whole command, for a repository that has a package already --
+            # which is the common case for this, since the skills are installed
+            # by the "pc init" that created it. Nothing is written to
+            # "partcad.yaml", so an existing one is neither read nor replaced,
+            # and the package need not exist at all.
+            if not install_skills:
+                pc.logging.error("'--skills-only' and '--no-skills' ask for opposite things")
+                return
+            if not pc.install_agent_skills(os.path.dirname(os.path.abspath(dst_path))):
+                # An error here, unlike below: installing them is the whole of
+                # what was asked for, so there is nothing left that succeeded.
+                pc.logging.error("Failed installing the AI agent skills!")
+            return
+
         if kwargs.get("interactive"):
             pc.logging.info("Validating package configuration...")
             for key in kwargs:
@@ -144,6 +180,8 @@ def cli(cli_ctx: CliContext, click_ctx: click.rich_context.RichContext, **kwargs
                 return
 
         pc.logging.info(f"Creating package configuration at '{dst_path}'...")
+        # "interactive" decided how the options above were collected; it is not
+        # part of the package configuration either.
         config_options = {key: value for key, value in kwargs.items() if key != "interactive"}
         if pc.create_package(dst_path, config_options):
             pc.logging.info(f"Successfully created package at '{dst_path}'")
@@ -151,6 +189,13 @@ def cli(cli_ctx: CliContext, click_ctx: click.rich_context.RichContext, **kwargs
             # "Render" command, in the launch configuration of the repository
             # this was run in. It reports what it did, and a failure to add it
             # is not a failure to create the package.
-            pc.add_render_configuration(os.path.dirname(os.path.abspath(dst_path)))
+            package_dir = os.path.dirname(os.path.abspath(dst_path))
+            pc.add_render_configuration(package_dir)
+            # And what the agent in the editor needs to press it: the skills
+            # that teach it to drive PartCAD, for Claude Code and for Cursor.
+            # Reported the same way, and a failure to install them is not a
+            # failure to create the package either.
+            if install_skills:
+                pc.install_agent_skills(package_dir)
         else:
             pc.logging.error(f"Failed creating '{dst_path}'!")

--- a/tests/dev_tools/test_changed_scopes.py
+++ b/tests/dev_tools/test_changed_scopes.py
@@ -217,8 +217,9 @@ def test_only_the_root_dependency_files_are_dependencies(tmp_path, path):
         (".claude/skills/steward/SKILL.md", "docs"),
         ("openspec/whatever.md", "docs"),
         # The Claude Code plugin, which is Markdown that ships.
-        ("ai-agents/common/skills/render/SKILL.md", "ai"),
         (".claude-plugin/marketplace.json", "ai"),
+        ("ai-agents/scripts/materialize.sh", "ai"),
+        ("ai-agents/README.md", "ai"),
         # The dev container.
         (".devcontainer/devcontainer.json", "devcontainer"),
         # The editor.
@@ -263,9 +264,27 @@ def test_documentation_alone_runs_only_the_documentation(tmp_path):
 
 
 def test_the_plugin_alone_runs_only_the_plugin(tmp_path):
-    subjects, _ = classify(tmp_path, ["ai-agents/common/skills/render/SKILL.md"])
+    subjects, _ = classify(tmp_path, ["ai-agents/scripts/materialize.sh"])
     assert subjects["plugin"]
     assert not any(v for k, v in subjects.items() if k != "plugin"), subjects
+
+
+def test_a_skill_is_the_plugin_and_the_wheel_both(tmp_path):
+    """The skills are shipped *in* the wheel, so they are source as well.
+
+    They are the one thing in this repository that two subjects are built out
+    of -- "src/partcad/ai_agents" symlinks into "ai-agents/common" -- and the
+    rule for them sits above the general "ai-agents/*" one for that reason:
+    matched there instead, a new skill would be validated as a plugin by a run
+    that never built it into a wheel.
+    """
+    _, buckets = classify(tmp_path, ["ai-agents/common/skills/render/SKILL.md"])
+    assert buckets == {"ai", "code"}
+
+    subjects, _ = classify(tmp_path, ["ai-agents/claude/.claude-plugin/plugin.json"])
+    assert subjects["plugin"]
+    assert subjects["wheel"]
+    assert subjects["pytest"]
 
 
 def test_the_dev_container_alone_runs_it_but_not_pytest_inside_it(tmp_path):
@@ -334,6 +353,10 @@ def test_every_top_level_entry_is_classified_deliberately(tmp_path):
         "CLAUDE.md": {"docs"},
         "LICENSE.txt": {"docs"},
         "README.md": {"docs"},
+        # Split: "ai-agents/common" and the plugin manifest are in the wheel
+        # too (see the test above); the rest of the directory is the plugin
+        # alone. "ai-agents/file.txt", which the loop below probes with, is the
+        # latter.
         "ai-agents": {"ai"},
         "apache20.svg": {"docs"},
         "behave.ini": {"code"},

--- a/tests/partcad/unit/test_ai_agents.py
+++ b/tests/partcad/unit/test_ai_agents.py
@@ -1,0 +1,257 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""Tests for the AI agent skills ``pc init`` installs into a repository.
+
+The skills themselves are checked by
+``tests/partcad_cli/unit/test_ai_agent_skills.py`` -- front matter, names,
+whether they are in the wheel at all. What is checked here is the installation:
+where the files land, what the two agents get (they do not get the same thing),
+and what is refused rather than overwritten.
+"""
+
+import json
+import os
+
+import pytest
+import yaml
+
+import partcad.ai_agents as ai_agents
+
+
+def read_front_matter(path):
+    """The skill's YAML front matter, parsed the way a session loading it would."""
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    return yaml.safe_load(text[4 : text.index("\n---", 3)])
+
+
+@pytest.fixture
+def repository(tmp_path):
+    """A git repository, as far as anything here can tell."""
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def test_the_wheel_carries_the_skills():
+    """Everything below is a way of copying these; there have to be some."""
+    assert ai_agents.available_skills()
+    assert os.path.isfile(ai_agents.CLAUDE_PLUGIN_MANIFEST)
+
+
+def test_claude_gets_a_plugin_rather_than_loose_skills(tmp_path):
+    """The manifest is what puts every skill under one `/pc:` namespace."""
+    assert ai_agents.install_claude_plugin(str(tmp_path))
+
+    plugin = tmp_path / ".claude" / "skills" / "pc"
+    manifest = json.loads((plugin / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+    assert manifest["name"] == "pc"
+    # The same manifest a marketplace install would produce, version included:
+    # the plugin and the CLI it drives come from one release.
+    assert manifest == ai_agents.plugin_manifest()
+
+    for skill in ai_agents.available_skills():
+        shipped = plugin / "skills" / skill / "SKILL.md"
+        assert shipped.is_file()
+        # Byte for byte. Claude has a namespace, so nothing has to be rewritten.
+        with open(os.path.join(ai_agents.SKILLS_DIR, skill, "SKILL.md"), "rb") as f:
+            assert shipped.read_bytes() == f.read()
+        assert read_front_matter(shipped)["name"] == skill
+
+
+def test_cursor_gets_prefixed_skills(tmp_path):
+    """Cursor has no plugin, so the prefix is the only namespace there is."""
+    assert ai_agents.install_cursor_skills(str(tmp_path))
+
+    skills = tmp_path / ".cursor" / "skills"
+    for skill in ai_agents.available_skills():
+        installed = skills / ("pc-" + skill)
+        assert (installed / "SKILL.md").is_file()
+        # The front matter has to name the directory, or the skill answers to a
+        # command nobody typed.
+        assert read_front_matter(installed / "SKILL.md")["name"] == "pc-" + skill
+
+    # And the generic names are not what got installed: an unprefixed `init` or
+    # `render` in a user's `.cursor/skills` is PartCAD claiming a word.
+    assert not (skills / "init").exists()
+    assert not (skills / "render").exists()
+
+
+def test_cursor_skills_do_not_point_at_a_namespace_cursor_has_not_got(tmp_path):
+    """`/pc:setup` resolves to nothing there, and these files are full of it."""
+    ai_agents.install_cursor_skills(str(tmp_path))
+
+    for skill in ai_agents.available_skills():
+        text = (tmp_path / ".cursor" / "skills" / ("pc-" + skill) / "SKILL.md").read_text(encoding="utf-8")
+        assert "pc:" not in text, "%s still refers to a skill through the plugin namespace" % skill
+
+
+def test_the_command_lines_in_the_text_are_left_alone(tmp_path):
+    """`pc render` is a command; `pc:render` is a skill. Only one is rewritten."""
+    ai_agents.install_cursor_skills(str(tmp_path))
+
+    installed = (tmp_path / ".cursor" / "skills" / "pc-render" / "SKILL.md").read_text(encoding="utf-8")
+    with open(os.path.join(ai_agents.SKILLS_DIR, "render", "SKILL.md"), encoding="utf-8") as f:
+        source = f.read()
+
+    assert "pc render" in source
+    assert installed.count("pc render") == source.count("pc render")
+
+
+def test_renaming_touches_the_name_and_the_cross_references_only():
+    original = "\n".join(
+        [
+            "---",
+            "name: render",
+            "description: Use when the user runs /pc:render, and see /pc:export.",
+            "---",
+            "",
+            "# pc:render",
+            "",
+            "Run `pc render --view front`. Not to be confused with pc:renderer.",
+            "",
+        ]
+    )
+    rewritten = ai_agents.rename_skill(original, "pc-render", ["render", "export"])
+
+    assert "name: pc-render" in rewritten
+    assert "/pc-render" in rewritten and "/pc-export" in rewritten
+    assert "# pc-render" in rewritten
+    # A command line, and a word that merely starts like a skill name.
+    assert "`pc render --view front`" in rewritten
+    assert "pc:renderer" in rewritten
+
+
+def test_everything_is_installed_beside_the_package_at_the_repository_root(repository):
+    """An editor opens the repository, not the package directory inside it."""
+    package = repository / "packages" / "widget"
+    package.mkdir(parents=True)
+
+    assert ai_agents.install_agent_skills(str(package))
+
+    assert (repository / ".claude" / "skills" / "pc" / ".claude-plugin" / "plugin.json").is_file()
+    assert (repository / ".cursor" / "skills" / "pc-init" / "SKILL.md").is_file()
+    assert not (package / ".claude").exists()
+    assert not (package / ".cursor").exists()
+
+
+def test_without_a_repository_they_go_next_to_the_package(tmp_path):
+    assert ai_agents.install_agent_skills(str(tmp_path))
+    assert (tmp_path / ".claude" / "skills" / "pc" / ".claude-plugin" / "plugin.json").is_file()
+
+
+def test_installing_twice_updates_rather_than_duplicates(tmp_path):
+    ai_agents.install_agent_skills(str(tmp_path))
+    stale = tmp_path / ".claude" / "skills" / "pc" / "skills" / "init" / "SKILL.md"
+    stale.write_text("# out of date\n", encoding="utf-8")
+
+    assert ai_agents.install_agent_skills(str(tmp_path))
+    assert stale.read_text(encoding="utf-8") != "# out of date\n"
+
+
+def test_a_skill_of_the_users_own_is_not_touched(tmp_path):
+    """Everything installed is namespaced, so nothing else in there is ours."""
+    theirs = tmp_path / ".cursor" / "skills" / "init"
+    theirs.mkdir(parents=True)
+    (theirs / "SKILL.md").write_text("---\nname: init\n---\n", encoding="utf-8")
+
+    ai_agents.install_agent_skills(str(tmp_path))
+
+    assert (theirs / "SKILL.md").read_text(encoding="utf-8") == "---\nname: init\n---\n"
+
+
+@pytest.fixture
+def one_skill_library(tmp_path, monkeypatch):
+    """A library of exactly one skill, so a failure can be arranged for all of it."""
+    library = tmp_path / "library" / "widget"
+    library.mkdir(parents=True)
+    (library / "SKILL.md").write_text("---\nname: widget\n---\n\n# pc:widget\n", encoding="utf-8")
+    monkeypatch.setattr(ai_agents, "SKILLS_DIR", str(library.parent))
+    return library.parent
+
+
+def test_an_installation_carrying_no_skills_installs_nothing(tmp_path, monkeypatch):
+    """What a wheel built without the `package-data` patterns would look like.
+
+    `tests/partcad_cli/unit/test_ai_agent_skills.py` is what keeps that from
+    happening; this is what the installer does if it ever did.
+    """
+    monkeypatch.setattr(ai_agents, "SKILLS_DIR", str(tmp_path / "not-in-this-install"))
+
+    assert ai_agents.available_skills() == []
+    assert not ai_agents.install_claude_plugin(str(tmp_path))
+    assert not ai_agents.install_cursor_skills(str(tmp_path))
+    assert not ai_agents.install_agent_skills(str(tmp_path))
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_a_copy_that_fails_is_reported_rather_than_raised(tmp_path, monkeypatch, one_skill_library):
+    """A full disk is not a reason for `pc init` to stop with a traceback.
+
+    The package is created before any of this runs, so the command has already
+    done the thing it was asked to do.
+    """
+
+    def full(*args, **kwargs):
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(ai_agents.shutil, "copytree", full)
+
+    assert not ai_agents.install_claude_plugin(str(tmp_path))
+    assert not ai_agents.install_cursor_skills(str(tmp_path))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlinks need a privilege Windows does not grant by default")
+def test_a_symlinked_skill_is_left_alone_one_by_one(tmp_path, one_skill_library):
+    """The per-skill half of the rule the whole destination is checked against."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    skills = tmp_path / ".cursor" / "skills"
+    skills.mkdir(parents=True)
+    os.symlink(elsewhere, skills / "pc-widget")
+
+    assert not ai_agents.install_cursor_skills(str(tmp_path))
+    assert not any(elsewhere.iterdir())
+
+
+def test_text_that_is_not_a_skill_is_returned_as_it_is():
+    """Front matter is the block at the top of the file, or there is none.
+
+    A `---` further down is a horizontal rule, and a file that opens one and
+    never closes it has no front matter to rewrite -- in neither case is there a
+    `name` to change, and in neither case is that an error.
+    """
+    assert ai_agents.rename_skill("# pc:render\n", "pc-render", ["render"]) == "# pc-render\n"
+
+    unterminated = "---\nname: render\n"
+    assert ai_agents.rename_skill(unterminated, "pc-render", ["render"]) == unterminated
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlinks need a privilege Windows does not grant by default")
+def test_a_symlinked_destination_is_refused(tmp_path):
+    """PartCAD's own repository has `.claude/skills/pc` pointing into the tree.
+
+    Following it would have `pc init` overwrite the working copy of the plugin
+    with the installed copy of itself.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (tmp_path / ".claude" / "skills").mkdir(parents=True)
+    os.symlink(elsewhere, tmp_path / ".claude" / "skills" / "pc")
+
+    assert not ai_agents.install_claude_plugin(str(tmp_path))
+    assert not any(elsewhere.iterdir())
+    # The other half is unaffected: one refusal is not the other's problem.
+    assert ai_agents.install_agent_skills(str(tmp_path))
+    assert (tmp_path / ".cursor" / "skills" / "pc-init" / "SKILL.md").is_file()
+
+
+def test_a_destination_that_is_a_file_is_refused(tmp_path):
+    (tmp_path / ".cursor").mkdir()
+    (tmp_path / ".cursor" / "skills").write_text("not a directory\n", encoding="utf-8")
+
+    assert not ai_agents.install_cursor_skills(str(tmp_path))
+    assert (tmp_path / ".cursor" / "skills").read_text(encoding="utf-8") == "not a directory\n"

--- a/tests/partcad_cli/unit/test_ai_agent_skills.py
+++ b/tests/partcad_cli/unit/test_ai_agent_skills.py
@@ -3,7 +3,7 @@
 #
 # Licensed under Apache License, Version 2.0.
 #
-"""The shared skills library and the Claude plugin that wraps it.
+"""The shared skills library, the Claude plugin, and the wheel that carries both.
 
 `claude plugin validate` runs in CI and is the authority on the manifests, but it
 cannot be the only check. Run against `ai-agents/claude` it reads *nothing*: the
@@ -13,18 +13,34 @@ no front matter, or with a `name` that does not match the directory it is in,
 passes the workflow that exists to catch exactly that and is discovered by
 whoever installs the plugin.
 
+The library ships in the wheel as well, because `pc init` installs it into a
+user's repository out of the installed PartCAD, and `src/partcad/ai_agents` is
+two symlinks that put it there. That is the second thing checked here: the
+symlinks, and whether `pyproject.toml` declares what they resolve to. Neither is
+visible to `claude plugin validate`, and neither would be noticed by a test run
+from a checkout, where every file is on disk whether it was packaged or not.
+
 These run wherever pytest runs, which includes the Windows jobs of the matrix,
-so nothing here asserts anything about symlinks: whether git materialized one is
-a property of the checkout, and the artifact that gets published has none by
-construction. `.github/workflows/plugin.yml` owns that end.
+so nothing here reads anything *through* a symlink: whether git materialized one
+is a property of the checkout, and the checks that do look at them skip when it
+did not. The published artifact has none by construction.
+`.github/workflows/plugin.yml` owns that end.
 """
 
+import fnmatch
 import json
 import re
 from pathlib import Path
 
 import pytest
 import yaml
+
+# `tomllib` is only in the standard library from Python 3.11, and this repo
+# still supports 3.10 -- see the same note in `test_versions.py`.
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SKILLS = REPO_ROOT / "ai-agents" / "common" / "skills"
@@ -61,13 +77,13 @@ def _front_matter(skill: Path) -> dict:
 
 def test_there_are_skills_to_ship():
     """An empty library is what a Windows checkout of the symlink looks like."""
-    assert _skill_dirs(), "no skill directories under ai-agents/common/skills"
+    assert _skill_dirs(), "no skill directories under %s" % SKILLS
 
 
 @pytest.mark.parametrize("name", _skill_ids())
 def test_every_skill_directory_holds_a_skill(name):
     """A directory with no SKILL.md ships as a component that loads nothing."""
-    assert (SKILLS / name / "SKILL.md").is_file(), "ai-agents/common/skills/%s has no SKILL.md" % name
+    assert (SKILLS / name / "SKILL.md").is_file(), "%s has no SKILL.md" % (SKILLS / name)
 
 
 @pytest.mark.parametrize("name", _skill_ids())
@@ -78,8 +94,8 @@ def test_every_skill_is_named_after_its_directory(name):
     renamed directory leaves a skill that answers to a command nobody typed.
     """
     front_matter = _front_matter(SKILLS / name)
-    assert front_matter.get("name") == name, "ai-agents/common/skills/%s: front matter names %r" % (
-        name,
+    assert front_matter.get("name") == name, "%s: front matter names %r" % (
+        SKILLS / name,
         front_matter.get("name"),
     )
     assert SKILL_NAME.match(name), "%r is not a usable command name for /pc:<name>" % name
@@ -89,8 +105,8 @@ def test_every_skill_is_named_after_its_directory(name):
 def test_every_skill_says_when_to_use_it(name):
     """The description is the whole of what an agent sees before invoking."""
     description = _front_matter(SKILLS / name).get("description")
-    assert isinstance(description, str) and description.strip(), (
-        "ai-agents/common/skills/%s has no description in its front matter" % name
+    assert isinstance(description, str) and description.strip(), "%s has no description in its front matter" % (
+        SKILLS / name
     )
 
 
@@ -109,3 +125,95 @@ def test_the_marketplace_entry_and_the_plugin_manifest_agree():
     # not to the ".claude-plugin" directory the catalog itself sits in.
     source = (REPO_ROOT / entries[0]["source"]).resolve()
     assert source == PLUGIN.resolve(), "the catalog's source %r is not %s" % (entries[0]["source"], PLUGIN)
+
+
+# --- Shipping: the wheel is where a user's copy comes from ---
+#
+# `pc init` reads the skills out of the *installed* PartCAD, so what matters is
+# not that they are in this repository but that they are in the distribution.
+# Two things put them there and neither is visible from a checkout: the symlinks
+# under `src/partcad/ai_agents`, and the `package-data` patterns that name what
+# they resolve to.
+
+
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PYINSTALLER_SPEC = REPO_ROOT / "dev-tools" / "pyinstaller" / "partcad.spec"
+
+# The package the library is data of, and the two names it is data under.
+DATA_PACKAGE = "partcad.ai_agents"
+DATA_DIR = REPO_ROOT / "src" / "partcad" / "ai_agents"
+SKILLS_LINK = DATA_DIR / "skills"
+MANIFEST_LINK = DATA_DIR / "plugin.json"
+
+
+def _library_files():
+    """Every file the library and the manifest consist of, as the wheel sees them.
+
+    Relative to the data package, which is what a `package-data` pattern is
+    matched against: `skills/init/SKILL.md`, `plugin.json`.
+    """
+    names = [p.relative_to(SKILLS.parent).as_posix() for p in SKILLS.rglob("*") if p.is_file()]
+    return sorted(names + [MANIFEST_LINK.name])
+
+
+def test_every_library_file_is_declared_as_package_data():
+    """A file setuptools does not know about is not in the wheel.
+
+    Nothing else would notice. The tests run from a checkout, where these files
+    are on disk whether they were packaged or not, so a pattern that misses one
+    produces an install where the skill exists in the repository, passes every
+    test above, and is simply absent from what a user gets.
+    """
+    patterns = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["tool"]["setuptools"]["package-data"]
+    declared = patterns.get(DATA_PACKAGE)
+    assert declared, "%s is not in [tool.setuptools.package-data] of pyproject.toml" % DATA_PACKAGE
+
+    missed = [
+        name
+        for name in _library_files()
+        # `**` in a setuptools pattern is `glob`'s: any number of directories.
+        # `fnmatch` has no such thing, so the pattern is lowered to one that
+        # spans separators, which is what `**/` means here.
+        if not any(fnmatch.fnmatch(name, pattern.replace("**/", "*")) for pattern in declared)
+    ]
+    assert not missed, "not covered by %s in pyproject.toml: %s" % (DATA_PACKAGE, missed)
+
+
+def test_the_frozen_bundle_carries_them_too():
+    """`package-data` is setuptools', and PyInstaller does not read it.
+
+    The standalone bundle is the install whose user is least likely to have
+    another copy of these files anywhere -- they have no Python at all -- and it
+    is built from a spec that lists its data by hand.
+    """
+    spec = PYINSTALLER_SPEC.read_text(encoding="utf-8")
+    assert '"partcad/ai_agents/skills"' in spec, "the spec does not carry the skills into the bundle"
+    assert '"partcad/ai_agents"' in spec, "the spec does not carry the plugin manifest into the bundle"
+
+
+# Skipped rather than failed where git did not materialize the symlinks: that is
+# a property of the checkout (Windows, without `core.symlinks`), and it is the
+# wheel *built* from such a checkout that would be short, not this repository.
+# What must not happen is that they quietly stop pointing at the library.
+
+
+@pytest.mark.skipif(not SKILLS_LINK.is_symlink(), reason="the checkout did not materialize symlinks")
+def test_the_wheel_ships_the_library_itself():
+    """One copy of every skill, not a second one under `src/` to keep in step."""
+    assert SKILLS_LINK.resolve() == SKILLS.resolve()
+
+
+@pytest.mark.skipif(not MANIFEST_LINK.is_symlink(), reason="the checkout did not materialize symlinks")
+def test_the_wheel_ships_the_manifest_that_gets_bumped():
+    """`dev-tools/bumpversion.toml` names the file in `ai-agents`; this is it.
+
+    The version in the installed plugin is therefore the version of the PartCAD
+    that installed it, with nothing keeping the two in step but this.
+    """
+    assert MANIFEST_LINK.resolve() == PLUGIN_MANIFEST.resolve()
+
+
+@pytest.mark.skipif(not SKILLS_LINK.is_symlink(), reason="the checkout did not materialize symlinks")
+def test_the_plugin_ships_the_library_itself():
+    """And so does the plugin, through a symlink of its own."""
+    assert (PLUGIN / "skills").resolve() == SKILLS.resolve()

--- a/tests/partcad_cli/unit/test_versions.py
+++ b/tests/partcad_cli/unit/test_versions.py
@@ -115,23 +115,26 @@ def test_every_bumpversion_search_string_still_matches():
 # importable modules, and the self-pin scan reads requirements files. Nothing
 # imports a plugin manifest and nothing pins it, which is why it sat at the
 # 0.1.0 it was created with while twenty-three releases went out around it.
-CLAUDE_PLUGIN_MANIFEST = REPO_ROOT / "ai-agents" / "claude" / ".claude-plugin" / "plugin.json"
+# The wheel ships this same file, through `src/partcad/ai_agents/plugin.json`,
+# so that `pc init` can install the plugin out of an installed PartCAD -- which
+# means the version below is also the version of the plugin a user ends up with.
+CLAUDE_PLUGIN = "ai-agents/claude/.claude-plugin/plugin.json"
+CLAUDE_PLUGIN_MANIFEST = REPO_ROOT / CLAUDE_PLUGIN
 
 
 def test_the_claude_plugin_states_the_release_version():
     """The plugin is published by the release, so it states the release."""
     version = json.loads(CLAUDE_PLUGIN_MANIFEST.read_text(encoding="utf-8"))["version"]
     assert version == _bumpversion()["current_version"], (
-        "ai-agents/claude/.claude-plugin/plugin.json is out of step with the release. The plugin is "
-        "published by the same release as the wheel and states the same version."
+        "%s is out of step with the release. The plugin is published by the same release as the "
+        "wheel and states the same version." % CLAUDE_PLUGIN
     )
 
 
 def test_the_claude_plugin_is_declared_in_bumpversion():
     """Declared, so that it moves; the test above only says that it has."""
     filenames = {entry["filename"] for entry in _bumpversion()["files"]}
-    expected = "ai-agents/claude/.claude-plugin/plugin.json"
-    assert expected in filenames, "%s is not in dev-tools/bumpversion.toml" % expected
+    assert CLAUDE_PLUGIN in filenames, "%s is not in dev-tools/bumpversion.toml" % CLAUDE_PLUGIN
 
 
 # The two distributions this repository publishes. Scoped deliberately: an


### PR DESCRIPTION
The skills were only ever reachable as the Claude plugin: find the repository, add the marketplace, install. A user who has PartCAD has the files already — so put them in the wheel and let `pc init` install them into the repository it just created a package in.

## Where the files live

They stay in `ai-agents/`, at the top of the tree where a visitor finds them; nothing moved. `src/partcad/ai_agents` is two symlinks into it:

```
src/partcad/ai_agents/
├── __init__.py                                          what `pc init` calls
├── skills      -> ../../../ai-agents/common/skills
└── plugin.json -> ../../../ai-agents/claude/.claude-plugin/plugin.json
```

`setuptools` resolves a symlink that is a path *component*, so `package-data = ["skills/**/*", "plugin.json"]` picks the library up through them and the wheel and sdist carry **real files and no symlinks at all** (verified on the built artifacts: 14 entries, 0 symlinks, and a clean-venv install of the wheel runs `pc init` end to end). One copy of every file, so the plugin and the wheel cannot ship different skills.

The frozen bundle gets its own entry in `partcad.spec`, naming the files under `ai-agents/` directly — it does not read `package-data`, and should not depend on a symlink having been materialized.

## What each agent gets

They are not the same thing:

- **Claude Code** gets the *plugin* — `.claude/skills/pc/`, manifest and all. That is what puts the skills in one namespace (`/pc:init`, not `/init`) and it is the same `pc` a marketplace install produces, so a project with both does not end up with two spellings of one skill. `SKILL.md` files are copied byte for byte.
- **Cursor** has no plugin to namespace anything, so the skills go in as `pc-init`, `pc-gen`, `pc-render`… Unprefixed, PartCAD would be claiming five of the most generic names there are. The front matter is rewritten to match the directory, and so are the `pc:<skill>` cross-references — keyed on the names actually shipped, so the `pc render` and `pc adhoc convert` command lines these files are full of are left alone.

Neither destination is written through a symlink, and *this repository* is why: `.claude/skills/pc` points at `ai-agents/claude`, so following it would have `pc init` overwrite the working tree with a copy of the installed PartCAD.

## Flags

`--no-skills` skips it. `--skills-only` installs them and touches no package at all — nothing is written to or read from `partcad.yaml` — which is how a repository that has a package already gets them, or gets a newer PartCAD's.

## Tests

`tests/partcad/unit/test_ai_agents.py` (new) covers the installation: what each agent gets, the rename, the repository root, re-runs, and the symlink / not-a-directory refusals. Three behave scenarios cover `--skills-only`, two the default install.

`test_ai_agent_skills.py` gains the half no plugin tooling can see: that the symlinks still point at the library, and that every file in it matches a `package-data` pattern. A pattern that misses one produces a wheel where `pc init` installs a skill that is not there — and nothing else would notice, since a test run from a checkout finds every file on disk whether it was packaged or not.

`changed-scopes` now classifies `ai-agents/common` and the plugin manifest into `ai` **and** `code`: they are in the wheel, so they are source as well.

Locally: 251 pytest tests and all 9 `features/init.feature` scenarios pass, `claude plugin validate .` passes with no warnings (it used to warn), and `materialize.sh` still produces a symlink-free plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)