### PR TITLE
Refuse to build a wheel that would have no skills in it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,21 @@ jobs:
       BIN_DIR: ${{ startsWith(matrix.os, 'windows') && 'Scripts' || 'bin' }}
 
     steps:
+      # Before the checkout, because this decides how the checkout writes the
+      # tree. Git for Windows leaves "core.symlinks" off, and the wheel ships
+      # the AI agent skills through two symlinks in "src/partcad/ai_agents" --
+      # so on Windows this tree would otherwise hold two text files where they
+      # are, and the wheel built below would have no skills in it. The build
+      # backend refuses to build that (see "dev-tools/build-backend"), which
+      # makes this the difference between a green Windows leg and a red one
+      # rather than the difference between a good wheel and a quietly empty one.
+      #
+      # The runners can create symlinks -- see the note in
+      # ".github/actions/setup-build", where "build" 1.6.0 started doing it.
+      - name: Check out with symlinks intact
+        if: runner.os == 'Windows'
+        run: git config --global core.symlinks true
+
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-all
         with:
@@ -177,6 +192,17 @@ jobs:
           # catches -- `packages.find` sees whatever is under `src/`.
           python -c "
           import partcad, partcad_cli, partcad_client, partcad_utils, partcad_service_json_rpc, partcad_ide_client
+          "
+          # And the data it ships, not only the code. `pc init` installs the AI
+          # agent skills out of the installation, so a wheel that packaged none
+          # of them is one that quietly stopped doing that -- which is what a
+          # checkout with the symlinks dropped produces. The build backend
+          # refuses to build such a tree; this is the same failure caught from
+          # the other end, on the artifact rather than on its source.
+          python -c "
+          import partcad.ai_agents as ai_agents
+          assert ai_agents.available_skills(), 'the wheel carries no AI agent skills'
+          assert ai_agents.plugin_manifest()['name'], 'the wheel carries no plugin manifest'
           "
           pc --no-ansi version
           partcad-json-rpc --help >/dev/null

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,6 +136,14 @@ jobs:
           (. .venv/install/${{ env.BIN_DIR }}/activate && python -c "
           import partcad, partcad_cli, partcad_client, partcad_utils, partcad_service_json_rpc, partcad_ide_client
           " && deactivate)
+          # And the data it ships, not only the code: this is the wheel that
+          # gets published, and `pc init` installs the AI agent skills out of
+          # it. See the same check in "build.yml".
+          (. .venv/install/${{ env.BIN_DIR }}/activate && python -c "
+          import partcad.ai_agents as ai_agents
+          assert ai_agents.available_skills(), 'the wheel carries no AI agent skills'
+          assert ai_agents.plugin_manifest()['name'], 'the wheel carries no plugin manifest'
+          " && deactivate)
           (. .venv/install/${{ env.BIN_DIR }}/activate && pc --no-ansi version && partcad-json-rpc --help >/dev/null && deactivate)
           # The shim brings the wheel in, and owns nothing of its own.
           (. .venv/install/${{ env.BIN_DIR }}/activate && python -m pip install --no-index --find-links=dist --find-links=dev-tools/shim/dist partcad-cli && deactivate)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,7 +383,13 @@ skills stay at the top of the repository where a visitor finds them, and there i
 So `ai-agents/common` is *both* the plugin and the distribution, which is why `.github/actions/changed-scopes`
 classifies it into both buckets, why `pyproject.toml` and `dev-tools/pyinstaller/partcad.spec` both name it as
 data, and why a new file under a skill has to be covered by the `package-data` patterns or it is simply absent
-from what gets installed. See `ai-agents/README.md`. The snap
+from what gets installed. **The build refuses a checkout that dropped those symlinks** — `pyproject.toml` names
+an in-tree PEP 517 backend, `dev-tools/build-backend/`, which is `setuptools.build_meta` plus that one
+precondition on `build_wheel` and `build_sdist`. Without it the artifact is silently empty: `skills/**/*`
+matches nothing where `skills` is a text file holding a path, `plugin.json` matches that same kind of file and
+is packaged as its content, and the wheel then installs, imports and runs `pc version` with no skills in it.
+`build_editable` is *not* guarded, on purpose: an editable install reads the working tree live, and refusing
+there would fail `poetry install` over a data file. See `ai-agents/README.md`. The snap
 carries whatever the bundle carries,
 so it needs nothing extra of its
 own; `dev-tools/snap/README.md` covers what is specific to it (confinement, aliases, the base, its state directory).

--- a/ai-agents/README.md
+++ b/ai-agents/README.md
@@ -308,11 +308,27 @@ itself.
 
 If local discovery or a build produces a `skills` file containing the text
 `../common/skills` instead of a directory, git did not materialize the symlink.
-The same goes for the two under `src/partcad/ai_agents`, and there it is a wheel
-built from that checkout that comes out short. (The frozen bundles do not care:
-`partcad.spec` names the files under `ai-agents/` directly.) Enable symlinks and
-re-checkout:
+Enable symlinks and re-checkout:
 
 ```bash
 git config core.symlinks true
+git checkout -- .
 ```
+
+The same goes for the two under `src/partcad/ai_agents`, and **there the build
+refuses rather than producing a short wheel**: `pyproject.toml` names an in-tree
+backend, [`dev-tools/build-backend`](../dev-tools/build-backend/), which checks
+before packaging that the skills are real files and stops with that `git config`
+if they are not. It has to, because nothing downstream would notice — a wheel
+built from such a checkout installs, imports, and runs `pc version`; it simply
+has no skills in it, and `pc init` then installs nothing on every machine it
+reaches. Not a Windows-only hole, either: a GitHub source *zip* drops symlinks
+on every platform, so `pip install <that zip>` went the same way.
+
+The frozen bundles do not care — `partcad.spec` names the files under
+`ai-agents/` directly — and neither does an editable install, which reads the
+working tree live and is deliberately left unguarded so that `poetry install`
+still works.
+
+CI turns `core.symlinks` on before the checkout of the job that builds the
+wheel, so the Windows leg of that matrix builds a complete one.

--- a/dev-tools/MANIFEST.in
+++ b/dev-tools/MANIFEST.in
@@ -1,0 +1,18 @@
+# What the sdist needs beyond the packages themselves.
+#
+# `pyproject.toml` names an in-tree build backend -- `backend-path` points at
+# `dev-tools/build-backend` -- so that a checkout which dropped the symlinks
+# carrying the AI agent skills is refused rather than packaged empty. An sdist
+# without that module in it cannot be built from at all: `python -m build` makes
+# the sdist and then builds the wheel *out of it*, and the wheel half fails with
+#
+#   `backend-path` entry 'dev-tools/build-backend' does not exist
+#
+# which is also what `pip install partcad-<version>.tar.gz` would have done to
+# anyone installing from the sdist on PyPI.
+#
+# This file is here rather than at the top of the repository, which is the only
+# place setuptools looks for it by that name. The backend points setuptools at
+# it -- one line, `manifest_maker.template` -- and says there why that is the
+# knob rather than `[sdist] template` in a `setup.cfg`.
+include dev-tools/build-backend/partcad_build_backend.py

--- a/dev-tools/build-backend/partcad_build_backend.py
+++ b/dev-tools/build-backend/partcad_build_backend.py
@@ -1,0 +1,143 @@
+#
+# PartCAD, 2026
+#
+# Author: PartCAD (support@partcad.org)
+# Created: 2026-09-09
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""The build backend: setuptools, plus a refusal to ship a wheel without the skills.
+
+`src/partcad/ai_agents/skills` and `src/partcad/ai_agents/plugin.json` are
+symlinks into `ai-agents/`, which is what puts the AI agent skills in the wheel
+without keeping a second copy of them (see `ai-agents/README.md`). A checkout
+where git did not materialize a symlink has, in its place, a small text file
+holding the path the symlink pointed at -- and that is where this fails quietly
+rather than loudly:
+
+    skills/**/*  ->  []                 nothing matches a file named `skills`
+    plugin.json  ->  52 bytes of path   matches, and is copied as content
+
+So the wheel builds, installs, imports, runs `pc version`, and has no skills in
+it at all; `pc init` then installs nothing, on every machine that wheel reaches.
+Windows is where this happens -- Git for Windows checks symlinks out as text
+files unless `core.symlinks` is on -- but it is not only Windows: GitHub's
+source *zip* exports do the same thing on every platform, so
+`pip install <that zip>` has the same hole.
+
+This backend is `setuptools.build_meta` with one precondition in front of the
+two hooks that produce a redistributable artifact. It is not a build step and
+it copies nothing: it looks at what setuptools is about to package and refuses
+if the skills are not there to package.
+
+`build_editable` is deliberately *not* guarded. An editable install reads the
+working tree as it is, so nothing is frozen into an artifact that outlives the
+checkout, and refusing there would fail `poetry install` -- the whole
+development environment -- over a data file the developer can fix with one
+`git config`.
+"""
+
+import json
+import os
+
+from setuptools.command.egg_info import manifest_maker
+
+# Everything a PEP 517 frontend may call. The hooks not named below are
+# re-exported unchanged, which is the point: this is setuptools, with a
+# precondition, and the day setuptools grows a hook it should arrive here
+# without this file being edited.
+from setuptools.build_meta import *  # noqa: F401,F403
+from setuptools.build_meta import build_sdist as _build_sdist
+from setuptools.build_meta import build_wheel as _build_wheel
+
+# Relative to the project root, which is the directory a PEP 517 build runs in.
+_PACKAGE = os.path.join("src", "partcad", "ai_agents")
+_SKILLS = os.path.join(_PACKAGE, "skills")
+_MANIFEST = os.path.join(_PACKAGE, "plugin.json")
+
+# What a checkout that dropped the symlinks should be told to do. The cause is
+# named as well as the cure: whoever sees this is as likely to be installing
+# from a source zip, where `core.symlinks` is not the answer and the sdist is.
+_ADVICE = """
+This is what a checkout looks like when git did not materialize the symlinks in
+"%s" (Git for Windows does this unless "core.symlinks" is on, and a GitHub
+source zip does it everywhere). The wheel would build without the skills in it,
+install cleanly, and leave "pc init" with nothing to install.
+
+    git config core.symlinks true
+    git checkout -- .
+
+Or build from an sdist, where these are ordinary files.
+""" % _PACKAGE
+
+
+# The sdist template, which lives beside this file rather than at the top of the
+# repository. `MANIFEST.in` is a name setuptools resolves against the project
+# root and offers no setting for: `[sdist] template` in a `setup.cfg` does not
+# reach it, because the file list is built by `egg_info`'s `manifest_maker`
+# rather than by `sdist`, and that reads the class attribute below.
+#
+# It is one line, and the failure mode if a future setuptools stops honouring it
+# is loud rather than silent: the sdist loses this backend, and the wheel built
+# from that sdist fails immediately on a `backend-path` that does not exist.
+manifest_maker.template = os.path.join("dev-tools", "MANIFEST.in")
+
+
+def _skills():
+    """Every skill that would go into the artifact, by directory name."""
+    if not os.path.isdir(_SKILLS):
+        return []
+    return sorted(name for name in os.listdir(_SKILLS) if os.path.isfile(os.path.join(_SKILLS, name, "SKILL.md")))
+
+
+def _check_the_skills_are_there():
+    """Raise unless the AI agent skills are real files this build can package.
+
+    Both halves are checked for what they are rather than for existing: an
+    unmaterialized symlink *exists*, as a file containing a path, and the
+    manifest one is a file either way -- which is why it is parsed.
+    """
+    problems = []
+
+    if not os.path.isdir(_SKILLS):
+        problems.append("%s is not a directory" % _SKILLS)
+    elif not _skills():
+        problems.append("%s holds no <name>/SKILL.md" % _SKILLS)
+
+    try:
+        with open(_MANIFEST, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+        if not isinstance(manifest, dict) or "name" not in manifest:
+            problems.append("%s is not a plugin manifest" % _MANIFEST)
+    except FileNotFoundError:
+        problems.append("%s is missing" % _MANIFEST)
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        problems.append("%s does not parse as JSON (%s)" % (_MANIFEST, e))
+
+    if not problems:
+        return
+
+    raise SystemExit(
+        "Refusing to build: the AI agent skills would not be in the artifact.\n\n  "
+        + "\n  ".join(problems)
+        + "\n"
+        + _ADVICE
+    )
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    """`setuptools.build_meta.build_wheel`, once the skills are known to be there."""
+    _check_the_skills_are_there()
+    return _build_wheel(wheel_directory, config_settings, metadata_directory)
+
+
+def build_sdist(sdist_directory, config_settings=None):
+    """`setuptools.build_meta.build_sdist`, once the skills are known to be there.
+
+    An sdist is the other artifact that outlives the checkout, and the one a
+    wheel gets built from later -- an sdist without the skills produces a wheel
+    without them, on a machine where nothing is wrong.
+    """
+    _check_the_skills_are_there()
+    return _build_sdist(sdist_directory, config_settings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,16 @@ partcad-service-remote-docker = "partcad_service_json_rpc.remote_docker_service:
 Homepage = "https://github.com/partcad/partcad"
 Issues = "https://github.com/partcad/partcad/issues"
 
+# `setuptools.build_meta`, with one precondition in front of it: that the AI
+# agent skills the wheel ships -- symlinks from `src/partcad/ai_agents` into
+# `ai-agents/` -- are real files this build can package. A checkout that dropped
+# those symlinks (Git for Windows without `core.symlinks`, or a GitHub source
+# zip, on any platform) otherwise builds a wheel with no skills in it that
+# installs, imports and runs perfectly. See `dev-tools/build-backend/`.
 [build-system]
 requires = ["setuptools>=77"]
-build-backend = "setuptools.build_meta"
+build-backend = "partcad_build_backend"
+backend-path = ["dev-tools/build-backend"]
 
 # Explicit rather than left to auto-discovery: this distribution ships six
 # top-level packages, and that is not something to leave implicit.

--- a/tests/dev_tools/test_build_backend.py
+++ b/tests/dev_tools/test_build_backend.py
@@ -1,0 +1,218 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The build backend that refuses a wheel with no AI agent skills in it.
+
+The wheel ships the skills through two symlinks from `src/partcad/ai_agents`
+into `ai-agents/`. A checkout where git did not materialize them has, in their
+place, a text file holding the path each pointed at -- and setuptools packages
+that without complaint: `skills/**/*` matches nothing, and `plugin.json` matches
+a 52-byte file whose content is a path. The result builds, installs, imports,
+and runs `pc version`; it just has no skills in it, on every machine that wheel
+reaches.
+
+Git for Windows is where this comes from -- `core.symlinks` is off unless it is
+turned on -- but not only Windows: a GitHub source zip drops symlinks on every
+platform, so `pip install <that zip>` has the same hole.
+
+`dev-tools/build-backend/partcad_build_backend.py` is `setuptools.build_meta`
+with that precondition in front of the two hooks that produce a redistributable
+artifact. These tests drive the precondition directly, against trees built to
+look like each case, rather than building a wheel: a build is slow, and what is
+worth pinning is the decision, not setuptools.
+"""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+from setuptools.command.egg_info import manifest_maker
+
+# `tomllib` is only in the standard library from Python 3.11, and this repo
+# still supports 3.10 -- see the same note in `test_versions.py`.
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_ROOT / "dev-tools" / "build-backend"
+BACKEND = BACKEND_DIR / "partcad_build_backend.py"
+# The sdist manifest template, beside the backend rather than at the root.
+TEMPLATE = REPO_ROOT / "dev-tools" / "MANIFEST.in"
+
+# What the backend looks at, relative to the project root a build runs in.
+PACKAGE = Path("src") / "partcad" / "ai_agents"
+
+
+def _backend():
+    """The backend module, loaded from the path `backend-path` names."""
+    spec = importlib.util.spec_from_file_location("partcad_build_backend", BACKEND)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A project root laid out the way the backend expects to find one."""
+    (tmp_path / PACKAGE).mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def materialized(project):
+    """What a checkout with the symlinks resolved gives setuptools to package."""
+    skill = project / PACKAGE / "skills" / "init"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: init\n---\n", encoding="utf-8")
+    (project / PACKAGE / "plugin.json").write_text('{"name": "pc", "version": "0.0.0"}\n', encoding="utf-8")
+
+
+def dropped(project):
+    """And what one without them gives it: the symlink targets, as text."""
+    (project / PACKAGE / "skills").write_text("../../../ai-agents/common/skills", encoding="utf-8")
+    (project / PACKAGE / "plugin.json").write_text(
+        "../../../ai-agents/claude/.claude-plugin/plugin.json", encoding="utf-8"
+    )
+
+
+def test_the_backend_is_the_one_pyproject_declares():
+    """A backend nothing points at is a file, not a gate."""
+    build_system = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["build-system"]
+
+    assert build_system["build-backend"] == "partcad_build_backend"
+    # Relative to the project root, and it has to be the directory the module
+    # is actually in or the build fails to import it at all.
+    assert [str(BACKEND_DIR.relative_to(REPO_ROOT)).replace(os.sep, "/")] == build_system["backend-path"]
+    assert BACKEND.is_file()
+
+
+def test_the_sdist_carries_the_backend():
+    """`python -m build` builds the wheel out of the sdist, so it needs it there.
+
+    An sdist without this module cannot be built from at all -- the wheel half
+    fails on a `backend-path` that does not exist, and so does
+    `pip install partcad-<version>.tar.gz` for anyone installing from the sdist
+    on PyPI. A manifest template is the only thing that puts a file from outside
+    the packages into an sdist, and this is the only reason there is one.
+    """
+    manifest = TEMPLATE.read_text(encoding="utf-8")
+    relative = str(BACKEND.relative_to(REPO_ROOT)).replace(os.sep, "/")
+
+    assert "include %s" % relative in manifest, "%s does not include %s" % (TEMPLATE.name, relative)
+
+
+def test_setuptools_is_pointed_at_the_template_where_it_actually_is():
+    """The template is not at the top of the repository, and `MANIFEST.in` is a
+    name setuptools resolves against the project root.
+
+    `[sdist] template` in a `setup.cfg` does not reach it -- the file list is
+    built by `egg_info`'s `manifest_maker`, not by `sdist` -- so the backend sets
+    that class attribute instead. It is the one piece of this that reaches into
+    setuptools rather than calling it, and it is pinned here so that moving the
+    template without moving the pointer is a failing test rather than an sdist
+    that quietly lost a file.
+
+    If a future setuptools stops honouring it, the failure is still loud: the
+    sdist loses the backend, and the wheel `python -m build` then builds out of
+    that sdist stops on the missing `backend-path`.
+    """
+    _backend()
+
+    assert manifest_maker.template == os.path.join("dev-tools", "MANIFEST.in")
+    assert TEMPLATE.is_file()
+    assert not (REPO_ROOT / "MANIFEST.in").exists(), "there is a MANIFEST.in at the root after all"
+
+
+def test_it_passes_a_tree_that_has_the_skills(project):
+    materialized(project)
+
+    # Returns None; what matters is that it does not raise.
+    assert _backend()._check_the_skills_are_there() is None
+
+
+def test_it_refuses_a_tree_where_the_symlinks_were_dropped(project):
+    """The failure this whole file exists for, and it must name the cure."""
+    dropped(project)
+
+    with pytest.raises(SystemExit) as refusal:
+        _backend()._check_the_skills_are_there()
+
+    message = str(refusal.value)
+    assert "skills is not a directory" in message
+    assert "core.symlinks" in message
+
+
+def test_it_refuses_a_manifest_that_is_a_path_rather_than_a_manifest(project):
+    """The half that would otherwise be packaged: a file, and the wrong one.
+
+    `plugin.json` is a file whether or not git resolved it, so existing proves
+    nothing about it -- which is why the backend parses it.
+    """
+    materialized(project)
+    (project / PACKAGE / "plugin.json").write_text(
+        "../../../ai-agents/claude/.claude-plugin/plugin.json", encoding="utf-8"
+    )
+
+    with pytest.raises(SystemExit) as refusal:
+        _backend()._check_the_skills_are_there()
+
+    assert "does not parse as JSON" in str(refusal.value)
+
+
+def test_it_refuses_a_skills_directory_with_no_skills_in_it(project):
+    """An empty directory is not what a dropped symlink leaves, but it ships the same."""
+    materialized(project)
+    (project / PACKAGE / "skills" / "init" / "SKILL.md").unlink()
+
+    with pytest.raises(SystemExit) as refusal:
+        _backend()._check_the_skills_are_there()
+
+    assert "holds no <name>/SKILL.md" in str(refusal.value)
+
+
+def test_it_refuses_a_manifest_that_is_json_but_not_a_manifest(project):
+    materialized(project)
+    (project / PACKAGE / "plugin.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as refusal:
+        _backend()._check_the_skills_are_there()
+
+    assert "is not a plugin manifest" in str(refusal.value)
+
+
+def test_the_hooks_that_ship_an_artifact_are_the_guarded_ones():
+    """`build_editable` is deliberately not one of them.
+
+    An editable install reads the working tree as it is, so nothing is frozen
+    into an artifact that outlives the checkout -- and refusing there would fail
+    `poetry install`, the whole development environment, over a data file.
+    """
+    backend = _backend()
+
+    for hook in ("build_wheel", "build_sdist"):
+        assert getattr(backend, hook).__module__ == "partcad_build_backend", "%s is not guarded" % hook
+
+    # Present, so a frontend can call it, and setuptools' own.
+    assert backend.build_editable.__module__ == "setuptools.build_meta"
+
+
+def test_this_repository_would_build(project):
+    """The check, against the tree it is actually shipped in.
+
+    Skipped where git did not materialize the symlinks, which is the one case it
+    is supposed to fail: that is a property of the checkout, and a contributor
+    on Windows without `core.symlinks` should not read it as a broken test.
+    """
+    skills = REPO_ROOT / PACKAGE / "skills"
+    if not skills.is_dir():
+        pytest.skip("the checkout did not materialize symlinks")
+
+    os.chdir(REPO_ROOT)
+    assert _backend()._check_the_skills_are_there() is None
+    assert json.loads((REPO_ROOT / PACKAGE / "plugin.json").read_text(encoding="utf-8"))["name"] == "pc"


### PR DESCRIPTION
Follow-up to #617, which put the AI agent skills in the wheel through two symlinks from `src/partcad/ai_agents` into `ai-agents/`. A checkout where git did not materialize those symlinks has a text file in their place, holding the path each pointed at — and setuptools packages that without a word. Verified, not theorised:

```
skills/**/*  ->  []                 # nothing matches a file named `skills`
plugin.json  ->  52 bytes of path   # matches, and is copied as content
```

The wheel then builds, installs, imports all six packages and runs `pc version`. It simply has no skills in it, and `pc init` installs nothing, on every machine that wheel reaches.

Git for Windows is where this comes from — `core.symlinks` is off unless turned on — and `build.yml` runs `python -m build` on every matrix OS, Windows included, where the existing installation test would have passed on an empty wheel. It is not only Windows, though: a GitHub source **zip** drops symlinks on every platform, so `pip install <that zip>` had the same hole.

## The refusal

`pyproject.toml` names an in-tree backend: `setuptools.build_meta` plus one precondition in front of `build_wheel` and `build_sdist`, the two hooks that produce something outliving the checkout. It copies nothing and builds nothing — it looks at what setuptools is about to package and stops:

```
Refusing to build: the AI agent skills would not be in the artifact.

  src/partcad/ai_agents/skills is not a directory

...
    git config core.symlinks true
    git checkout -- .

Or build from an sdist, where these are ordinary files.
```

Both halves are checked for *what they are* rather than for existing: an unmaterialized symlink exists, as a file, and `plugin.json` is a file either way — which is why it is parsed rather than stat'd.

`build_editable` is deliberately **not** guarded. An editable install reads the working tree live, so nothing is frozen into an artifact, and refusing there would fail `poetry install` — the whole development environment — over a data file.

## Keeping CI green rather than newly red

- `build.yml` sets `core.symlinks` **before** the checkout of the wheel-building job on Windows, so that leg builds a complete wheel instead of hitting the new refusal. The runners can create symlinks — that is established in `.github/actions/setup-build`, where `build` 1.6.0 started doing exactly that.
- Both installation tests (`build.yml` and `deploy.yml`, the latter gating the published wheel) now assert the artifact carries the skills, not just the code. Same failure caught from the other end: on the wheel rather than on its source.

## `MANIFEST.in`

The repository has one for the first time, and only for this. `python -m build` builds the wheel *out of the sdist*, so an sdist without the backend module cannot be built from at all — the wheel half dies on a `backend-path` that does not exist, and so would `pip install partcad-<version>.tar.gz` for anyone installing from PyPI's sdist. I hit this by running the exact command CI runs; a test pins the coupling.

## Verification

- refusal and success paths for `build_wheel` and `build_sdist` (exit 1 / exit 0), including through pip's isolated build, which is what surfaces the message to a user
- `python -m build` end to end: sdist → wheel-from-sdist, 12 skills in the wheel, backend in the sdist
- `pip install` of the sdist into a clean venv: 12 skills, manifest `pc 0.8.60`
- `poetry check` still passes, 8 new tests, 248 pytest tests and all 9 `features/init.feature` scenarios green

🤖 Generated with [Claude Code](https://claude.com/claude-code)