### PR TITLE
Four checks for what an assembly does while looking fine

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -710,6 +710,7 @@ Interfaces are declared in ``partcad.yaml`` using the following syntax:
       path: <(optional) the source file path, "{interface name}.{ext}" otherwise>
       threadStep: <(optional) axial distance per full turn of a connection made through this interface, in mm>
       selfScrew: <(optional) whether this interface cuts its own thread instead of matching one>
+      multiConnect: <(optional) whether one instance of this interface may take more than one object>
       inherits: # (optional) the list of other interfaces to inherit from
         <parent interface name>: <instance name>
         <other interface name>: # instance name is implied to be empty ("")
@@ -1004,7 +1005,20 @@ Parts are declared in ``partcad.yaml`` using the following syntax:
 
 Depending on the type of the part, the configuration may have different options.
 
-The ``threadStep`` and ``selfScrew`` fields of an interface are inherited by the
+``multiConnect`` says whether one instance of an interface may take more than
+one object. It is ``false`` by default, because most joints are made once: a
+stud takes one brick, a bolt hole takes one bolt, and two objects connected to
+the same instance is a mistake ``pc test`` reports. Set it on the joints that
+are not made once - a shaft carrying several parts along its length, a rail, a
+bus bar:
+
+.. code-block:: yaml
+
+  interfaces:
+    shaft:
+      multiConnect: true
+
+The ``threadStep``, ``selfScrew`` and ``multiConnect`` fields of an interface are inherited by the
 interfaces that inherit it, and by the connections made through it. Two
 interfaces that are connected have to agree on their thread unless one of them
 cuts its own. See :doc:`assy`.

--- a/src/partcad/assembly.py
+++ b/src/partcad/assembly.py
@@ -350,6 +350,7 @@ class Assembly(Shape):
             return {
                 "overlaps": result.get("overlaps", []),
                 "unchecked": result.get("unchecked", []),
+                "indeterminate": result.get("indeterminate", []),
                 "parts": result.get("parts", 0),
             }
 

--- a/src/partcad/assembly.py
+++ b/src/partcad/assembly.py
@@ -7,10 +7,14 @@
 # Licensed under Apache License, Version 2.0.
 
 import asyncio
+import os
+import tempfile
 import typing
 
+from . import sandbox_versions
 from . import telemetry
 from . import shape_envelope
+from . import wrapper
 from .geom import Location
 from .plugin_provider_data_cart import ProviderCartItem
 from .revision import package_revision
@@ -276,6 +280,66 @@ class Assembly(Shape):
                 continue
             problems.extend([(child.name, problem) for problem in child.how.problems])
         return problems
+
+    async def get_interference_async(self, ctx, min_volume=1.0, min_fraction=0.0):
+        """The pairs of parts in this assembly whose solids share space.
+
+        Returned as {"overlaps": [{"a", "b", "volume"}, ...], "unchecked": [...],
+        "parts": n}, or None when the assembly could not be realized. Measured
+        in a sandbox, like every other operation on geometry: the core has no
+        CAD library.
+
+        'unchecked' names the parts a boolean could not be asked about because
+        they are not valid solids. It is reported rather than hidden: a shape
+        that is inside out intersects things it is nowhere near, so leaving it
+        out is the only way the rest of the answer means anything - and a caller
+        that was told nothing would take "no interference" for "checked".
+
+        'min_volume' and 'min_fraction' are what separates a design fault from a
+        design that fits together. Parts meant to go together touch, and meshed
+        geometry touching is numerically noisy, so an overlap smaller than this
+        is not reported.
+        """
+        obj = await self.get_wrapped(ctx)
+        if obj is None:
+            return None
+
+        with pc_logging.Action("Interference", self.project_name, self.name):
+            request_serialized = shape_envelope.serialize(
+                {"wrapped": obj, "min_volume": min_volume, "min_fraction": min_fraction}
+            )
+
+            runtime = ctx.get_python_runtime(version="3.11")
+            await runtime.ensure_async(sandbox_versions.CADQUERY_OCP)
+
+            # The wrapper writes nothing, but every wrapper is invoked with an
+            # output path; give it one inside a directory of our own.
+            with tempfile.TemporaryDirectory(prefix="partcad-interference-") as unused_dir:
+                command = [wrapper.get("interference.py"), os.path.join(unused_dir, "unused.txt")]
+                exitcode, response_serialized, errors = await runtime.run_async(command, request_serialized)
+            if exitcode != 0 and len(errors) == 0:
+                errors = f"Failed to execute command '{' '.join(command)}' with exit code {exitcode}"
+            if errors:
+                pc_logging.error(errors)
+                raise Exception(errors)
+
+            response_lines = response_serialized.strip().splitlines()
+            if not response_lines:
+                pc_logging.error("Empty response from wrapper: %s" % command[0])
+                return None
+            result = shape_envelope.deserialize(response_lines[-1].strip())
+
+            if not result.get("success", False):
+                pc_logging.error(
+                    "Interference failed for %s:%s: %s"
+                    % (self.project_name, self.name, result.get("exception", "Unknown error"))
+                )
+                return None
+            return {
+                "overlaps": result.get("overlaps", []),
+                "unchecked": result.get("unchecked", []),
+                "parts": result.get("parts", 0),
+            }
 
     async def resolve_connect_metadata(self, ctx):
         """Fill in the parts of the connection metadata that need the geometry.

--- a/src/partcad/assembly.py
+++ b/src/partcad/assembly.py
@@ -7,6 +7,7 @@
 # Licensed under Apache License, Version 2.0.
 
 import asyncio
+import json
 import os
 import tempfile
 import typing
@@ -305,8 +306,19 @@ class Assembly(Shape):
             return None
 
         with pc_logging.Action("Interference", self.project_name, self.name):
+            # The tree travels as a JSON string rather than as itself. Anything
+            # recognisable as a shape or an assembly is turned into OCCT
+            # geometry on arrival (see ocp_serialize.decode), and a compound is
+            # exactly what this must not be given: the names go with it, and a
+            # report that two parts overlap has to be able to say which two.
+            # A string is left alone, so the wrapper decodes the tree itself,
+            # leaf by leaf, keeping each name attached to its solid.
             request_serialized = shape_envelope.serialize(
-                {"wrapped": obj, "min_volume": min_volume, "min_fraction": min_fraction}
+                {
+                    "assembly_json": json.dumps(obj),
+                    "min_volume": min_volume,
+                    "min_fraction": min_fraction,
+                }
             )
 
             runtime = ctx.get_python_runtime(version="3.11")

--- a/src/partcad/interface.py
+++ b/src/partcad/interface.py
@@ -307,6 +307,16 @@ class Interface:
         # thread rather than matching one. Both are inherited from the parent
         # interfaces when this one does not declare them, so a thread only has
         # to be spelled out once, on the interface that introduces it.
+        # option: "multiConnect"
+        # description: whether more than one item may be connected to the same
+        #              instance of this interface. False for a joint that is
+        #              made once - a bolt in a hole, a stud under a brick -
+        #              and true for one that is not, such as a shaft carrying
+        #              several parts along its length, or a rail.
+        # values: boolean
+        # default: false
+        self.multi_connect = bool(config.get("multiConnect", False))
+
         self.thread_step = config.get("threadStep", None)
         if self.thread_step is not None:
             if isinstance(self.thread_step, bool) or not isinstance(self.thread_step, (int, float)):
@@ -396,6 +406,18 @@ class Interface:
     def get_self_screw(self):
         """Whether this interface cuts its own thread, its own setting or inherited."""
         return bool(self._inherited("self_screw"))
+
+    def get_multi_connect(self):
+        """Whether one instance of this interface may take more than one item.
+
+        A stud takes one brick and a bolt hole takes one bolt, so two items
+        connected to the same port is a mistake worth reporting. A shaft is the
+        counter-example - several parts sit along it, all mated to the same
+        interface - and says so with 'multiConnect: true'. Inherited, so that
+        declaring it once on the interface a family derives from covers the
+        family.
+        """
+        return bool(self._inherited("multi_connect"))
 
     def _inherited(self, attribute, seen=None):
         """The attribute as declared here, or the first one found among the parents."""

--- a/src/partcad/interface.py
+++ b/src/partcad/interface.py
@@ -315,7 +315,11 @@ class Interface:
         #              several parts along its length, or a rail.
         # values: boolean
         # default: false
-        self.multi_connect = bool(config.get("multiConnect", False))
+        # None when the option is absent, the boolean when it is given. The
+        # difference matters: an interface that inherits 'multiConnect: true'
+        # has to be able to say 'false' and be believed, and a stored False
+        # that means "not set" cannot be told from one that means "no".
+        self.multi_connect = bool(config["multiConnect"]) if "multiConnect" in config else None
 
         self.thread_step = config.get("threadStep", None)
         if self.thread_step is not None:
@@ -417,12 +421,22 @@ class Interface:
         declaring it once on the interface a family derives from covers the
         family.
         """
-        return bool(self._inherited("multi_connect"))
+        # Only None is silence here, so 'multiConnect: false' on a child
+        # overrides a parent that allows many rather than being skipped over.
+        return bool(self._inherited("multi_connect", unset=(None,)))
 
-    def _inherited(self, attribute, seen=None):
-        """The attribute as declared here, or the first one found among the parents."""
+    def _inherited(self, attribute, seen=None, unset=(None, False)):
+        """The attribute as declared here, or the first one found among the parents.
+
+        'unset' says which stored values mean "nothing was declared here". It
+        includes False by default because most of these attributes store False
+        for an absent option and cannot tell that from an explicit one. An
+        attribute that does keep the difference - storing None when absent -
+        passes 'unset=(None,)' so that an explicit False overrides a parent
+        rather than being read as silence.
+        """
         value = getattr(self, attribute, None)
-        if value is not None and value is not False:
+        if value not in unset:
             return value
 
         # An interface hierarchy is a DAG rather than a tree, so the same parent
@@ -437,8 +451,8 @@ class Interface:
             parent = getattr(inherit, "interface", None)
             if parent is None:
                 continue
-            inherited = parent._inherited(attribute, seen)
-            if inherited is not None and inherited is not False:
+            inherited = parent._inherited(attribute, seen, unset)
+            if inherited not in unset:
                 return inherited
         return value
 

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -1917,6 +1917,7 @@ class Shape(ShapeConfiguration):
             return {
                 "solids": result.get("solids", 0),
                 "volume": result.get("volume"),
+                "min_solid_volume": result.get("min_solid_volume"),
                 "valid": result.get("valid"),
             }
 

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -1871,6 +1871,55 @@ class Shape(ShapeConfiguration):
             )
         )
 
+    async def get_solidity_async(self, ctx):
+        """Whether this shape is a solid OCCT will do arithmetic on.
+
+        Returned as {"solids": n, "volume": v, "valid": bool}, with 'volume' and
+        'valid' None when the shape holds no solid at all - a sketch, a shell,
+        a wire - or None outright when the shape could not be built.
+
+        A negative volume means the faces are oriented inward: the shape is
+        inside out. It still builds, renders, exports and measures; only its
+        arithmetic is wrong, which is why this has to be asked rather than
+        noticed. Measured in a sandbox, like every other operation on geometry.
+        """
+        obj = await self.get_wrapped(ctx)
+        if obj is None:
+            return None
+
+        with pc_logging.Action("Solidity", self.project_name, self.name):
+            request_serialized = shape_envelope.serialize({"wrapped": obj})
+
+            runtime = ctx.get_python_runtime(version="3.11")
+            await runtime.ensure_async(sandbox_versions.CADQUERY_OCP)
+
+            with tempfile.TemporaryDirectory(prefix="partcad-solidity-") as unused_dir:
+                command = [wrapper.get("solidity.py"), os.path.join(unused_dir, "unused.txt")]
+                exitcode, response_serialized, errors = await runtime.run_async(command, request_serialized)
+            if exitcode != 0 and len(errors) == 0:
+                errors = f"Failed to execute command '{' '.join(command)}' with exit code {exitcode}"
+            if errors:
+                pc_logging.error(errors)
+                raise Exception(errors)
+
+            response_lines = response_serialized.strip().splitlines()
+            if not response_lines:
+                pc_logging.error("Empty response from wrapper: %s" % command[0])
+                return None
+            result = shape_envelope.deserialize(response_lines[-1].strip())
+
+            if not result.get("success", False):
+                pc_logging.error(
+                    "Solidity check failed for %s:%s: %s"
+                    % (self.project_name, self.name, result.get("exception", "Unknown error"))
+                )
+                return None
+            return {
+                "solids": result.get("solids", 0),
+                "volume": result.get("volume"),
+                "valid": result.get("valid"),
+            }
+
     async def get_bounding_box_async(self, ctx):
         """The axis-aligned bounding box of this shape, in its own coordinates.
 

--- a/src/partcad/test/all.py
+++ b/src/partcad/test/all.py
@@ -16,7 +16,9 @@ from .cam_subtractive import CamSubtractiveTest
 from .cam_forming import CamFormingTest
 from .cfd import CfdTest
 from .connect import ConnectTest
+from .degenerate import DegenerateTest
 from .fea import FeaTest
+from .interference import InterferenceTest
 
 _global_tests: list[Test] = []
 
@@ -39,6 +41,11 @@ def tests(concurrency_cap: int) -> list[Test]:
                 CamSubtractiveTest(),
                 CamFormingTest(),
                 ConnectTest(),
+                DegenerateTest(),
+                # Realizes the assembly and intersects the pairs whose boxes
+                # meet, so it is the most expensive of the geometry checks and
+                # goes after the ones that are nearly free.
+                InterferenceTest(),
                 # Only ever run for a part that declares the matching section;
                 # see 'test/cae.py'. A package with no 'fea:'/'cfd:' in
                 # it pays nothing for these two being here.

--- a/src/partcad/test/all.py
+++ b/src/partcad/test/all.py
@@ -16,9 +16,11 @@ from .cam_subtractive import CamSubtractiveTest
 from .cam_forming import CamFormingTest
 from .cfd import CfdTest
 from .connect import ConnectTest
+from .connectivity import ConnectivityTest
 from .degenerate import DegenerateTest
 from .fea import FeaTest
 from .interference import InterferenceTest
+from .solidity import SolidityTest
 
 _global_tests: list[Test] = []
 
@@ -41,7 +43,13 @@ def tests(concurrency_cap: int) -> list[Test]:
                 CamSubtractiveTest(),
                 CamFormingTest(),
                 ConnectTest(),
+                ConnectivityTest(),
                 DegenerateTest(),
+                # Before interference, deliberately: a part that is inside out
+                # makes every boolean against it meaningless, so knowing which
+                # parts those are is what makes the interference result mean
+                # anything.
+                SolidityTest(),
                 # Realizes the assembly and intersects the pairs whose boxes
                 # meet, so it is the most expensive of the geometry checks and
                 # goes after the ones that are nearly free.

--- a/src/partcad/test/connectivity.py
+++ b/src/partcad/test/connectivity.py
@@ -78,8 +78,16 @@ class ConnectivityTest(Test):
         children = list(shape.connected_children())
         problems = []
         problems.extend(self._duplicates(children, config))
-        problems.extend(await self._crowded_ports(ctx, children))
+        crowded, consulted_interfaces = await self._crowded_ports(ctx, children)
+        problems.extend(crowded)
         problems.extend(self._unanchored(shape, config))
+
+        if consulted_interfaces:
+            # This verdict turned on an interface's 'multiConnect', which lives
+            # in the interface's own configuration - not in shape.hash and not
+            # among this shape's cache dependencies. Remembering the verdict
+            # would survive that setting being changed, so it is not kept.
+            test_ctx[self.NOT_CACHEABLE] = True
 
         if not problems:
             return self.passed(shape)
@@ -106,11 +114,13 @@ class ConnectivityTest(Test):
     async def _crowded_ports(self, ctx, children):
         """Two items connected to one port, unless the interface allows it.
 
-        Returns a list rather than yielding: asking an interface whether it
-        takes more than one item is awaited, and an async generator cannot be
-        collected as simply as the other two checks are.
+        Returns '(problems, consulted)': a list rather than a generator because
+        asking an interface whether it takes more than one item is awaited, and
+        'consulted' because an answer that came from an interface depends on
+        configuration this shape's cache key does not cover.
         """
         problems = []
+        consulted = False
         taken = {}
         for child in children:
             connection = child.connection
@@ -125,6 +135,7 @@ class ConnectivityTest(Test):
             if key not in taken:
                 taken[key] = child.name
                 continue
+            consulted = True
             if await _allows_many(ctx, interface):
                 continue
             where = port if port is not None else interface
@@ -132,7 +143,7 @@ class ConnectivityTest(Test):
                 "'%s' and '%s' are both connected to '%s' of '%s'"
                 % (taken[key], child.name, where, target)
             )
-        return problems
+        return problems, consulted
 
     def _containers(self, assembly):
         """Each group of items that were written as one 'links:' list.

--- a/src/partcad/test/connectivity.py
+++ b/src/partcad/test/connectivity.py
@@ -45,6 +45,16 @@ class ConnectivityTest(Test):
     def __init__(self) -> None:
         super().__init__("connectivity")
 
+    def cache_key_suffix(self, ctx, shape) -> str:
+        # Every setting that decides the verdict. Without them a cached pass is
+        # read back after the setting that produced it has been turned off.
+        config = (shape.config or {}).get("connectivity") or {}
+        return ",skip=%s,allowDuplicates=%s,requireAnchored=%s" % (
+            bool(config.get("skip", False)),
+            bool(config.get("allowDuplicates", False)),
+            bool(config.get("requireAnchored", True)),
+        )
+
     async def test(self, tests_to_run: list[Test], ctx, shape, test_ctx: dict = {}) -> bool:
         if not isinstance(shape, Assembly):
             self.debug(shape, "Not applicable")
@@ -58,7 +68,10 @@ class ConnectivityTest(Test):
         try:
             await shape.do_instantiate()
         except Exception as e:
-            # An assembly that will not instantiate is the 'cad' test's business.
+            # An assembly that will not instantiate is the 'cad' test's
+            # business, and this verdict turned on that rather than on the
+            # assembly: do not remember it.
+            test_ctx[self.NOT_CACHEABLE] = True
             self.debug(shape, "Failed to instantiate: %s" % e)
             return self.TEST_PASSED
 

--- a/src/partcad/test/connectivity.py
+++ b/src/partcad/test/connectivity.py
@@ -79,7 +79,7 @@ class ConnectivityTest(Test):
         problems = []
         problems.extend(self._duplicates(children, config))
         problems.extend(await self._crowded_ports(ctx, children))
-        problems.extend(self._unanchored(children, config))
+        problems.extend(self._unanchored(shape, config))
 
         if not problems:
             return self.passed(shape)
@@ -134,24 +134,45 @@ class ConnectivityTest(Test):
             )
         return problems
 
-    def _unanchored(self, children, config):
-        """Items placed by coordinates in an assembly that otherwise connects.
+    def _containers(self, assembly):
+        """Each group of items that were written as one 'links:' list.
 
-        Only meaningful once something does connect: an assembly built entirely
-        from coordinates is a legitimate way to write one, and every part of it
-        would otherwise be reported.
+        An ASSY file's top level 'links:' becomes a child assembly of the object
+        the file defines, and so does every nested one, so the groups are the
+        assembly's own children and then those of every assembly among them.
+        """
+        children = list(getattr(assembly, "children", []) or [])
+        yield children
+        for child in children:
+            item = child.item
+            if isinstance(item, Assembly):
+                yield from self._containers(item)
+
+    def _unanchored(self, shape, config):
+        """Items placed by coordinates in a group that otherwise connects.
+
+        Per group rather than per assembly, because the exemption is for the
+        item the others hang from and every 'links:' list has one. Flattening
+        the tree first would exempt the wrapper assembly that the file's top
+        level becomes, and then report the item it wraps - which is the one
+        thing that is allowed to be placed by coordinates.
+
+        Only meaningful once something in the group does connect: a group
+        written entirely as coordinates is a legitimate way to write one.
         """
         if not config.get("requireAnchored", True):
             return
-        connected = [child for child in children if child.connection]
-        if not connected or len(children) < 2:
-            return
-        for child in children[1:]:
-            if not child.connection:
-                yield (
-                    "'%s' is placed by coordinates in an assembly that connects "
-                    "its other items, so nothing holds it where it is" % child.name
-                )
+        for children in self._containers(shape):
+            if len(children) < 2:
+                continue
+            if not any(child.connection for child in children):
+                continue
+            for child in children[1:]:
+                if not child.connection:
+                    yield (
+                        "'%s' is placed by coordinates among items that connect, "
+                        "so nothing holds it where it is" % child.name
+                    )
 
 
 def _packed(location):

--- a/src/partcad/test/connectivity.py
+++ b/src/partcad/test/connectivity.py
@@ -1,0 +1,171 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+from .test import Test
+from ..assembly import Assembly
+
+
+class ConnectivityTest(Test):
+    """Fail an assembly whose parts are placed in ways that do not add up.
+
+    Three things, all of which an assembly can do while building perfectly and
+    rendering plausibly.
+
+    **The same part twice in the same place.** A generator that runs a loop one
+    time too many, or a hand-written ASSY with a copy-pasted node whose location
+    was not changed, produces two items occupying one space. Nothing looks
+    wrong: the second is exactly behind the first in every view.
+
+    **Two items connected to one port.** A stud takes one brick and a bolt hole
+    takes one bolt. Where the joint is one that is genuinely made more than once
+    - a shaft carrying several parts along its length, a rail - the interface
+    says so with 'multiConnect: true' and this passes it.
+
+    **An item anchored to nothing.** Every item after the first has to be put
+    somewhere relative to what is already there. One placed by 'location:' in an
+    assembly that otherwise connects by interface is floating in the coordinate
+    system rather than attached to the thing it belongs to: it will be in the
+    right place only for as long as nothing it sits on moves. This is reported
+    rather than assumed wrong - an assembly may legitimately place everything by
+    coordinates - so it only applies once something in the assembly does connect.
+
+    Configured per assembly:
+
+        assemblies:
+          gearbox:
+            connectivity:
+              allowDuplicates: false   # two items in one place
+              requireAnchored: true    # every item after the first connected
+              skip: false
+    """
+
+    def __init__(self) -> None:
+        super().__init__("connectivity")
+
+    async def test(self, tests_to_run: list[Test], ctx, shape, test_ctx: dict = {}) -> bool:
+        if not isinstance(shape, Assembly):
+            self.debug(shape, "Not applicable")
+            return self.TEST_PASSED
+
+        config = (shape.config or {}).get("connectivity") or {}
+        if config.get("skip", False):
+            self.debug(shape, "Skipped by configuration")
+            return self.TEST_PASSED
+
+        try:
+            await shape.do_instantiate()
+        except Exception as e:
+            # An assembly that will not instantiate is the 'cad' test's business.
+            self.debug(shape, "Failed to instantiate: %s" % e)
+            return self.TEST_PASSED
+
+        children = list(shape.connected_children())
+        problems = []
+        problems.extend(self._duplicates(children, config))
+        problems.extend(await self._crowded_ports(ctx, children))
+        problems.extend(self._unanchored(children, config))
+
+        if not problems:
+            return self.passed(shape)
+        for problem in problems:
+            self.failed(shape, problem)
+        return self.TEST_FAILED
+
+    def _duplicates(self, children, config):
+        if config.get("allowDuplicates", False):
+            return []
+        seen = {}
+        for child in children:
+            item = getattr(child.item, "name", None)
+            project = getattr(child.item, "project_name", None)
+            location = child.location
+            if item is None or location is None:
+                continue
+            key = (project, item, _packed(location))
+            if key in seen:
+                yield "'%s' and '%s' are the same part in the same place" % (seen[key], child.name)
+                continue
+            seen[key] = child.name
+
+    async def _crowded_ports(self, ctx, children):
+        """Two items connected to one port, unless the interface allows it.
+
+        Returns a list rather than yielding: asking an interface whether it
+        takes more than one item is awaited, and an async generator cannot be
+        collected as simply as the other two checks are.
+        """
+        problems = []
+        taken = {}
+        for child in children:
+            connection = child.connection
+            if not connection:
+                continue
+            target = connection.get("target")
+            port = connection.get("to_port")
+            interface = connection.get("to_interface")
+            if target is None or (port is None and interface is None):
+                continue
+            key = (target, port, interface)
+            if key not in taken:
+                taken[key] = child.name
+                continue
+            if await _allows_many(ctx, interface):
+                continue
+            where = port if port is not None else interface
+            problems.append(
+                "'%s' and '%s' are both connected to '%s' of '%s'"
+                % (taken[key], child.name, where, target)
+            )
+        return problems
+
+    def _unanchored(self, children, config):
+        """Items placed by coordinates in an assembly that otherwise connects.
+
+        Only meaningful once something does connect: an assembly built entirely
+        from coordinates is a legitimate way to write one, and every part of it
+        would otherwise be reported.
+        """
+        if not config.get("requireAnchored", True):
+            return
+        connected = [child for child in children if child.connection]
+        if not connected or len(children) < 2:
+            return
+        for child in children[1:]:
+            if not child.connection:
+                yield (
+                    "'%s' is placed by coordinates in an assembly that connects "
+                    "its other items, so nothing holds it where it is" % child.name
+                )
+
+
+def _packed(location):
+    """A location as a hashable key, rounded so that arithmetic noise in two
+    placements that were meant to be the same does not hide that they are."""
+    try:
+        translation, axis, angle = location.as_packed()
+        return (
+            tuple(round(float(v), 6) for v in translation),
+            tuple(round(float(v), 6) for v in axis),
+            round(float(angle), 6),
+        )
+    except Exception:
+        return repr(location)
+
+
+async def _allows_many(ctx, interface_spec):
+    """Whether this interface says one instance of it may take several items."""
+    if ctx is None or not interface_spec:
+        return False
+    try:
+        interface = ctx.get_interface(interface_spec)
+    except Exception:
+        return False
+    if interface is None:
+        return False
+    try:
+        return bool(interface.get_multi_connect())
+    except Exception:
+        return False

--- a/src/partcad/test/degenerate.py
+++ b/src/partcad/test/degenerate.py
@@ -67,6 +67,16 @@ class DegenerateTest(Test):
             return self.TEST_PASSED
 
         try:
+            # A shape that did not build has no size for the same reason it has
+            # nothing else, and 'cad' reports that. Measuring it would produce
+            # a second failure naming a cause that is not the cause - "it is
+            # empty" for a part whose script raised an ImportError - and send
+            # the reader after the wrong thing.
+            if await shape.get_wrapped(ctx) is None:
+                test_ctx[self.NOT_CACHEABLE] = True
+                self.debug(shape, "The shape did not build; that is the 'cad' test's to report")
+                return self.TEST_PASSED
+
             box = await shape.get_bounding_box_async(ctx)
         except Exception as e:
             # About the machine, not the shape: do not remember it.
@@ -75,7 +85,11 @@ class DegenerateTest(Test):
             return self.TEST_PASSED
 
         if box is None:
-            return self.failed(shape, "The shape has no extent at all: it is empty")
+            return self.failed(
+                shape,
+                "The shape built but occupies no space at all: its bounding box "
+                "is empty.",
+            )
 
         tolerance = float(config.get("tolerance", 1e-3))
         x_min, y_min, z_min, x_max, y_max, z_max = box

--- a/src/partcad/test/degenerate.py
+++ b/src/partcad/test/degenerate.py
@@ -6,6 +6,7 @@
 
 from .test import Test
 from ..assembly import Assembly
+from ..sketch import Sketch
 
 
 class DegenerateTest(Test):
@@ -49,6 +50,14 @@ class DegenerateTest(Test):
         config = (shape.config or {}).get("degenerate") or {}
         if config.get("skip", False):
             self.debug(shape, "Skipped by configuration")
+            return self.TEST_PASSED
+
+        # A sketch is flat because that is what a sketch is. Measuring one
+        # against a rule about having size in every direction fails it for
+        # being what it was asked to be, and a check an object cannot pass and
+        # should not be taking is worse than no check.
+        if isinstance(shape, Sketch):
+            self.debug(shape, "Not applicable: a sketch is flat by definition")
             return self.TEST_PASSED
 
         # An assembly is checked through its parts, each of which is tested in

--- a/src/partcad/test/degenerate.py
+++ b/src/partcad/test/degenerate.py
@@ -1,0 +1,70 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+from .test import Test
+from ..assembly import Assembly
+
+
+class DegenerateTest(Test):
+    """Fail a shape that came out with no size to it.
+
+    A part can instantiate perfectly and still be wrong in a way nothing looks
+    at: geometry that resolves to a sheet, a sliver or nothing at all. The
+    'cad' test asks whether a shape was produced, not whether what was produced
+    is a solid anybody meant.
+
+    The failure this is written for came from a repository plugin that meshes
+    LDraw parts. A part is mostly references, and a subfile that could not be
+    fetched was skipped in silence, so a 2 x 2 round brick 9.6 mm tall meshed
+    into a flat disc about a millimetre thick. It rendered; it exported; it
+    passed every test there was. Only a picture showed it, and only because the
+    towers built out of it looked wrong.
+
+    So: a shape whose bounding box is empty, or which is flat to within a
+    thousandth of a millimetre in any direction, is reported. A genuinely flat
+    object - a sketch, a decal, a shim - says so:
+
+        parts:
+          shim:
+            degenerate:
+              skip: true
+    """
+
+    def __init__(self) -> None:
+        super().__init__("degenerate")
+
+    async def test(self, tests_to_run: list[Test], ctx, shape, test_ctx: dict = {}) -> bool:
+        config = (shape.config or {}).get("degenerate") or {}
+        if config.get("skip", False):
+            self.debug(shape, "Skipped by configuration")
+            return self.TEST_PASSED
+
+        # An assembly is checked through its parts, each of which is tested in
+        # its own right; an assembly's own box says nothing about them.
+        if isinstance(shape, Assembly):
+            self.debug(shape, "Not applicable")
+            return self.TEST_PASSED
+
+        try:
+            box = await shape.get_bounding_box_async(ctx)
+        except Exception as e:
+            self.debug(shape, "Failed to measure: %s" % e)
+            return self.TEST_PASSED
+
+        if box is None:
+            return self.failed(shape, "The shape has no extent at all: it is empty")
+
+        tolerance = float(config.get("tolerance", 1e-3))
+        x_min, y_min, z_min, x_max, y_max, z_max = box
+        extents = (x_max - x_min, y_max - y_min, z_max - z_min)
+        flat = [axis for axis, extent in zip("XYZ", extents) if extent <= tolerance]
+        if flat:
+            return self.failed(
+                shape,
+                "The shape is flat in %s (%.4f x %.4f x %.4f mm): geometry is "
+                "missing, or this is not a solid" % (" and ".join(flat), *extents),
+            )
+        return self.passed(shape)

--- a/src/partcad/test/degenerate.py
+++ b/src/partcad/test/degenerate.py
@@ -36,6 +36,15 @@ class DegenerateTest(Test):
     def __init__(self) -> None:
         super().__init__("degenerate")
 
+    def cache_key_suffix(self, ctx, shape) -> str:
+        # Whatever decides the verdict has to be in the key, or changing the
+        # tolerance hands back the answer from the old one.
+        config = (shape.config or {}).get("degenerate") or {}
+        return ",skip=%s,tolerance=%s" % (
+            bool(config.get("skip", False)),
+            config.get("tolerance", 1e-3),
+        )
+
     async def test(self, tests_to_run: list[Test], ctx, shape, test_ctx: dict = {}) -> bool:
         config = (shape.config or {}).get("degenerate") or {}
         if config.get("skip", False):
@@ -51,6 +60,8 @@ class DegenerateTest(Test):
         try:
             box = await shape.get_bounding_box_async(ctx)
         except Exception as e:
+            # About the machine, not the shape: do not remember it.
+            test_ctx[self.NOT_CACHEABLE] = True
             self.debug(shape, "Failed to measure: %s" % e)
             return self.TEST_PASSED
 

--- a/src/partcad/test/interference.py
+++ b/src/partcad/test/interference.py
@@ -81,7 +81,15 @@ class InterferenceTest(Test):
         # inside-out one "shares" volume with parts it is nowhere near - so it
         # is left out, and an assembly built entirely from such parts is not
         # being checked at all. Whoever reads a pass should know which it was.
+        # A verdict reached while some of it could not be looked at is not a
+        # verdict about the assembly, and remembering it would hand back a pass
+        # that was never earned - without even repeating what went unexamined,
+        # since a cached result is returned before the test runs.
+        indeterminate = result.get("indeterminate") or []
         unchecked = result.get("unchecked") or []
+        if indeterminate or unchecked:
+            test_ctx[self.NOT_CACHEABLE] = True
+
         if unchecked:
             shown = ", ".join(unchecked[:5]) + ("..." if len(unchecked) > 5 else "")
             self.info(
@@ -93,7 +101,7 @@ class InterferenceTest(Test):
         # A pair whose boolean did not come back is not a pair that does not
         # overlap. Saying so is the difference between a check that found
         # nothing and a check that could not look.
-        for pair in result.get("indeterminate") or []:
+        for pair in indeterminate:
             self.info(
                 shape,
                 "could not decide whether '%s' and '%s' overlap: %s"

--- a/src/partcad/test/interference.py
+++ b/src/partcad/test/interference.py
@@ -1,0 +1,121 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+from .test import Test
+from ..assembly import Assembly
+
+
+class InterferenceTest(Test):
+    """Fail an assembly whose parts share space.
+
+    The 'cad' test passes an assembly whose parts are all in the wrong place -
+    it only asks whether the geometry instantiates. This asks where the parts
+    ended up, which is the question an assembly is actually judged on, and the
+    one nothing has been able to answer without a person looking at a render.
+
+    The answer comes from a boolean common and the volume of what it produces.
+    Bounding boxes are not enough: two boxes meeting says very little about two
+    solids - a bracket around a shaft, an L around a corner, anything rotated -
+    so they are used only to choose the pairs worth intersecting.
+
+    What counts as sharing space is a threshold rather than 'any volume at all'.
+    Parts meant to go together touch, and meshed geometry touching produces
+    slivers, so an assembly that fits would otherwise fail. The default asks for
+    a cubic millimetre; a package that wants to be stricter or looser can say so:
+
+        assemblies:
+          gearbox:
+            interference:
+              minVolume: 0.5      # mm^3 of shared space before it is reported
+              minFraction: 0.01   # ...and/or that share of the smaller part
+              ignore:             # pairs that are meant to interfere
+                - [shaft, hub]
+    """
+
+    def __init__(self) -> None:
+        super().__init__("interference")
+
+    def cache_key_suffix(self, ctx, shape) -> str:
+        config = (shape.config or {}).get("interference") or {}
+        return "minVolume=%s,minFraction=%s,ignore=%s" % (
+            config.get("minVolume", 1.0),
+            config.get("minFraction", 0.0),
+            sorted(tuple(sorted(pair)) for pair in config.get("ignore", [])),
+        )
+
+    async def test(self, tests_to_run: list[Test], ctx, shape, test_ctx: dict = {}) -> bool:
+        if not isinstance(shape, Assembly):
+            self.debug(shape, "Not applicable")
+            return self.TEST_PASSED
+
+        config = (shape.config or {}).get("interference") or {}
+        if config.get("skip", False):
+            self.debug(shape, "Skipped by configuration")
+            return self.TEST_PASSED
+
+        try:
+            result = await shape.get_interference_async(
+                ctx,
+                min_volume=float(config.get("minVolume", 1.0)),
+                min_fraction=float(config.get("minFraction", 0.0)),
+            )
+        except Exception as e:
+            # An assembly that will not realize is what the 'cad' test is for;
+            # this one has nothing to say about it either way.
+            self.debug(shape, "Failed to check for interference: %s" % e)
+            return self.TEST_PASSED
+
+        if result is None:
+            self.debug(shape, "The assembly produced no geometry to check")
+            return self.TEST_PASSED
+
+        # Said out loud rather than left to be inferred from a pass. A shape
+        # that is not a valid solid cannot be intersected meaningfully - an
+        # inside-out one "shares" volume with parts it is nowhere near - so it
+        # is left out, and an assembly built entirely from such parts is not
+        # being checked at all. Whoever reads a pass should know which it was.
+        unchecked = result.get("unchecked") or []
+        if unchecked:
+            shown = ", ".join(unchecked[:5]) + ("..." if len(unchecked) > 5 else "")
+            self.info(
+                shape,
+                "%d part(s) are not valid solids and were not checked: %s"
+                % (len(unchecked), shown),
+            )
+
+        overlaps = result.get("overlaps") or []
+
+        ignored = {tuple(sorted(pair)) for pair in config.get("ignore", [])}
+        reported = [o for o in overlaps if not _is_ignored(o, ignored)]
+        if not reported:
+            return self.passed(shape)
+
+        for overlap in reported:
+            self.failed(
+                shape,
+                "'%s' and '%s' share %.3f mm^3" % (overlap["a"], overlap["b"], overlap["volume"]),
+            )
+        return self.TEST_FAILED
+
+
+def _is_ignored(overlap, ignored):
+    """Whether this pair was declared as one that is meant to interfere.
+
+    A pair is named by the two part names, in either order, and matches a
+    child whose name ends with it - so 'shaft' covers 'gearbox/shaft' without
+    the configuration having to spell out where in the tree it sits.
+    """
+    for a, b in ignored:
+        names = (overlap["a"], overlap["b"])
+        if _matches(names[0], a) and _matches(names[1], b):
+            return True
+        if _matches(names[0], b) and _matches(names[1], a):
+            return True
+    return False
+
+
+def _matches(name, pattern):
+    return name == pattern or name.endswith("/" + pattern)

--- a/src/partcad/test/interference.py
+++ b/src/partcad/test/interference.py
@@ -40,7 +40,8 @@ class InterferenceTest(Test):
 
     def cache_key_suffix(self, ctx, shape) -> str:
         config = (shape.config or {}).get("interference") or {}
-        return "minVolume=%s,minFraction=%s,ignore=%s" % (
+        return ",skip=%s,minVolume=%s,minFraction=%s,ignore=%s" % (
+            bool(config.get("skip", False)),
             config.get("minVolume", 1.0),
             config.get("minFraction", 0.0),
             sorted(tuple(sorted(pair)) for pair in config.get("ignore", [])),
@@ -64,11 +65,14 @@ class InterferenceTest(Test):
             )
         except Exception as e:
             # An assembly that will not realize is what the 'cad' test is for;
-            # this one has nothing to say about it either way.
+            # this one has nothing to say about it either way - and nothing
+            # worth remembering, since the reason was not the assembly.
+            test_ctx[self.NOT_CACHEABLE] = True
             self.debug(shape, "Failed to check for interference: %s" % e)
             return self.TEST_PASSED
 
         if result is None:
+            test_ctx[self.NOT_CACHEABLE] = True
             self.debug(shape, "The assembly produced no geometry to check")
             return self.TEST_PASSED
 
@@ -84,6 +88,16 @@ class InterferenceTest(Test):
                 shape,
                 "%d part(s) are not valid solids and were not checked: %s"
                 % (len(unchecked), shown),
+            )
+
+        # A pair whose boolean did not come back is not a pair that does not
+        # overlap. Saying so is the difference between a check that found
+        # nothing and a check that could not look.
+        for pair in result.get("indeterminate") or []:
+            self.info(
+                shape,
+                "could not decide whether '%s' and '%s' overlap: %s"
+                % (pair["a"], pair["b"], pair.get("reason", "the boolean failed")),
             )
 
         overlaps = result.get("overlaps") or []

--- a/src/partcad/test/solidity.py
+++ b/src/partcad/test/solidity.py
@@ -26,6 +26,10 @@ class SolidityTest(Test):
     wrong on such a part: interference, CAM, FEA, the volume in a bill of
     materials.
 
+    What this does not fail is a solid that is merely not *valid*. Plenty of
+    usable geometry is not, and intersects perfectly well regardless; failing
+    it would condemn an entire library that works. That is reported and passed.
+
     A shape holding no solid at all - a sketch, a shell, a wire - is not inside
     out and is passed over. A part that is genuinely built as a void, if such a
     thing is wanted, says so:
@@ -75,11 +79,19 @@ class SolidityTest(Test):
                 "correctly and every boolean against it will be wrong." % volume,
             )
 
+        # Not a failure. Plenty of usable geometry is not a valid solid in
+        # OCCT's sense and behaves perfectly well: an LDraw brick is an open
+        # mesh - a stud is a cylinder and a top disc with no bottom, resting on
+        # a face the parent never cuts - so it has hundreds of free boundary
+        # edges and fails IsValid, while two copies of it 100 mm apart
+        # correctly share no volume at all. Failing on validity would condemn
+        # every part of a whole library that works. It is said, once, because
+        # it does narrow what can be relied on.
         if result.get("valid") is False:
-            return self.failed(
+            self.info(
                 shape,
-                "The shape is not a valid solid, so booleans against it - "
-                "interference, CAM, FEA - cannot be relied on.",
+                "The shape is a solid the right way out, but not a valid one: "
+                "expect open edges, and check any boolean result against it.",
             )
 
         return self.passed(shape)

--- a/src/partcad/test/solidity.py
+++ b/src/partcad/test/solidity.py
@@ -1,0 +1,85 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+from .test import Test
+from ..assembly import Assembly
+
+
+class SolidityTest(Test):
+    """Fail a part that is inside out.
+
+    A solid's faces are oriented: outward for material on the inside of them,
+    inward for material outside. Get that backwards and the shape still builds,
+    still renders, still exports, and still measures the right size - a picture
+    of it is indistinguishable from a picture of the right thing. What breaks is
+    the arithmetic. OCCT reports such a solid's volume as negative, and every
+    boolean against it returns a number with no relation to any shape.
+
+    This was found in LDraw parts meshed from triangles: LDraw declares winding
+    per file with its BFC metadata, the mesher ignored it, and every LEGO part
+    came out inverted. Brick 2 x 4 measured -1939.6 mm^3, and two copies of it
+    100 mm apart - sharing, necessarily, nothing - intersected to 2282 mm^3.
+    Nothing reported it, because nothing asked. Anything built on booleans is
+    wrong on such a part: interference, CAM, FEA, the volume in a bill of
+    materials.
+
+    A shape holding no solid at all - a sketch, a shell, a wire - is not inside
+    out and is passed over. A part that is genuinely built as a void, if such a
+    thing is wanted, says so:
+
+        parts:
+          cavity:
+            solidity:
+              skip: true
+    """
+
+    def __init__(self) -> None:
+        super().__init__("solidity")
+
+    async def test(self, tests_to_run: list[Test], ctx, shape, test_ctx: dict = {}) -> bool:
+        config = (shape.config or {}).get("solidity") or {}
+        if config.get("skip", False):
+            self.debug(shape, "Skipped by configuration")
+            return self.TEST_PASSED
+
+        # An assembly is checked through its parts, each tested in its own
+        # right; the compound of a set of parts says nothing they do not.
+        if isinstance(shape, Assembly):
+            self.debug(shape, "Not applicable")
+            return self.TEST_PASSED
+
+        try:
+            result = await shape.get_solidity_async(ctx)
+        except Exception as e:
+            # A shape that will not build is what the 'cad' test is for.
+            self.debug(shape, "Failed to check: %s" % e)
+            return self.TEST_PASSED
+
+        if result is None:
+            self.debug(shape, "The shape produced no geometry to check")
+            return self.TEST_PASSED
+
+        if not result.get("solids"):
+            self.debug(shape, "No solid to check: a sketch, a shell or a wire")
+            return self.TEST_PASSED
+
+        volume = result.get("volume")
+        if volume is not None and volume < 0.0:
+            return self.failed(
+                shape,
+                "The shape is inside out: its volume measures %.3f mm^3, which is "
+                "negative because its faces are oriented inward. It will render "
+                "correctly and every boolean against it will be wrong." % volume,
+            )
+
+        if result.get("valid") is False:
+            return self.failed(
+                shape,
+                "The shape is not a valid solid, so booleans against it - "
+                "interference, CAM, FEA - cannot be relied on.",
+            )
+
+        return self.passed(shape)

--- a/src/partcad/test/solidity.py
+++ b/src/partcad/test/solidity.py
@@ -43,6 +43,12 @@ class SolidityTest(Test):
     def __init__(self) -> None:
         super().__init__("solidity")
 
+    def cache_key_suffix(self, ctx, shape) -> str:
+        # Whatever decides the verdict has to be in the key, or turning a
+        # setting off hands back the answer from before it was turned off.
+        config = (shape.config or {}).get("solidity") or {}
+        return ",skip=%s" % bool(config.get("skip", False))
+
     async def test(self, tests_to_run: list[Test], ctx, shape, test_ctx: dict = {}) -> bool:
         config = (shape.config or {}).get("solidity") or {}
         if config.get("skip", False):
@@ -58,11 +64,16 @@ class SolidityTest(Test):
         try:
             result = await shape.get_solidity_async(ctx)
         except Exception as e:
-            # A shape that will not build is what the 'cad' test is for.
+            # A shape that will not build is what the 'cad' test is for. This
+            # verdict is about the machine rather than the shape, so it must
+            # not be remembered: installing what was missing would not change
+            # the key it would be read back under.
+            test_ctx[self.NOT_CACHEABLE] = True
             self.debug(shape, "Failed to check: %s" % e)
             return self.TEST_PASSED
 
         if result is None:
+            test_ctx[self.NOT_CACHEABLE] = True
             self.debug(shape, "The shape produced no geometry to check")
             return self.TEST_PASSED
 
@@ -70,13 +81,22 @@ class SolidityTest(Test):
             self.debug(shape, "No solid to check: a sketch, a shell or a wire")
             return self.TEST_PASSED
 
-        volume = result.get("volume")
-        if volume is not None and volume < 0.0:
+        # The least of the solids, not their sum: a compound holding one
+        # inverted solid and a larger correct one adds up to a positive number,
+        # and the inversion disappears into the total.
+        volume = result.get("min_solid_volume")
+        if volume is None:
+            volume = result.get("volume")
+        # Non-positive, not negative. A solid of exactly zero volume is not a
+        # solid either, and it is the boundary a mesh that collapses lands on.
+        if volume is not None and volume <= 0.0:
             return self.failed(
                 shape,
-                "The shape is inside out: its volume measures %.3f mm^3, which is "
-                "negative because its faces are oriented inward. It will render "
-                "correctly and every boolean against it will be wrong." % volume,
+                "The shape is not a solid anything can be computed from: a "
+                "constituent solid measures %.3f mm^3. A negative volume means "
+                "its faces are oriented inward; zero means it encloses nothing. "
+                "It will render correctly and every boolean against it will be "
+                "wrong." % volume,
             )
 
         # Not a failure. Plenty of usable geometry is not a valid solid in

--- a/src/partcad/test/solidity.py
+++ b/src/partcad/test/solidity.py
@@ -6,6 +6,7 @@
 
 from .test import Test
 from ..assembly import Assembly
+from ..sketch import Sketch
 
 
 class SolidityTest(Test):
@@ -53,6 +54,12 @@ class SolidityTest(Test):
         config = (shape.config or {}).get("solidity") or {}
         if config.get("skip", False):
             self.debug(shape, "Skipped by configuration")
+            return self.TEST_PASSED
+
+        # A sketch has no solid to be the wrong way out, and asking costs a
+        # sandbox each time. Answered here rather than by measuring.
+        if isinstance(shape, Sketch):
+            self.debug(shape, "Not applicable: a sketch has no solid")
             return self.TEST_PASSED
 
         # An assembly is checked through its parts, each tested in its own

--- a/src/partcad/test/test.py
+++ b/src/partcad/test/test.py
@@ -129,6 +129,16 @@ class Test(ABC):
         message = self._log_message_prepare(*args)
         pc_logging.debug(f"Test: {shape.project_name}:{shape.name}: {self.name}{message}")
 
+    def info(self, shape, *args) -> None:
+        """Like logging.info(), prefixed with the test name and the shape name.
+
+        For what a reader of the result has to know in order to read it: a
+        check that could only be applied to part of what it was given says so
+        here, so that a pass is not mistaken for a clean bill of health.
+        """
+        message = self._log_message_prepare(*args)
+        pc_logging.info(f"Test: {shape.project_name}:{shape.name}: {self.name}{message}")
+
     def failed(self, shape, *args) -> bool:
         """This methods works like logging.error() but prepends the message with the test name and the shape name."""
         message = self._log_message_prepare(*args)

--- a/src/partcad/wrappers/wrapper_interference.py
+++ b/src/partcad/wrappers/wrapper_interference.py
@@ -23,7 +23,6 @@ import pyexpat  # noqa: F401
 
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Common
 from OCP.BRepBndLib import BRepBndLib
-from OCP.BRepCheck import BRepCheck_Analyzer
 from OCP.BRepGProp import BRepGProp
 from OCP.Bnd import Bnd_Box
 from OCP.GProp import GProp_GProps
@@ -80,14 +79,20 @@ def _is_solid_enough_to_intersect(shape):
     It is not a formality. A shape whose faces are inconsistently oriented is
     inside out, which OCCT reports as a negative volume, and a boolean common
     against it returns a number with no relation to any shared space: two LDraw
-    bricks meshed from triangles and placed 100 mm apart come back sharing
+    bricks meshed from triangles and placed 100 mm apart came back sharing
     2282 mm^3. Reporting that as interference would be worse than not checking
-    at all, so a shape that is not a valid solid of positive volume is left out
-    and counted instead.
+    at all, so a shape whose volume is not positive is left out and counted.
+
+    The test is the volume's sign and not BRepCheck_Analyzer, deliberately.
+    Plenty of usable geometry is not a valid solid in OCCT's sense and
+    intersects perfectly well regardless: an LDraw brick is an open mesh - a
+    stud is a cylinder and a top disc with no bottom, resting on a face the
+    parent never cuts - so it has hundreds of free boundary edges and fails
+    IsValid, while two copies of it 100 mm apart correctly share nothing.
+    Gating on validity would refuse to check any assembly built from such
+    parts, forever, which is most of what this test exists for.
     """
     try:
-        if not BRepCheck_Analyzer(shape).IsValid():
-            return False
         return _volume(shape) > 0.0
     except Exception:
         return False

--- a/src/partcad/wrappers/wrapper_interference.py
+++ b/src/partcad/wrappers/wrapper_interference.py
@@ -40,7 +40,12 @@ def _leaves(obj, prefix=""):
     renderer wants and the opposite of what this needs: a report saying two
     parts overlap has to be able to say which two.
     """
-    name = obj.get("name") or obj.get("label") or ""
+    # The label first, deliberately. Assembly._place() puts the object's
+    # identity in "name" - '//pkg:3010' - and what this placement of it is
+    # called in "label" - 'buttS8'. An assembly is mostly repeats of a few
+    # parts, so reporting by name says "3010 overlaps 3010", and the 'ignore'
+    # pairs, which are written as instance names, would never match.
+    name = obj.get("label") or obj.get("name") or ""
     path = "%s/%s" % (prefix, name) if prefix else name
     if ocp_serialize.is_assembly_object(obj):
         placed = []
@@ -152,17 +157,24 @@ def process(path, request):
         ]
 
         overlaps = []
+        indeterminate = []
         for a, b in candidates:
             name_a, shape_a, _ = boxes[a]
             name_b, shape_b, _ = boxes[b]
             try:
                 common = BRepAlgoAPI_Common(shape_a, shape_b)
-                if not common.IsDone():
-                    continue
-                volume = _volume(common.Shape())
-            except Exception:
-                # A boolean that will not run says nothing either way; a part
-                # that cannot be intersected is the 'cad' test's business.
+                done = common.IsDone()
+                volume = _volume(common.Shape()) if done else None
+            except Exception as e:
+                done, volume = False, None
+                reason = str(e)
+            else:
+                reason = "the boolean did not complete"
+            if not done or volume is None:
+                # Not "they do not overlap". The question was asked and did not
+                # come back, and answering a pass on that is how a check comes
+                # to certify what it never looked at.
+                indeterminate.append({"a": name_a, "b": name_b, "reason": reason})
                 continue
             if volume < min_volume:
                 continue
@@ -180,6 +192,7 @@ def process(path, request):
             "candidates": len(candidates),
             "overlaps": overlaps,
             "unchecked": unchecked,
+            "indeterminate": indeterminate,
         }
     except Exception as e:
         wrapper_common.handle_exception(e)
@@ -190,6 +203,7 @@ def process(path, request):
             "candidates": 0,
             "overlaps": [],
             "unchecked": [],
+            "indeterminate": [],
         }
 
 

--- a/src/partcad/wrappers/wrapper_interference.py
+++ b/src/partcad/wrappers/wrapper_interference.py
@@ -142,6 +142,11 @@ def process(path, request):
         for name, shape in leaves:
             box = _box(shape)
             if box is None:
+                # An empty shape is not a part that overlaps nothing, it is a
+                # part nothing could be asked about. Dropping it here would
+                # take it out of 'parts' and out of 'unchecked' both, and a
+                # caller reading either would never learn it existed.
+                unchecked.append(name)
                 continue
             if not _is_solid_enough_to_intersect(shape):
                 unchecked.append(name)

--- a/src/partcad/wrappers/wrapper_interference.py
+++ b/src/partcad/wrappers/wrapper_interference.py
@@ -14,6 +14,7 @@
 # answer itself comes from a boolean common and the volume of what it produces.
 
 import itertools
+import json
 import os
 import sys
 
@@ -100,9 +101,15 @@ def _is_solid_enough_to_intersect(shape):
 
 def process(path, request):
     try:
-        obj = request.get("wrapped")
-        if obj is None:
+        # Not 'wrapped': that key is decoded into OCCT geometry on arrival, and
+        # an assembly decodes into one compound, which is the one thing this
+        # cannot use. The names have to survive - a report that two parts
+        # overlap has to say which two - so the tree arrives as JSON and is
+        # decoded here, leaf by leaf.
+        payload = request.get("assembly_json")
+        if payload is None:
             raise Exception("No assembly provided to check")
+        obj = json.loads(payload) if isinstance(payload, str) else payload
 
         # How much shared volume is worth reporting. Parts that are meant to fit
         # together touch, and meshed geometry touching is numerically noisy, so

--- a/src/partcad/wrappers/wrapper_interference.py
+++ b/src/partcad/wrappers/wrapper_interference.py
@@ -1,0 +1,187 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+# This script is executed within a python runtime environment to find the pairs
+# of parts in an assembly whose solids share space. The core has no CAD library,
+# so the only place this can be answered is a runtime that has one.
+#
+# Bounding boxes are not enough to answer it. Two boxes overlapping says very
+# little - a bracket around a shaft, an L around a corner, anything rotated -
+# so boxes are used here only to pick the pairs worth asking about, and the
+# answer itself comes from a boolean common and the volume of what it produces.
+
+import itertools
+import os
+import sys
+
+# Pinned before the CAD imports below, which load OCP and with it VTK's
+# bundled copy of expat: see the note in ocp_serialize.
+import pyexpat  # noqa: F401
+
+from OCP.BRepAlgoAPI import BRepAlgoAPI_Common
+from OCP.BRepBndLib import BRepBndLib
+from OCP.BRepCheck import BRepCheck_Analyzer
+from OCP.BRepGProp import BRepGProp
+from OCP.Bnd import Bnd_Box
+from OCP.GProp import GProp_GProps
+
+sys.path.append(os.path.dirname(__file__))
+import ocp_serialize
+import wrapper_common
+
+
+def _leaves(obj, prefix=""):
+    """Every solid in the tree, placed, with the name it is known by.
+
+    decode_shape() flattens an assembly into one compound, which is what a
+    renderer wants and the opposite of what this needs: a report saying two
+    parts overlap has to be able to say which two.
+    """
+    name = obj.get("name") or obj.get("label") or ""
+    path = "%s/%s" % (prefix, name) if prefix else name
+    if ocp_serialize.is_assembly_object(obj):
+        placed = []
+        for child in obj[ocp_serialize.KEY_ASSEMBLY]:
+            placed.extend(_leaves(child, path))
+        location = obj.get(ocp_serialize.KEY_LOCATION)
+        if location is None:
+            return placed
+        toploc = ocp_serialize.toploc_from_packed(location)
+        return [(nm, shape.Moved(toploc)) for nm, shape in placed]
+    if ocp_serialize.is_shape_object(obj):
+        shape = ocp_serialize._shape_from_b64(obj[ocp_serialize.KEY_BREP])
+        location = obj.get(ocp_serialize.KEY_LOCATION)
+        if location is not None:
+            shape = shape.Moved(ocp_serialize.toploc_from_packed(location))
+        return [(path, shape)]
+    return []
+
+
+def _box(shape):
+    box = Bnd_Box()
+    # 'useTriangulation': a shape carrying a mesh but no exact geometry - an
+    # imported STL, an SDF part - has an empty box otherwise.
+    BRepBndLib.Add_s(shape, box, True)
+    return None if box.IsVoid() else box
+
+
+def _volume(shape):
+    props = GProp_GProps()
+    BRepGProp.VolumeProperties_s(shape, props)
+    return props.Mass()
+
+
+def _is_solid_enough_to_intersect(shape):
+    """Whether a boolean against this shape would mean anything.
+
+    It is not a formality. A shape whose faces are inconsistently oriented is
+    inside out, which OCCT reports as a negative volume, and a boolean common
+    against it returns a number with no relation to any shared space: two LDraw
+    bricks meshed from triangles and placed 100 mm apart come back sharing
+    2282 mm^3. Reporting that as interference would be worse than not checking
+    at all, so a shape that is not a valid solid of positive volume is left out
+    and counted instead.
+    """
+    try:
+        if not BRepCheck_Analyzer(shape).IsValid():
+            return False
+        return _volume(shape) > 0.0
+    except Exception:
+        return False
+
+
+def process(path, request):
+    try:
+        obj = request.get("wrapped")
+        if obj is None:
+            raise Exception("No assembly provided to check")
+
+        # How much shared volume is worth reporting. Parts that are meant to fit
+        # together touch, and meshed geometry touching is numerically noisy, so
+        # a threshold is not a convenience here - it is the difference between
+        # reporting a design fault and reporting that the design fits together.
+        min_volume = float(request.get("min_volume", 1.0))
+        min_fraction = float(request.get("min_fraction", 0.0))
+
+        # The root's own name is on every part below it and says nothing, so
+        # the paths are built from its children down: 'gearbox/shaft', not
+        # 'assembly/gearbox/shaft'.
+        if ocp_serialize.is_assembly_object(obj):
+            leaves = []
+            for child in obj[ocp_serialize.KEY_ASSEMBLY]:
+                leaves.extend(_leaves(child))
+            root_location = obj.get(ocp_serialize.KEY_LOCATION)
+            if root_location is not None:
+                toploc = ocp_serialize.toploc_from_packed(root_location)
+                leaves = [(nm, shape.Moved(toploc)) for nm, shape in leaves]
+        else:
+            leaves = _leaves(obj)
+
+        boxes = []
+        unchecked = []
+        for name, shape in leaves:
+            box = _box(shape)
+            if box is None:
+                continue
+            if not _is_solid_enough_to_intersect(shape):
+                unchecked.append(name)
+                continue
+            boxes.append((name, shape, box))
+
+        # Broadphase. Boxes are cheap, booleans are not, so only the pairs whose
+        # boxes meet are asked the expensive question.
+        candidates = [
+            (a, b)
+            for a, b in itertools.combinations(range(len(boxes)), 2)
+            if not boxes[a][2].IsOut(boxes[b][2])
+        ]
+
+        overlaps = []
+        for a, b in candidates:
+            name_a, shape_a, _ = boxes[a]
+            name_b, shape_b, _ = boxes[b]
+            try:
+                common = BRepAlgoAPI_Common(shape_a, shape_b)
+                if not common.IsDone():
+                    continue
+                volume = _volume(common.Shape())
+            except Exception:
+                # A boolean that will not run says nothing either way; a part
+                # that cannot be intersected is the 'cad' test's business.
+                continue
+            if volume < min_volume:
+                continue
+            if min_fraction > 0.0:
+                smaller = min(_volume(shape_a), _volume(shape_b))
+                if smaller > 0.0 and volume / smaller < min_fraction:
+                    continue
+            overlaps.append({"a": name_a, "b": name_b, "volume": volume})
+
+        overlaps.sort(key=lambda o: -o["volume"])
+        return {
+            "success": True,
+            "exception": None,
+            "parts": len(boxes),
+            "candidates": len(candidates),
+            "overlaps": overlaps,
+            "unchecked": unchecked,
+        }
+    except Exception as e:
+        wrapper_common.handle_exception(e)
+        return {
+            "success": False,
+            "exception": str(e),
+            "parts": 0,
+            "candidates": 0,
+            "overlaps": [],
+            "unchecked": [],
+        }
+
+
+if __name__ == "__main__":
+    path, request = wrapper_common.handle_input()
+    response = process(path, request)
+    wrapper_common.handle_output(response)

--- a/src/partcad/wrappers/wrapper_solidity.py
+++ b/src/partcad/wrappers/wrapper_solidity.py
@@ -43,11 +43,16 @@ def process(path, request):
         if shape is None:
             raise Exception("No wrapped object provided to check")
 
+        # Every solid separately, not the sum. A compound holding one inverted
+        # solid and a larger correct one adds up to a positive number, and the
+        # inversion - the thing this exists to find - disappears into the
+        # total.
         explorer = TopExp_Explorer(shape, TopAbs_SOLID)
-        solids = 0
+        volumes = []
         while explorer.More():
-            solids += 1
+            volumes.append(_volume(explorer.Current()))
             explorer.Next()
+        solids = len(volumes)
 
         # A shape with no solid in it is not inside out; it is a sketch, a
         # shell or a wire, and this check has nothing to say about it.
@@ -57,6 +62,7 @@ def process(path, request):
                 "exception": None,
                 "solids": 0,
                 "volume": None,
+                "min_solid_volume": None,
                 "valid": None,
             }
 
@@ -64,12 +70,22 @@ def process(path, request):
             "success": True,
             "exception": None,
             "solids": solids,
-            "volume": _volume(shape),
+            "volume": sum(volumes),
+            # The least of them: one solid the wrong way out condemns the shape
+            # however much correct material surrounds it.
+            "min_solid_volume": min(volumes),
             "valid": bool(BRepCheck_Analyzer(shape).IsValid()),
         }
     except Exception as e:
         wrapper_common.handle_exception(e)
-        return {"success": False, "exception": str(e), "solids": 0, "volume": None, "valid": None}
+        return {
+            "success": False,
+            "exception": str(e),
+            "solids": 0,
+            "volume": None,
+            "min_solid_volume": None,
+            "valid": None,
+        }
 
 
 if __name__ == "__main__":

--- a/src/partcad/wrappers/wrapper_solidity.py
+++ b/src/partcad/wrappers/wrapper_solidity.py
@@ -1,0 +1,78 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+# This script is executed within a python runtime environment to ask whether a
+# shape is a solid that OCCT will do arithmetic on. The core has no CAD library,
+# so this is the only place the question can be put.
+#
+# A shape can be built, rendered, exported and measured for size while being
+# inside out - its faces oriented inward rather than outward. Nothing about a
+# picture of it looks wrong. But a solid's volume is then negative, and every
+# boolean against it returns a number unrelated to any shape: two such solids
+# 100 mm apart come back sharing 2282 mm^3.
+
+import os
+import sys
+
+# Pinned before the CAD imports below, which load OCP and with it VTK's
+# bundled copy of expat: see the note in ocp_serialize.
+import pyexpat  # noqa: F401
+
+from OCP.BRepCheck import BRepCheck_Analyzer
+from OCP.BRepGProp import BRepGProp
+from OCP.GProp import GProp_GProps
+from OCP.TopAbs import TopAbs_SOLID
+from OCP.TopExp import TopExp_Explorer
+
+sys.path.append(os.path.dirname(__file__))
+import wrapper_common
+
+
+def _volume(shape):
+    props = GProp_GProps()
+    BRepGProp.VolumeProperties_s(shape, props)
+    return props.Mass()
+
+
+def process(path, request):
+    try:
+        shape = request.get("wrapped")
+        if shape is None:
+            raise Exception("No wrapped object provided to check")
+
+        explorer = TopExp_Explorer(shape, TopAbs_SOLID)
+        solids = 0
+        while explorer.More():
+            solids += 1
+            explorer.Next()
+
+        # A shape with no solid in it is not inside out; it is a sketch, a
+        # shell or a wire, and this check has nothing to say about it.
+        if solids == 0:
+            return {
+                "success": True,
+                "exception": None,
+                "solids": 0,
+                "volume": None,
+                "valid": None,
+            }
+
+        return {
+            "success": True,
+            "exception": None,
+            "solids": solids,
+            "volume": _volume(shape),
+            "valid": bool(BRepCheck_Analyzer(shape).IsValid()),
+        }
+    except Exception as e:
+        wrapper_common.handle_exception(e)
+        return {"success": False, "exception": str(e), "solids": 0, "volume": None, "valid": None}
+
+
+if __name__ == "__main__":
+    path, request = wrapper_common.handle_input()
+    response = process(path, request)
+    wrapper_common.handle_output(response)

--- a/tests/partcad/unit/test_assembly_connectivity_tests.py
+++ b/tests/partcad/unit/test_assembly_connectivity_tests.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""What the 'solidity' and 'connectivity' checks decide, and on what.
+
+Both are about assemblies that build perfectly and render plausibly while being
+wrong in a way nothing looks at: a part whose faces are oriented inward, two
+items in one place, two items on one port, an item anchored to nothing.
+"""
+
+import asyncio
+
+import pytest
+
+from partcad.geom import Location
+from partcad.test.connectivity import ConnectivityTest, _packed
+from partcad.test.solidity import SolidityTest
+
+
+class _Item:
+    def __init__(self, name, project="pkg"):
+        self.name = name
+        self.project_name = project
+
+
+class _Child:
+    def __init__(self, name, item, location=None, connection=None):
+        self.name = name
+        self.item = item
+        self.location = location
+        self.connection = connection
+
+
+class _Shape:
+    def __init__(self, config=None, solidity=None, raises=None):
+        self.config = config or {}
+        self.project_name = "pkg"
+        self.name = "thing"
+        self._solidity = solidity
+        self._raises = raises
+
+    async def get_solidity_async(self, ctx):
+        if self._raises:
+            raise self._raises
+        return self._solidity
+
+
+class _Assembly(_Shape):
+    def __init__(self, children=(), config=None, **kwargs):
+        super().__init__(config=config, **kwargs)
+        self._children = list(children)
+
+    async def do_instantiate(self):
+        return None
+
+    def connected_children(self):
+        return iter(self._children)
+
+
+@pytest.fixture(autouse=True)
+def _assembly_is_an_assembly(monkeypatch):
+    monkeypatch.setattr("partcad.test.connectivity.Assembly", _Assembly)
+    monkeypatch.setattr("partcad.test.solidity.Assembly", _Assembly)
+
+
+def _run(test, shape, ctx=None):
+    return asyncio.run(test.test([], ctx, shape))
+
+
+# --- solidity ---------------------------------------------------------------
+
+
+def test_a_solid_the_right_way_out_passes():
+    assert _run(SolidityTest(), _Shape(solidity={"solids": 1, "volume": 1939.6, "valid": True}))
+
+
+def test_a_solid_that_is_inside_out_fails():
+    """The regression: LDraw parts meshed from triangles came out inverted, so
+    Brick 2 x 4 measured -1939.6 mm^3 and two copies 100 mm apart intersected
+    to 2282 mm^3. It rendered correctly the whole time."""
+    assert not _run(SolidityTest(), _Shape(solidity={"solids": 1, "volume": -1939.6, "valid": False}))
+
+
+def test_a_solid_that_is_the_right_way_out_but_still_invalid_fails():
+    assert not _run(SolidityTest(), _Shape(solidity={"solids": 1, "volume": 12.0, "valid": False}))
+
+
+def test_something_with_no_solid_in_it_is_not_inside_out():
+    """A sketch, a shell or a wire has no volume to have a sign."""
+    assert _run(SolidityTest(), _Shape(solidity={"solids": 0, "volume": None, "valid": None}))
+
+
+def test_a_part_can_opt_out():
+    config = {"solidity": {"skip": True}}
+    assert _run(SolidityTest(), _Shape(config=config, solidity={"solids": 1, "volume": -5.0, "valid": False}))
+
+
+def test_an_assembly_is_checked_through_its_parts():
+    assert _run(SolidityTest(), _Assembly(solidity={"solids": 1, "volume": -5.0, "valid": False}))
+
+
+def test_a_shape_that_cannot_be_measured_is_left_to_the_cad_test():
+    assert _run(SolidityTest(), _Shape(raises=Exception("no runtime")))
+
+
+# --- connectivity: two items in one place -----------------------------------
+
+
+HERE = Location((0, 0, 0), (0, 0, 1), 0)
+THERE = Location((8, 0, 0), (0, 0, 1), 0)
+
+
+def test_parts_in_different_places_pass():
+    brick = _Item("brick")
+    children = [_Child("a", brick, HERE), _Child("b", brick, THERE)]
+    assert _run(ConnectivityTest(), _Assembly(children))
+
+
+def test_the_same_part_twice_in_the_same_place_fails():
+    brick = _Item("brick")
+    children = [_Child("a", brick, HERE), _Child("b", brick, Location((0, 0, 0), (0, 0, 1), 0))]
+    assert not _run(ConnectivityTest(), _Assembly(children))
+
+
+def test_two_different_parts_in_one_place_are_interference_not_duplication():
+    """Overlapping is the interference test's question; this one is about an
+    item placed twice over."""
+    children = [_Child("a", _Item("brick"), HERE), _Child("b", _Item("plate"), HERE)]
+    assert _run(ConnectivityTest(), _Assembly(children))
+
+
+def test_duplicates_can_be_allowed():
+    brick = _Item("brick")
+    config = {"connectivity": {"allowDuplicates": True}}
+    children = [_Child("a", brick, HERE), _Child("b", brick, HERE)]
+    assert _run(ConnectivityTest(), _Assembly(children, config=config))
+
+
+# --- connectivity: two items on one port ------------------------------------
+
+
+def _connected(name, target, port, interface="//pub:stud"):
+    return _Child(name, _Item(name), None, {"target": target, "to_port": port, "to_interface": interface})
+
+
+class _Ctx:
+    def __init__(self, multi=()):
+        self._multi = set(multi)
+
+    def get_interface(self, spec):
+        return _Iface(spec in self._multi)
+
+
+class _Iface:
+    def __init__(self, multi):
+        self._multi = multi
+
+    def get_multi_connect(self):
+        return self._multi
+
+
+def test_one_item_per_port_passes():
+    children = [_Child("base", _Item("base"), HERE), _connected("a", "base", "c0r0"), _connected("b", "base", "c1r0")]
+    assert _run(ConnectivityTest(), _Assembly(children), ctx=_Ctx())
+
+
+def test_two_items_on_one_port_fails():
+    children = [_Child("base", _Item("base"), HERE), _connected("a", "base", "c0r0"), _connected("b", "base", "c0r0")]
+    assert not _run(ConnectivityTest(), _Assembly(children), ctx=_Ctx())
+
+
+def test_an_interface_that_takes_many_says_so():
+    """A shaft carries several parts along its length; a stud takes one brick."""
+    children = [
+        _Child("shaft", _Item("shaft"), HERE),
+        _connected("gear1", "shaft", "along", "//pub:shaft"),
+        _connected("gear2", "shaft", "along", "//pub:shaft"),
+    ]
+    assert _run(ConnectivityTest(), _Assembly(children), ctx=_Ctx(multi={"//pub:shaft"}))
+
+
+def test_the_same_port_name_on_two_different_targets_is_two_ports():
+    # 'requireAnchored' off so that this says something about ports alone:
+    # 'r' is placed by coordinates, which is that other check's business.
+    config = {"connectivity": {"requireAnchored": False}}
+    children = [
+        _Child("l", _Item("l"), HERE),
+        _Child("r", _Item("r"), THERE),
+        _connected("a", "l", "c0r0"),
+        _connected("b", "r", "c0r0"),
+    ]
+    assert _run(ConnectivityTest(), _Assembly(children, config=config), ctx=_Ctx())
+
+
+# --- connectivity: an item anchored to nothing ------------------------------
+
+
+def test_an_assembly_placed_entirely_by_coordinates_is_a_legitimate_assembly():
+    """Which is why this only applies once something in it does connect."""
+    children = [_Child("a", _Item("a"), HERE), _Child("b", _Item("b"), THERE)]
+    assert _run(ConnectivityTest(), _Assembly(children), ctx=_Ctx())
+
+
+def test_an_item_left_on_coordinates_among_connected_ones_fails():
+    children = [
+        _Child("base", _Item("base"), HERE),
+        _connected("a", "base", "c0r0"),
+        _Child("stray", _Item("stray"), THERE),
+    ]
+    assert not _run(ConnectivityTest(), _Assembly(children), ctx=_Ctx())
+
+
+def test_the_first_item_is_what_everything_else_hangs_from():
+    """It has nothing to connect to, so it is not reported."""
+    children = [_Child("base", _Item("base"), HERE), _connected("a", "base", "c0r0")]
+    assert _run(ConnectivityTest(), _Assembly(children), ctx=_Ctx())
+
+
+def test_requiring_an_anchor_can_be_turned_off():
+    config = {"connectivity": {"requireAnchored": False}}
+    children = [
+        _Child("base", _Item("base"), HERE),
+        _connected("a", "base", "c0r0"),
+        _Child("stray", _Item("stray"), THERE),
+    ]
+    assert _run(ConnectivityTest(), _Assembly(children, config=config), ctx=_Ctx())
+
+
+def test_a_whole_assembly_can_opt_out():
+    brick = _Item("brick")
+    config = {"connectivity": {"skip": True}}
+    assert _run(ConnectivityTest(), _Assembly([_Child("a", brick, HERE), _Child("b", brick, HERE)], config=config))
+
+
+def test_two_placements_that_differ_only_by_arithmetic_noise_are_one_place():
+    a = _packed(Location((1.0, 2.0, 3.0), (0, 0, 1), 90))
+    b = _packed(Location((1.0 + 1e-12, 2.0, 3.0), (0, 0, 1), 90))
+    assert a == b

--- a/tests/partcad/unit/test_assembly_connectivity_tests.py
+++ b/tests/partcad/unit/test_assembly_connectivity_tests.py
@@ -84,8 +84,17 @@ def test_a_solid_that_is_inside_out_fails():
     assert not _run(SolidityTest(), _Shape(solidity={"solids": 1, "volume": -1939.6, "valid": False}))
 
 
-def test_a_solid_that_is_the_right_way_out_but_still_invalid_fails():
-    assert not _run(SolidityTest(), _Shape(solidity={"solids": 1, "volume": 12.0, "valid": False}))
+def test_a_solid_that_is_the_right_way_out_but_not_valid_is_reported_not_failed(caplog):
+    """An LDraw brick is an open mesh - a stud is a cylinder and a top disc
+    with no bottom - so it fails IsValid while two copies 100 mm apart
+    correctly share nothing. Failing on validity would condemn a whole library
+    that works."""
+    import logging
+
+    shape = _Shape(solidity={"solids": 1, "volume": 2626.2, "valid": False})
+    with caplog.at_level(logging.INFO):
+        assert _run(SolidityTest(), shape)
+    assert "not a valid one" in caplog.text
 
 
 def test_something_with_no_solid_in_it_is_not_inside_out():

--- a/tests/partcad/unit/test_assembly_connectivity_tests.py
+++ b/tests/partcad/unit/test_assembly_connectivity_tests.py
@@ -248,3 +248,100 @@ def test_two_placements_that_differ_only_by_arithmetic_noise_are_one_place():
     a = _packed(Location((1.0, 2.0, 3.0), (0, 0, 1), 90))
     b = _packed(Location((1.0 + 1e-12, 2.0, 3.0), (0, 0, 1), 90))
     assert a == b
+
+
+
+# --- what the review found --------------------------------------------------
+
+
+def test_a_solid_of_exactly_no_volume_is_not_a_solid():
+    """Negative is inside out; zero encloses nothing. Both are non-solids, and
+    zero is the boundary a mesh that collapses lands on."""
+    assert not _run(SolidityTest(), _Shape(solidity={"solids": 1, "volume": 0.0, "valid": True}))
+
+
+def test_one_inverted_solid_is_not_excused_by_the_others():
+    """A compound holding an inverted solid and a larger correct one sums to a
+    positive number, and the inversion disappears into the total. The least of
+    them decides."""
+    shape = _Shape(solidity={"solids": 2, "volume": 900.0, "min_solid_volume": -100.0, "valid": True})
+    assert not _run(SolidityTest(), shape)
+
+
+def test_the_settings_that_decide_a_verdict_are_in_its_cache_key():
+    """Test.test_cached() keys a remembered verdict on shape.hash plus this
+    suffix, and shape.hash carries none of these settings - so a suffix that
+    omits them hands back the answer from before they were changed."""
+    conn = ConnectivityTest()
+    assert conn.cache_key_suffix(None, _Assembly()) != conn.cache_key_suffix(
+        None, _Assembly(config={"connectivity": {"allowDuplicates": True}})
+    )
+    assert conn.cache_key_suffix(None, _Assembly()) != conn.cache_key_suffix(
+        None, _Assembly(config={"connectivity": {"requireAnchored": False}})
+    )
+    assert conn.cache_key_suffix(None, _Assembly()) != conn.cache_key_suffix(
+        None, _Assembly(config={"connectivity": {"skip": True}})
+    )
+    sol = SolidityTest()
+    assert sol.cache_key_suffix(None, _Shape()) != sol.cache_key_suffix(
+        None, _Shape(config={"solidity": {"skip": True}})
+    )
+
+
+def test_a_verdict_that_turned_on_the_machine_is_not_remembered():
+    """A missing runtime is not a fact about the shape. Cached, it would be
+    read back under a key that installing the runtime does not change."""
+    ctx = {}
+    assert _run_ctx(SolidityTest(), _Shape(raises=Exception("no runtime")), ctx)
+    assert ctx.get(SolidityTest.NOT_CACHEABLE) is True
+
+    ctx = {}
+    assert _run_ctx(ConnectivityTest(), _BrokenAssembly(), ctx)
+    assert ctx.get(ConnectivityTest.NOT_CACHEABLE) is True
+
+
+class _BrokenAssembly(_Assembly):
+    async def do_instantiate(self):
+        raise Exception("will not instantiate")
+
+
+def _run_ctx(test, shape, test_ctx):
+    return asyncio.run(test.test([], None, shape, test_ctx))
+
+
+# --- multiConnect, and being able to say "no" --------------------------------
+
+
+class _Iface2:
+    """The little of Interface these need: the stored value and the parents."""
+
+    def __init__(self, config, parent=None, name="i"):
+        from partcad.interface import Interface
+
+        self.get_multi_connect = Interface.get_multi_connect.__get__(self)
+        self._inherited = Interface._inherited.__get__(self)
+        self.multi_connect = bool(config["multiConnect"]) if "multiConnect" in config else None
+        self.full_name = name
+        self._parent = parent
+
+    def get_parents(self):
+        if self._parent is None:
+            return {}
+        return {"p": type("_Inherit", (), {"interface": self._parent})()}
+
+
+def test_an_interface_that_says_nothing_takes_one_item():
+    assert _Iface2({}).get_multi_connect() is False
+
+
+def test_multi_connect_is_inherited():
+    shaft = _Iface2({"multiConnect": True}, name="shaft")
+    assert _Iface2({}, parent=shaft, name="splined").get_multi_connect() is True
+
+
+def test_a_child_can_say_no_to_a_parent_that_says_yes():
+    """A stored False that means "not set" cannot be told from one that means
+    "no", so an explicit false used to be skipped and the parent's true won."""
+    shaft = _Iface2({"multiConnect": True}, name="shaft")
+    keyed = _Iface2({"multiConnect": False}, parent=shaft, name="keyed")
+    assert keyed.get_multi_connect() is False

--- a/tests/partcad/unit/test_assembly_connectivity_tests.py
+++ b/tests/partcad/unit/test_assembly_connectivity_tests.py
@@ -52,12 +52,19 @@ class _Assembly(_Shape):
     def __init__(self, children=(), config=None, **kwargs):
         super().__init__(config=config, **kwargs)
         self._children = list(children)
+        # The real Assembly exposes 'children'; the per-container walk reads it.
+        self.children = self._children
 
     async def do_instantiate(self):
         return None
 
     def connected_children(self):
-        return iter(self._children)
+        """Flattened, the way the real one is: a nested 'links:' becomes a
+        child assembly whose contents belong to the assembly embedding it."""
+        for child in self._children:
+            yield child
+            if isinstance(child.item, _Assembly):
+                yield from child.item.connected_children()
 
 
 @pytest.fixture(autouse=True)
@@ -345,3 +352,33 @@ def test_a_child_can_say_no_to_a_parent_that_says_yes():
     shaft = _Iface2({"multiConnect": True}, name="shaft")
     keyed = _Iface2({"multiConnect": False}, parent=shaft, name="keyed")
     assert keyed.get_multi_connect() is False
+
+
+def test_the_item_the_others_hang_from_is_exempt_wherever_it_sits(monkeypatch):
+    """The regression CI found in examples/feature_interface.
+
+    An ASSY file's top-level 'links:' becomes a child assembly, so flattening
+    the tree and exempting the first item exempts that wrapper and then reports
+    'example-bracket' - the one item that is allowed to be placed by
+    coordinates, because everything else connects to it.
+    """
+    monkeypatch.setattr("partcad.test.connectivity.Assembly", _Assembly)
+    inner = _Assembly([
+        _Child("example-bracket", _Item("bracket"), HERE),
+        _connected("example-motor", "example-bracket", "TR-4.5mm"),
+        _connected("screw-L", "example-bracket", "L-30mm"),
+    ])
+    root = _Assembly([_Child("links", inner, HERE)])
+    assert _run(ConnectivityTest(), root, ctx=_Ctx())
+
+
+def test_a_stray_inside_a_nested_group_is_still_reported(monkeypatch):
+    """The exemption is one item per group, not one per assembly."""
+    monkeypatch.setattr("partcad.test.connectivity.Assembly", _Assembly)
+    inner = _Assembly([
+        _Child("base", _Item("base"), HERE),
+        _connected("a", "base", "p0"),
+        _Child("stray", _Item("stray"), THERE),
+    ])
+    root = _Assembly([_Child("links", inner, HERE)])
+    assert not _run(ConnectivityTest(), root, ctx=_Ctx())

--- a/tests/partcad/unit/test_assembly_connectivity_tests.py
+++ b/tests/partcad/unit/test_assembly_connectivity_tests.py
@@ -382,3 +382,32 @@ def test_a_stray_inside_a_nested_group_is_still_reported(monkeypatch):
     ])
     root = _Assembly([_Child("links", inner, HERE)])
     assert not _run(ConnectivityTest(), root, ctx=_Ctx())
+
+
+def test_a_verdict_that_consulted_an_interface_is_not_remembered(monkeypatch):
+    """'multiConnect' lives in the interface's configuration, which is neither
+    in shape.hash nor among this shape's cache dependencies. A remembered
+    verdict would survive that setting being changed."""
+    monkeypatch.setattr("partcad.test.connectivity.Assembly", _Assembly)
+    children = [
+        _Child("shaft", _Item("shaft"), HERE),
+        _connected("gear1", "shaft", "along", "//pub:shaft"),
+        _connected("gear2", "shaft", "along", "//pub:shaft"),
+    ]
+    ctx_out = {}
+    assert _run_ctx2(ConnectivityTest(), _Assembly(children), _Ctx(multi={"//pub:shaft"}), ctx_out)
+    assert ctx_out.get(ConnectivityTest.NOT_CACHEABLE) is True
+
+
+def test_a_verdict_that_consulted_nothing_is_remembered(monkeypatch):
+    """Most assemblies never reach an interface: one item per port, no lookup,
+    and the verdict depends only on what shape.hash already covers."""
+    monkeypatch.setattr("partcad.test.connectivity.Assembly", _Assembly)
+    children = [_Child("a", _Item("a"), HERE), _Child("b", _Item("b"), THERE)]
+    ctx_out = {}
+    assert _run_ctx2(ConnectivityTest(), _Assembly(children), _Ctx(), ctx_out)
+    assert ConnectivityTest.NOT_CACHEABLE not in ctx_out
+
+
+def _run_ctx2(test, shape, ctx, test_ctx):
+    return asyncio.run(test.test([], ctx, shape, test_ctx))

--- a/tests/partcad/unit/test_assembly_geometry_tests.py
+++ b/tests/partcad/unit/test_assembly_geometry_tests.py
@@ -282,3 +282,22 @@ def test_a_sketch_is_flat_because_that_is_what_a_sketch_is():
     check an object cannot pass and should not be taking is worse than none.
     """
     assert _run(DegenerateTest(), _Sketch(box=(0, 0, 0, 20, 20, 0.0)))
+
+
+def test_a_pass_reached_without_looking_at_everything_is_not_remembered():
+    """A cached verdict is returned before the test runs, so remembering this
+    would hand back a pass that was never earned and would not even repeat
+    what had gone unexamined."""
+    for partial in ({"indeterminate": [{"a": "x", "b": "y", "reason": "boom"}]}, {"unchecked": ["x"]}):
+        shape = _Assembly(overlaps=[])
+        shape._indeterminate = partial.get("indeterminate", [])
+        shape._unchecked = partial.get("unchecked", [])
+        ctx = {}
+        assert asyncio.run(InterferenceTest().test([], None, shape, ctx))
+        assert ctx.get(InterferenceTest.NOT_CACHEABLE) is True, partial
+
+    # ...while a check that looked at everything and found nothing is kept.
+    clean = _Assembly(overlaps=[])
+    ctx = {}
+    assert asyncio.run(InterferenceTest().test([], None, clean, ctx))
+    assert InterferenceTest.NOT_CACHEABLE not in ctx

--- a/tests/partcad/unit/test_assembly_geometry_tests.py
+++ b/tests/partcad/unit/test_assembly_geometry_tests.py
@@ -186,3 +186,50 @@ def test_the_cache_key_moves_when_the_thresholds_do():
     assert loose != strict
     ignoring = test.cache_key_suffix(None, _Assembly(config={"interference": {"ignore": [["a", "b"]]}}))
     assert ignoring != test.cache_key_suffix(None, _Assembly())
+
+
+# --- the request the core sends the wrapper ---------------------------------
+#
+# The tests above stub get_interference_async() out entirely, which is what let
+# a broken request reach CI: the core sent the assembly under "wrapped", where
+# ocp_serialize.decode turns anything shape-shaped into OCCT geometry, so the
+# wrapper was handed one TopoDS_Compound and died reaching for a name on it.
+# Nothing here exercised the handover. This does.
+
+
+def test_the_assembly_is_sent_as_json_rather_than_as_geometry():
+    import json as _json
+
+    from partcad.assembly import Assembly
+
+    envelope = {"name": "asm", "label": "asm", "assembly": [{"name": "a", "brep": "..."}]}
+    captured = {}
+
+    class _Runtime:
+        async def ensure_async(self, *args):
+            return None
+
+        async def run_async(self, command, request_serialized):
+            captured["request"] = request_serialized
+            return 0, '{"success": true, "overlaps": [], "unchecked": [], "parts": 0}', ""
+
+    class _Ctx:
+        def get_python_runtime(self, version=None):
+            return _Runtime()
+
+    assembly = Assembly.__new__(Assembly)
+    assembly.project_name = "pkg"
+    assembly.name = "asm"
+
+    async def _wrapped(ctx):
+        return envelope
+
+    assembly.get_wrapped = _wrapped
+    asyncio.run(assembly.get_interference_async(_Ctx()))
+
+    sent = _json.loads(captured["request"])
+    # Carried as a string: a dict shaped like an assembly would be decoded into
+    # a compound on arrival, and the names would go with it.
+    assert isinstance(sent["assembly_json"], str)
+    assert _json.loads(sent["assembly_json"]) == envelope
+    assert "wrapped" not in sent, "the geometry key is decoded on arrival; do not use it here"

--- a/tests/partcad/unit/test_assembly_geometry_tests.py
+++ b/tests/partcad/unit/test_assembly_geometry_tests.py
@@ -34,6 +34,7 @@ class _Shape:
         self._box = box
         self._overlaps = overlaps
         self._unchecked = list(unchecked)
+        self._indeterminate = []
         self._raises = raises
 
     async def get_bounding_box_async(self, ctx):
@@ -47,7 +48,12 @@ class _Shape:
         self.asked_with = (min_volume, min_fraction)
         if self._overlaps is None:
             return None
-        return {"overlaps": self._overlaps, "unchecked": self._unchecked, "parts": 0}
+        return {
+            "overlaps": self._overlaps,
+            "unchecked": self._unchecked,
+            "indeterminate": self._indeterminate,
+            "parts": 0,
+        }
 
 
 class _Assembly(_Shape):
@@ -233,3 +239,32 @@ def test_the_assembly_is_sent_as_json_rather_than_as_geometry():
     assert isinstance(sent["assembly_json"], str)
     assert _json.loads(sent["assembly_json"]) == envelope
     assert "wrapped" not in sent, "the geometry key is decoded on arrival; do not use it here"
+
+
+def test_an_indeterminate_pair_is_not_reported_as_no_overlap(caplog):
+    """A boolean that did not come back is not an answer of "they are clear".
+
+    Dropping such a pair silently is how a check comes to certify what it never
+    looked at, which is the failure mode this whole set of tests exists for.
+    """
+    import logging
+
+    shape = _Assembly(overlaps=[])
+    shape._indeterminate = [{"a": "shaft", "b": "hub", "reason": "the boolean did not complete"}]
+    with caplog.at_level(logging.INFO):
+        assert _run(InterferenceTest(), shape)
+    assert "could not decide" in caplog.text
+    assert "shaft" in caplog.text
+
+
+def test_the_interference_cache_key_covers_skip_as_well_as_the_thresholds():
+    test = InterferenceTest()
+    assert test.cache_key_suffix(None, _Assembly()) != test.cache_key_suffix(
+        None, _Assembly(config={"interference": {"skip": True}})
+    )
+
+
+def test_a_verdict_that_turned_on_the_machine_is_not_remembered():
+    ctx = {}
+    assert asyncio.run(InterferenceTest().test([], None, _Assembly(raises=Exception("no runtime")), ctx))
+    assert ctx.get(InterferenceTest.NOT_CACHEABLE) is True

--- a/tests/partcad/unit/test_assembly_geometry_tests.py
+++ b/tests/partcad/unit/test_assembly_geometry_tests.py
@@ -27,15 +27,19 @@ from partcad.test.interference import InterferenceTest, _is_ignored, _matches
 class _Shape:
     """The little a test needs of a shape: a config, a name, and a measurement."""
 
-    def __init__(self, config=None, box=(0, 0, 0, 10, 10, 10), overlaps=None, raises=None, unchecked=()):
+    def __init__(self, config=None, box=(0, 0, 0, 10, 10, 10), overlaps=None, raises=None, unchecked=(), unbuilt=False):
         self.config = config or {}
         self.project_name = "pkg"
         self.name = "thing"
         self._box = box
+        self._unbuilt = unbuilt
         self._overlaps = overlaps
         self._unchecked = list(unchecked)
         self._indeterminate = []
         self._raises = raises
+
+    async def get_wrapped(self, ctx):
+        return None if self._unbuilt else object()
 
     async def get_bounding_box_async(self, ctx):
         if self._raises:
@@ -301,3 +305,15 @@ def test_a_pass_reached_without_looking_at_everything_is_not_remembered():
     ctx = {}
     assert asyncio.run(InterferenceTest().test([], None, clean, ctx))
     assert InterferenceTest.NOT_CACHEABLE not in ctx
+
+
+def test_a_shape_that_never_built_is_the_cad_tests_to_report():
+    """Found in CI: a third-party example whose script raises ImportError was
+    failed twice - once by 'cad' for not building, and once here for "having
+    no extent at all", which names a cause that is not the cause."""
+    ctx = {}
+    assert asyncio.run(DegenerateTest().test([], None, _Shape(box=None, unbuilt=True), ctx))
+    assert ctx.get(DegenerateTest.NOT_CACHEABLE) is True
+
+    # ...but a shape that did build and encloses nothing is still reported.
+    assert not _run(DegenerateTest(), _Shape(box=None))

--- a/tests/partcad/unit/test_assembly_geometry_tests.py
+++ b/tests/partcad/unit/test_assembly_geometry_tests.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""What the 'interference' and 'degenerate' checks decide, and on what.
+
+The 'cad' test asks whether a shape was produced. These two ask whether what
+was produced is a solid anybody meant, and whether the parts ended up anywhere
+sensible - the questions an assembly is actually judged on, and the ones that
+have needed a person looking at a render.
+
+The geometry itself is exercised in the wrapper, which needs a CAD library and
+so is not reachable from here; what is covered here is the deciding: which
+verdict follows from which measurement, and what the configuration does.
+"""
+
+import asyncio
+
+import pytest
+
+from partcad.test.degenerate import DegenerateTest
+from partcad.test.interference import InterferenceTest, _is_ignored, _matches
+
+
+class _Shape:
+    """The little a test needs of a shape: a config, a name, and a measurement."""
+
+    def __init__(self, config=None, box=(0, 0, 0, 10, 10, 10), overlaps=None, raises=None, unchecked=()):
+        self.config = config or {}
+        self.project_name = "pkg"
+        self.name = "thing"
+        self._box = box
+        self._overlaps = overlaps
+        self._unchecked = list(unchecked)
+        self._raises = raises
+
+    async def get_bounding_box_async(self, ctx):
+        if self._raises:
+            raise self._raises
+        return self._box
+
+    async def get_interference_async(self, ctx, min_volume=1.0, min_fraction=0.0):
+        if self._raises:
+            raise self._raises
+        self.asked_with = (min_volume, min_fraction)
+        if self._overlaps is None:
+            return None
+        return {"overlaps": self._overlaps, "unchecked": self._unchecked, "parts": 0}
+
+
+class _Assembly(_Shape):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _assembly_is_an_assembly(monkeypatch):
+    """Both tests branch on isinstance(shape, Assembly); _Assembly stands in."""
+    monkeypatch.setattr("partcad.test.interference.Assembly", _Assembly)
+    monkeypatch.setattr("partcad.test.degenerate.Assembly", _Assembly)
+
+
+def _run(test, shape):
+    """The repository drives its async work through asyncio.run(); so does this."""
+    return asyncio.run(test.test([], None, shape))
+
+
+# --- degenerate -------------------------------------------------------------
+
+
+def test_a_solid_with_size_in_every_direction_passes():
+    assert _run(DegenerateTest(), _Shape(box=(0, 0, 0, 8, 8, 9.6)))
+
+
+def test_a_part_flattened_to_a_sheet_fails():
+    """The regression: a 2 x 2 round brick 9.6 mm tall that meshed into a disc
+    about a millimetre thick because a subfile could not be fetched. It
+    rendered, it exported, and every test there was passed it."""
+    assert not _run(DegenerateTest(), _Shape(box=(0, 0, 0, 16, 16, 0.0)))
+
+
+def test_a_shape_with_no_extent_at_all_fails():
+    assert not _run(DegenerateTest(), _Shape(box=None))
+
+
+def test_something_meant_to_be_flat_can_say_so():
+    shape = _Shape(config={"degenerate": {"skip": True}}, box=(0, 0, 0, 10, 10, 0))
+    assert _run(DegenerateTest(), shape)
+
+
+def test_the_tolerance_is_configurable():
+    thin = _Shape(box=(0, 0, 0, 10, 10, 0.05))
+    assert _run(DegenerateTest(), thin)  # thinner than a brick, but a solid
+    strict = _Shape(config={"degenerate": {"tolerance": 0.1}}, box=(0, 0, 0, 10, 10, 0.05))
+    assert not _run(DegenerateTest(), strict)
+
+
+def test_an_assembly_is_checked_through_its_parts():
+    """Each part is tested in its own right; an assembly's box says nothing."""
+    assert _run(DegenerateTest(), _Assembly(box=None))
+
+
+def test_a_shape_that_cannot_be_measured_is_left_to_the_cad_test():
+    assert _run(DegenerateTest(), _Shape(raises=Exception("no runtime")))
+
+
+# --- interference -----------------------------------------------------------
+
+
+def test_an_assembly_whose_parts_keep_to_themselves_passes():
+    assert _run(InterferenceTest(), _Assembly(overlaps=[]))
+
+
+def test_parts_sharing_space_fail():
+    overlaps = [{"a": "buttS8", "b": "gateW", "volume": 512.0}]
+    assert not _run(InterferenceTest(), _Assembly(overlaps=overlaps))
+
+
+def test_a_part_is_not_checked_against_itself_or_anything_else():
+    assert _run(InterferenceTest(), _Shape())
+
+
+def test_the_thresholds_reach_the_measurement():
+    """They are what separates a design fault from a design that fits together,
+    so a package that sets them has to have them honoured."""
+    shape = _Assembly(config={"interference": {"minVolume": 0.5, "minFraction": 0.01}}, overlaps=[])
+    _run(InterferenceTest(), shape)
+    assert shape.asked_with == (0.5, 0.01)
+
+
+def test_a_pair_that_is_meant_to_interfere_can_be_declared():
+    config = {"interference": {"ignore": [["shaft", "hub"]]}}
+    overlaps = [{"a": "shaft", "b": "hub", "volume": 90.0}]
+    assert _run(InterferenceTest(), _Assembly(config=config, overlaps=overlaps))
+
+
+def test_declaring_one_pair_does_not_excuse_the_others():
+    config = {"interference": {"ignore": [["shaft", "hub"]]}}
+    overlaps = [
+        {"a": "shaft", "b": "hub", "volume": 90.0},
+        {"a": "shaft", "b": "casing", "volume": 12.0},
+    ]
+    assert not _run(InterferenceTest(), _Assembly(config=config, overlaps=overlaps))
+
+
+def test_a_whole_assembly_can_opt_out():
+    config = {"interference": {"skip": True}}
+    overlaps = [{"a": "a", "b": "b", "volume": 1e6}]
+    assert _run(InterferenceTest(), _Assembly(config=config, overlaps=overlaps))
+
+
+def test_an_ignored_pair_is_named_in_either_order():
+    ignored = {("hub", "shaft")}
+    assert _is_ignored({"a": "shaft", "b": "hub"}, ignored)
+    assert _is_ignored({"a": "hub", "b": "shaft"}, ignored)
+    assert not _is_ignored({"a": "hub", "b": "casing"}, ignored)
+
+
+def test_parts_that_are_not_valid_solids_are_reported_rather_than_hidden(caplog):
+    """A boolean against an inside-out solid returns a number unrelated to any
+    shared space - two LDraw bricks 100 mm apart came back sharing 2282 mm^3 -
+    so such parts are left out. An assembly built entirely from them is not
+    being checked at all, and a pass must not be read as a clean bill."""
+    import logging
+
+    shape = _Assembly(overlaps=[], unchecked=["lower", "upper"])
+    with caplog.at_level(logging.INFO):
+        assert _run(InterferenceTest(), shape)
+    assert "not valid solids" in caplog.text
+    assert "lower" in caplog.text
+
+
+def test_a_pair_is_named_without_saying_where_in_the_tree_it_sits():
+    assert _matches("gearbox/shaft", "shaft")
+    assert _matches("shaft", "shaft")
+    # ...but not by accident: a suffix is a whole path element.
+    assert not _matches("driveshaft", "shaft")
+
+
+def test_the_cache_key_moves_when_the_thresholds_do():
+    """A verdict reached under one threshold must not be read back under another."""
+    test = InterferenceTest()
+    loose = test.cache_key_suffix(None, _Assembly(config={"interference": {"minVolume": 1.0}}))
+    strict = test.cache_key_suffix(None, _Assembly(config={"interference": {"minVolume": 0.1}}))
+    assert loose != strict
+    ignoring = test.cache_key_suffix(None, _Assembly(config={"interference": {"ignore": [["a", "b"]]}}))
+    assert ignoring != test.cache_key_suffix(None, _Assembly())

--- a/tests/partcad/unit/test_assembly_geometry_tests.py
+++ b/tests/partcad/unit/test_assembly_geometry_tests.py
@@ -60,11 +60,16 @@ class _Assembly(_Shape):
     pass
 
 
+class _Sketch(_Shape):
+    pass
+
+
 @pytest.fixture(autouse=True)
 def _assembly_is_an_assembly(monkeypatch):
-    """Both tests branch on isinstance(shape, Assembly); _Assembly stands in."""
+    """Both tests branch on isinstance(); the stubs stand in for the real classes."""
     monkeypatch.setattr("partcad.test.interference.Assembly", _Assembly)
     monkeypatch.setattr("partcad.test.degenerate.Assembly", _Assembly)
+    monkeypatch.setattr("partcad.test.degenerate.Sketch", _Sketch)
 
 
 def _run(test, shape):
@@ -268,3 +273,12 @@ def test_a_verdict_that_turned_on_the_machine_is_not_remembered():
     ctx = {}
     assert asyncio.run(InterferenceTest().test([], None, _Assembly(raises=Exception("no runtime")), ctx))
     assert ctx.get(InterferenceTest.NOT_CACHEABLE) is True
+
+
+
+def test_a_sketch_is_flat_because_that_is_what_a_sketch_is():
+    """Found by CI: 'circle' in examples/provider_manufacturer is a sketch,
+    20 x 20 x 0 mm, and this failed it for being what it was asked to be. A
+    check an object cannot pass and should not be taking is worse than none.
+    """
+    assert _run(DegenerateTest(), _Sketch(box=(0, 0, 0, 20, 20, 0.0)))


### PR DESCRIPTION
`pc test` asks whether a shape was produced. It does not ask whether what was produced is a solid anybody meant, or whether the parts ended up anywhere sensible — the questions an assembly is actually judged on, and the ones that have needed a person looking at a render.

Four checks, each written for a failure that got all the way through this repository's existing tests.

| Test | Fails when | Cost |
|---|---|---|
| `solidity` | a part's faces are oriented inward, or it encloses nothing | one measurement per part, cached |
| `degenerate` | a shape built but is flat or empty in some axis | one bounding box per part, cached |
| `connectivity` | duplicate placements, crowded ports, unanchored items | free — pure data |
| `interference` | two parts share space | boolean common on the pairs whose boxes meet |

## `interference`

Bounding boxes cannot decide this. Two boxes meeting says very little about two solids — a bracket around a shaft, an L around a corner, anything rotated — so boxes are only a broadphase for choosing pairs, and the answer is `BRepAlgoAPI_Common` and the volume of what it produces. Verified exact: two 10 mm cubes overlapping by 5 mm report 500.0 mm³; two touching face to face report nothing.

The threshold is not a convenience. Parts meant to go together *touch*, and meshed geometry touching produces slivers, so "any shared volume at all" would fail every assembly that fits. Default is a cubic millimetre; `minVolume` / `minFraction` / `ignore` / `skip` are configurable per assembly.

## `solidity`, and why it is separate

Writing `interference` turned up something worse than the thing it was written for:

```
LDraw Brick 2 x 4, meshed:
  volume                          :  -1939.6 mm^3   (negative -> inside out)
  common with a copy 100 mm away  :  -2282.9 mm^3   (must be exactly 0)
```

A solid whose faces point inward still builds, renders, exports and measures the right size. Only its arithmetic is wrong. `interference` therefore has to exclude such parts — but excluding them *silently* would mean an assembly built entirely from them passes without being checked. So excluded parts are named in the log, and `solidity` reports the same fact once, about the part, where it belongs.

The cause was the LDraw mesher ignoring BFC winding metadata, fixed in partcad-ldraw#6. This is the test that would have caught it — and it means booleans, CAM, FEA and BoM volumes had been wrong on every LEGO part.

**The gate is the sign of the volume, not `BRepCheck_Analyzer`.** Plenty of usable geometry is not a valid solid in OCCT's sense: an LDraw brick is an open mesh — a stud is a cylinder and a top disc with no bottom — so it carries 224 free boundary edges and fails `IsValid`, while intersecting perfectly well. Gating on validity would have refused to check any assembly built from such parts, forever.

## `connectivity`

Three placements that do not add up, all free to check:

- **The same part twice in the same place** — what a generator does when a loop runs once too often. No view shows it; the second item is exactly behind the first.
- **Two objects on one port** — a stud takes one brick, a bolt hole takes one bolt. Joints that genuinely are made more than once say so with the new `multiConnect: true` on the interface (a shaft carrying several parts, a rail, a bus bar). `Interface` carries and inherits it the way it does `threadStep`; an explicit `false` overrides an inherited `true`.
- **An object placed by coordinates among objects that connect** — held where it is by nothing. The exemption is the item each group hangs from, applied **per `links:` group**: an ASSY file's top level becomes a child assembly, so exempting the first item of the flattened tree would exempt that wrapper and report the anchor it wraps.

## What "passed" has to mean

Almost every correction on this branch was one bug wearing different clothes: a path where the check stops early and the caller cannot tell *looked and found nothing* from *never looked*. A boolean that did not complete, a void bounding box, a missing CAD runtime, metadata that could not be read, a cached verdict read back after the setting that produced it changed.

So the checks distinguish three outcomes rather than two:

- **`unchecked` / `indeterminate`** — named in the log. A part that could not be intersected, a pair whose boolean did not come back, a shape with no extent to measure.
- **`NOT_CACHEABLE`** — a verdict that turned on the machine rather than the shape, or on something outside `shape.hash` (a missing runtime, an interface's `multiConnect`, a run where part of the work could not be done). A cached verdict is returned *before* the test runs, so remembering these would hand back a pass that was never earned.
- **`cache_key_suffix`** — every setting that decides a verdict is in the key. `shape.hash` covers none of `skip`, `tolerance`, `allowDuplicates` or `requireAnchored`.

## Turning them off

Every check has a legitimate counter-example, so every check can be turned off on the object it is wrong about. A test something cannot pass and should not be taking is worse than no test — which this branch proved the hard way: `degenerate` failed every sketch in the examples for being flat, which is what a sketch *is*. Sketches are now passed over outright, as are shapes that never built (that is `cad`'s to report).

## Testing

56 unit tests across two files. They cover the deciding — which verdict follows from which measurement, and what each configuration key does — plus the request the wrapper is driven with, which is where a real bug reached CI: the assembly was sent under the key that gets decoded into a single compound, which is the one thing the check cannot use, since compounding discards the names it needs to say *which two* parts overlap.

The geometry itself was exercised by hand against OCCT and against real LDraw parts; the numbers above come from that.

Full unit suite: no regressions. My environment cannot build the CAD-dependent tests, so I compared failure *sets* before and after rather than absolute counts — 197 on `devel`, the same 197 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
