### PR TITLE
Key a shape on everything about it that is not prose

### DIFF
--- a/src/partcad/cache_hash.py
+++ b/src/partcad/cache_hash.py
@@ -24,7 +24,12 @@ from . import logging as pc_logging
 #   2: the shape cache stores the payload alone - the outer layer (name, label,
 #      placement) is stripped on write and wrapped back on read (see
 #      cache_shape.py), and a lone shape is stored as raw BREP bytes.
-VERSION = 2
+#   3: a shape's key covers its whole configuration bar the keys that only
+#      describe it, instead of 'parameters'/'offset'/'scale' alone (see
+#      _NON_GEOMETRIC_CONFIG_KEYS in shape.py). Entries written under 2 were
+#      keyed on too little - parts that differ only in a key the allow-list did
+#      not name shared one - so none of them may be read back.
+VERSION = 3
 
 # What the version contributes to a hash. Namespaced so that it cannot be
 # confused with the data hashed after it.

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -126,6 +126,56 @@ TEXT_PART_TYPES = frozenset({"step", "iges", "brep", "obj", "threejs", "svg", "d
 SUPPORTED_PART_TYPES = frozenset(LIVE_OBJECT_PART_TYPES | SERIALIZED_PART_TYPES)
 
 
+# What a shape's configuration says about the shape to a reader, rather than
+# what its geometry is made of. Everything else in the configuration is hashed
+# into the cache key.
+#
+# A deny-list rather than an allow-list, on purpose. An allow-list has to know
+# every key that can change a shape, and it cannot: a partType of kind
+# 'wrapper' is a package-supplied script that reads configuration keys of its
+# own invention. The ':ldraw' partType identifies its part with 'dat', which
+# the previous allow-list of 'parameters'/'offset'/'scale' did not name, so
+# every LDraw part hashed to the same key and whichever was meshed first was
+# handed back for all the others - four different parts exported byte-identical
+# geometry, and an assembly of bricks rendered as cones.
+#
+# The two mistakes are not symmetrical: hashing a key that turns out not to
+# matter costs a rebuild, while missing one that does matter serves the wrong
+# shape and says nothing. So a key this does not know about is hashed.
+_NON_GEOMETRIC_CONFIG_KEYS = frozenset(
+    {
+        "aliases",
+        "author",
+        "cache",
+        "cache_dependencies_ignore",
+        "category",
+        "desc",
+        "docs",
+        "example",
+        "images",
+        "label",
+        "license",
+        "manufacturable",
+        "manufacturing",
+        # A shape's own name is not what it is made of: two parts alike but for
+        # their names are one shape and share an entry. What a file-backed part
+        # is built from reaches the key as the file's content, not as its name.
+        "name",
+        "orig_name",
+        # Outputs, not inputs. A part that gains a material has not become a
+        # different shape (see test_shape_properties.py).
+        "properties",
+        "sku",
+        "summary",
+        "supplier",
+        "tags",
+        "title",
+        "url",
+        "vendor",
+    }
+)
+
+
 @telemetry.instrument(exclude=["locked"])
 class Shape(ShapeConfiguration):
     name: str
@@ -191,10 +241,9 @@ class Shape(ShapeConfiguration):
         self.owns_cache_entry = True
 
         if self.cacheable:
-            cad_config = {}
-            for key in ["parameters", "offset", "scale"]:
-                if key in self.config:
-                    cad_config[key] = self.config[key]
+            cad_config = {
+                key: value for key, value in self.config.items() if key not in _NON_GEOMETRIC_CONFIG_KEYS
+            }
             self.hash.add_dict(cad_config)
 
     def set_environment_cache_key(self, environment_cache_key: str) -> None:

--- a/tests/partcad/unit/test_shape_cache_key.py
+++ b/tests/partcad/unit/test_shape_cache_key.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""What of a shape's configuration reaches its cache key.
+
+The key has to cover everything that decides the geometry. It used to cover an
+allow-list of 'parameters', 'offset' and 'scale', which cannot be complete: a
+partType of kind 'wrapper' is a package-supplied script reading configuration
+keys of its own invention, and the ':ldraw' partType identifies its part with
+'dat'. Every LDraw part therefore hashed to one key, and whichever was meshed
+first was served for all of them - four different parts exported byte-identical
+geometry.
+
+So the rule is inverted here: everything is hashed except the keys that only
+describe the shape to a reader.
+"""
+
+from partcad.shape import Shape
+
+
+def _key(config):
+    shape = Shape("pkg", config)
+    shape.set_environment_cache_key("env")
+    return shape.hash.get()
+
+
+def test_a_wrapper_part_type_key_separates_parts_it_alone_understands():
+    """The regression: 'dat' is what says which LDraw part this is."""
+    brick = _key({"name": "part", "type": ":ldraw", "dat": "3001.dat"})
+    other = _key({"name": "part", "type": ":ldraw", "dat": "3003.dat"})
+    assert brick != other
+
+
+def test_prose_about_a_shape_does_not_move_its_key():
+    """A description is not geometry; rewording one must not force a rebuild."""
+    bare = _key({"name": "part", "type": ":ldraw", "dat": "3001.dat"})
+    described = _key(
+        {
+            "name": "part",
+            "type": ":ldraw",
+            "dat": "3001.dat",
+            "desc": "Brick  2 x  4",
+            "author": "James Jessiman",
+            "license": "CC BY 4.0",
+            "url": "https://library.ldraw.org/",
+        }
+    )
+    assert bare == described
+
+
+def test_a_key_the_hash_has_never_heard_of_is_still_hashed():
+    """An unknown key is assumed to matter.
+
+    The two mistakes are not symmetrical. Hashing a key that turns out not to
+    matter costs a rebuild; missing one that does matter serves the wrong shape
+    and says nothing.
+    """
+    without = _key({"name": "part", "type": "step", "path": "a.step"})
+    with_it = _key({"name": "part", "type": "step", "path": "a.step", "someFutureKey": 7})
+    assert without != with_it
+
+
+def test_the_geometry_keys_that_were_always_hashed_still_are():
+    base = {"name": "part", "type": "step", "path": "a.step"}
+    assert _key(base) != _key({**base, "parameters": {"n": {"type": "int", "default": 1}}})
+    assert _key(base) != _key({**base, "offset": [[1, 0, 0], [0, 0, 1], 0]})
+    assert _key(base) != _key({**base, "scale": 2.0})
+
+
+def test_the_file_a_part_is_built_from_reaches_the_key():
+    assert _key({"name": "part", "type": "step", "path": "a.step"}) != _key(
+        {"name": "part", "type": "step", "path": "b.step"}
+    )
+
+
+def test_what_a_shape_is_called_is_not_what_it_is_made_of():
+    """Two parts alike but for their names are one shape, and share an entry.
+
+    A file-backed part reaches its key through the file's content, so the name
+    it happens to carry - and the 'orig_name' the factory records beside it -
+    are not part of what is being cached.
+    """
+    assert _key({"name": "a", "orig_name": "a", "type": "step", "path": "body.step"}) == _key(
+        {"name": "b", "orig_name": "b", "type": "step", "path": "body.step"}
+    )
+
+
+def test_properties_are_outputs_and_do_not_move_the_key():
+    """A part that gains a material has not become a different shape."""
+    base = {"name": "part", "type": "step", "path": "a.step"}
+    assert _key(base) == _key({**base, "properties": {"material": "steel"}})


### PR DESCRIPTION
Reopens #616 against `devel`.

#616 was targeted at `main` by mistake and squash-merged there as `8e665944`, which left `main` unable to fast-forward to `devel` and left `devel` without the fix. `devel` still has `VERSION = 2` and no `_NON_GEOMETRIC_CONFIG_KEYS`, so the collision described below is still live on the development branch — and a release cut from `devel` would ship it.

The change is unchanged from #616, cherry-picked onto `devel`.

---

A shape's cache key covered `parameters`, `offset` and `scale` and nothing else of its configuration:

```python
if self.cacheable:
    cad_config = {}
    for key in ["parameters", "offset", "scale"]:
        if key in self.config:
            cad_config[key] = self.config[key]
    self.hash.add_dict(cad_config)
```

An allow-list cannot be complete here. A partType of kind `wrapper` is a package-supplied script that reads configuration keys of its own invention, and PartCAD has no way to know them. The `:ldraw` partType identifies its part with `dat`, which the list did not name — and since those parts declare no `parameters`, `offset` or `scale`, `cad_config` was `{}` and `add_dict` returned early without even marking the hash non-empty. **Every LDraw part in one environment hashed to the same key**, and whichever was meshed first was served for all the others.

The same md5, minutes apart:

```
792bcd456515ee2fa639d5555f6a1a4d  ->  //pub/universe/lego/ldraw/Cone:6233
792bcd456515ee2fa639d5555f6a1a4d  ->  //pub/universe/lego/ldraw/Cone:3942b
```

`pc export -t stl` of four different parts wrote four **byte-identical** STL files; a six-part assembly of bricks rendered as four cones.

## The change

Everything in the configuration is hashed except the keys that only describe the shape to a reader. The two mistakes are not symmetrical — hashing a key that turns out not to matter costs a rebuild, while missing one that does matter serves the wrong shape silently — so a key the deny-list has never heard of is hashed.

What stays out, and why, is each an invariant the test suite already asserted: `name`/`orig_name` (`test_object_type_parameters.py` asserts two parts alike but for their names share an entry), `properties` (`test_shape_properties.py`: "a part that gains a material has not become a different shape"), and documentation fields.

`VERSION` goes 2 → 3: entries written under 2 were keyed on too little and must not be read back.

## Testing

`tests/partcad/unit/test_shape_cache_key.py`, 7 tests, all passing on `devel`. Three fail against unfixed `shape.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)