### PR TITLE
Stop loading the CAD kernel to answer a question with no geometry in it

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2562,7 +2562,7 @@ or a new piece of metadata needs no new API:
   the whole repository
 - ``deps`` -- the names of the child packages
 - ``meta`` -- package-level properties (``desc``, ``render``, ``manufacturable``,
-  ...)
+  ...), and ``objectKinds`` (see below)
 - ``files/<path>`` -- the base64-encoded content of a file an object references
   by ``path``. A plugin-backed package has no source tree, so a file-backed
   object's file is fetched from the plugin and materialized into the package's
@@ -2571,6 +2571,29 @@ or a new piece of metadata needs no new API:
 For a hierarchy, a child package's requests are prefixed with its
 ``subfolder``: a child in ``motors`` asks for ``motors/objects/part``,
 ``motors/deps`` and so on, all served by the same script.
+
+Say which kinds a package has
+-----------------------------
+
+Every key is a separate run of the script, and a package has ten kinds of
+object. Something as ordinary as listing the packages that hold anything to
+look at asks after four of them, per package, and for a hierarchy of a hundred
+packages that is four hundred runs -- most of them to be told "none".
+
+A package's ``meta`` may therefore carry ``objectKinds``, the kinds that
+package holds at all:
+
+.. code-block:: json
+
+  {"desc": "LDraw parts in the 'Brick' category.", "objectKinds": ["part", "partType"]}
+
+PartCAD then answers "none" for every other kind without asking. This narrows
+what is asked for and never what may be served: a plugin that lists a kind it
+turns out to have none of is simply asked a question it answers emptily, and a
+plugin that says nothing is asked about everything, as before. It is read out
+of the metadata PartCAD has already fetched and is never worth a request of its
+own, so a package reached on its own -- rather than through a traversal, which
+reads ``meta`` for every package as it goes -- is queried exactly as it was.
 
 Responses are cached per key (in memory and on disk), so a repository that is
 slow or remote is queried as little as possible. See

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2555,9 +2555,10 @@ generic key/value request:
 The keys address every kind of data uniformly, so serving a new kind of object
 or a new piece of metadata needs no new API:
 
-- ``objects/<kind>`` -- all objects of a kind, as ``{name: config, ...}`` (kinds
-  are ``sketch``, ``part``, ``assembly``, ``interface``, ``provider``,
-  ``repository``, ``software``)
+- ``objects/<kind>`` -- all objects of a kind, as ``{name: config, ...}``. The
+  kinds are the ten in ``Project.OBJECT_KINDS``: ``material``, ``interface``,
+  ``sketch``, ``part``, ``assembly``, ``scene``, ``provider``, ``repository``,
+  ``software``, ``partType``
 - ``objects/<kind>/<name>`` -- a single object's config, fetched without listing
   the whole repository
 - ``deps`` -- the names of the child packages

--- a/examples/plugin_repository_tree/remote.py
+++ b/examples/plugin_repository_tree/remote.py
@@ -12,8 +12,10 @@ PartCAD runs this for every data request, with the generic key in
 The key space is uniform (see ProjectExternalRepository):
 
     deps                          -> child package names of the top package
+    meta                          -> the top package's properties
     objects/<kind>                -> the top package's objects of that kind
     <subfolder>/deps              -> child names under that subfolder
+    <subfolder>/meta              -> that subfolder's properties
     <subfolder>/objects/<kind>    -> that subfolder's objects
 
 So a child in 'motors' is served the same way as the top package, just under
@@ -35,15 +37,24 @@ _SCRIPTS = {
 # child external package, served under its own key prefix - which is how PartCAD
 # forwards a child's requests. The catalog is static; a real plugin would look
 # it up remotely.
+#
+# Each package's 'meta' declares 'objectKinds', which is worth doing in any
+# plugin serving more than a handful of packages. PartCAD has ten kinds of
+# object and asks after them one key at a time - a separate run of this script
+# each - so a package that says it has only parts is never asked about the other
+# nine. It narrows what is asked for and never what may be served.
 CATALOG = {
     "deps": ["brackets", "motors"],
+    "meta": {"objectKinds": []},  # the top package is a directory: children only
     # The 'brackets' sub-package.
     "brackets/deps": [],
+    "brackets/meta": {"objectKinds": ["part"]},
     "brackets/objects/part": {
         "l_bracket": {"type": "cadquery", "path": "l_bracket.py"},
     },
     # The 'motors' sub-package.
     "motors/deps": [],
+    "motors/meta": {"objectKinds": ["part"]},
     "motors/objects/part": {
         "shaft": {"type": "cadquery", "path": "shaft.py"},
     },

--- a/examples/plugin_repository_tree/test_tree_remote.py
+++ b/examples/plugin_repository_tree/test_tree_remote.py
@@ -49,3 +49,11 @@ def test_leaf_subfolders_have_no_children():
 def test_unknown_key_is_none():
     assert _get("objects/part") is None  # the top package has no parts of its own
     assert _get("nonexistent/objects/part") is None
+
+
+def test_each_package_says_which_object_kinds_it_has():
+    """So PartCAD asks for the one kind that is here and not the other nine."""
+    assert _get("meta")["objectKinds"] == []  # the top package holds only children
+    assert _get("brackets/meta")["objectKinds"] == ["part"]
+    for kind in _get("brackets/meta")["objectKinds"]:
+        assert _get("brackets/objects/" + kind)

--- a/src/partcad/context.py
+++ b/src/partcad/context.py
@@ -48,6 +48,21 @@ from .test.all import tests as all_tests
 HAS_STUFF_KINDS = ("sketch", "part", "assembly", "scene")
 
 
+def _is_within(name: str, parent_name: Optional[str]) -> bool:
+    """Whether a package name is 'parent_name' or sits underneath it.
+
+    A package name is a path, so the boundary has to be the separator and not
+    just a prefix: '//foo' is not the parent of '//foobar', and matching it as
+    one made a listing of '//foo' include its neighbour -- and now also send a
+    round trip to that neighbour's repository plugin (see
+    '_prefetch_object_configs'). The root, '//', is the parent of everything,
+    which falls out of the same rule once the trailing separator is stripped.
+    """
+    if parent_name is None:
+        return True
+    return name == parent_name or name.startswith(parent_name.rstrip("/") + "/")
+
+
 def connectivity_probe():
     """The one address to ask "is there a network out of here?".
 
@@ -794,9 +809,7 @@ class Context:
         A no-op for the packages that are local, which is most of them; what it
         is for is the plugin-backed ones, where the enumerations are remote.
         """
-        projects = list(self.projects.values())
-        if parent_name is not None:
-            projects = [p for p in projects if p.name.startswith(parent_name)]
+        projects = [p for p in self.projects.values() if _is_within(p.name, parent_name)]
         projects = [p for p in projects if not p.skipped]
         if not projects:
             return
@@ -823,7 +836,7 @@ class Context:
         """
         projects = self.projects.values()
         if parent_name is not None:
-            projects = filter(lambda x: x.name.startswith(parent_name), projects)
+            projects = filter(lambda x: _is_within(x.name, parent_name), projects)
 
         # Unconditionally, not only under 'has_stuff': a skipped package holds
         # no objects, so the filter below would drop it anyway, but a caller

--- a/src/partcad/context.py
+++ b/src/partcad/context.py
@@ -41,6 +41,12 @@ from .plugin_provider_data_cart import *
 from . import telemetry
 from .test.all import tests as all_tests
 
+# What makes a package worth listing to a user interface: the kinds of object it
+# would have something to show for. Named once because two things read it and
+# they have to agree -- the filter in 'get_packages', and the prefetch in
+# 'get_all_packages' that warms exactly what that filter is about to read.
+HAS_STUFF_KINDS = ("sketch", "part", "assembly", "scene")
+
 
 def connectivity_probe():
     """The one address to ask "is there a network out of here?".
@@ -773,9 +779,48 @@ class Context:
     def get_all_packages(self, parent_name=None, has_stuff: bool = True):
         # TODO(clairbee): leverage root_project.get_child_project_names()
         self.import_all(parent_name)
+        if has_stuff:
+            # 'get_packages' below reads HAS_STUFF_KINDS out of every package,
+            # one kind at a time, and for a plugin-backed package each of those
+            # is a round trip to the plugin. Warm them here instead: every
+            # package and every kind at once, on the traversal's event loop, so
+            # what follows reads a memo. See Project.prefetch_object_configs_async.
+            self._prefetch_object_configs(parent_name, HAS_STUFF_KINDS)
         return self.get_packages(parent_name=parent_name, has_stuff=has_stuff)
 
+    def _prefetch_object_configs(self, parent_name, kinds):
+        """Warm 'kinds' across every loaded package, concurrently.
+
+        A no-op for the packages that are local, which is most of them; what it
+        is for is the plugin-backed ones, where the enumerations are remote.
+        """
+        projects = list(self.projects.values())
+        if parent_name is not None:
+            projects = [p for p in projects if p.name.startswith(parent_name)]
+        projects = [p for p in projects if not p.skipped]
+        if not projects:
+            return
+
+        async def prefetch():
+            # This is a warm-up and nothing depends on it having worked: a
+            # package whose prefetch failed is read the slow way by the
+            # accessors below, which report the failure themselves. So one
+            # unreachable repository must not take the listing down with it.
+            await asyncio.gather(
+                *(p.prefetch_object_configs_async(kinds) for p in projects),
+                return_exceptions=True,
+            )
+
+        # Called from the synchronous listing path, right after 'import_all'
+        # ran its own 'asyncio.run', so there is no loop to nest inside.
+        asyncio.run(prefetch())
+
     def get_packages(self, parent_name: str = None, has_stuff: bool = True) -> list[dict[str, str]]:
+        """Every loaded package, or only those with something to look at in them.
+
+        'has_stuff' is what makes it the second: a package is kept only if it
+        holds an object of one of HAS_STUFF_KINDS.
+        """
         projects = self.projects.values()
         if parent_name is not None:
             projects = filter(lambda x: x.name.startswith(parent_name), projects)
@@ -793,11 +838,7 @@ class Context:
             # instantiated dicts, so a plugin-backed package - which enumerates
             # lazily and does not instantiate up front - is counted correctly.
             projects = filter(
-                lambda x: x.object_count("sketch")
-                + x.object_count("part")
-                + x.object_count("assembly")
-                + x.object_count("scene")
-                > 0,
+                lambda x: sum(x.object_count(kind) for kind in HAS_STUFF_KINDS) > 0,
                 projects,
             )
         return list(

--- a/src/partcad/project.py
+++ b/src/partcad/project.py
@@ -575,6 +575,17 @@ class Project(project_config.Configuration):
         """
         return None
 
+    async def prefetch_object_configs_async(self, kinds) -> None:
+        """Warm the enumerations of 'kinds' from within an async context.
+
+        A no-op for a local package, whose objects are known at construction. A
+        plugin-backed package overrides this to fetch several kinds at once and
+        concurrently, so that a caller which then reads them one after another
+        through the synchronous accessors pays one round trip's latency rather
+        than one per kind (see Context.get_all_packages).
+        """
+        return None
+
     def object_count(self, kind: str) -> int:
         """Number of declared objects of a kind, without instantiating them."""
         return len(self.object_configs(kind))

--- a/src/partcad/project_external_repository.py
+++ b/src/partcad/project_external_repository.py
@@ -24,6 +24,10 @@ _MISSING = object()
 # '_served_kinds()'.
 OBJECT_KINDS_KEY = "objectKinds"
 
+# Distinguishes "the metadata has not been parsed yet" from a parse that
+# concluded the package declares nothing.
+_UNPARSED = object()
+
 
 class ProjectExternalRepository(ProjectPlugin):
     """A package whose contents are served by an external repository plugin.
@@ -81,6 +85,11 @@ class ProjectExternalRepository(ProjectPlugin):
         self._cache_version = cache_version
         self._request_cache: dict[str, object] = {}
         self._request_lock = threading.Lock()
+        # The parsed 'objectKinds', once the metadata has arrived. Kept apart
+        # from the metadata memo so that parsing happens once per package
+        # rather than once per kind asked about - and so that a malformed
+        # declaration is complained about once rather than ten times.
+        self._served_kinds_parsed = _UNPARSED
         # Objects are instantiated once, lazily, the first time this package's
         # 'parts'/'sketches'/'assemblies' are accessed (see '_lazy_objects').
         # '_instantiating' is the reentrancy guard so factories can write into
@@ -204,7 +213,14 @@ class ProjectExternalRepository(ProjectPlugin):
         with enough packages in it for this to matter.
         """
         meta = self._peek_data("meta")
-        return None if meta is _MISSING else self._parse_served_kinds(meta)
+        if meta is _MISSING:
+            # The metadata has not been read yet, so nothing is known about
+            # what this package holds: ask about every kind, as before. Not
+            # remembered - the answer changes as soon as 'meta' arrives.
+            return None
+        if self._served_kinds_parsed is _UNPARSED:
+            self._served_kinds_parsed = self._parse_served_kinds(meta)
+        return self._served_kinds_parsed
 
     def _peek_data(self, key: str):
         """The memoized value for 'key', or _MISSING - never a fetch."""

--- a/src/partcad/project_external_repository.py
+++ b/src/partcad/project_external_repository.py
@@ -20,6 +20,10 @@ from . import tags as pc_tags
 # Distinguishes "no cached value" from a cached value of None.
 _MISSING = object()
 
+# What a package's metadata calls the list of object kinds it holds. See
+# '_served_kinds()'.
+OBJECT_KINDS_KEY = "objectKinds"
+
 
 class ProjectExternalRepository(ProjectPlugin):
     """A package whose contents are served by an external repository plugin.
@@ -38,6 +42,10 @@ class ProjectExternalRepository(ProjectPlugin):
         objects/<kind>/<name>       -> config                (single fetch)
         deps                        -> [child package names]
         meta                        -> package-level metadata
+
+    A package's metadata may carry 'objectKinds' to say which kinds it holds at
+    all; the kinds it leaves out are then never asked for. See
+    '_served_kinds()'.
 
     'get_data(key)' is the single method a repository plugin must implement; the
     accessors below are expressed entirely in terms of it.
@@ -167,6 +175,62 @@ class ProjectExternalRepository(ProjectPlugin):
         with self._request_lock:
             return self._request_cache.setdefault(scoped, value)
 
+    def _served_kinds(self):
+        """The object kinds this package holds, or None if it does not say.
+
+        A package has ten kinds of object (see 'Project.OBJECT_KINDS') and a
+        consumer that wants to know whether a package holds anything asks after
+        four of them - which, for a package served by a plugin, is four separate
+        runs of that plugin's script, one per kind, most of them to be told
+        'none'. 'pc list packages -r' over LDraw's 92 categories is 368 such
+        runs, and 276 of them are about kinds no LDraw category has ever had.
+
+        So a repository may say, in a package's metadata, which kinds that
+        package actually holds:
+
+            {"desc": "...", "objectKinds": ["part", "partType"]}
+
+        and every other kind is answered 'none' from here, without asking. This
+        narrows what is asked for and never what may be served: a repository
+        that says nothing is asked about everything exactly as before, and one
+        that lists a kind it turns out to have none of is merely asked a
+        question it answers emptily, as it is today.
+
+        Read from the metadata this package has *already* fetched, and never
+        fetched on its own account - a round trip to find out what not to ask
+        for would be a second round trip in the one case that today costs one:
+        a single package, reached without the traversal. Every traversal warms
+        'meta' as it goes (see 'ensure_enumerated_async'), which is every case
+        with enough packages in it for this to matter.
+        """
+        meta = self._peek_data("meta")
+        return None if meta is _MISSING else self._parse_served_kinds(meta)
+
+    def _peek_data(self, key: str):
+        """The memoized value for 'key', or _MISSING - never a fetch."""
+        with self._request_lock:
+            return self._request_cache.get(self._scope(key), _MISSING)
+
+    def _parse_served_kinds(self, meta):
+        if not isinstance(meta, dict):
+            return None
+        kinds = meta.get(OBJECT_KINDS_KEY)
+        if kinds is None:
+            return None
+        if not isinstance(kinds, (list, tuple, set)) or not all(isinstance(k, str) for k in kinds):
+            # Not something to guess at: ask about every kind, as if it had not
+            # been said at all, and say why once.
+            pc_logging.warning(
+                "%s: ignoring '%s' in the package metadata: expected a list of strings, got %r"
+                % (self.name, OBJECT_KINDS_KEY, kinds)
+            )
+            return None
+        return frozenset(kinds)
+
+    def _serves_kind(self, kind: str) -> bool:
+        kinds = self._served_kinds()
+        return kinds is None or kind in kinds
+
     def _cache_hash(self, scoped_key: str) -> CacheHash:
         # The cache directory is already scoped to this repository instance, so
         # the scoped key alone identifies the entry within it.
@@ -237,6 +301,25 @@ class ProjectExternalRepository(ProjectPlugin):
         await self._materialize_meta_async()
         # Warm 'deps' so the synchronous 'dependencies()' is a cache hit.
         await self.get_data_async("deps")
+
+    async def prefetch_object_configs_async(self, kinds) -> None:
+        """Fetch the enumerations of 'kinds' at once, concurrently.
+
+        Each key is a separate run of the plugin's script, so a caller that
+        reads several kinds through the synchronous accessors pays each round
+        trip end to end, one after another. Here they are in flight together and
+        land in the memo the accessors read, which is the whole difference
+        between 'pc list packages -r' over a plugin-backed hierarchy taking one
+        round trip per package and taking one per package per kind.
+
+        Only the kinds this package says it holds are asked for; the rest are
+        answered from '_served_kinds()' without a request at all.
+        """
+        served = self._served_kinds()
+        wanted = [kind for kind in kinds if served is None or kind in served]
+        if not wanted:
+            return
+        await asyncio.gather(*(self.get_data_async("objects/" + kind) for kind in wanted))
 
     def _instantiate_enumerated(self):
         """Instantiate this package's enumerated objects into the eager dicts.
@@ -359,12 +442,16 @@ class ProjectExternalRepository(ProjectPlugin):
         return config
 
     def _enumerate_object_configs(self, kind):
+        if not self._serves_kind(kind):
+            return {}
         configs = self.get_data("objects/" + kind)
         if not configs:
             return {}
         return {name: self._augment(config) for name, config in configs.items()}
 
     def _fetch_object_config(self, kind, name):
+        if not self._serves_kind(kind):
+            return None
         return self._augment(self.get_data("objects/" + kind + "/" + name))
 
     def dependencies(self):

--- a/src/partcad/wrappers/ocp_serialize.py
+++ b/src/partcad/wrappers/ocp_serialize.py
@@ -394,13 +394,20 @@ def encode(obj, name=None, label=None):
     non-shape OCCT object (a Location/Axis a build123d script showed) drops to
     null - every consumer already discards it - and any other unknown type
     raises, to catch real bugs.
+
+    Every JSON-native kind is settled before OCP is reached for, and that
+    ordering is the point rather than tidiness. Importing OCP is the better part
+    of a second - it is OpenCASCADE, several hundred megabytes of it - and the
+    answers that carry no geometry at all are not rare: a repository plugin's
+    reply is a dict of strings, and PartCAD asks a plugin one key at a time, in
+    a process of its own, hundreds of times over to list a large package tree.
+    Asking "is this dict a TopoDS_Shape?" first made every one of those calls
+    load the kernel to find out it was not. A value only reaches _ensure_ocp()
+    here when it is neither a scalar nor a container, which is the only way it
+    could be OCCT.
     """
     if obj is None or isinstance(obj, (bool, int, float, str)):
         return obj
-
-    _ensure_ocp()
-    if isinstance(obj, OCP.TopoDS.TopoDS_Shape):
-        return encode_shape(obj, name=name, label=label)
 
     if isinstance(obj, dict):
         # An already-built shape/assembly object keeps its own metadata verbatim.
@@ -427,6 +434,11 @@ def encode(obj, name=None, label=None):
 
     if isinstance(obj, BaseException):
         return str(obj)
+
+    # Nothing JSON-native is left, so this is where the kernel is needed.
+    _ensure_ocp()
+    if isinstance(obj, OCP.TopoDS.TopoDS_Shape):
+        return encode_shape(obj, name=name, label=label)
 
     if type(obj).__module__.split(".")[0] == "OCP":
         _warn("dropping non-shape OCCT object of type %s" % type(obj))

--- a/tests/partcad/unit/test_context_package_paths.py
+++ b/tests/partcad/unit/test_context_package_paths.py
@@ -1,0 +1,37 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""A package name is a path, so a parent match has to stop at the separator.
+
+'//foo' is not the parent of '//foobar'. Matching it as one put the neighbour
+in a listing of '//foo' - and, since the listing now warms what it is about to
+read, sent a round trip to that neighbour's repository plugin as well.
+"""
+
+from partcad.context import _is_within
+
+
+def test_a_package_is_within_itself():
+    assert _is_within("//foo", "//foo")
+
+
+def test_a_child_is_within_its_parent():
+    assert _is_within("//foo/bar", "//foo")
+    assert _is_within("//foo/bar/baz", "//foo")
+
+
+def test_a_neighbour_sharing_a_prefix_is_not_a_child():
+    assert not _is_within("//foobar", "//foo")
+    assert not _is_within("//foo-bar", "//foo")
+
+
+def test_the_root_is_the_parent_of_everything():
+    assert _is_within("//pub/examples", "//")
+    assert _is_within("//", "//")
+
+
+def test_no_parent_matches_every_package():
+    assert _is_within("//anything", None)

--- a/tests/partcad/unit/test_ocp_serialize_lazy.py
+++ b/tests/partcad/unit/test_ocp_serialize_lazy.py
@@ -1,0 +1,111 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""An answer with no geometry in it must not load the CAD kernel to say so.
+
+Every wrapper call is a process of its own, and importing OCP is the better part
+of a second in it. A repository plugin's answer is a dict of strings, and PartCAD
+asks a plugin one key at a time - hundreds of times over to list a large package
+tree - so a kernel loaded to decide that a dict is not a shape was most of what
+each of those calls cost.
+
+The "did it load" half is checked in a subprocess, because within one test
+session something else has already imported OCP.
+"""
+
+import base64
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+import partcad as pc
+
+WRAPPERS = os.path.join(os.path.dirname(pc.__file__), "wrappers")
+sys.path.append(WRAPPERS)
+import ocp_serialize  # noqa: E402
+
+
+def _serialized_without_ocp(expression):
+    """Serialize 'expression' in a fresh interpreter; (output, whether OCP loaded)."""
+    script = "\n".join(
+        [
+            "import json, sys",
+            "sys.path.insert(0, %r)" % WRAPPERS,
+            "import ocp_serialize",
+            "out = ocp_serialize.serialize(%s)" % expression,
+            'print(json.dumps({"ocp": "OCP" in sys.modules, "out": out}))',
+        ]
+    )
+    completed = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=300)
+    assert completed.returncode == 0, completed.stderr
+    answer = json.loads(completed.stdout.strip().splitlines()[-1])
+    return json.loads(answer["out"]), answer["ocp"]
+
+
+def test_a_geometry_free_answer_does_not_import_the_kernel():
+    """What a repository plugin returns: nested dicts, lists and scalars."""
+    payload = {"result": {"3001": {"type": ":ldraw", "implements": {"stud": [1, 2.5, None, True]}}}}
+    out, ocp = _serialized_without_ocp(repr(payload))
+    assert ocp is False
+    assert out == payload
+
+
+def test_an_exception_answer_does_not_import_the_kernel_either():
+    out, ocp = _serialized_without_ocp('{"exception": ValueError("no such part")}')
+    assert ocp is False
+    assert out == {"exception": "no such part"}
+
+
+def test_bytes_still_travel_without_the_kernel():
+    out, ocp = _serialized_without_ocp('{"blob": b"abc"}')
+    assert ocp is False
+    assert base64.b64decode(out["blob"][ocp_serialize.KEY_BYTES]) == b"abc"
+
+
+def _volume(shape):
+    from OCP.BRepGProp import BRepGProp
+    from OCP.GProp import GProp_GProps
+
+    props = GProp_GProps()
+    BRepGProp.VolumeProperties_s(shape, props)
+    return props.Mass()
+
+
+def test_a_shape_is_still_encoded_as_a_shape():
+    """The lazy import changes when the kernel is loaded, not what is produced."""
+    from OCP.BRepPrimAPI import BRepPrimAPI_MakeBox
+
+    box = BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape()
+    encoded = json.loads(ocp_serialize.serialize({"shape": box}, name="n", label="l"))
+    assert ocp_serialize.KEY_BREP in encoded["shape"]
+    assert encoded["shape"]["name"] == "n" and encoded["shape"]["label"] == "l"
+
+    restored = ocp_serialize.deserialize(json.dumps(encoded))["shape"]
+    assert _volume(restored) == pytest.approx(_volume(box))
+
+
+def test_a_shape_nested_in_a_container_is_still_found():
+    """Containers are walked before the kernel is reached for, not instead of."""
+    from OCP.BRepPrimAPI import BRepPrimAPI_MakeBox
+
+    box = BRepPrimAPI_MakeBox(1.0, 2.0, 3.0).Shape()
+    encoded = json.loads(ocp_serialize.serialize({"parts": [{"a": box}]}))
+    assert ocp_serialize.KEY_BREP in encoded["parts"][0]["a"]
+
+
+def test_a_non_shape_occt_object_is_still_dropped():
+    """It used to be found by the isinstance() that ran first; now by the last check."""
+    from OCP.gp import gp_Pnt
+
+    assert json.loads(ocp_serialize.serialize({"where": gp_Pnt(1, 2, 3)})) == {"where": None}
+
+
+def test_an_unencodable_type_still_raises():
+    with pytest.raises(TypeError):
+        ocp_serialize.serialize({"bad": object()})

--- a/tests/partcad/unit/test_project_external_repository.py
+++ b/tests/partcad/unit/test_project_external_repository.py
@@ -220,3 +220,121 @@ def test_hierarchy_forwards_under_a_subfolder():
     child._repository = fake
     assert child.object_names("part") == ["rotor"]
     assert "motors/objects/part" in fake.keys
+
+
+# --- 'objectKinds': the kinds a repository says it does not have -------------
+#
+# A package has ten kinds of object and every one of them is a separate key -
+# which, for a plugin-backed package, is a separate run of the plugin's script.
+# A repository that says which kinds it holds is not asked about the rest.
+#
+# The declaration is read out of the metadata the traversal has already
+# fetched, so these warm it the way 'ensure_enumerated_async' does.
+
+
+def test_a_kind_the_metadata_leaves_out_is_never_asked_for():
+    ctx = pc.Context("examples")
+    data = {
+        "meta": {"desc": "Parts only", "objectKinds": ["part"]},
+        "objects/part": {"bolt": {"type": "step"}},
+        # Served, but never asked for: the metadata does not list the kind.
+        "objects/sketch": {"outline": {"type": "basic"}},
+    }
+    repo, fake = _make_repo(ctx, data)
+    asyncio.run(repo.ensure_enumerated_async())
+
+    assert repo.object_names("part") == ["bolt"]
+    assert repo.object_names("sketch") == []
+    assert repo.object_config("sketch", "outline") is None
+    assert "objects/sketch" not in fake.keys
+    assert "objects/sketch/outline" not in fake.keys
+
+
+def test_a_repository_that_says_nothing_is_asked_about_everything():
+    """The default, and what every repository written before this did."""
+    ctx = pc.Context("examples")
+    data = {"meta": {"desc": "No declaration"}, "objects/sketch": {"outline": {"type": "basic"}}}
+    repo, fake = _make_repo(ctx, data)
+    asyncio.run(repo.ensure_enumerated_async())
+
+    assert repo.object_names("sketch") == ["outline"]
+    assert "objects/sketch" in fake.keys
+
+
+def test_a_malformed_declaration_is_ignored_rather_than_guessed_at():
+    ctx = pc.Context("examples")
+    data = {"meta": {"objectKinds": "part"}, "objects/sketch": {"outline": {"type": "basic"}}}
+    repo, fake = _make_repo(ctx, data)
+    asyncio.run(repo.ensure_enumerated_async())
+
+    assert repo.object_names("sketch") == ["outline"]
+    assert "objects/sketch" in fake.keys
+
+
+def test_the_declaration_is_never_worth_a_round_trip_of_its_own():
+    """It narrows what is asked for; it must not add a question to find out.
+
+    A package reached without the traversal has not read its metadata, so the
+    kinds are asked for as they always were - one fetch, not two.
+    """
+    ctx = pc.Context("examples")
+    data = {
+        "meta": {"objectKinds": ["part"]},
+        "objects/part": {"bolt": {"type": "step"}},
+        "objects/sketch": {"outline": {"type": "basic"}},
+    }
+    repo, fake = _make_repo(ctx, data)
+
+    assert repo.object_names("part") == ["bolt"]
+    assert fake.keys == ["objects/part"]  # no 'meta' fetched to decide
+
+
+# --- prefetching the kinds a listing is about to read ------------------------
+
+
+def test_prefetch_fetches_the_declared_kinds_together():
+    ctx = pc.Context("examples")
+    data = {
+        "meta": {"objectKinds": ["part", "assembly"]},
+        "objects/part": {"bolt": {"type": "step"}},
+        "objects/assembly": {"rig": {"type": "assy"}},
+    }
+    repo, fake = _make_repo(ctx, data)
+    asyncio.run(repo.ensure_enumerated_async())
+
+    asyncio.run(repo.prefetch_object_configs_async(("sketch", "part", "assembly", "scene")))
+    # Only the declared kinds were asked for...
+    assert sorted(k for k in fake.keys if k.startswith("objects/")) == [
+        "objects/assembly",
+        "objects/part",
+    ]
+
+    # ...and the synchronous accessors that follow add no round trips at all.
+    before = list(fake.keys)
+    assert repo.object_names("part") == ["bolt"]
+    assert repo.object_names("assembly") == ["rig"]
+    assert repo.object_names("sketch") == []
+    assert repo.object_names("scene") == []
+    assert fake.keys == before
+
+
+def test_prefetch_of_an_undeclared_repository_warms_every_kind_asked_for():
+    ctx = pc.Context("examples")
+    data = {"objects/part": {"bolt": {"type": "step"}}}
+    repo, fake = _make_repo(ctx, data)
+
+    asyncio.run(repo.prefetch_object_configs_async(("part", "scene")))
+    assert sorted(k for k in fake.keys if k.startswith("objects/")) == ["objects/part", "objects/scene"]
+    before = list(fake.keys)
+    assert repo.object_names("part") == ["bolt"]
+    assert fake.keys == before
+
+
+def test_a_local_package_has_nothing_to_prefetch():
+    """The hook exists on every package; for a local one it is a no-op."""
+    ctx = pc.Context("examples")
+    project = ctx.get_project(ctx.name)
+    assert project is not None
+    before = project.object_count("part")
+    asyncio.run(project.prefetch_object_configs_async(("part",)))
+    assert project.object_count("part") == before

--- a/tests/partcad/unit/test_project_external_repository.py
+++ b/tests/partcad/unit/test_project_external_repository.py
@@ -184,9 +184,7 @@ def test_cache_version_propagates_to_children():
     """The cache version is inherited by every child of a plugin-backed
     hierarchy, so the whole tree shares one versioned cache namespace."""
     ctx = pc.Context("examples")
-    top = ProjectExternalRepository(
-        ctx, "//ext", "/tmp/ext", plugin_ref="//ext:remote", cache_version=3
-    )
+    top = ProjectExternalRepository(ctx, "//ext", "/tmp/ext", plugin_ref="//ext:remote", cache_version=3)
     top._repository = FakeRepository({"deps": ["motors"]})
     child = top.dependencies()["motors"]
     assert child["cacheVersion"] == 3
@@ -361,61 +359,99 @@ def test_a_malformed_declaration_is_complained_about_once():
 
 # --- the listing warms what it is about to read ------------------------------
 #
-# 'Context.get_all_packages' prefetches HAS_STUFF_KINDS before 'get_packages'
-# reads them back one at a time. Nothing exercised that wiring: the two
-# 'get_all_packages' calls elsewhere in the suite pass has_stuff=False, which
-# skips the prefetch entirely, so the whole point of the change went untested.
+# 'Context.get_all_packages(has_stuff=True)' prefetches HAS_STUFF_KINDS before
+# 'get_packages' reads them back one at a time. Nothing exercised that wiring:
+# the two 'get_all_packages' calls elsewhere in the suite pass has_stuff=False,
+# which skips the prefetch entirely, so the whole point of the change went
+# untested. These go in through the listing rather than through
+# '_prefetch_object_configs', so that the wiring is what is under test: a
+# listing that stopped prefetching would still pass a test that prefetched for
+# it.
 
 
-def _plugin_backed(ctx, name, data):
-    """A plugin-backed package registered in the context, with a fake behind it."""
+def _listing_context(tmp_path, data, name="//test/ext"):
+    """A context with one plugin-backed package in it, ready to be listed.
+
+    The package is injected rather than imported: a real one would need a
+    plugin to run, and what is under test here is the listing rather than the
+    import. Everything after that point sees an ordinary loaded package.
+    """
+    (tmp_path / "partcad.yaml").write_text("name: //test\ndesc: root\n")
+    ctx = pc.Context(str(tmp_path))
     repo = ProjectExternalRepository(ctx, name, "/tmp/ext", config_obj={})
     fake = FakeRepository(data)
     repo._repository = fake
-    asyncio.run(repo.ensure_enumerated_async())
+    asyncio.run(repo.ensure_enumerated_async())  # as the import would have
     ctx.projects[name] = repo
-    return repo, fake
+    return ctx, repo, fake
 
 
-def test_the_listing_warms_the_kinds_it_is_about_to_read():
-    ctx = pc.Context("examples")
-    repo, fake = _plugin_backed(
-        ctx, "//ext", {"meta": {"objectKinds": ["part"]}, "objects/part": {"bolt": {"type": "step"}}}
+def _record_prefetches(repo):
+    """What the listing asks this package to warm, in the order it asks."""
+    asked = []
+    original = repo.prefetch_object_configs_async
+
+    async def spy(kinds):
+        asked.append(tuple(kinds))
+        await original(kinds)
+
+    repo.prefetch_object_configs_async = spy
+    return asked
+
+
+def test_the_listing_warms_the_kinds_it_is_about_to_read(tmp_path):
+    ctx, repo, fake = _listing_context(
+        tmp_path, {"meta": {"objectKinds": ["part"]}, "objects/part": {"bolt": {"type": "step"}}}
     )
+    asked = _record_prefetches(repo)
 
-    ctx._prefetch_object_configs(None, pc_context.HAS_STUFF_KINDS)
-    assert "objects/part" in fake.keys
-    # ...and only the declared kind; the other three are answered from the metadata.
+    listed = [package["name"] for package in ctx.get_all_packages(has_stuff=True)]
+
+    # The listing warmed the package, once, for exactly the kinds it filters on.
+    assert asked == [pc_context.HAS_STUFF_KINDS]
+    # Only the declared kind was a round trip; the other three are answered from
+    # the metadata -- and there is only one of it, so what 'get_packages' read
+    # back afterwards was the memo. That cache hit is the whole point.
     assert [k for k in fake.keys if k.startswith("objects/")] == ["objects/part"]
-
-    # What the listing then reads is a cache hit, which is the whole point.
-    before = list(fake.keys)
-    assert sum(repo.object_count(kind) for kind in pc_context.HAS_STUFF_KINDS) == 1
-    assert fake.keys == before
+    assert "//test/ext" in listed
 
 
-def test_the_prefetch_skips_packages_outside_the_parent():
-    ctx = pc.Context("examples")
-    _, fake = _plugin_backed(ctx, "//ext", {"objects/part": {"bolt": {"type": "step"}}})
+def test_a_listing_that_filters_on_nothing_warms_nothing(tmp_path):
+    """has_stuff=False reads no kinds out of the packages, so it warms none."""
+    ctx, repo, fake = _listing_context(tmp_path, {"objects/part": {"bolt": {"type": "step"}}})
+    asked = _record_prefetches(repo)
 
-    # '//other' is not this package's parent, so nothing is warmed for it -- and
-    # in particular no round trip is sent to a repository out of scope.
-    ctx._prefetch_object_configs("//other", pc_context.HAS_STUFF_KINDS)
+    listed = [package["name"] for package in ctx.get_all_packages(has_stuff=False)]
+
+    assert asked == []
+    assert [k for k in fake.keys if k.startswith("objects/")] == []
+    assert "//test/ext" in listed
+
+
+def test_the_listing_skips_packages_outside_the_parent(tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "partcad.yaml").write_text("desc: sub\n")
+    ctx, repo, fake = _listing_context(tmp_path, {"objects/part": {"bolt": {"type": "step"}}})
+    ctx.import_all()  # so that '//test/sub' is a package a listing can start from
+    asked = _record_prefetches(repo)
+
+    # '//test/sub' is not this package's parent, so nothing is warmed for it --
+    # and in particular no round trip is sent to a repository out of scope.
+    ctx.get_all_packages(parent_name="//test/sub", has_stuff=True)
+    assert asked == []
     assert [k for k in fake.keys if k.startswith("objects/")] == []
 
 
-def test_an_unreachable_repository_does_not_take_the_listing_down():
+def test_an_unreachable_repository_does_not_take_the_listing_down(tmp_path):
     """The prefetch is a warm-up; nothing downstream depends on it having worked."""
 
     class Unreachable:
         async def get_data(self, key):
             raise RuntimeError("the repository is not answering")
 
-    ctx = pc.Context("examples")
-    repo = ProjectExternalRepository(ctx, "//ext", "/tmp/ext", config_obj={})
+    ctx, repo, _ = _listing_context(tmp_path, {})
     repo._repository = Unreachable()
-    ctx.projects["//ext"] = repo
 
-    ctx._prefetch_object_configs(None, pc_context.HAS_STUFF_KINDS)  # must not raise
+    ctx.get_all_packages(has_stuff=True)  # must not raise
     # ...and the package is still readable afterwards, the slow way.
     assert repo.object_count("part") == 0

--- a/tests/partcad/unit/test_project_external_repository.py
+++ b/tests/partcad/unit/test_project_external_repository.py
@@ -338,3 +338,21 @@ def test_a_local_package_has_nothing_to_prefetch():
     before = project.object_count("part")
     asyncio.run(project.prefetch_object_configs_async(("part",)))
     assert project.object_count("part") == before
+
+
+def test_a_malformed_declaration_is_complained_about_once():
+    """Ten kinds asked about must not be ten copies of the same warning."""
+    ctx = pc.Context("examples")
+    data = {"meta": {"objectKinds": "part"}, "objects/sketch": {"outline": {"type": "basic"}}}
+    repo, _ = _make_repo(ctx, data)
+    asyncio.run(repo.ensure_enumerated_async())
+
+    warnings = []
+    original = pc.logging.warning
+    pc.logging.warning = lambda msg, *a: warnings.append(msg)
+    try:
+        for kind in ("sketch", "part", "assembly", "scene"):
+            repo.object_names(kind)
+    finally:
+        pc.logging.warning = original
+    assert len(warnings) == 1, warnings

--- a/tests/partcad/unit/test_project_external_repository.py
+++ b/tests/partcad/unit/test_project_external_repository.py
@@ -14,6 +14,7 @@ import asyncio
 import shutil
 
 import partcad as pc
+from partcad import context as pc_context
 from partcad.cache import Cache
 from partcad.cache_backend_files import FilesCacheBackend
 from partcad.project_external_repository import ProjectExternalRepository
@@ -356,3 +357,65 @@ def test_a_malformed_declaration_is_complained_about_once():
     finally:
         pc.logging.warning = original
     assert len(warnings) == 1, warnings
+
+
+# --- the listing warms what it is about to read ------------------------------
+#
+# 'Context.get_all_packages' prefetches HAS_STUFF_KINDS before 'get_packages'
+# reads them back one at a time. Nothing exercised that wiring: the two
+# 'get_all_packages' calls elsewhere in the suite pass has_stuff=False, which
+# skips the prefetch entirely, so the whole point of the change went untested.
+
+
+def _plugin_backed(ctx, name, data):
+    """A plugin-backed package registered in the context, with a fake behind it."""
+    repo = ProjectExternalRepository(ctx, name, "/tmp/ext", config_obj={})
+    fake = FakeRepository(data)
+    repo._repository = fake
+    asyncio.run(repo.ensure_enumerated_async())
+    ctx.projects[name] = repo
+    return repo, fake
+
+
+def test_the_listing_warms_the_kinds_it_is_about_to_read():
+    ctx = pc.Context("examples")
+    repo, fake = _plugin_backed(
+        ctx, "//ext", {"meta": {"objectKinds": ["part"]}, "objects/part": {"bolt": {"type": "step"}}}
+    )
+
+    ctx._prefetch_object_configs(None, pc_context.HAS_STUFF_KINDS)
+    assert "objects/part" in fake.keys
+    # ...and only the declared kind; the other three are answered from the metadata.
+    assert [k for k in fake.keys if k.startswith("objects/")] == ["objects/part"]
+
+    # What the listing then reads is a cache hit, which is the whole point.
+    before = list(fake.keys)
+    assert sum(repo.object_count(kind) for kind in pc_context.HAS_STUFF_KINDS) == 1
+    assert fake.keys == before
+
+
+def test_the_prefetch_skips_packages_outside_the_parent():
+    ctx = pc.Context("examples")
+    _, fake = _plugin_backed(ctx, "//ext", {"objects/part": {"bolt": {"type": "step"}}})
+
+    # '//other' is not this package's parent, so nothing is warmed for it -- and
+    # in particular no round trip is sent to a repository out of scope.
+    ctx._prefetch_object_configs("//other", pc_context.HAS_STUFF_KINDS)
+    assert [k for k in fake.keys if k.startswith("objects/")] == []
+
+
+def test_an_unreachable_repository_does_not_take_the_listing_down():
+    """The prefetch is a warm-up; nothing downstream depends on it having worked."""
+
+    class Unreachable:
+        async def get_data(self, key):
+            raise RuntimeError("the repository is not answering")
+
+    ctx = pc.Context("examples")
+    repo = ProjectExternalRepository(ctx, "//ext", "/tmp/ext", config_obj={})
+    repo._repository = Unreachable()
+    ctx.projects["//ext"] = repo
+
+    ctx._prefetch_object_configs(None, pc_context.HAS_STUFF_KINDS)  # must not raise
+    # ...and the package is still readable afterwards, the slow way.
+    assert repo.object_count("part") == 0


### PR DESCRIPTION
## Copilot Summary

A repository plugin serves a whole package tree, and PartCAD asks it one key at a time, in a process of its own. Listing `//pub/universe/lego/ldraw` is 558 of those and took **7m51s** on a four-core machine — almost none of it the plugin. Three things, none of them the plugin's:

### 1. Every wrapper answer imported OpenCASCADE to decide it was not a shape

`ocp_serialize.encode()` asked "is this a `TopoDS_Shape`?" before anything else, and answering that means `import OCP`. A repository plugin's reply is a dict of strings. **0.71 s of each 0.95 s call** was a CAD kernel loaded to conclude that a dict is not a shape.

Every JSON-native kind is now settled first; a value reaches the kernel only when it is neither a scalar nor a container — the only way it could be OCCT. A shape is encoded exactly as before, nested inside containers included.

Splitting `_ensure_ocp()` finer would buy nothing — the submodules live inside the one shared library:

```
import OCP (bare)   0.824s / 1.498s / 0.753s   ← 166 MB .so, all of the cost
  OCP.TopAbs        0.002s
  OCP.TopoDS        0.002s
  OCP.BRep          0.148s
  OCP.BRepTools     0.001s
```

On a cold page cache that same import measured **26 s**, which is the plausible mechanism behind a plugin call blowing its 180 s deadline on a machine under memory pressure.

Two wrapper invocations are geometry-free in both directions and both benefit: `wrapper_plugin.py` (all of `query_script` — repository, provider and supplier queries alike) and `wrapper_render_pdf.py`, verified to produce a PDF with OCP never loaded. Everything else receives or returns a BREP envelope and genuinely needs the kernel. The core was already clean: `import partcad` does not load OCP.

### 2. Ten object kinds, asked one at a time

`get_packages(has_stuff=True)` reads four kinds out of every package — four separate runs of the plugin's script per package, most of them to be told "none". A package's `meta` may now carry `objectKinds`, the kinds it holds at all, and the rest are answered "none" without asking.

It narrows what is asked for and never what may be served: a repository that says nothing is asked about everything exactly as before, and one that lists a kind it turns out to have none of is merely asked a question it answers emptily. It is read out of metadata the traversal has already fetched and is never worth a request of its own, so a single package reached on its own is queried exactly as it was.

### 3. Those four reads were serial

`get_all_packages` now warms them first — every package and every kind at once, on the traversal's event loop — through a new `Project.prefetch_object_configs_async` hook that is a no-op for a local package. Nothing depends on it having worked: a package whose prefetch failed is read the slow way by the accessors, which report the failure themselves.

### Result

Measured on a four-core machine with a warm sandbox, `pc list packages -r` over the LDraw library, with partcad/partcad-ldraw#7:

| | before | after |
|---|---|---|
| wall clock | 7m51s | **14.9s** |
| plugin invocations | 558 | 278 |
| per-invocation cost | 0.95 s | 0.081 s |

Same 92 packages listed, no errors.

### Also

`examples/plugin_repository_tree` declares `objectKinds` as the worked example, and `docs/source/configuration.rst` documents it under Repositories.

### Testing

- `poetry run pytest tests cad/freecad -p no:error-for-skips -p no:warnings --dist no` — **3362 passed, 36 skipped** in 18m23s, exit 0.
- New `tests/partcad/unit/test_ocp_serialize_lazy.py` (7 tests): proves a geometry-free payload serializes without OCP in a fresh interpreter, and that shapes — bare, nested in containers, and non-shape OCCT objects — encode exactly as before.
- `tests/partcad/unit/test_project_external_repository.py` extended to 20 tests covering `objectKinds` and the prefetch, including that the declaration never costs a round trip of its own.
- End-to-end: a build123d part exports to a correct STL through the wrapper; `pc list parts` over a plugin-backed hierarchy returns the same parts with the same descriptions.
- `behave` not run here (no dev container on this machine); CI shards it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gx767koeczmUXjcBd4Jc8w


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gx767koeczmUXjcBd4Jc8w)_