### PR TITLE
Build the bundles and the IDE on the version bump, not on the merge too

### DIFF
--- a/.github/actions/changed-scopes/action.yml
+++ b/.github/actions/changed-scopes/action.yml
@@ -309,11 +309,13 @@ runs:
         # It is a trade, and this is the other half of it: a source change *can*
         # break the freeze (a lazily imported module, a file read relative to
         # "__file__" -- see "dev-tools/pyinstaller/README.md"), and that is now
-        # found on the push to "devel" that follows the merge rather than on the
-        # pull request. The push trigger of "build-standalone.yml" still lists
-        # "src/**" for exactly this, a release still refuses to publish with a
-        # platform missing, and "#deepTest" builds the whole set before a merge
-        # for a change that warrants it.
+        # found on "devel" after the merge rather than on the pull request. Not
+        # on the merge's own push any more: "build-standalone.yml" runs on the
+        # version bump that follows it, which is the same tree plus a version and
+        # the commit a release is cut from, so the bundles are frozen once and
+        # carry the version they will be published under. A release still refuses
+        # to publish with a platform missing, and "#deepTest" builds the whole set
+        # before a merge for a change that warrants it.
         emit bundle              deps ci packaging
         # Not "code": the IDE downloads the bundles rather than freezing them,
         # so what rebuilds it is the application around them.

--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -505,9 +505,12 @@ jobs:
               exit 1
             fi
 
-            # No run at all for this commit -- yet, or ever.
+            # Nothing usable for this commit -- yet, or ever. "Usable" rather
+            # than "no run at all" because a skipped run is passed over above
+            # and lands here, and a log that then says there is no run
+            # contradicts the line that just named one.
             if [ "${elapsed}" -lt "${GRACE_SECONDS}" ]; then
-              say "No run for ${HEAD_SHA} yet (${elapsed}s in, deciding at ${GRACE_SECONDS}s)."
+              say "No usable run for ${HEAD_SHA} yet (${elapsed}s in, deciding at ${GRACE_SECONDS}s)."
               sleep "${POLL_SECONDS}"
               continue
             fi
@@ -521,7 +524,8 @@ jobs:
           # the newest one on the base branch keeps that coverage -- as long as
           # nobody reading the log can mistake it for this commit's.
           if [ -z "${use_run}" ]; then
-            say "No \"Standalone\" run exists for ${HEAD_SHA}; falling back to ${base}."
+            say "No \"Standalone\" run has bundles for ${HEAD_SHA} -- none ran," \
+                "or the one that did declined the commit. Falling back to ${base}."
             listing=$(runs_on_branch "${base}")
             while IFS=$'\t' read -r id sha conclusion; do
               [ -n "${id}" ] || continue

--- a/.github/workflows/build-ide-standalone.yml
+++ b/.github/workflows/build-ide-standalone.yml
@@ -20,22 +20,24 @@ on:
   merge_group:
   # Not on every change: this builds the standalone command line bundles first,
   # to put them inside the IDE, and those pull ~500MB of OpenCASCADE per runner.
-  # Only the changes that can alter what ships.
+  # Only the changes that can alter what ships, and on "devel" only once per
+  # version.
   #
-  # On a push that is a "paths:" filter and stays one. On a pull request it is
-  # the "set-matrix" job's gate instead, for the two reasons
-  # "build-standalone.yml" sets out beside its own trigger: "merge_group"
-  # supports no "paths:" filter, so this workflow used to build three IDEs in the
-  # queue for a change to a README; and a workflow skipped by "paths:" never
-  # creates the check run a required check waits for, while a skipped job does.
+  # Nothing filters this trigger. On a pull request and in the merge queue the
+  # "set-matrix" job's gate decides, for the two reasons "build-standalone.yml"
+  # sets out beside its own trigger: "merge_group" supports no "paths:" filter,
+  # so this workflow used to build three IDEs in the queue for a change to a
+  # README; and a workflow skipped by "paths:" never creates the check run a
+  # required check waits for, while a skipped job does. On a push it is the
+  # version-bump clause of that same gate, which "build-standalone.yml" now
+  # carries too -- an IDE archive is stamped with a version, and the one built
+  # for the merge carried the version that merge replaced. The "paths:" list
+  # that used to be here would only hide that gate: a bump touches
+  # "ide/vscode/package.json" today, so it passed, and the day
+  # "dev-tools/bumpversion.toml" stops naming a file under one of those paths no
+  # IDE is ever built on "devel" again with nothing to say so.
   push:
     branches: ["devel"]
-    paths:
-      - "ide/standalone/**"
-      - "ide/vscode/**"
-      - ".vscode/extensions.json"
-      - "install.sh"
-      - ".github/workflows/build-ide-standalone.yml"
   pull_request:
     branches: ["main", "devel"]
 
@@ -135,6 +137,28 @@ jobs:
     name: "Set matrix"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Only a version bump builds an IDE on a push to "devel", the same guard
+    # "build-standalone.yml", "test.yml", "build.yml" and "test-dev.yml" carry;
+    # the long note is in "test.yml" and the one beside this workflow's trigger
+    # says what it means here.
+    #
+    # It is not only about what an archive is stamped with. The "bundles" job
+    # below reads the sibling "Standalone" run for this commit, and that workflow
+    # now declines a push that is not a bump -- so an IDE built for one would be
+    # an IDE looking for bundles that, by design, were never frozen.
+    #
+    # `inputs.tools_in_this_run` leads for the reason `inputs.called` leads
+    # there: "deploy.yml" calls this workflow to build what a release carries,
+    # and a called instance runs whatever the caller's commit message says.
+    # `github.event_name` cannot be asked -- inside a called workflow the whole
+    # `github` context is the caller's, so it reads "push" on the release path --
+    # and only a push carries `head_commit`, which is why the event name comes
+    # before the message test rather than after it.
+    if: >-
+      ${{ toJSON(inputs.tools_in_this_run) != 'null'
+      || github.event_name != 'push'
+      || github.ref != 'refs/heads/devel'
+      || startsWith(github.event.head_commit.message, 'Version updated') }}
     outputs:
       build: ${{ steps.set-matrix.outputs.build }}
       install: ${{ steps.set-matrix.outputs.install }}
@@ -305,8 +329,11 @@ jobs:
       # Note that a sibling run is no longer guaranteed even in the merge queue.
       # "build-standalone.yml" is gated on what the change touches now, so a
       # change to "ide/standalone" alone -- which is not a change to what gets
-      # frozen -- leaves this commit with no "Standalone" run anywhere. That is
-      # the case the base-branch fallback below was written for; what it costs is
+      # frozen -- leaves this commit with no "Standalone" run anywhere; and on a
+      # push it is gated on the commit being a version bump, so a dispatch of
+      # this workflow at any other commit on "devel" finds a run that was
+      # skipped, which is the same thing wearing a conclusion. That is the case
+      # the base-branch fallback below was written for; what it costs is
       # GRACE_SECONDS of waiting to establish that there is nothing to wait for.
       - name: Find the "Standalone" run that built the bundles
         id: resolve
@@ -415,6 +442,18 @@ jobs:
                 [ -n "${pending_first}" ] || pending_first="${id}"
                 continue
               fi
+              # A run whose every job was skipped is not a run that failed to
+              # produce bundles -- it is "Standalone" declining the commit. Its
+              # push trigger is gated on a version bump now, so every other push
+              # to "devel" leaves exactly that behind, and so does a manual
+              # dispatch of *this* workflow at such a commit. Counting it as
+              # barren below would fail the job over a freeze nobody asked for.
+              # It is evidence of nothing, so it is passed over as if it did not
+              # exist, which lands on the base branch fallback.
+              if [ "${conclusion}" = "skipped" ]; then
+                say "Run ${id} was skipped: \"Standalone\" declined ${HEAD_SHA}."
+                continue
+              fi
               names=$(bundles_of "${id}")
               if [ -n "${names}" ]; then
                 use_run="${id}"
@@ -475,9 +514,9 @@ jobs:
             break
           done
 
-          # (2) No run for this commit. That is legitimate: the two workflows
-          # have different path filters, and a change confined to
-          # "ide/standalone/**" fires this one and not that one. The
+          # (2) No run for this commit, or one that declined it. That is
+          # legitimate: the two workflows gate on different things, and a change
+          # confined to "ide/standalone/**" runs this one and not that one. The
           # IDE build only needs a working bundle to embed and smoke-test, so
           # the newest one on the base branch keeps that coverage -- as long as
           # nobody reading the log can mistake it for this commit's.
@@ -502,16 +541,17 @@ jobs:
                 "last 30 finished runs on ${base} still has an unexpired" \
                 "partcad-standalone-* artifact (they are kept for 14 days)." \
                 "The IDE cannot be built without them. Run the \"Standalone\"" \
-                "workflow on ${base} -- manually, or by pushing a change under" \
-                "one of its paths -- and then re-run this one."
+                "workflow on ${base} -- manually, or by landing a change there," \
+                "which bumps the version and freezes them -- and then re-run" \
+                "this one."
               exit 1
             fi
 
             echo "::warning::The command line bundles inside this IDE build are" \
               "NOT from ${HEAD_SHA}. They come from \"Standalone\" run ${use_run}," \
               "which built ${use_sha} on ${base}: $(run_url "${use_run}")." \
-              "\"Standalone\" never ran for this commit -- its path filters did" \
-              "not match it -- so an older bundle is the only one there is, and" \
+              "\"Standalone\" froze nothing for this commit -- its own gate did" \
+              "not select it -- so an older bundle is the only one there is, and" \
               "embedding it still exercises the IDE build end to end. Do not" \
               "read a green result as having tested this commit's command line" \
               "tools, though, because it has not."

--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -27,39 +27,40 @@ on:
         default: true
   merge_group:
   # Freezing pulls ~500MB of OpenCASCADE per runner, so this does not run on
-  # every change: only on the ones that can change what is frozen.
+  # every change: only on the ones that can change what is frozen, and on
+  # "devel" only once per version.
   #
-  # On a push that is a "paths:" filter, and it stays one -- a push is a single
-  # commit on a branch, which is exactly what the filter was designed for.
   # "main" is absent on purpose: a push there runs "deploy.yml", which calls this
   # workflow itself. Listing it here would build everything twice.
   #
-  # Both "snap/**" and ".snapcraft.yaml" are listed. The recipe lives at the
-  # root, but snapcraft still reads assets -- hooks, gui, keys -- from "snap/".
-  # That directory is empty today, so the pattern matches nothing; it is here so
-  # that the first hook someone adds is built rather than silently untested.
+  # No filtering of any kind sits on this trigger. What governs a push is the
+  # "set-matrix" gate below -- only a commit whose message starts with "Version
+  # updated" builds anything -- which is what "test.yml", "build.yml" and
+  # "test-dev.yml" have always done and what this workflow did not. Every other
+  # push to "devel" is followed by a bump within minutes ("version-bump.yml"
+  # runs on all of them), and the bump carries the source change that preceded
+  # it, so the bundles are frozen once, from the commit a release is cut from,
+  # and are stamped with that version. They used to be frozen twice: once for
+  # the merge, carrying the version it replaced, and again for the bump.
+  #
+  # The "paths:" list that used to be here cannot come back, not even as a
+  # narrowing filter in front of that gate. A bump happens to touch
+  # "pyproject.toml" and "src/**", so it would pass today; the day
+  # "dev-tools/bumpversion.toml" stops naming a file on such a list, nothing is
+  # ever frozen on "devel" again and nothing says so. One gate, in one place,
+  # that a reader can see the whole of.
   push:
     branches: ["devel"]
-    paths:
-      - "dev-tools/pyinstaller/**"
-      - "dev-tools/snap/**"
-      - ".snapcraft.yaml"
-      - "snap/**"
-      - "install.sh"
-      - ".github/workflows/build-standalone.yml"
-      - "src/**"
-      - "pyproject.toml"
-      - "requirements*.txt"
-  # A pull request carries no "paths:" filter any more, and that is not the same
+  # A pull request carries no "paths:" filter either, and that is not the same
   # as running on everything -- the filtering moved into the "build" job below,
   # where the merge queue obeys it too.
   #
   # It had to move. "merge_group" supports no "paths:" filter at all: GitHub
-  # filters that event on branches only. So the list above governed the pull
-  # request and then stopped governing anything the moment the same commit
-  # entered the queue, where this workflow froze four bundles for a change to a
-  # README. The second reason is required checks: a workflow skipped by a
-  # "paths:" filter creates no check run, and a required check that is never
+  # filters that event on branches only. So the list this workflow used to carry
+  # governed the pull request and then stopped governing anything the moment the
+  # same commit entered the queue, where this workflow froze four bundles for a
+  # change to a README. The second reason is required checks: a workflow skipped
+  # by a "paths:" filter creates no check run, and a required check that is never
   # created leaves a pull request waiting forever, while a job skipped by an
   # "if:" reports "skipped", which counts as passing.
   pull_request:
@@ -320,6 +321,38 @@ jobs:
   set-matrix:
     name: "Set matrix"
     runs-on: ubuntu-latest
+    # Only a version bump freezes anything on a push to "devel", as in
+    # "test.yml", "build.yml" and "test-dev.yml" -- that first file carries the
+    # long note, and this is the same guard for the same reason. Every other
+    # push there is followed by a bump within minutes, and the bump is the
+    # commit a release is cut from, so freezing for both means freezing the same
+    # tree twice and publishing the first copy under the version it replaced.
+    #
+    # Stated here and nowhere else in this workflow: every other job needs this
+    # one, directly or through "build", and a job that needs a skipped job is
+    # skipped.
+    #
+    # Two clauses lead the message test, and neither is decoration.
+    #
+    #   * A called instance always runs. "deploy.yml" calls this workflow to
+    #     build what a release carries, and the caller has already decided. It
+    #     calls from "main" and from a tag, so the ref clause would let it
+    #     through today as well -- `inputs.called` says so directly rather than
+    #     by geography, and keeps saying it if a caller is ever added on "devel".
+    #     The note on `concurrency` above says why that marker, and not
+    #     `github.event_name` or `github.workflow`, is what identifies a called
+    #     run: inside one the whole `github` context is the caller's.
+    #   * Only a push carries `head_commit`. On every other trigger it is null,
+    #     `startsWith` reads that as the empty string, and without the event-name
+    #     clause the whole condition would be false -- which is how the nightly
+    #     run of "test.yml" came to be skipped every night until the same clause
+    #     was put first there. Here that would be the merge queue and every
+    #     manual dispatch.
+    if: >-
+      ${{ toJSON(inputs.called) != 'null'
+      || github.event_name != 'push'
+      || github.ref != 'refs/heads/devel'
+      || startsWith(github.event.head_commit.message, 'Version updated') }}
     outputs:
       build: ${{ steps.set-matrix.outputs.build }}
       install: ${{ steps.set-matrix.outputs.install }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,13 +298,18 @@ One bucket boundary in there is a deliberate trade rather than a fact, and it is
 `dev-tools/pyinstaller/`, `dev-tools/snap/`, `.snapcraft.yaml` and `install.sh` — not on `src/**`. Freezing
 is the most expensive thing here, and what makes a bundle differ from a working wheel is nearly always what
 went into it. A source change *can* break the freeze all the same (see `dev-tools/pyinstaller/README.md`),
-and the safety net for that is the push trigger of `build-standalone.yml`, which still lists `src/**` and
-fires on the push to `devel` after the merge — do not remove it, it is now the only thing that builds a
-bundle for a source change short of `#deepTest`.
+and the safety net for that is what `devel` does after the merge: the version bump that follows it is the same tree
+with a version on it, and `build-standalone.yml` freezes there. Short of `#deepTest` that bump is the only thing that
+builds a bundle for a source change, so do not narrow what a push to `devel` runs.
 
-`docs/source/contributing.rst` explains both to contributors. Note that a push to `devel` runs no matrix at
-all unless its head commit message starts with `Version updated` — the `set-matrix` job, and every job that
-depends on it, is skipped otherwise.
+`docs/source/contributing.rst` explains both to contributors. Note that a push to `devel` runs no matrix at all unless
+its head commit message starts with `Version updated` — the `set-matrix` job, and every job that depends on it, is
+skipped otherwise. That holds for every workflow now, `Standalone` and `IDE` included. Those two used to run on the
+merge as well: the same tree was built twice, minutes apart, and the first set of artifacts carried the version that
+merge had just replaced. Neither carries a `paths:` filter on its push trigger any more, because the gate is what
+decides and a filter in front of it could only ever hide it — a bump touches `pyproject.toml` and
+`ide/vscode/package.json` today, and the day `dev-tools/bumpversion.toml` stops naming such a file nothing would ever
+be built on `devel` again, with nothing to say so.
 
 **Neither gate trusts pytest's exit code.** On Windows it disagrees with the run in both directions — exit `0`
 with a test having failed (which is what #444 was written for), and exit `127` after a session where every test

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -819,11 +819,22 @@ CI fans out over operating systems, and a pull request does not pay for all of t
        over-running is the safe direction. If a description has to name the marker without asking for it,
        write it split across two code spans.
 
-A push to ``devel`` is the exception to all three: it runs no matrix at all unless its head commit message
-starts with ``Version updated``, which is the release commit. That exception applies to pushes and to nothing
-else -- the nightly run has no head commit to read a message from, so the guard leads with the event name and
-lets every other trigger through. It did not, from the day the guard was written until 0.8.32, and the nightly
-was skipped every night in between: if you change that condition, keep the event-name clause first.
+A push to ``devel`` is the exception to all three: it runs no matrix at all unless its head commit message starts with
+``Version updated``, which is the release commit. Every push to ``devel`` is followed by one of those within minutes
+and it carries the same tree, so what a merge costs is one build of that tree rather than two -- and the artifacts it
+produces are stamped with the version they will be released under rather than with the one the merge replaced.
+``Standalone`` and ``IDE`` are gated on this too; they used to run on the merge as well, which is where the second
+build and the stale version number came from. Neither has a ``paths:`` filter on its push trigger any more: the gate
+is what decides, and a filter in front of it could only ever hide it -- a version bump happens to touch
+``pyproject.toml`` and ``ide/vscode/package.json`` today, and the day ``dev-tools/bumpversion.toml`` stops naming such
+a file nothing would be built on ``devel`` again with nothing to say so.
+
+That exception applies to pushes and to nothing else -- the nightly run has no head commit to read a message from, so
+the guard leads with the event name and lets every other trigger through. It did not, from the day the guard was
+written until 0.8.32, and the nightly was skipped every night in between: if you change that condition, keep the
+event-name clause first. The two workflows that can also be *called* -- ``Standalone`` and ``IDE``, both of which
+``Deployment`` calls to build what a release carries -- lead with their ``inputs`` marker before that, because inside
+a called workflow the whole ``github`` context is the caller's and there is no other way to recognise one.
 
 The ``Standalone`` workflow reads the same tiers, job by job:
 
@@ -923,12 +934,12 @@ went *into* it: a dependency shipping a data file PyInstaller cannot see, a new 
 no build for one platform. So a dependency change freezes and a change to ``src/`` alone does not.
 
 That is a trade rather than a fact. A source change *can* break the freeze -- a lazily imported module, a file
-read relative to ``__file__``; ``dev-tools/pyinstaller/README.md`` has the list -- and that is now found on the
-push to ``devel`` after the merge rather than on the pull request. The push trigger of ``build-standalone.yml``
-still lists ``src/**`` for exactly this, a release still refuses to publish with a platform missing, and
-``#deepTest`` still builds the whole set before a merge for a change that warrants it. Note also which way the
-last row falls: an unclassified path counts as **both** source and dependency, so a bundle is skipped only for
-a directory somebody has named as source.
+read relative to ``__file__``; ``dev-tools/pyinstaller/README.md`` has the list -- and that is now found on
+``devel`` after the merge rather than on the pull request. Specifically on the version bump that follows the
+merge, which is the same tree with a version on it and the commit a release is cut from; a release still
+refuses to publish with a platform missing, and ``#deepTest`` still builds the whole set before a merge for a
+change that warrants it. Note also which way the last row falls: an unclassified path counts as **both**
+source and dependency, so a bundle is skipped only for a directory somebody has named as source.
 
 Two properties are worth knowing before you edit that list. It is **fail-safe**: a path it has not been taught
 counts as both source and a dependency, so it runs everything a source change runs, the standalone bundles

--- a/tests/dev_tools/test_ci_version_gate.py
+++ b/tests/dev_tools/test_ci_version_gate.py
@@ -1,0 +1,159 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The one commit on "devel" that CI builds, and the gate that says so.
+
+Every push to `devel` is followed within minutes by the version bump
+`version-bump.yml` makes of it, so a workflow that fans out over a matrix on
+both builds the same tree twice -- and the first of the two produces artifacts
+stamped with the version that merge had just replaced. `test.yml`, `build.yml`
+and `test-dev.yml` have always declined the merge and waited for the bump;
+`build-standalone.yml` and `build-ide-standalone.yml` did not, which is how
+`devel` came to hold two sets of standalone bundles per merge, the earlier one
+carrying the older version.
+
+Nothing fails when that gate is dropped or written the wrong way round. Too
+loose and CI merely does the work twice, which looks like CI being slow; too
+tight -- the `head_commit` test put before the event name, say -- and the merge
+queue, every manual dispatch and every release path go quiet, which looks like
+nothing at all. `test.yml`'s nightly run was skipped every night for exactly
+that reason, from the day its guard was written until 0.8.32.
+
+So these pin the shape of the condition, and that the whole workflow really
+hangs off it: one job with no `needs`, carrying the gate, that every other job
+reaches.
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Every workflow that fans out over a matrix on a push to "devel". The four
+# cheap ones -- the extension's "npm test", the ".vsix" and the plugin builds,
+# the version bump itself -- are not here: they run one job on one image, and
+# two of them have no push trigger at all.
+GATED = [
+    "test.yml",
+    "build.yml",
+    "test-dev.yml",
+    "build-standalone.yml",
+    "build-ide-standalone.yml",
+]
+
+
+def workflow(name):
+    """One workflow file, parsed.
+
+    `on:` comes back as the boolean `True`: YAML 1.1 reads the bare word as one,
+    and every parser this repository has does the same thing to it.
+    """
+    loaded = yaml.safe_load((WORKFLOWS / name).read_text())
+    loaded["on"] = loaded.pop(True, loaded.get("on"))
+    return loaded
+
+
+def gate_job(parsed):
+    """The job everything else in the workflow hangs off: the one with no `needs`."""
+    roots = [name for name, job in parsed["jobs"].items() if not job.get("needs")]
+    assert len(roots) == 1, f"expected exactly one job with no 'needs', found {roots}"
+    return roots[0], parsed["jobs"][roots[0]]
+
+
+def gate_condition(parsed):
+    """That job's `if`, whitespace collapsed -- these are written as folded scalars."""
+    name, job = gate_job(parsed)
+    assert "if" in job, f"the '{name}' job carries no condition at all"
+    return " ".join(str(job["if"]).split())
+
+
+@pytest.mark.parametrize("name", GATED)
+def test_the_matrix_is_gated_on_the_version_bump(name):
+    """A push to "devel" builds the bump and nothing else.
+
+    The bump carries the merge's own tree, so this is not coverage given up: it
+    is the same build, once, from the commit a release is cut from and under the
+    version it will be published as.
+    """
+    condition = gate_condition(workflow(name))
+
+    assert "refs/heads/devel" in condition
+    assert "startsWith(github.event.head_commit.message, 'Version updated')" in condition
+
+
+@pytest.mark.parametrize("name", GATED)
+def test_the_event_name_leads_the_message_test(name):
+    """Only a push carries `head_commit`.
+
+    On every other trigger it is null, `startsWith` reads that as the empty
+    string, and a condition that asks the message first is false for the merge
+    queue, for a manual dispatch and for the nightly run -- silently, since a
+    skipped job reports "skipped" and that counts as passing.
+    """
+    condition = gate_condition(workflow(name))
+
+    assert "github.event_name != 'push'" in condition
+    assert condition.index("github.event_name != 'push'") < condition.index("startsWith(")
+
+
+@pytest.mark.parametrize("name", GATED)
+def test_a_called_workflow_is_let_through_first(name):
+    """A caller has already decided; the commit message is not its to read.
+
+    "deploy.yml" calls "build-standalone.yml" and "build-ide-standalone.yml" to
+    build what a release carries. Inside a called workflow the whole `github`
+    context is the *caller's* -- `github.event_name` reads "push" on the release
+    path, never "workflow_call" -- so the `inputs` context, which exists only
+    under `workflow_call` and `workflow_dispatch`, is the only thing that can
+    recognise one.
+    """
+    parsed = workflow(name)
+    if "workflow_call" not in parsed["on"]:
+        pytest.skip("nothing calls this workflow")
+
+    condition = gate_condition(parsed)
+
+    assert condition.startswith("${{ toJSON(inputs."), condition
+    assert "!= 'null'" in condition.split("||")[0]
+
+
+@pytest.mark.parametrize("name", GATED)
+def test_nothing_runs_without_passing_the_gate(name):
+    """Which is what lets the gate be stated in one place.
+
+    A job that does not reach the gating job through `needs` runs on a merge as
+    happily as on a bump, so the guard above would be describing a workflow it
+    does not govern.
+    """
+    parsed = workflow(name)
+    gate, _ = gate_job(parsed)
+
+    def reaches(job_name, seen):
+        needs = parsed["jobs"][job_name].get("needs") or []
+        needs = [needs] if isinstance(needs, str) else needs
+        return any(n == gate or (n not in seen and reaches(n, seen | {n})) for n in needs)
+
+    orphans = [n for n in parsed["jobs"] if n != gate and not reaches(n, {n})]
+    assert not orphans, f"these jobs do not depend on '{gate}': {orphans}"
+
+
+@pytest.mark.parametrize("name", GATED)
+def test_no_paths_filter_stands_in_front_of_the_gate(name):
+    """A second filter on the trigger could only ever hide the first one.
+
+    A bump touches "pyproject.toml", "src/**" and "ide/vscode/package.json"
+    today, so the lists these triggers used to carry passed it. The day
+    "dev-tools/bumpversion.toml" stops naming a file on one of them, that
+    workflow stops running on "devel" entirely and says nothing about it -- the
+    failure being a missing run rather than a failing one.
+    """
+    push = workflow(name)["on"]["push"]
+
+    assert "devel" in push["branches"]
+    assert "paths" not in push
+    assert "paths-ignore" not in push


### PR DESCRIPTION
## Copilot Summary

`Standalone` and `IDE` were the two matrix workflows that ran on **every** push to `devel` matching their
`paths:` filter, rather than only on the version bump — which is what `test.yml`, `build.yml` and
`test-dev.yml` have always done. Since `version-bump.yml` turns every merge into a `Version updated` commit
within minutes, and that commit touches `pyproject.toml`, `src/**` and `ide/vscode/package.json`, both
filters matched it too: each merge built the same tree twice, half an hour apart, and the earlier set of
artifacts carried the version the merge had just replaced.

### What changed

* **The gate**, on the `set-matrix` job of both workflows — the job everything else needs, so a skip there
  skips the run:

  ```yaml
  if: >-
    ${{ toJSON(inputs.called) != 'null'
    || github.event_name != 'push'
    || github.ref != 'refs/heads/devel'
    || startsWith(github.event.head_commit.message, 'Version updated') }}
  ```

  The `inputs` marker leads because `deploy.yml` calls both to build what a release carries, and inside a
  called workflow the whole `github` context is the caller's — `github.event_name` reads `push` on the
  release path, never `workflow_call`. The event name comes next because only a push carries `head_commit`;
  putting the message test first is how `test.yml`'s nightly run went quiet for months.

* **The `paths:` filter on each push trigger is gone.** It cannot narrow what the gate already decides, and
  it can hide it: a bump passes those lists only by coincidence, and the day `dev-tools/bumpversion.toml`
  stops naming a file on one, that workflow silently stops running on `devel` altogether.

* **The IDE's bundle resolver tolerates a skipped sibling run.** It reads the `Standalone` run for the
  commit, and a run whose jobs were all skipped is `completed` with no artifacts — which it read as "the
  freeze produced nothing" and failed on. That is now passed over as if the run did not exist, so the
  base-branch fallback takes it. Without this, a `devel` push touching `install.sh` (in both path lists) or a
  manual dispatch of the IDE workflow at a non-bump commit would fail.

* **Docs**, where they said the `src/**` push trigger was the safety net for a source change breaking the
  freeze: that safety net is now the bump that follows the merge — same tree, one build, right version.
  `AGENTS.md`, `docs/source/contributing.rst`, and the note in `.github/actions/changed-scopes`.

* **`tests/dev_tools/test_ci_version_gate.py`** pins the invariant across all five matrix workflows: the
  message test, the event name before it, the `inputs` marker before that where the workflow is callable,
  every job reaching the job that carries the gate, and no `paths:` filter standing in front of it.

### Not changed

Pull requests and the merge queue are byte-identical. The gate's first two clauses let every non-push trigger
through, and the `paths:` lists removed were on the `push:` trigger only — both `pull_request:` entries
carried `branches:` alone before and after. Depth (`test-depth`) and scope (`changed-scopes`) still decide a
pull request exactly as they did.

### Testing

* `tests/dev_tools` — 117 passed, 3 skipped. The new test fails on the pre-change workflows (8 failures) and
  passes after.
* `check-jsonschema` (`vendor.github-workflows`, `vendor.github-actions`) over both workflows and the edited
  action; `black` and `isort` over the new test.
* No `behave` features were run: this session has no Docker, so no dev container, and the change touches no
  code that suite covers. CI runs it.

One honest limit: this pull request exercises the gate expression (it evaluates and passes), but not the
behaviour being changed. The push path is only exercised once this lands on `devel` — the merge's own push
should leave a `Standalone` run with every job skipped, and the bump minutes later the real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5aGV3VAZRNRunjzktntyf


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5aGV3VAZRNRunjzktntyf)_