### PR TITLE
Build every container before any test that could run in one, and let a 'scad' part be one homogeneous body

### DIFF
--- a/.github/workflows/container-kicad.yml
+++ b/.github/workflows/container-kicad.yml
@@ -63,15 +63,16 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v7
 
-      # "setup-devcontainer" builds IMAGE_TAG out of "env.VERSION", and a called
-      # workflow inherits none of its caller's "env" -- nor can a caller pass it
-      # in, the "env" context not being available in a job's "with:".
+      # The tag this builds, and a called workflow inherits none of its caller's
+      # "env" -- nor can a caller pass it in, the "env" context not being
+      # available in a job's "with:".
       #
       # So read it from the file the release really lives in. A literal here
       # would be a third copy of the version to keep in step with the other two,
       # which is the arrangement "dev-tools/bumpversion.toml" exists to avoid;
       # "tests/partcad_cli/unit/test_versions.py" is what keeps the value read
-      # here equal to the "VERSION:" both callers state.
+      # here equal to the "VERSION:" both callers state, and equal in turn to
+      # the "__version__" the two readers of this image build their tag from.
       - name: The release this commit is
         shell: bash
         run: |
@@ -84,10 +85,6 @@ jobs:
           echo "VERSION=${version}"
           echo "VERSION=${version}" >> "$GITHUB_ENV"
 
-      - name: Setup Dev Container
-        id: setup
-        uses: ./.github/actions/setup-devcontainer
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
@@ -95,12 +92,37 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The release, and nothing else. Both readers of this image build the tag
+      # the same way -- "part_factory_kicad.get_runtime" and
+      # "partcad_client.external.KICAD" each write
+      # '...-container-kicad:' + __version__ -- so a tag with anything else in
+      # it is a tag nobody pulls.
+      #
+      # This step used to take "setup-devcontainer"'s IMAGE_TAG, which is the
+      # release on a version bump and '<release>-<branch>' on every other
+      # commit. Half of that was invisible and half of it was the bug: the
+      # branch-suffixed tag was published where nothing looks, and on the one
+      # commit whose tests need a new image -- the bump -- it happened to agree
+      # by accident. Nothing here needs the branch, so nothing here carries it.
+      #
+      # Published, though, only where publishing is this run's to do, which is
+      # the same rule "Build the Python sandbox images" states at length in
+      # "test.yml": build always, because the build is the test, and publish on
+      # the version bump, because a tag somebody else pulls is not a thing an
+      # unreviewed branch may hand them. On a pull request, the merge queue or
+      # the nightly this builds the image and pushes nothing, and the KiCad
+      # tests go on running against the release image, exactly as they did
+      # before this workflow existed.
       - name: Build Container for Kicad
         uses: devcontainers/ci@v0.3
         with:
-          cacheFrom:
-            "${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}-container-kicad:${{ steps.setup.outputs.IMAGE_TAG }}"
+          cacheFrom: "${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}-container-kicad:${{ env.VERSION }}"
           imageName: ${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}-container-kicad
-          imageTag: ${{ steps.setup.outputs.IMAGE_TAG }}
+          imageTag: ${{ env.VERSION }}
           configFile: tools/containers/devcontainer-kicad.json
-          push: always
+          push: >-
+            ${{ ((github.event_name == 'push'
+            && github.ref == 'refs/heads/devel'
+            && startsWith(github.event.head_commit.message, 'Version updated'))
+            || github.event_name == 'workflow_dispatch')
+            && 'always' || 'never' }}

--- a/.github/workflows/container-kicad.yml
+++ b/.github/workflows/container-kicad.yml
@@ -13,6 +13,18 @@
 # 'APIError: ... ("manifest unknown")' -- a test written to fail when the KiCad
 # path is broken failing instead because an image had not been pushed yet.
 #
+# The window is far wider than it looks, and that is the part worth knowing:
+# "devcontainers/ci" builds in its step and **pushes in its post-job step**, so
+# the tag reaches the registry when the whole job ends, not when the build
+# finishes. Inside the old "build-containers" that put twenty-five minutes
+# between the two -- "Build Container for Kicad" was done at 22:37:25 on
+# 0.8.70 and the push ran at 23:03:12, the Python sandbox images having been
+# built in between -- and the dev container's pytest reached the KiCad test at
+# 23:02:30, ninety seconds early. Waiting on the *job* is therefore the only
+# thing that helps, which is exactly what "needs:" waits for; waiting on the
+# step would not have. It is also why this job builds nothing else: alone, its
+# post step pushes a minute after its build rather than half an hour after.
+#
 # A reusable workflow is what gives each caller a real "needs:" edge on the one
 # build, the way "vsix.yml" gives "build.yml" and "deploy.yml" one .vsix. The
 # alternative -- each workflow building the image for itself -- is the same

--- a/.github/workflows/container-kicad.yml
+++ b/.github/workflows/container-kicad.yml
@@ -1,0 +1,94 @@
+# The KiCad sandbox image, built and published by a job both test workflows wait
+# for.
+#
+# It is a workflow of its own because two workflows need the image and "needs:"
+# does not reach across one. "test.yml" always built it; "test-dev.yml" runs the
+# same unit tests inside the dev container, and
+# "tests/partcad/unit/test_part.py::test_part_example_kicad" there starts
+# "ghcr.io/partcad/partcad-container-kicad:<release>" -- the release PartCAD
+# itself reports, see "part_factory_kicad.get_runtime". On a version bump that
+# tag does not exist anywhere yet: the run that bumps the version is the run
+# that first creates it. So the dev container's "Run: pytest" raced the other
+# workflow's build and lost, on every version bump, with
+# 'APIError: ... ("manifest unknown")' -- a test written to fail when the KiCad
+# path is broken failing instead because an image had not been pushed yet.
+#
+# A reusable workflow is what gives each caller a real "needs:" edge on the one
+# build, the way "vsix.yml" gives "build.yml" and "deploy.yml" one .vsix. The
+# alternative -- each workflow building the image for itself -- is the same
+# recipe written twice, and two answers to "which image is this release's".
+name: Container (KiCad)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CONTAINER_REGISTRY: ghcr.io
+
+jobs:
+  kicad:
+    name: "Build Container for Kicad"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    # One build per commit rather than one per caller: both workflows call this
+    # for the same ref, and the second to arrive waits for the first instead of
+    # rebuilding and re-pushing the tag beside it (the second run then reads the
+    # layers the first published through "cacheFrom" below).
+    #
+    # "cancel-in-progress: false" is the point of the block, not a default left
+    # in place: a cancelled build here is precisely the missing image that
+    # everything waiting on this job is waiting for.
+    concurrency:
+      group: container-kicad-${{ github.event.pull_request.number || github.ref }}-${{ github.sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v7
+
+      # "setup-devcontainer" builds IMAGE_TAG out of "env.VERSION", and a called
+      # workflow inherits none of its caller's "env" -- nor can a caller pass it
+      # in, the "env" context not being available in a job's "with:".
+      #
+      # So read it from the file the release really lives in. A literal here
+      # would be a third copy of the version to keep in step with the other two,
+      # which is the arrangement "dev-tools/bumpversion.toml" exists to avoid;
+      # "tests/partcad_cli/unit/test_versions.py" is what keeps the value read
+      # here equal to the "VERSION:" both callers state.
+      - name: The release this commit is
+        shell: bash
+        run: |
+          set -e
+          version="$(sed -n 's/^version = "\(.*\)"$/\1/p' pyproject.toml | head -1)"
+          if [ -z "${version}" ]; then
+            echo "::error title=Container (KiCad)::no 'version = \"...\"' in pyproject.toml"
+            exit 1
+          fi
+          echo "VERSION=${version}"
+          echo "VERSION=${version}" >> "$GITHUB_ENV"
+
+      - name: Setup Dev Container
+        id: setup
+        uses: ./.github/actions/setup-devcontainer
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Container for Kicad
+        uses: devcontainers/ci@v0.3
+        with:
+          cacheFrom:
+            "${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}-container-kicad:${{ steps.setup.outputs.IMAGE_TAG }}"
+          imageName: ${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}-container-kicad
+          imageTag: ${{ steps.setup.outputs.IMAGE_TAG }}
+          configFile: tools/containers/devcontainer-kicad.json
+          push: always

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -171,7 +171,14 @@ jobs:
   # waited for by both workflows: see ".github/workflows/container-kicad.yml".
   container-kicad:
     needs: scope
-    if: ${{ needs.scope.outputs.pytest == 'true' }}
+    # The "devcontainer" scope, not the narrower "pytest" one this job was
+    # first written with, because all three jobs below wait for it now and two
+    # of them run on a change that "devcontainer-pytest" excludes -- a change
+    # under ".devcontainer" runs "Run: behave" and "Run: pc" and not
+    # "Run: pytest". Gated on "pytest" it would be skipped for such a change,
+    # and a job whose dependency is skipped is skipped: the two jobs that
+    # change is for would quietly stop running.
+    if: ${{ needs.scope.outputs.devcontainer == 'true' }}
     permissions:
       contents: read
       packages: write
@@ -341,7 +348,13 @@ jobs:
     # get a larger bump because they also cover Windows and macOS.
     timeout-minutes: 90
 
-    needs: poetry-install
+    # The KiCad image as well, on the same rule as "test.yml": no test job
+    # starts before every container it might run in has been published.
+    # Nothing here starts that container today -- "features/open.feature"
+    # asks "pc open" what it would do rather than doing it -- and the wait
+    # is free either way, the build running from "scope" while
+    # "poetry-install" is still going.
+    needs: [poetry-install, container-kicad]
     permissions:
       # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
       contents: read
@@ -562,7 +575,13 @@ jobs:
     name: "Run: pc"
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    needs: poetry-install
+    # The KiCad image as well, on the same rule as "test.yml": no test job
+    # starts before every container it might run in has been published.
+    # Nothing here starts that container today -- "features/open.feature"
+    # asks "pc open" what it would do rather than doing it -- and the wait
+    # is free either way, the build running from "scope" while
+    # "poetry-install" is still going.
+    needs: [poetry-install, container-kicad]
     permissions:
       # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
       contents: read

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -163,13 +163,27 @@ jobs:
             echo "All installation attempts failed after 3 tries"
             exit 1
 
+  # The KiCad sandbox image "test_part_example_kicad" starts, by the release
+  # PartCAD reports. "test.yml" publishes the very same image, but a "needs:"
+  # does not reach across a workflow, so the job below used to race that build
+  # and pull a tag that did not exist yet -- on every version bump, which is
+  # the one commit for which nothing has ever pushed that tag. One build,
+  # waited for by both workflows: see ".github/workflows/container-kicad.yml".
+  container-kicad:
+    needs: scope
+    if: ${{ needs.scope.outputs.pytest == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/container-kicad.yml
+
   pytest:
     name: "Run: pytest"
     runs-on: ubuntu-24.04
     # 30 -> 45: the larger OCP 7.9 / build123d 0.11 install per sandbox, in
     # line with the "Pytest" job in test.yml.
     timeout-minutes: 45
-    needs: [scope, poetry-install]
+    needs: [scope, poetry-install, container-kicad]
     # The one job in this file that a change to ".devcontainer" alone does not
     # run. What it does is the "Pytest" matrix in "test.yml" over again, on one
     # image and one interpreter, and a change to the container's configuration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,29 @@ env:
   PC_TELEMETRY_PERFORMANCE: false
 
 jobs:
+  # Every container this workflow publishes is built before any job that could
+  # run a test inside one. Both builders below therefore appear in the "needs:"
+  # of every test job that can reach a container -- which on Linux is nearly all
+  # of them, the "docker" Python sandbox being the default wherever a runtime
+  # answers.
+  #
+  # It is close to free, and where it is not, it is the case it is for. On a
+  # pull request "Build Docker Containers" is a minute: the registry cache hits
+  # and only amd64 is built. It is the version-bump push to "devel" that takes
+  # half an hour, and that is the one run where the images do not exist yet and
+  # a test reaching for one finds nothing -- so the run that pays for the wait
+  # is the run that needs it.
+  #
+  # What it buys differs by image, and only one of the two is a hard failure.
+  # A missing Python sandbox image is caught: ".github/actions/sandbox-image"
+  # builds the tree's own copy when the pull comes up empty, so the job stays
+  # honest either way -- but on a push to "devel" or "main" that fallback is
+  # precisely what the job did not want, the published tag being the subject
+  # there, and until this ordering existed it took the fallback every time. A
+  # missing KiCad image is not caught by anything: "get_runtime" hands the tag
+  # to "containers.run()", which pulls, and a pull of a tag nobody has pushed
+  # is 'APIError: ... ("manifest unknown")'.
+  #
   # The KiCad sandbox image. It used to be the first step of
   # "build-containers" below; it is a call into "container-kicad.yml" now
   # because "test-dev.yml" needs the same image and needs it *finished* -- and
@@ -211,7 +234,17 @@ jobs:
   # "set-matrix" (see the long note there) rather than being restated here.
   container-kicad:
     needs: set-matrix
-    if: ${{ needs.set-matrix.outputs.pytest == 'true' }}
+    # The union of what the jobs needing this one are gated on, and it has to
+    # be: a job whose dependency is skipped is skipped, so a gate narrower than
+    # its dependents' would not delay "Behave" -- it would silently delete it.
+    # The three scopes come out of the same buckets today ("emit pytest code
+    # deps ci", and the same line for the other two), so the union is no wider
+    # in practice than the "pytest" gate this used to carry; it is written out
+    # so that the day they stop agreeing is not the day a suite disappears.
+    if: >-
+      ${{ needs.set-matrix.outputs.pytest == 'true'
+      || needs.set-matrix.outputs.behave == 'true'
+      || needs.set-matrix.outputs.examples == 'true' }}
     permissions:
       contents: read
       packages: write
@@ -229,7 +262,13 @@ jobs:
     # (see the long note there); a job that needs a skipped job is skipped, so
     # stating it twice would only be two places to keep in step.
     needs: set-matrix
-    if: ${{ needs.set-matrix.outputs.pytest == 'true' }}
+    # The union, for the reason given on "container-kicad" above: every test
+    # job that can render in the sandbox waits for this one now, and a gate
+    # narrower than theirs would skip them rather than delay them.
+    if: >-
+      ${{ needs.set-matrix.outputs.pytest == 'true'
+      || needs.set-matrix.outputs.behave == 'true'
+      || needs.set-matrix.outputs.examples == 'true' }}
     permissions:
       packages: write
     steps:
@@ -690,6 +729,10 @@ jobs:
     name: "Behave"
     needs:
       - set-matrix
+      # Both container builds, per the note at the top of "jobs:": no test
+      # starts before every image it might run in exists.
+      - build-containers
+      - container-kicad
       # - cache-preheat
     # Same gate as "Pytest" above. Note that a change to ".devcontainer" is not
     # in it: these jobs run natively, with mamba, and never enter the dev
@@ -828,6 +871,10 @@ jobs:
     name: "Examples (PartCAD)"
     needs:
       - set-matrix
+      # Both container builds, per the note at the top of "jobs:": no test
+      # starts before every image it might run in exists.
+      - build-containers
+      - container-kicad
       # - cache-preheat
     if: ${{ needs.set-matrix.outputs.examples == 'true' }}
     strategy:
@@ -1006,6 +1053,10 @@ jobs:
     name: "Examples (All)"
     needs:
       - set-matrix
+      # Both container builds, per the note at the top of "jobs:": no test
+      # starts before every image it might run in exists.
+      - build-containers
+      - container-kicad
       # - cache-preheat
     # Deep runs only: the nightly schedule, a manual dispatch, a push, or
     # "#deepTest". Not on a pull request and not in the merge queue.
@@ -1100,6 +1151,10 @@ jobs:
     name: "Repo //pub"
     needs:
       - set-matrix
+      # Both container builds, per the note at the top of "jobs:": no test
+      # starts before every image it might run in exists.
+      - build-containers
+      - container-kicad
       # - cache-preheat
     # Deep runs only. That tier was chosen when this job's one substantive step
     # was "continue-on-error" and so could not report a regression before a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,11 +197,32 @@ env:
   PC_TELEMETRY_PERFORMANCE: false
 
 jobs:
+  # The KiCad sandbox image. It used to be the first step of
+  # "build-containers" below; it is a call into "container-kicad.yml" now
+  # because "test-dev.yml" needs the same image and needs it *finished* -- and
+  # a "needs:" does not reach across a workflow, so the dev container's pytest
+  # job raced this build and pulled a tag that did not exist yet. See the note
+  # at the top of that file.
+  #
+  # "needs: set-matrix" carries the same two things it carries for
+  # "build-containers": only "test-pytest" consumes this image, so it follows
+  # that job's gate rather than carrying one of its own, and the "only a
+  # version bump runs the matrix on a push to devel" guard lives on
+  # "set-matrix" (see the long note there) rather than being restated here.
+  container-kicad:
+    needs: set-matrix
+    if: ${{ needs.set-matrix.outputs.pytest == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/container-kicad.yml
+
   build-containers:
     name: "Build Docker Containers"
     runs-on: ubuntu-24.04
-    # The KiCad sandbox image, which only "test-pytest" below consumes, so it
-    # follows that job's gate rather than carrying one of its own.
+    # The Python sandbox images, which "test-pytest" below pulls on a push to
+    # "devel" or "main" (see ".github/actions/sandbox-image"), so this follows
+    # that job's gate rather than carrying one of its own.
     #
     # "needs: set-matrix" is also what carries the "only a version bump runs the
     # matrix on a push to devel" guard here. That guard lives on "set-matrix"
@@ -214,10 +235,11 @@ jobs:
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@v7
-      - name: Setup Dev Container
-        id: setup
-        uses: ./.github/actions/setup-devcontainer
 
+      # No "setup-devcontainer" here: its one output, IMAGE_TAG, was read by the
+      # KiCad step that has moved to "container-kicad.yml". The images below are
+      # tagged from "env.VERSION" directly, the branch name having no place in a
+      # tag a package is invited to pin.
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
@@ -225,19 +247,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Container for Kicad
-        uses: devcontainers/ci@v0.3
-        with:
-          cacheFrom:
-            "${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}-container-kicad:${{ steps.setup.outputs.IMAGE_TAG }}"
-          imageName: ${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}-container-kicad
-          imageTag: ${{ steps.setup.outputs.IMAGE_TAG }}
-          configFile: tools/containers/devcontainer-kicad.json
-          push: always
-
       # QEMU and buildx are what the Python base images below are built with:
-      # they fan out over architectures, and "devcontainers/ci" above builds for
-      # the runner's alone.
+      # they fan out over architectures, unlike the KiCad image in
+      # "container-kicad.yml", which "devcontainers/ci" builds for the runner's
+      # alone (that sandbox is linux/amd64 only -- see "tools/containers/kicad").
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
         with:
@@ -566,6 +579,10 @@ jobs:
     needs:
       - set-matrix
       - build-containers
+      # "test_part_example_kicad" starts the KiCad sandbox by the release
+      # PartCAD reports, so the image has to be published before this runs --
+      # never mind that this workflow is the one publishing it.
+      - container-kicad
       # - cache-preheat
     # Skipped when nothing this suite can see has changed -- documentation, the
     # Claude Code plugin, the VS Code extension, the dev container's own

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1409,8 +1409,8 @@ be true for one ``material:``, one ``color:`` or one ``tolerance:`` to be true
 of the whole part. A mesh is one body: an STL file is a surface with nothing
 inside it to vary, and the only way it has a material at all is for somebody to
 say so. So is a solid built by a script, and so is one extruded from a single
-sketch. ``stl``, ``cadquery``, ``build123d``, ``sdf`` and ``extrude`` accept
-all three.
+sketch. ``stl``, ``cadquery``, ``build123d``, ``sdf``, ``scad`` and ``extrude``
+accept all three.
 
 A STEP file is not one body. It can carry many solids, each already stating a
 material and a colour of its own, and naming one for the file would be a claim

--- a/src/partcad/part_factory_homogen.py
+++ b/src/partcad/part_factory_homogen.py
@@ -20,9 +20,18 @@ class PartFactoryHomogen(PartFactory):
     tolerance. A mesh is one body: an STL file is a surface with nothing inside
     it to vary, and the only way it has a material at all is for somebody to
     say so. A solid a script builds is one
-    body too - a CadQuery, build123d or SDF part is the result of one modelling
-    session, and PartCAD hands the whole of it to a manufacturer as one thing.
-    An extrusion of one sketch is the same case.
+    body too - a CadQuery, build123d, SDF or OpenSCAD part is the result of one
+    modelling session, and PartCAD hands the whole of it to a manufacturer as
+    one thing. An extrusion of one sketch is the same case.
+
+    'scad' arrived here later than the rest, and the case that brought it is
+    worth keeping: '//pub/std/metric/bosl2' generates a part per BOSL2 module by
+    parsing the module's signature, so a module argument called 'tolerance' -
+    the fit clearance several of BOSL2's bottlecap adapters take - became a
+    parameter of that name on a 'scad' part. The package was making no claim
+    about manufacturing at all, and the whole public-index sweep went red on it.
+    An OpenSCAD part was a homogeneous body the entire time; nothing but the
+    opt-in was missing.
 
     A STEP file is not. It can carry many solids, each with a material and a
     colour of its own already stated in the file, so naming one for the file

--- a/src/partcad/part_factory_scad.py
+++ b/src/partcad/part_factory_scad.py
@@ -20,6 +20,7 @@ from . import telemetry, wrapper
 from .process_output import decode as decode_output
 from .healthcheck.openscad import find_executable as find_openscad_executable
 from .part_factory_file import PartFactoryFile
+from .part_factory_homogen import PartFactoryHomogen
 from . import sandbox_versions
 
 from . import shape_envelope
@@ -139,7 +140,7 @@ def _build_render_args(scad_executable, stl_path, source_path, config):
 
 
 @telemetry.instrument()
-class PartFactoryScad(PartFactoryFile):
+class PartFactoryScad(PartFactoryHomogen, PartFactoryFile):
     # The sandboxed runtime used to keep build123d out of the main process
     PYTHON_SANDBOX_VERSION = sandbox_versions.DEFAULT_PYTHON_VERSION
 

--- a/tests/dev_tools/test_container_kicad.py
+++ b/tests/dev_tools/test_container_kicad.py
@@ -66,6 +66,17 @@ def test_the_build_is_not_cancellable():
     assert job["concurrency"]["cancel-in-progress"] is False
 
 
+def test_nothing_else_is_built_alongside_it():
+    """`devcontainers/ci` pushes in its *post-job* step, so the tag appears when
+    the job ends rather than when the build finishes. A second image built in
+    this job would hold the push back by however long that image takes -- which
+    is how a build that finished at 22:37 came to publish at 23:03.
+    """
+    (job,) = _jobs("container-kicad.yml").values()
+    builds = [s for s in job["steps"] if "docker build" in s.get("run", "") or "buildx build" in s.get("run", "")]
+    assert builds == []
+
+
 @pytest.mark.parametrize("workflow", sorted(CALLERS))
 def test_both_test_workflows_call_it(workflow):
     calls = [name for name, job in _jobs(workflow).items() if job.get("uses") == REUSABLE]

--- a/tests/dev_tools/test_container_kicad.py
+++ b/tests/dev_tools/test_container_kicad.py
@@ -1,0 +1,85 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+"""The one KiCad image, and the two workflows that have to wait for it.
+
+`tests/partcad/unit/test_part.py::test_part_example_kicad` starts
+`ghcr.io/partcad/partcad-container-kicad:<release>` -- the release PartCAD
+itself reports, see `part_factory_kicad.get_runtime`. Nothing in that test, or
+in the workflow that runs it, says where the image comes from: it is published
+by a CI job, and a commit that bumps the version is the first and only commit
+for which that tag has never existed.
+
+So the two workflows that run that test have to *wait* for the job that
+publishes it, and neither can wait on a job in the other file -- `needs:` does
+not reach across a workflow. What makes that possible is that the build lives in
+a reusable workflow both of them call. Lose the call from either one and the
+failure is not a missing job: it is `APIError: ... ("manifest unknown")` from a
+test whose whole purpose is to fail when the KiCad path is broken, hours into a
+run, on the version bump and nowhere else.
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+REUSABLE = "./.github/workflows/container-kicad.yml"
+
+# The workflow, and the job in it that runs the unit tests.
+CALLERS = {
+    "test.yml": "test-pytest",
+    "test-dev.yml": "pytest",
+}
+
+
+def _jobs(workflow):
+    return yaml.safe_load((WORKFLOWS / workflow).read_text())["jobs"]
+
+
+def _needs(job):
+    """A job's dependencies, whichever of the two spellings it uses."""
+    needs = job.get("needs") or []
+    return [needs] if isinstance(needs, str) else needs
+
+
+def test_the_image_is_built_by_one_reusable_workflow():
+    jobs = _jobs("container-kicad.yml")
+    assert len(jobs) == 1
+    (job,) = jobs.values()
+
+    step = [s for s in job["steps"] if s.get("uses", "").startswith("devcontainers/ci")]
+    assert len(step) == 1
+    assert step[0]["with"]["configFile"] == "tools/containers/devcontainer-kicad.json"
+    # Published, not merely built: what waits on this job waits for a tag it can
+    # pull from somewhere else entirely.
+    assert step[0]["with"]["push"] == "always"
+
+
+def test_the_build_is_not_cancellable():
+    """Cancelling it is exactly the missing image everything else waits for."""
+    (job,) = _jobs("container-kicad.yml").values()
+    assert job["concurrency"]["cancel-in-progress"] is False
+
+
+@pytest.mark.parametrize("workflow", sorted(CALLERS))
+def test_both_test_workflows_call_it(workflow):
+    calls = [name for name, job in _jobs(workflow).items() if job.get("uses") == REUSABLE]
+    assert calls == ["container-kicad"], workflow
+
+
+@pytest.mark.parametrize("workflow", sorted(CALLERS))
+def test_the_job_running_the_unit_tests_waits_for_it(workflow):
+    job = _jobs(workflow)[CALLERS[workflow]]
+    assert "container-kicad" in _needs(job), workflow
+
+
+@pytest.mark.parametrize("workflow", sorted(CALLERS))
+def test_the_caller_grants_the_permission_to_publish(workflow):
+    """A called workflow gets the calling job's permissions and no more."""
+    job = _jobs(workflow)["container-kicad"]
+    assert job["permissions"]["packages"] == "write"

--- a/tests/dev_tools/test_container_ordering.py
+++ b/tests/dev_tools/test_container_ordering.py
@@ -45,16 +45,22 @@ CALLERS = {
 
 
 def _jobs(workflow):
+    """The `jobs:` mapping of one workflow file, parsed."""
     return yaml.safe_load((WORKFLOWS / workflow).read_text())["jobs"]
 
 
 def _needs(job):
-    """A job's dependencies, whichever of the two spellings it uses."""
+    """A job's dependencies, whichever of the two spellings it uses.
+
+    `needs:` takes a bare string as readily as a list, and a workflow here uses
+    both, so a membership test against the raw value would pass on a substring.
+    """
     needs = job.get("needs") or []
     return [needs] if isinstance(needs, str) else needs
 
 
 def test_the_image_is_built_by_one_reusable_workflow():
+    """One build step, and it is the KiCad devcontainer definition it builds."""
     jobs = _jobs("container-kicad.yml")
     assert len(jobs) == 1
     (job,) = jobs.values()
@@ -62,9 +68,47 @@ def test_the_image_is_built_by_one_reusable_workflow():
     step = [s for s in job["steps"] if s.get("uses", "").startswith("devcontainers/ci")]
     assert len(step) == 1
     assert step[0]["with"]["configFile"] == "tools/containers/devcontainer-kicad.json"
-    # Published, not merely built: what waits on this job waits for a tag it can
-    # pull from somewhere else entirely.
-    assert step[0]["with"]["push"] == "always"
+
+
+def test_the_tag_it_publishes_is_the_tag_the_runtime_pulls():
+    """`:<release>`, with nothing else in it.
+
+    Both readers build the tag the same way -- `part_factory_kicad.get_runtime`
+    and `partcad_client.external.KICAD` each write
+    `...-container-kicad:` + `__version__` -- so a tag carrying anything else is
+    a tag nobody pulls. This step used to take `setup-devcontainer`'s
+    IMAGE_TAG, which is `<release>-<branch>` on every commit that is not a
+    version bump: published where nothing looks, and agreeing with the readers
+    on the one commit whose tests need a new image only by accident.
+    """
+    (job,) = _jobs("container-kicad.yml").values()
+    (step,) = [s for s in job["steps"] if s.get("uses", "").startswith("devcontainers/ci")]
+
+    assert step["with"]["imageTag"] == "${{ env.VERSION }}"
+    assert step["with"]["cacheFrom"].endswith(":${{ env.VERSION }}")
+
+    for source in ("src/partcad/part_factory_kicad.py", "src/partcad_client/external.py"):
+        text = (REPO_ROOT / source).read_text()
+        assert 'partcad-container-kicad:" + ' in text, source
+        assert "partcad-container-kicad:%s" not in text, source
+
+
+def test_it_publishes_on_the_version_bump_and_not_from_a_branch():
+    """The rule "Build the Python sandbox images" states at length in test.yml.
+
+    Build always, because the build is the test; publish on the version bump,
+    because a tag somebody else pulls is not a thing an unreviewed branch may
+    hand them. Now that the tag is the bare release rather than a
+    branch-suffixed one, an unconditional `push: always` here would have every
+    pull request overwrite the image a released PartCAD pulls.
+    """
+    (job,) = _jobs("container-kicad.yml").values()
+    (step,) = [s for s in job["steps"] if s.get("uses", "").startswith("devcontainers/ci")]
+    push = " ".join(step["with"]["push"].split())
+
+    assert "'always' || 'never'" in push
+    assert "github.ref == 'refs/heads/devel'" in push
+    assert "startsWith(github.event.head_commit.message, 'Version updated')" in push
 
 
 def test_the_build_is_not_cancellable():
@@ -86,19 +130,25 @@ def test_nothing_else_is_built_alongside_it():
 
 @pytest.mark.parametrize("workflow", sorted(CALLERS))
 def test_both_test_workflows_call_it(workflow):
+    """Once each. A caller that loses the call loses the wait with it."""
     calls = [name for name, job in _jobs(workflow).items() if job.get("uses") == REUSABLE]
     assert calls == ["container-kicad"], workflow
 
 
 @pytest.mark.parametrize("workflow", sorted(CALLERS))
 def test_the_job_running_the_unit_tests_waits_for_it(workflow):
+    """`test_part_example_kicad` lives in both, and starts the container."""
     job = _jobs(workflow)[CALLERS[workflow]]
     assert "container-kicad" in _needs(job), workflow
 
 
 @pytest.mark.parametrize("workflow", sorted(CALLERS))
 def test_the_caller_grants_the_permission_to_publish(workflow):
-    """A called workflow gets the calling job's permissions and no more."""
+    """A called workflow gets the calling job's permissions and no more.
+
+    Declared in the called workflow too, but that can only narrow: without the
+    grant here the publish fails on the one run that has to make it.
+    """
     job = _jobs(workflow)["container-kicad"]
     assert job["permissions"]["packages"] == "write"
 
@@ -120,12 +170,19 @@ SCOPES = ("pytest", "behave", "examples")
 
 
 def _scopes_named(job):
+    """The `changed-scopes` outputs a job's `if:` is gated on.
+
+    Read out of the condition text rather than evaluated: what matters is which
+    scopes a gate mentions at all, since that is what decides whether a builder
+    can be skipped on a run where something waiting for it is not.
+    """
     condition = str(job.get("if") or "")
     return {scope for scope in SCOPES if "outputs.%s ==" % scope in condition}
 
 
 @pytest.mark.parametrize("workflow", sorted(CONSUMERS))
 def test_every_test_job_waits_for_every_container(workflow):
+    """The rule, job by job: no test starts before every image exists."""
     jobs = _jobs(workflow)
     for consumer in CONSUMERS[workflow]:
         missing = [b for b in BUILDERS[workflow] if b not in _needs(jobs[consumer])]

--- a/tests/dev_tools/test_container_ordering.py
+++ b/tests/dev_tools/test_container_ordering.py
@@ -3,7 +3,7 @@
 #
 # Licensed under Apache License, Version 2.0.
 #
-"""The one KiCad image, and the two workflows that have to wait for it.
+"""No test starts before every container it might run in has been published.
 
 `tests/partcad/unit/test_part.py::test_part_example_kicad` starts
 `ghcr.io/partcad/partcad-container-kicad:<release>` -- the release PartCAD
@@ -19,6 +19,13 @@ a reusable workflow both of them call. Lose the call from either one and the
 failure is not a missing job: it is `APIError: ... ("manifest unknown")` from a
 test whose whole purpose is to fail when the KiCad path is broken, hours into a
 run, on the version bump and nowhere else.
+
+The rule the later half of this file pins is the general form of that: a test
+job waits for every container it might run in, and a container's build is gated
+no more narrowly than the jobs waiting for it. The second half is not a detail.
+A job whose dependency is skipped is skipped rather than delayed, so a builder
+gated on less than its dependents does not make them wait -- it deletes them,
+and a suite that stops running is the one kind of CI failure nothing reports.
 """
 
 import pathlib
@@ -94,3 +101,65 @@ def test_the_caller_grants_the_permission_to_publish(workflow):
     """A called workflow gets the calling job's permissions and no more."""
     job = _jobs(workflow)["container-kicad"]
     assert job["permissions"]["packages"] == "write"
+
+
+# Every job that runs a test and can reach a container. On Linux that is all of
+# them: the "docker" Python sandbox is the default wherever a container runtime
+# answers, and "Sandbox (docker)" is left out only because it builds the image
+# it runs in rather than consuming a published one.
+CONSUMERS = {
+    "test.yml": ["test-pytest", "test-behave", "test-examples-partcad", "test-examples-all", "test-pub-repo"],
+    "test-dev.yml": ["pytest", "behave", "integration-tests"],
+}
+
+BUILDERS = {"test.yml": ["build-containers", "container-kicad"], "test-dev.yml": ["container-kicad"]}
+
+# The scopes a job can be gated on. "deep" is not one of them: it only ever
+# narrows a gate further, and a builder is not obliged to cover it.
+SCOPES = ("pytest", "behave", "examples")
+
+
+def _scopes_named(job):
+    condition = str(job.get("if") or "")
+    return {scope for scope in SCOPES if "outputs.%s ==" % scope in condition}
+
+
+@pytest.mark.parametrize("workflow", sorted(CONSUMERS))
+def test_every_test_job_waits_for_every_container(workflow):
+    jobs = _jobs(workflow)
+    for consumer in CONSUMERS[workflow]:
+        missing = [b for b in BUILDERS[workflow] if b not in _needs(jobs[consumer])]
+        assert missing == [], "%s: %s does not wait for %s" % (workflow, consumer, missing)
+
+
+def test_the_builders_are_gated_no_narrower_than_what_waits_for_them():
+    """A job whose dependency is skipped is skipped, not delayed.
+
+    So a builder gated on less than its dependents does not make them wait --
+    it deletes them. "Behave" is gated on the `behave` scope and "Examples" on
+    `examples`, while both builders carried the `pytest` gate they were written
+    with; the three come out of the same buckets today, which is exactly what
+    would have made the day they stop agreeing hard to see.
+    """
+    jobs = _jobs("test.yml")
+    wanted = set()
+    for consumer in CONSUMERS["test.yml"]:
+        wanted |= _scopes_named(jobs[consumer])
+    assert wanted == set(SCOPES)  # or this test is checking less than it reads
+
+    for builder in BUILDERS["test.yml"]:
+        assert _scopes_named(jobs[builder]) >= wanted, builder
+
+
+def test_the_dev_container_build_follows_the_scope_that_runs_its_dependents():
+    """`devcontainer`, not `devcontainer-pytest`.
+
+    A change under ".devcontainer" runs "Run: behave" and "Run: pc" and not
+    "Run: pytest" -- so the narrower gate would skip this build, and with it
+    the two jobs that such a change is the whole reason to run.
+    """
+    jobs = _jobs("test-dev.yml")
+    assert "outputs.devcontainer ==" in jobs["container-kicad"]["if"]
+    assert "outputs.pytest ==" not in jobs["container-kicad"]["if"]
+    # ...and it is the same gate the chain those jobs hang off already carries.
+    assert jobs["container-kicad"]["if"] == jobs["devcontainer"]["if"]

--- a/tests/partcad/unit/test_object_type_parameters.py
+++ b/tests/partcad/unit/test_object_type_parameters.py
@@ -23,7 +23,7 @@ import yaml
 import partcad as pc
 from partcad.part_factory import PartFactory
 
-ACCEPTING_TYPES = ["stl", "cadquery", "build123d", "sdf", "extrude"]
+ACCEPTING_TYPES = ["stl", "cadquery", "build123d", "sdf", "extrude", "scad"]
 REJECTING_TYPES = ["step", "kicad"]
 POLICED = ["material", "color", "tolerance"]
 
@@ -42,7 +42,7 @@ def _write_package(tmp_path, parts):
         "parts": parts,
     }
     (tmp_path / "partcad.yaml").write_text(yaml.safe_dump(config))
-    for extension in [".stl", ".py", ".step"]:
+    for extension in [".stl", ".py", ".step", ".scad"]:
         for name in parts:
             (tmp_path / (name + extension)).write_text("")
             path = parts[name].get("path")


### PR DESCRIPTION
## Copilot Summary

Two of the failures on the 0.8.69 version bump, fixed at the place each one comes from.

### `Run: pytest` fails `test_part_example_kicad` on every version bump

0.8.68, 0.8.69 and 0.8.70 all failed the same way:

```
docker.errors.APIError: 500 Server Error for .../images/create?tag=0.8.70&
  fromImage=ghcr.io/partcad/partcad-container-kicad: Internal Server Error ("manifest unknown")
```

`part_factory_kicad.get_runtime` starts the sandbox by the release PartCAD reports, and a version bump is the one commit for which nothing has ever pushed that tag. `test.yml` publishes it; `test-dev.yml` consumes it; a `needs:` does not reach across a workflow.

The window is far wider than it looks, which is the part worth recording. `devcontainers/ci` builds in its step and **pushes in its post-job step**, so the tag reaches the registry when the whole job ends. On 0.8.70:

| | |
|---|---|
| `Build Container for Kicad` finishes | 22:37:25 |
| `Build the Python sandbox images` finishes | 23:03:08 |
| `Post Build Container for Kicad` pushes `:0.8.70` | 23:03:12 |
| CI-Dev pytest reaches the KiCad test | 23:02:30 |

So waiting on the *job* is the only wait that helps — waiting on the step would have passed twenty-five minutes early. The build moves into a reusable workflow, `container-kicad.yml`, that both workflows call and both pytest jobs `needs:`, the way `vsix.yml` gives `build.yml` and `deploy.yml` one `.vsix`. It builds nothing else on purpose: alone in a job, its post step pushes a minute after its build. One build per commit — the job's concurrency group serialises the two callers, with `cancel-in-progress: false`, a cancelled build here being exactly the image everything is waiting for. It reads the release out of `pyproject.toml` rather than restating it, a called workflow inheriting none of its caller's `env` and the `env` context not being available in a job's `with:`.

**The tag it publishes** is the bare release, which it was not before (CodeRabbit caught this). `setup-devcontainer`'s `IMAGE_TAG` is the release on a version bump and `<release>-<branch>` on every other commit, while both readers — `part_factory_kicad.get_runtime` and `partcad_client.external.KICAD` — write `...-container-kicad:` + `__version__`. So this published where nobody looks on every commit that is not a bump, and agreed with its readers on the bump by accident. `setup-devcontainer` is gone from this workflow; its `IMAGE_TAG` was the only thing wanted from it and it was the bug. The publish is now gated on the rule `Build the Python sandbox images` already states in `test.yml` — build always, because the build is the test; publish on the version bump, because a tag somebody else pulls is not a thing an unreviewed branch may hand them. A bare `imageTag: ${{ env.VERSION }}` with the old `push: always` would have had every pull request overwrite the image a released PartCAD pulls.

### Every container is now built before any job that could run a test in one

`test-pytest` already waited. `Behave`, both `Examples` jobs and `Repo //pub` did not, and on Linux all of them render in a container. They all wait now, in both workflows.

Cheap, and this PR's own first CI run measures it (run 34670787325):

| | |
|---|---|
| `Set matrix` | 03:35:39 → 03:35:48 |
| `container-kicad / Build Container for Kicad` | 03:37:37 → 03:38:22 (45s) |
| `Build Docker Containers` | 03:35:52 → 03:39:52 (4m) |
| first `Pytest` / `Behave` / `Examples` job starts | 03:39:55 |

So about four minutes of added wait on a pull request — the registry cache hits and only amd64 is built. (It was one minute on #627's run; four is the number this PR measured, and the honest one to plan against.) It is the version-bump push that takes half an hour, and that is the run where the images do not exist yet — so the run that pays most for the wait is the run that needed it.

Only one of the two images was a hard failure. A missing Python sandbox image is caught: `sandbox-image` builds the tree's own copy when the pull comes up empty. But that fallback is exactly what a push to `devel`/`main` did not want — the published tag is the subject there — and with the publish racing the jobs that read it, the fallback is what they took every time. The published image has in practice never been the thing tested on `devel`.

Both builders are regated onto the **union** of what their dependents are gated on, and that half is not an optimisation. `pytest`, `behave` and `examples` are three separate `changed-scopes` outputs and both builders carried the `pytest` gate they were written with. A job whose dependency is skipped is skipped rather than delayed, so a run where `behave` was true and `pytest` was not would not have delayed `Behave` — it would have deleted it. The three come out of the same buckets today, which is what would have made the day they stop agreeing impossible to see. Likewise in `test-dev.yml`, where the KiCad build moves from `devcontainer-pytest` to `devcontainer`: a change under `.devcontainer` runs `Run: behave` and `Run: pc` and not `Run: pytest`, and those two wait for this build now.

`Sandbox (docker)` is deliberately not in the list: it builds the image it runs in rather than consuming a published one, and it ran in parallel throughout.

### `Repo //pub` fails `pc list all` on a BOSL2 bottlecap

```
Failed to create the part '//pub/std/metric/bosl2/bottlecaps:bottle_adapter_neck_to_cap':
  the part type 'scad' does not accept the 'tolerance' parameter
```

`partcad-bosl2` generates a part per BOSL2 module by parsing the module's signature, and several bottlecap adapters take an argument called `tolerance` — the fit clearance. The package was claiming nothing about manufacturing; the name collided with a policed one.

An OpenSCAD part is one solid built by one modelling session, which is the test `PartFactoryHomogen` applies, so `scad` mixes it in and accepts `material`, `color` and `tolerance` like `cadquery`, `build123d`, `sdf` and `extrude`. The only other change is the message `pc test` gives a manufactured `scad` part with no tolerance declared: "No manufacturing tolerance is specified" rather than "the part type does not accept one". Both were failures before and both are failures now.

### Tests

`tests/dev_tools/test_container_ordering.py` pins the ordering, the gating and the tag: both workflows call the reusable build, every test job waits for every container, the build is not cancellable, nothing else is built beside it, neither builder is gated more narrowly than what waits for it, the published tag is the one both readers build, and the publish is conditional on the version bump. `tests/partcad/unit/test_object_type_parameters.py` gains `scad` to the accepting types.

### Not in this PR

- `//pub`'s second failure, `The parameter 'length' of 'fastener/countersunk-iso7046;length=3.5,size=M2.5-0.45' is an integer, and '3.5' is not one`. The parameter should be a float: `cq_warehouse`'s `Screw`/`CounterSunkScrew` type `length: float` (mm), and the `int` comes from `partcad-cqwarehouse`'s `macros.j2`. `socket_clearance` has the same problem in `metric.yaml` (`Optional[float] = 6 * MM` upstream). Six `type: int` declarations there, all physical dimensions. PartCAD's side is right — it accepts `4.0` and refuses `3.5` rather than truncating.
- That `ValueError` aborts the whole `pc test` sweep instead of being recorded against the one object via `record_broken_object()`.

### Ran

`tests/dev_tools` (132 passed, 3 pre-existing skips), `test_object_type_parameters.py`, `test_runtime_python_docker.py`, `test_versions.py`, and the OpenSCAD suites including a real parameterized `.scad` instantiation — 335 passed there. `black` and `flake8` over the changed Python, `check-jsonschema --builtin-schema vendor.github-workflows` over every workflow. No `behave` run: this machine has no dev container, and nothing in `features/` touches these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01282ym3MusvoZKkVohHqse3