### PR TITLE
Retire, stamp and choose: the installed skills get a lifecycle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,54 @@ jobs:
           assert ai_agents.plugin_manifest()['name'], 'the wheel carries no plugin manifest'
           "
           pc --no-ansi version
+
+      # What the wheel carries is one thing; what `pc init` writes out of it is
+      # what a user actually gets, and it is a different code path. `plugin.yml`
+      # validates the plugin this repository *publishes*; nothing validated the
+      # one `pc init` installs until this. The manifests are compared byte for
+      # byte, so `claude plugin validate` passing there carries over to here.
+      - name: Test what `pc init` installs
+        shell: bash -el {0}
+        run: |
+          . ~/.bashrc
+          . ~/.bash_profile
+          mamba activate ${{ format('env-test-build-{0}', matrix.python-version) }}
+          export WORKSPACE="$(mktemp -d)"
+          export REPO="${PWD}"
+          ( cd "${WORKSPACE}" && git init -q . && pc --no-ansi init )
+          python -c "
+          import filecmp, json, os
+          import partcad
+          import partcad.ai_agents as ai_agents
+
+          workspace = os.environ['WORKSPACE']
+          repo = os.environ['REPO']
+          shipped = ai_agents.available_skills()
+
+          # Claude gets the plugin, and the skills under it verbatim.
+          plugin = os.path.join(workspace, '.claude', 'skills', ai_agents.plugin_name())
+          installed = os.path.join(plugin, '.claude-plugin', 'plugin.json')
+          published = os.path.join(repo, 'ai-agents', 'claude', '.claude-plugin', 'plugin.json')
+          assert filecmp.cmp(installed, published, shallow=False), 'the installed manifest is not the published one'
+          assert json.load(open(installed))['version'] == partcad.__version__, 'the manifest states another version'
+          for skill in shipped:
+              here = os.path.join(plugin, 'skills', skill, 'SKILL.md')
+              there = os.path.join(ai_agents.SKILLS_DIR, skill, 'SKILL.md')
+              assert filecmp.cmp(here, there, shallow=False), skill + ' was not installed verbatim for Claude'
+
+          # Cursor gets them prefixed, renamed to match, and stamped.
+          for skill in shipped:
+              name = ai_agents.CURSOR_PREFIX + skill
+              text = open(os.path.join(workspace, '.cursor', 'skills', name, 'SKILL.md'), encoding='utf-8').read()
+              # A literal rather than a regex: '$' inside a double-quoted shell
+              # heredoc is one more thing that has to survive two quoting layers.
+              assert ('name: ' + name + '\n') in text, name + ' does not name its own directory'
+              assert ai_agents.stamped_version(text) == partcad.__version__, name + ' is not stamped with this version'
+              assert 'pc:' not in text, name + ' still points at the plugin namespace Cursor has not got'
+
+          print('pc init installed', len(shipped), 'skills for', ', '.join(sorted(ai_agents.AGENTS)))
+          "
+          rm -rf "${WORKSPACE}"
           partcad-json-rpc --help >/dev/null
           # The shim brings the wheel in, and owns nothing of its own.
           python -m pip install --no-index --find-links=dist --find-links=dev-tools/shim/dist partcad-cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,7 +389,16 @@ precondition on `build_wheel` and `build_sdist`. Without it the artifact is sile
 matches nothing where `skills` is a text file holding a path, `plugin.json` matches that same kind of file and
 is packaged as its content, and the wheel then installs, imports and runs `pc version` with no skills in it.
 `build_editable` is *not* guarded, on purpose: an editable install reads the working tree live, and refusing
-there would fail `poetry install` over a data file. See `ai-agents/README.md`. The snap
+there would fail `poetry install` over a data file.
+
+The installed copies have a lifecycle of their own. Re-running `pc init` updates them and **removes what
+PartCAD no longer ships** — a retired skill left behind describes a CLI that has moved, and the agent follows
+it anyway. The Claude plugin directory is entirely PartCAD's, so anything unshipped there goes; under
+`.cursor/skills` the `pc-` prefix is not proof of authorship, so those copies carry a `metadata.partcad` stamp
+and only stamped ones are removed. That stamp is `partcad.__version__` read at install time and **must not
+become a literal**: a literal is one more `dev-tools/bumpversion.toml` entry and one more thing to forget,
+which is how the plugin manifest sat at 0.1.0 for twenty-three releases. The `AgentSkills` healthcheck reads
+the same stamp — `pc upgrade` replaces PartCAD and leaves the skills alone, so something has to notice. See `ai-agents/README.md`. The snap
 carries whatever the bundle carries,
 so it needs nothing extra of its
 own; `dev-tools/snap/README.md` covers what is specific to it (confinement, aliases, the base, its state directory).

--- a/ai-agents/README.md
+++ b/ai-agents/README.md
@@ -105,11 +105,50 @@ get the same thing:
   rewritten, so the `pc render` and `pc adhoc convert` command lines these files
   are full of are left alone.
 
+`--agents` chooses which of them to install for — `all` (the default), or a
+comma-separated list. An agent PartCAD does not know is an error rather than a
+quiet no-op: a typo that installs nothing looks exactly like an agent that is
+not supported yet. Adding a third agent is a line in `AGENTS` in
+`src/partcad/ai_agents/__init__.py` and a function saying where its directory is
+— the skills themselves are vendor-neutral and are not copied per agent.
+
 Neither destination is written through a symlink, and this repository is why:
 `.claude/skills/pc` here points at `ai-agents/claude`, so following it would
 have `pc init` overwrite the working tree with a copy of the installed PartCAD.
-Everything installed is namespaced, so a re-run updates PartCAD's own skills and
-touches nothing else in those directories.
+
+### What a re-run does
+
+Installing again updates what is there, and **removes what PartCAD has stopped
+shipping**. A retired skill left behind goes on describing a CLI that has moved,
+which is worse than having no skill at all: the agent follows it, and it looks
+like a working one.
+
+Only PartCAD's own go. The whole `.claude/skills/pc/` directory is the plugin,
+so there it is anything not currently shipped. Under `.cursor/skills` the `pc-`
+prefix is not proof of authorship, so the Cursor copies carry a stamp:
+
+```yaml
+metadata:
+  partcad: 0.8.69
+```
+
+A `pc-` skill without one is somebody else's — hand-written, or installed by a
+PartCAD older than the stamp — and is never touched. The cost is a retired skill
+lingering for whoever has not reinstalled since; the alternative is deleting a
+file PartCAD did not write.
+
+The same stamp is what `pc healthcheck` reads: it compares the installed skills
+against the running PartCAD and reports the ones an older release wrote, since
+`pc upgrade` replaces PartCAD and leaves them alone. `--fix` reinstalls them,
+for the agents that had them and no others. On the Claude side the plugin
+manifest already carries the version, so nothing extra is needed there.
+
+**The version in that stamp is never a literal in the source.** It is
+`partcad.__version__`, read at install time. A literal would be one more entry
+in `dev-tools/bumpversion.toml` and one more thing to forget on a release —
+which is exactly how the plugin manifest sat at `0.1.0` for twenty-three
+releases (see *Versioning* below). `__version__` is already bumped and
+`tests/partcad_cli/unit/test_versions.py` already fails if it stops moving.
 
 The plugin folder is named `claude`, but the command namespace comes from
 `plugin.json`'s `name` field (`pc`), so skills invoke as `/pc:<skill>`.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -185,7 +185,15 @@ Package commands
 
   ``--no-skills`` skips the skills. ``--skills-only`` installs *just* them and touches no package at all, which
   is how a repository that has a package already gets them, or gets a newer PartCAD's -- there is nothing to
-  create, so an existing ``partcad.yaml`` is neither read nor replaced.
+  create, so an existing ``partcad.yaml`` is neither read nor replaced. ``--agents`` chooses which agents to
+  install for: ``all`` (the default), or a comma-separated list of ``claude`` and ``cursor``. An agent PartCAD
+  does not know is an error, because a typo that installs nothing looks exactly like an agent that is not
+  supported yet.
+
+  Installing again updates what is there and **removes the skills PartCAD has stopped shipping**: a retired
+  skill left behind describes a CLI that has moved on, which is worse than no skill at all because the agent
+  follows it anyway. Only PartCAD's own are removed -- the Cursor copies carry a ``metadata.partcad`` stamp
+  saying which release wrote them, and a ``pc-`` skill without one is somebody else's and is left alone.
 
 ``pc install``
   Download everything the current package needs to be built - the PartCAD counterpart of ``npm install``.
@@ -509,6 +517,12 @@ Other commands
 ``pc healthcheck``
   Check the host system for known issues. Use ``--dry-run`` to list the available checks, ``--filters`` to run
   only checks with the given tags, and ``--fix`` to attempt automatic fixes.
+
+  One of them is about this repository rather than the host: ``AgentSkills`` compares the AI agent skills
+  installed here against the PartCAD running, and reports the ones an older release wrote. ``pc upgrade``
+  replaces PartCAD and leaves them where they are, so without this an agent goes on reading instructions for a
+  CLI that has moved -- silently, since a stale skill looks exactly like a current one. ``--fix`` reinstalls
+  them, for the agents that had them and no others.
 
 ``pc search``
   Search for objects by keyword. Subcommands: ``all``, ``parts``, ``sketches``, ``assemblies``,

--- a/features/init.feature
+++ b/features/init.feature
@@ -86,6 +86,23 @@ Feature: `pc init` command
     And a file named "partcad.yaml" should not exist
     And a file named ".vscode/launch.json" should not exist
 
+  @pc-init @agent-skills @agents
+  Scenario: Install the skills for one agent only
+    Given a file named "partcad.yaml" does not exist
+    When I run "pc --no-ansi init --agents cursor"
+    Then the command should exit with a status code of "0"
+    And a file named ".cursor/skills/pc-init/SKILL.md" should be created
+    And a directory named ".claude" should not exist
+
+  @pc-init @agent-skills @agents @failure
+  Scenario: Ask for an agent PartCAD does not know
+    # A typo that installs nothing looks exactly like an agent that is not
+    # supported yet, so it is an error rather than a quiet no-op.
+    When I run "pc --no-ansi init --skills-only --agents kursor"
+    Then the command should exit with a status code of "1"
+    And STDERR should contain "Unknown agent(s): kursor"
+    And a directory named ".cursor" should not exist
+
   @pc-init @agent-skills @skills-only @failure
   Scenario: Ask for the skills and for no skills at once
     When I run "pc --no-ansi init --skills-only --no-skills"

--- a/src/partcad/ai_agents/__init__.py
+++ b/src/partcad/ai_agents/__init__.py
@@ -53,6 +53,7 @@ import re
 import shutil
 from typing import Optional
 
+from .. import __version__
 from .. import logging as pc_logging
 from ..launch_config import find_repository_root
 
@@ -85,6 +86,26 @@ CLAUDE_PLUGIN_DIR = ".claude-plugin"
 # prefix is the plugin's name because they are the same skill: `/pc:init` in
 # Claude Code is `pc-init` in Cursor.
 CURSOR_PREFIX = "pc-"
+
+# The front matter key the Cursor copies are stamped with, under `metadata:`.
+# Two things depend on it and neither has another way to know:
+#
+#   * staleness -- the skills a user has are the ones the PartCAD that wrote
+#     them shipped, and nothing else in a `.cursor/skills` directory says which
+#     PartCAD that was. The Claude side has `plugin.json` for this.
+#   * ownership -- a `pc-` directory carrying this stamp is one PartCAD wrote,
+#     so it is one PartCAD may remove when the skill behind it is retired. A
+#     `pc-something` a user wrote themselves has no stamp and is never touched.
+#
+# The value is `partcad.__version__`, read here, at install time. It is
+# deliberately *not* a literal in this file: a literal would be one more entry
+# in `dev-tools/bumpversion.toml` and one more thing to forget on a release --
+# which is exactly how the Claude plugin manifest sat at 0.1.0 for twenty-three
+# releases (see the note at the top of that file). `__version__` is already
+# bumped, `tests/partcad_cli/unit/test_versions.py` already fails if it stops
+# moving, and reading it costs nothing. Do not replace this with a constant.
+STAMP_KEY = "partcad"
+STAMP_SECTION = "metadata"
 
 
 def plugin_manifest() -> dict:
@@ -120,14 +141,66 @@ def _front_matter_bounds(text: str) -> Optional[tuple[int, int]]:
     return 4, end + 1
 
 
-def rename_skill(text: str, name: str, skills: list[str]) -> str:
+def _stamp(front_matter: str, version: str) -> str:
+    """Return `front_matter` carrying `metadata.partcad: <version>`.
+
+    Inserted as text rather than by parsing and re-dumping the YAML: a round
+    trip through a parser reflows the long `description:` line every skill has
+    and reorders the keys, so every install would rewrite files it did not
+    change. An existing `metadata:` block is added to rather than replaced --
+    the skills in this repository have none, but an author's may.
+    """
+    line = "%s: %s" % (STAMP_KEY, version)
+
+    section = re.search(r"^%s:[ \t]*$" % re.escape(STAMP_SECTION), front_matter, re.MULTILINE)
+    if section is None:
+        separator = "" if front_matter.endswith("\n") else "\n"
+        return front_matter + separator + "%s:\n  %s\n" % (STAMP_SECTION, line)
+
+    body = front_matter[section.end() :]
+    # The indentation the block already uses, so that this belongs to it.
+    nested = re.match(r"\n([ \t]+)\S", body)
+    indent = nested.group(1) if nested else "  "
+
+    existing = re.search(r"^%s%s:[ \t]*.*$" % (re.escape(indent), re.escape(STAMP_KEY)), body, re.MULTILINE)
+    if existing is not None:
+        start = section.end() + existing.start()
+        end = section.end() + existing.end()
+        return front_matter[:start] + indent + line + front_matter[end:]
+
+    return front_matter[: section.end()] + "\n" + indent + line + front_matter[section.end() :]
+
+
+def stamped_version(text: str) -> Optional[str]:
+    """The PartCAD version that wrote this skill, or None if nothing did.
+
+    None is the answer for a skill a user wrote themselves *and* for one an
+    older PartCAD installed before it stamped anything. Both are left alone by
+    everything that reads this, which is the safe direction: the cost is a
+    retired skill lingering for somebody who has not reinstalled since, and the
+    alternative is deleting a file PartCAD may not have written.
+    """
+    bounds = _front_matter_bounds(text)
+    if bounds is None:
+        return None
+    start, end = bounds
+    found = re.search(
+        r"^[ \t]+%s:[ \t]*(?P<version>\S+)[ \t]*$" % re.escape(STAMP_KEY),
+        text[start:end],
+        re.MULTILINE,
+    )
+    return found.group("version") if found else None
+
+
+def rename_skill(text: str, name: str, skills: list[str], version: Optional[str] = None) -> str:
     """Return `text` as the skill `name`, for an agent with no plugin namespace.
 
-    Two things change, and only these two. The `name` in the front matter, which
-    has to match the directory the skill is installed in or it answers to a
-    command nobody typed. And every `pc:<skill>` in the text -- `/pc:setup` in
+    Three things change, and only these three. The `name` in the front matter,
+    which has to match the directory the skill is installed in or it answers to
+    a command nobody typed. Every `pc:<skill>` in the text -- `/pc:setup` in
     prose, `# pc:init` as a title -- which names a skill through the plugin
-    namespace that does not exist here.
+    namespace that does not exist here. And the stamp, which says which PartCAD
+    wrote the file and marks it as PartCAD's to replace or retire.
 
     `skills` is what makes the second one safe: only the names actually shipped
     are rewritten, so a `pc:` that is something else, and the `pc render` and
@@ -143,6 +216,8 @@ def rename_skill(text: str, name: str, skills: list[str]) -> str:
             count=1,
             flags=re.MULTILINE,
         )
+        if version is not None:
+            front_matter = _stamp(front_matter, version)
         text = text[:start] + front_matter + text[end:]
 
     if skills:
@@ -171,6 +246,63 @@ def _writable_destination(path: str, what: str) -> bool:
         pc_logging.warning("Not installing %s: '%s' is not a directory" % (what, path))
         return False
     return True
+
+
+def _ours_to_retire(directory: str) -> Optional[str]:
+    """The name of a Cursor skill PartCAD may remove, or None to leave it alone.
+
+    Ours is a `pc-` directory carrying the stamp: `pc init` wrote it, so `pc
+    init` may retire it when the skill behind it is gone. Anything else in that
+    directory belongs to somebody else -- a `pc-` skill an author wrote by hand,
+    or one an older PartCAD installed before it stamped anything -- and a
+    retired skill lingering there is a much smaller harm than deleting a file
+    PartCAD did not write.
+    """
+    name = os.path.basename(directory)
+    if not name.startswith(CURSOR_PREFIX):
+        return None
+
+    try:
+        with open(os.path.join(directory, "SKILL.md"), "r", encoding="utf-8") as f:
+            text = f.read()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    if stamped_version(text) is None:
+        pc_logging.debug("Leaving '%s' in place: PartCAD does not ship it and did not write it" % directory)
+        return None
+    return name
+
+
+def _retire(parent: str, keep: list[str], owned) -> list[str]:
+    """Remove the skills under `parent` that PartCAD no longer ships.
+
+    A skill retired upstream keeps being offered to the agent otherwise, and an
+    agent that follows it drives a CLI that no longer works that way -- which is
+    worse than having no skill at all, because it looks like a working one. That
+    is what makes this a removal rather than a warning.
+
+    `owned` decides what may go: the whole plugin directory is PartCAD's, so
+    there it is every name; under `.cursor/skills` it is the stamped ones.
+    Returns the names removed, for the caller to report.
+    """
+    if not os.path.isdir(parent):
+        return []
+
+    retired = []
+    for name in sorted(os.listdir(parent)):
+        directory = os.path.join(parent, name)
+        if name in keep or os.path.islink(directory) or not os.path.isdir(directory):
+            continue
+        if owned(directory) is None:
+            continue
+        try:
+            shutil.rmtree(directory)
+        except OSError as e:
+            pc_logging.warning("Failed to remove the retired skill '%s': %s" % (directory, e))
+            continue
+        retired.append(name)
+    return retired
 
 
 def install_claude_plugin(root: str) -> bool:
@@ -202,7 +334,10 @@ def install_claude_plugin(root: str) -> bool:
         pc_logging.warning("Failed to install the Claude plugin into '%s': %s" % (destination, e))
         return False
 
+    retired = _retire(os.path.join(destination, "skills"), skills, lambda directory: directory)
     pc_logging.info("Installed the '%s' plugin (%d skills) into '%s'" % (name, len(skills), destination))
+    if retired:
+        pc_logging.info("Removed %d skill(s) PartCAD no longer ships: %s" % (len(retired), ", ".join(retired)))
     return True
 
 
@@ -237,7 +372,7 @@ def install_cursor_skills(root: str) -> bool:
             with open(os.path.join(source, "SKILL.md"), "r", encoding="utf-8") as f:
                 text = f.read()
             with open(os.path.join(target, "SKILL.md"), "w", encoding="utf-8", newline="\n") as f:
-                f.write(rename_skill(text, name, skills))
+                f.write(rename_skill(text, name, skills, __version__))
         except OSError as e:
             pc_logging.warning("Failed to install '%s' into '%s': %s" % (name, target, e))
             continue
@@ -246,24 +381,49 @@ def install_cursor_skills(root: str) -> bool:
     if not installed:
         return False
 
+    retired = _retire(destination, [CURSOR_PREFIX + skill for skill in skills], _ours_to_retire)
     pc_logging.info("Installed %d skills into '%s' as '%s*'" % (installed, destination, CURSOR_PREFIX))
+    if retired:
+        pc_logging.info("Removed %d skill(s) PartCAD no longer ships: %s" % (len(retired), ", ".join(retired)))
     return True
 
 
-def install_agent_skills(package_dir: str = ".") -> bool:
-    """Install the skills for every agent, beside the package in `package_dir`.
+# Every agent this knows how to install for, and what installing means for it.
+# The skills themselves are vendor-neutral `SKILL.md` folders, so an agent is
+# added here by teaching this one function where its directory is and whether it
+# has a namespace of its own -- not by writing a second copy of the library.
+AGENTS = {
+    "claude": install_claude_plugin,
+    "cursor": install_cursor_skills,
+}
+
+
+def install_agent_skills(package_dir: str = ".", agents=None) -> bool:
+    """Install the skills for `agents`, beside the package in `package_dir`.
 
     The files go to the root of the git repository holding the package, because
     that is what an editor opens as its workspace; when the package is not in a
     repository, they go next to the package itself. This is the same root
     `add_render_configuration` writes into, and for the same reason.
 
+    `agents` is the names to install for, defaulting to all of them. An unknown
+    name is an error rather than a no-op: a typo that silently installs nothing
+    looks exactly like an agent PartCAD does not support yet.
+
     Returns True when anything was installed. Nothing here is a reason for
     `pc init` to fail -- the package is created either way -- so every failure
     is reported and returns False.
     """
+    if agents is None:
+        agents = list(AGENTS)
+
+    unknown = [agent for agent in agents if agent not in AGENTS]
+    if unknown:
+        pc_logging.error("Unknown agent(s): %s. Known: %s" % (", ".join(sorted(unknown)), ", ".join(sorted(AGENTS))))
+        return False
+
     root = find_repository_root(package_dir) or os.path.abspath(package_dir)
-    # `or` short-circuits, and both of these have to run.
-    claude = install_claude_plugin(root)
-    cursor = install_cursor_skills(root)
-    return claude or cursor
+    # Every one of them runs: a refusal for one agent is not a reason to skip
+    # the next, so this must not short-circuit the way `and`/`or` would.
+    installed = [AGENTS[agent](root) for agent in agents]
+    return any(installed)

--- a/src/partcad/healthcheck/agent_skills.py
+++ b/src/partcad/healthcheck/agent_skills.py
@@ -1,0 +1,138 @@
+#
+# PartCAD, 2026
+#
+# Author: PartCAD (support@partcad.org)
+# Created: 2026-09-11
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""The AI agent skills installed in this repository, against the PartCAD running.
+
+`pc init` installs the skills out of the PartCAD that runs it, so they match it
+exactly -- on the day they are installed. `pc upgrade` then replaces PartCAD and
+leaves them where they are, and nothing says a word: an agent goes on reading
+instructions written for a CLI that has moved on, which is worse than having no
+skills at all, because a stale skill looks like a working one.
+
+This is the thing that says the word. It compares what is installed against the
+version running and offers to reinstall, which is `pc init --skills-only` and
+which also retires whatever PartCAD has stopped shipping.
+
+Each agent is asked in its own terms. Claude Code has the plugin manifest, whose
+`version` moves with the release. Cursor has no manifest, so the skills carry a
+`metadata.partcad` stamp instead -- see `STAMP_KEY` in `partcad.ai_agents`, and
+the note there about why neither of those is a literal anybody has to remember
+to bump.
+"""
+
+import json
+import os
+
+from .tests import HealthCheckReport, HealthCheckTest
+from .. import __version__
+from .. import ai_agents
+from ..launch_config import find_repository_root
+
+
+class AgentSkillsCheck(HealthCheckTest):
+    """Report AI agent skills that an older PartCAD installed."""
+
+    def __init__(self):
+        super().__init__(
+            name="AgentSkills",
+            tags=["skills", "agents", "claude", "cursor"],
+            description="check whether the installed AI agent skills match this PartCAD",
+        )
+        # Where `pc init` would have put them: the repository holding the
+        # current directory, or the directory itself when it is in none.
+        self._root = find_repository_root(os.getcwd()) or os.path.abspath(os.getcwd())
+        self._stale: list[str] = []
+
+    def auto_fixable(self) -> bool:
+        return True
+
+    def _claude_plugin(self) -> str:
+        return os.path.join(self._root, ai_agents.CLAUDE_SKILLS_DIR, ai_agents.plugin_name())
+
+    def _cursor_skills(self) -> str:
+        return os.path.join(self._root, ai_agents.CURSOR_SKILLS_DIR)
+
+    def is_applicable(self) -> bool:
+        """Only where somebody has installed them. Absent is not stale."""
+        if os.path.isdir(self._claude_plugin()):
+            return True
+        cursor = self._cursor_skills()
+        if not os.path.isdir(cursor):
+            return False
+        return any(name.startswith(ai_agents.CURSOR_PREFIX) for name in os.listdir(cursor))
+
+    def _claude_version(self):
+        """The version in the installed plugin manifest, or None if unreadable."""
+        manifest = os.path.join(self._claude_plugin(), ai_agents.CLAUDE_PLUGIN_DIR, "plugin.json")
+        try:
+            with open(manifest, "r", encoding="utf-8") as f:
+                return json.load(f).get("version")
+        except (OSError, UnicodeDecodeError, ValueError):
+            return None
+
+    def _cursor_versions(self) -> dict:
+        """The stamp on each installed Cursor skill that carries one.
+
+        A skill with no stamp is not reported: it is either a user's own or one
+        an older PartCAD wrote before stamping existed, and neither is something
+        to tell the user is out of date. `partcad.ai_agents` leaves both alone
+        for the same reason.
+        """
+        versions = {}
+        cursor = self._cursor_skills()
+        if not os.path.isdir(cursor):
+            return versions
+
+        for name in sorted(os.listdir(cursor)):
+            if not name.startswith(ai_agents.CURSOR_PREFIX):
+                continue
+            try:
+                with open(os.path.join(cursor, name, "SKILL.md"), "r", encoding="utf-8") as f:
+                    stamp = ai_agents.stamped_version(f.read())
+            except (OSError, UnicodeDecodeError):
+                continue
+            if stamp is not None:
+                versions[name] = stamp
+        return versions
+
+    def test(self) -> HealthCheckReport:
+        self.findings = []
+        self._stale = []
+
+        claude = self._claude_version()
+        if claude is not None and claude != __version__:
+            self._stale.append("claude")
+            self.findings.append(
+                "The Claude plugin in '%s' is from PartCAD %s; this is %s"
+                % (self._claude_plugin(), claude, __version__)
+            )
+
+        outdated = sorted({name for name, stamp in self._cursor_versions().items() if stamp != __version__})
+        if outdated:
+            self._stale.append("cursor")
+            self.findings.append(
+                "%d Cursor skill(s) in '%s' are from an older PartCAD: %s"
+                % (len(outdated), self._cursor_skills(), ", ".join(outdated))
+            )
+
+        if self.findings:
+            self.findings.append("Run 'pc init --skills-only' to update them")
+
+        return HealthCheckReport(self.name, self.findings)
+
+    def fix(self) -> bool:
+        """Reinstall for the agents that were found stale, and only those.
+
+        Installing for an agent whose skills are not here would be creating a
+        `.cursor/skills` for somebody who does not use Cursor, which is not a
+        repair.
+        """
+        if not self._stale:
+            return True
+        return ai_agents.install_agent_skills(self._root, self._stale)

--- a/src/partcad_cli/click/commands/init.py
+++ b/src/partcad_cli/click/commands/init.py
@@ -117,6 +117,14 @@ class DynamicPromptOption(click.Option):
     help="Install the AI agent skills only, leaving any package alone",
 )
 @click.option(
+    "--agents",
+    type=str,
+    default="all",
+    show_default=True,
+    show_envvar=True,
+    help="Which agents to install the skills for: 'all', or a comma-separated list (claude, cursor)",
+)
+@click.option(
     "-p",
     "--private",
     is_flag=True,
@@ -145,6 +153,10 @@ def cli(cli_ctx: CliContext, click_ctx: click.rich_context.RichContext, **kwargs
         # about the repository around the package rather than the package.
         install_skills = kwargs.pop("skills")
         skills_only = kwargs.pop("skills_only")
+        # "all" rather than a literal list, so that an agent added to
+        # "partcad.ai_agents.AGENTS" is installed for without touching the CLI.
+        agents = kwargs.pop("agents")
+        agents = None if agents.strip() == "all" else [a.strip() for a in agents.split(",") if a.strip()]
 
         if skills_only:
             # The whole command, for a repository that has a package already --
@@ -155,7 +167,7 @@ def cli(cli_ctx: CliContext, click_ctx: click.rich_context.RichContext, **kwargs
             if not install_skills:
                 pc.logging.error("'--skills-only' and '--no-skills' ask for opposite things")
                 return
-            if not pc.install_agent_skills(os.path.dirname(os.path.abspath(dst_path))):
+            if not pc.install_agent_skills(os.path.dirname(os.path.abspath(dst_path)), agents):
                 # An error here, unlike below: installing them is the whole of
                 # what was asked for, so there is nothing left that succeeded.
                 pc.logging.error("Failed installing the AI agent skills!")
@@ -196,6 +208,6 @@ def cli(cli_ctx: CliContext, click_ctx: click.rich_context.RichContext, **kwargs
             # Reported the same way, and a failure to install them is not a
             # failure to create the package either.
             if install_skills:
-                pc.install_agent_skills(package_dir)
+                pc.install_agent_skills(package_dir, agents)
         else:
             pc.logging.error(f"Failed creating '{dst_path}'!")

--- a/tests/partcad/unit/test_ai_agents.py
+++ b/tests/partcad/unit/test_ai_agents.py
@@ -19,6 +19,7 @@ import os
 import pytest
 import yaml
 
+import partcad
 import partcad.ai_agents as ai_agents
 
 
@@ -255,3 +256,135 @@ def test_a_destination_that_is_a_file_is_refused(tmp_path):
 
     assert not ai_agents.install_cursor_skills(str(tmp_path))
     assert (tmp_path / ".cursor" / "skills").read_text(encoding="utf-8") == "not a directory\n"
+
+
+# --- The stamp: which PartCAD wrote a skill, and whose skill it is ---
+
+
+def test_installed_cursor_skills_say_which_partcad_wrote_them(tmp_path):
+    """Nothing else in a `.cursor/skills` directory records that.
+
+    The Claude side has the plugin manifest; this is the Cursor equivalent, and
+    it is what `pc healthcheck` compares against the version running.
+    """
+    ai_agents.install_cursor_skills(str(tmp_path))
+
+    for skill in ai_agents.available_skills():
+        text = (tmp_path / ".cursor" / "skills" / ("pc-" + skill) / "SKILL.md").read_text(encoding="utf-8")
+        assert ai_agents.stamped_version(text) == partcad.__version__
+
+
+def test_the_stamp_is_added_to_an_existing_metadata_block():
+    """An author's own `metadata:` is added to rather than replaced."""
+    original = "\n".join(["---", "name: render", "metadata:", "  author: somebody", "---", "", "body", ""])
+    stamped = ai_agents.rename_skill(original, "pc-render", ["render"], "1.2.3")
+
+    assert "  author: somebody" in stamped
+    assert "  partcad: 1.2.3" in stamped
+    assert stamped.count("metadata:") == 1
+    assert ai_agents.stamped_version(stamped) == "1.2.3"
+
+
+def test_re_stamping_replaces_rather_than_repeats():
+    """Installing twice must not leave two versions in one file."""
+    once = ai_agents.rename_skill("---\nname: render\n---\n\nbody\n", "pc-render", ["render"], "1.0.0")
+    twice = ai_agents.rename_skill(once, "pc-render", ["render"], "2.0.0")
+
+    assert ai_agents.stamped_version(twice) == "2.0.0"
+    assert twice.count("partcad:") == 1
+
+
+def test_an_unstamped_skill_reports_no_version():
+    """A user's own skill, and one an older PartCAD installed, look the same."""
+    assert ai_agents.stamped_version("---\nname: mine\n---\n") is None
+    assert ai_agents.stamped_version("no front matter at all\n") is None
+
+
+# --- Retirement: a skill PartCAD stopped shipping stops being offered ---
+
+
+def test_a_retired_skill_is_removed_from_both_agents(tmp_path):
+    """It would otherwise be offered forever, describing a CLI that moved on.
+
+    That is worse than no skill at all: the agent follows it, and it looks like
+    a working one.
+    """
+    ai_agents.install_agent_skills(str(tmp_path))
+
+    ghost = tmp_path / ".cursor" / "skills" / "pc-ghost"
+    ghost.mkdir()
+    (ghost / "SKILL.md").write_text(
+        "---\nname: pc-ghost\ndescription: retired\nmetadata:\n  partcad: 0.0.1\n---\n", encoding="utf-8"
+    )
+    plugin_ghost = tmp_path / ".claude" / "skills" / "pc" / "skills" / "ghost"
+    plugin_ghost.mkdir()
+    (plugin_ghost / "SKILL.md").write_text("---\nname: ghost\n---\n", encoding="utf-8")
+
+    ai_agents.install_agent_skills(str(tmp_path))
+
+    assert not ghost.exists()
+    assert not plugin_ghost.exists()
+    # And everything still shipped survived the pruning.
+    assert len(list((tmp_path / ".claude" / "skills" / "pc" / "skills").iterdir())) == len(ai_agents.available_skills())
+
+
+def test_a_skill_the_user_wrote_is_never_retired(tmp_path):
+    """`pc-` is PartCAD's namespace, but the stamp is what proves authorship.
+
+    Somebody's hand-written `pc-mine` has none, so it stays -- and so does one
+    an older PartCAD installed before stamping existed. The cost is a retired
+    skill lingering; the alternative is deleting a file PartCAD did not write.
+    """
+    theirs = tmp_path / ".cursor" / "skills" / "pc-mine"
+    theirs.mkdir(parents=True)
+    (theirs / "SKILL.md").write_text("---\nname: pc-mine\ndescription: mine\n---\n", encoding="utf-8")
+    unrelated = tmp_path / ".cursor" / "skills" / "openspec-propose"
+    unrelated.mkdir()
+    (unrelated / "SKILL.md").write_text("---\nname: openspec-propose\n---\n", encoding="utf-8")
+
+    ai_agents.install_cursor_skills(str(tmp_path))
+
+    assert (theirs / "SKILL.md").is_file()
+    assert (unrelated / "SKILL.md").is_file()
+
+
+def test_retirement_does_not_follow_symlinks(tmp_path):
+    """The same rule the installation side keeps: never write through one."""
+    if os.name == "nt":
+        pytest.skip("symlinks need a privilege Windows does not grant by default")
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "SKILL.md").write_text("---\nname: pc-linked\nmetadata:\n  partcad: 0.0.1\n---\n", encoding="utf-8")
+    skills = tmp_path / ".cursor" / "skills"
+    skills.mkdir(parents=True)
+    os.symlink(elsewhere, skills / "pc-linked")
+
+    ai_agents.install_cursor_skills(str(tmp_path))
+
+    assert (elsewhere / "SKILL.md").is_file()
+
+
+# --- Which agents ---
+
+
+def test_only_the_named_agents_are_installed_for(tmp_path):
+    assert ai_agents.install_agent_skills(str(tmp_path), ["cursor"])
+
+    assert (tmp_path / ".cursor" / "skills" / "pc-init" / "SKILL.md").is_file()
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_an_unknown_agent_is_an_error_rather_than_a_quiet_no_op(tmp_path):
+    """A typo that installs nothing looks exactly like an unsupported agent."""
+    assert not ai_agents.install_agent_skills(str(tmp_path), ["cursor", "emacs"])
+
+    assert not (tmp_path / ".cursor").exists()
+
+
+def test_every_agent_is_installed_for_by_default(tmp_path):
+    ai_agents.install_agent_skills(str(tmp_path))
+
+    assert sorted(ai_agents.AGENTS) == ["claude", "cursor"]
+    assert (tmp_path / ".claude" / "skills" / "pc").is_dir()
+    assert (tmp_path / ".cursor" / "skills" / "pc-init").is_dir()

--- a/tests/partcad/unit/test_healthcheck_agent_skills.py
+++ b/tests/partcad/unit/test_healthcheck_agent_skills.py
@@ -1,0 +1,170 @@
+#
+# PartCAD, 2026
+#
+# Licensed under Apache License, Version 2.0.
+#
+
+"""The healthcheck that notices AI agent skills an older PartCAD installed.
+
+`pc init` installs them out of the PartCAD running it, so they match on the day
+they are written. `pc upgrade` then replaces PartCAD and leaves them alone, and
+an agent goes on reading instructions for a CLI that has moved -- silently,
+because a stale skill looks exactly like a current one. This is what breaks the
+silence, so what is checked here is mostly that it stays quiet when it should
+and speaks when it should.
+"""
+
+import json
+
+import pytest
+
+import partcad
+import partcad.ai_agents as ai_agents
+from partcad.healthcheck.agent_skills import AgentSkillsCheck
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    """A repository the check will look at, as the current directory."""
+    (tmp_path / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def age_the_cursor_skill(workspace, name="pc-init", version="0.0.1"):
+    """Rewrite one Cursor skill's stamp, the way an older install left it."""
+    path = workspace / ".cursor" / "skills" / name / "SKILL.md"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("  partcad: %s" % partcad.__version__, "  partcad: %s" % version),
+        encoding="utf-8",
+    )
+
+
+def age_the_plugin(workspace, version="0.0.1"):
+    """And the Claude plugin manifest, which is where its version lives."""
+    path = workspace / ".claude" / "skills" / "pc" / ".claude-plugin" / "plugin.json"
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    manifest["version"] = version
+    path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def test_it_does_not_apply_where_nothing_is_installed(workspace):
+    """Absent is not stale. Most repositories have no skills in them at all."""
+    assert not AgentSkillsCheck().is_applicable()
+
+
+def test_it_is_quiet_about_a_fresh_install(workspace):
+    ai_agents.install_agent_skills(str(workspace))
+
+    check = AgentSkillsCheck()
+    assert check.is_applicable()
+    assert check.test().findings == []
+
+
+def test_it_reports_an_older_plugin(workspace):
+    ai_agents.install_agent_skills(str(workspace))
+    age_the_plugin(workspace)
+
+    findings = AgentSkillsCheck().test().findings
+
+    assert any("0.0.1" in finding and partcad.__version__ in finding for finding in findings)
+    assert any("pc init --skills-only" in finding for finding in findings)
+
+
+def test_it_reports_older_cursor_skills_by_name(workspace):
+    ai_agents.install_agent_skills(str(workspace))
+    age_the_cursor_skill(workspace)
+
+    findings = AgentSkillsCheck().test().findings
+
+    assert any("pc-init" in finding for finding in findings)
+
+
+def test_it_says_nothing_about_skills_it_did_not_write(workspace):
+    """An unstamped `pc-` skill is a user's own, or predates stamping.
+
+    Telling somebody their own file is out of date would be wrong, and offering
+    to overwrite it would be worse.
+    """
+    theirs = workspace / ".cursor" / "skills" / "pc-mine"
+    theirs.mkdir(parents=True)
+    (theirs / "SKILL.md").write_text("---\nname: pc-mine\ndescription: mine\n---\n", encoding="utf-8")
+
+    check = AgentSkillsCheck()
+    assert check.is_applicable()
+    assert check.test().findings == []
+
+
+def test_the_fix_reinstalls_what_was_stale(workspace):
+    ai_agents.install_agent_skills(str(workspace))
+    age_the_plugin(workspace)
+    age_the_cursor_skill(workspace)
+
+    check = AgentSkillsCheck()
+    check.test()
+    assert check.fix()
+
+    assert check.test().findings == []
+
+
+def test_the_fix_does_not_install_for_an_agent_that_was_not_there(workspace):
+    """Repairing Cursor must not create a `.claude` for somebody who has none."""
+    ai_agents.install_agent_skills(str(workspace), ["cursor"])
+    age_the_cursor_skill(workspace)
+
+    check = AgentSkillsCheck()
+    check.test()
+    assert check.fix()
+
+    assert not (workspace / ".claude").exists()
+
+
+def test_it_is_found_by_the_healthcheck_discovery(workspace):
+    """The runner discovers checks by walking the package, so this must be in it.
+
+    It is also gated on `is_applicable`, which is why this installs first: a
+    check that is never applicable is discovered and then dropped.
+    """
+    ai_agents.install_agent_skills(str(workspace))
+
+    from partcad.healthcheck.tests import discover_healthchecks
+
+    assert any(isinstance(check, AgentSkillsCheck) for check in discover_healthchecks())
+
+
+def test_it_looks_at_the_repository_rather_than_the_directory(tmp_path, monkeypatch):
+    """`pc init` writes at the repository root; this has to read the same place."""
+    (tmp_path / ".git").mkdir()
+    ai_agents.install_agent_skills(str(tmp_path))
+    package = tmp_path / "packages" / "widget"
+    package.mkdir(parents=True)
+    monkeypatch.chdir(package)
+
+    assert AgentSkillsCheck().is_applicable()
+
+
+def test_an_unreadable_manifest_is_not_reported_as_stale(workspace):
+    """A manifest that cannot be parsed says nothing about which version wrote it.
+
+    Guessing "stale" there would offer to overwrite a file on the strength of
+    not having understood it.
+    """
+    ai_agents.install_agent_skills(str(workspace))
+    path = workspace / ".claude" / "skills" / "pc" / ".claude-plugin" / "plugin.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    assert AgentSkillsCheck().test().findings == []
+
+
+def test_the_version_is_the_running_one_rather_than_a_literal(workspace):
+    """The stamp and the manifest are compared against `partcad.__version__`.
+
+    Nothing in this feature carries a version literal that a release would have
+    to remember to bump -- see the note on `STAMP_KEY` in `partcad.ai_agents`.
+    """
+    ai_agents.install_agent_skills(str(workspace))
+    monkeyed = partcad.__version__ + ".1"
+
+    age_the_plugin(workspace, monkeyed)
+
+    assert any(monkeyed in finding for finding in AgentSkillsCheck().test().findings)


### PR DESCRIPTION
`pc init` installed the AI agent skills and then never thought about them again. Five things followed from that; this is all five, in the order I'd review them.

## 1. A retired skill was never removed

I planted a `pc-ghost` and re-ran the install: it survived, in both agents. A skill PartCAD stops shipping goes on being offered, describing a CLI that has moved — worse than no skill at all, because the agent follows it and it looks like a working one.

Installing again now retires them. The whole `.claude/skills/pc/` directory is the plugin, so there it is anything not currently shipped. Under `.cursor/skills` the `pc-` prefix is *not* proof of authorship, which is what 2 is for.

## 2. The stamp — and the bump-version question

The Cursor copies now carry `metadata.partcad: <version>` in their front matter. It answers two questions nothing else could: which release wrote the file (the Claude side has the plugin manifest), and whether the file is PartCAD's to replace or retire. A `pc-` skill without a stamp is somebody else's — hand-written, or written by a PartCAD older than the stamp — and is never touched. The cost is a retired skill lingering for whoever has not reinstalled since; the alternative is deleting a file PartCAD did not write.

**On the bump-version process, as asked:** the value is `partcad.__version__`, read at install time, and it deliberately is **not** a literal anywhere in the source. A literal would mean one more entry in `dev-tools/bumpversion.toml` and one more thing to forget on a release — which is precisely how the plugin manifest sat at `0.1.0` for twenty-three releases. `__version__` is already bumped, and `tests/partcad_cli/unit/test_versions.py` already fails if it stops moving. **So this adds nothing to the release process**, and a comment in `ai_agents/__init__.py`, a line in `AGENTS.md` and a test all say not to turn it into a constant.

## 3. Nothing noticed when they went stale

`pc upgrade` replaces PartCAD and leaves every installed copy alone, silently. The new `AgentSkills` healthcheck reads the stamp and the manifest, reports what an older release wrote, and points at `pc init --skills-only`:

```
Healthcheck: AgentSkills: ["The Claude plugin in '...' is from PartCAD 0.0.1; this is 0.8.69",
                           "1 Cursor skill(s) ... are from an older PartCAD: pc-init",
                           "Run 'pc init --skills-only' to update them"]
```

`--fix` reinstalls, for the agents that had them and no others — repairing Cursor must not create a `.claude` for somebody who does not use Claude.

## 4. CI never looked at what `pc init` installs

`plugin.yml` validates the plugin this repository *publishes*; the installed one is a different code path. The installation test now runs `pc init` and checks what lands: every Claude skill byte-identical to the wheel's, every Cursor skill prefixed, renamed to match its directory, stamped, and free of `pc:` references. The manifest is compared **byte for byte** against the published one, so `claude plugin validate` passing in `plugin.yml` carries over to what a user gets.

## 5. Two agents, hard-coded

For a library of vendor-neutral `SKILL.md` folders. `--agents` takes `all` (default) or a comma-separated list; a third agent is an entry in `AGENTS` plus a function saying where its directory is — no second copy of the library. An unknown name is an error, because a typo that installs nothing looks exactly like an agent that is not supported yet.

## Verification

From a wheel built here, installed into a clean venv:

- `--agents cursor` installs Cursor only; `--agents kursor` exits 1 naming the known agents
- the installed skills are stamped `0.8.69`; a planted `pc-ghost` is removed on reinstall while a hand-written unstamped `pc-mine` and an unrelated `openspec-propose` are kept
- ageing a stamp makes the healthcheck report it by name; `--fix` restores it and creates no `.claude`
- the CI assertion script was extracted from the YAML and run verbatim: `pc init installed 12 skills for claude, cursor`

294 pytest tests (26 + 11 new), 11 behave scenarios in `features/init.feature`, black and flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)