### PR TITLE
Make black and flake8 gate too, and close the holes that let #629 through

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -841,6 +841,8 @@ filelock==3.32.0 ; python_version >= "3.10" and python_version < "3.15" \
 findpython==0.8.0 ; python_version >= "3.10" and python_version < "3.15" \
     --hash=sha256:4a61ee1618a8b55014f7d41f59345d322be93f6ce62395bdccccc651b3f7e28a \
     --hash=sha256:53b32264874dfa5990bd09d717819386d8db3149d89fe20f88fe1078de286bae
+flake8-pyproject==1.2.4 ; python_version >= "3.10" and python_version < "3.15" \
+    --hash=sha256:ea34c057f9a9329c76d98723bb2bb498cc6ba8ff9872c4d19932d48c91249a77
 flake8==7.3.0 ; python_version >= "3.10" and python_version < "3.15" \
     --hash=sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e \
     --hash=sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -297,48 +297,6 @@ jobs:
           path: allure-report/
           retention-days: 7
 
-  # pre-commit:
-  #   name: "Run: pre-commit"
-  #   needs: devcontainer
-  #   runs-on: ubuntu-24.04
-  #   timeout-minutes: 10
-  #   steps:
-  #     - name: Checkout (GitHub)
-  #       uses: actions/checkout@v7
-  #     - name: Setup Dev Container
-  #       id: setup
-  #       uses: ./.github/actions/setup-devcontainer
-
-  #     - name: Login to GitHub Container Registry
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ${{ env.CONTAINER_REGISTRY }}
-  #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Cache pre-commit dependencies
-  #       uses: actions/cache@v6
-  #       with:
-  #         path: |
-  #           .pre-commit
-  #         key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-pre-commit-
-  #     - name: Run pre-commit hooks
-  #       uses: devcontainers/ci@v0.3
-  #       with:
-  #         imageName: "${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.setup.outputs.IMAGE_TAG }}"
-  #         cacheFrom: "${{ env.CONTAINER_REGISTRY }}/${{env.IMAGE_NAME }}:${{ env.VERSION }}"
-  #         configFile: .devcontainer/.devcontainer.json
-  #         push: never
-  #         # TODO-24: Add custom @dependabot-like job to open PR to update dependencies
-  #         # TODO: Run ggshield and/or other secrets scanning tools as separate job
-  #         env: |
-  #           SKIP=poetry-export,poetry-lock,ggshield
-  #         runCmd:
-  #           pre-commit run --config .devcontainer/.pre-commit-config.yaml --show-diff-on-failure --color=always
-  #           --all-files
-
   behave:
     name: "Run: behave"
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -613,13 +613,23 @@ jobs:
   #         job: cache-preheat
   #         preheat_only: "true"
 
+  # None of the four lint jobs is gated on "changed-scopes", and for the isort
+  # job that is a correction rather than an omission. It used to check
+  # "src tests", which is always the "code" bucket, so gating it on `pytest` was
+  # consistent. All three now check the whole repository (the scope is in
+  # "pyproject.toml"), and several of the trees that brings in belong to buckets
+  # that leave `pytest` false: "ide/standalone/tests/*.py" is `ide`, "docs/*.py"
+  # and every "AGENTS.md" are `docs`, "dev-tools/pyinstaller" is `packaging`.
+  # Gated, a change to any of those would skip the linters and merge an unsorted
+  # file -- which is how #629 merged three of them 83 seconds after the isort
+  # gate landed in #633. Each job is seconds on one runner; the gate is not
+  # worth that.
+  #
+  # "needs: set-matrix" stays, and is what keeps the "a push to devel runs
+  # nothing unless the commit is a version bump" rule applying to these jobs.
   lint-isort:
     name: "Lint (isort)"
     needs: set-matrix
-    # Same gate as "Pytest": the source tree is what this can say anything
-    # about. "changed-scopes" is fail-safe, so a path it does not recognise
-    # turns this back on.
-    if: ${{ needs.set-matrix.outputs.pytest == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -643,8 +653,123 @@ jobs:
       # "--filter-files" so the "extend_skip"/"extend_skip_glob" entries in
       # "pyproject.toml" are honoured -- see the comment beside them for what
       # they protect and why sorting those files is a bug rather than a tidy-up.
+      #
+      # "." rather than a list of directories: what is in scope is stated in
+      # "pyproject.toml", once, for all three linters, so that this job, the
+      # "pre-commit" hook and a developer's own "poetry run isort ." cannot come
+      # to disagree about it. A path list here would be a fourth answer, and the
+      # one that silently stops covering a directory somebody adds.
       - name: Check import order
-        run: isort --check-only --diff --filter-files --settings-path pyproject.toml src tests
+        run: isort --check-only --diff --filter-files --settings-path pyproject.toml .
+
+  # Siblings of the job above rather than steps inside it, deliberately: the
+  # check name is what a branch-protection rule names, so each linter gets a
+  # name of its own that can be required independently, and a red check says
+  # which linter is unhappy without opening the log. Each is seconds on one
+  # runner; the cost of three is not worth collapsing.
+  lint-black:
+    name: "Lint (black)"
+    needs: set-matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      # Same version as the pre-commit hook and as `pyproject.toml` resolves.
+      # black's stable style changes between major versions, so an unpinned
+      # runner would reformat the tree from under the hook that just passed.
+      - name: Install black
+        run: pip install "black==26.5.1"
+      # "." for the reason the isort job above gives: "force-exclude" in
+      # "pyproject.toml" is what holds "examples/" and "features/" out.
+      - name: Check formatting
+        run: black --check --diff .
+
+  lint-flake8:
+    name: "Lint (flake8)"
+    needs: set-matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      # `Flake8-pyproject` is what makes flake8 read `[tool.flake8]` at all.
+      # Install flake8 without it and this job checks at 79 columns and fails
+      # on a tree the hook just passed.
+      - name: Install flake8
+        run: pip install "flake8==7.3.0" "Flake8-pyproject==1.2.4"
+      # "." for the reason the isort job above gives. flake8's own
+      # "extend-exclude" holds the two trees out, and unlike the other two
+      # tools it only applies that to files it discovers by walking -- which is
+      # exactly what this is, and why the hook needs an "exclude:" of its own.
+      - name: Lint
+        run: flake8 .
+
+  # The `pre-commit` hooks that are not otherwise gated. There used to be a job
+  # for this in "test-dev.yml"; it was commented out, and had been for long
+  # enough that both paths in it had gone stale
+  # ("dev-tools/pre-commit-config.yaml" moved, ".devcontainer/.devcontainer.json"
+  # never existed under that name). So `shellcheck`, `hadolint`, the workflow
+  # and YAML schema checks, the whitespace fixers and the "examples reference a
+  # checked-in image" check were enforced only for people who happened to commit
+  # from inside the dev container.
+  #
+  # This replaces it with a job that needs no dev container at all: the hooks
+  # below install their own tools, so a plain runner with `pre-commit` on it is
+  # the whole requirement.
+  #
+  # Ungated for the reason the three jobs above are, and then some: these hooks
+  # cover shell scripts, Dockerfiles, workflow YAML and the examples tree, which
+  # no single bucket implies at all.
+  lint-pre-commit:
+    name: "Lint (pre-commit)"
+    needs: set-matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('dev-tools/pre-commit-config.yaml') }}
+      - name: Install pre-commit
+        run: pip install "pre-commit==4.4.0"
+      # Two hooks shell out to a binary rather than installing one: the
+      # `shellcheck` hook declared `language: system` in
+      # "dev-tools/pre-commit-config.yaml", and hadolint, whose upstream hook is
+      # also `system`. The dev container's image carries both; a plain runner
+      # has shellcheck and not hadolint, so fetch it -- at the same version the
+      # hook's `rev:` pins, so this job and the hook check with one tool.
+      - name: Tools the system hooks need
+        run: |
+          set -e
+          shellcheck --version >/dev/null
+          sudo curl -fsSL -o /usr/local/bin/hadolint \
+            https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64
+          sudo chmod +x /usr/local/bin/hadolint
+          hadolint --version
+      # SKIP, and why each:
+      #   pytest, behave          -- their own jobs, and they need the CAD stack
+      #   isort, black, flake8    -- the three jobs above; running them here too
+      #                              would put two red checks on one problem
+      #   eslint                  -- needs `npm install` under ide/vscode; the
+      #                              extension has its own workflow
+      #   poetry-lock/export/install -- these rewrite files rather than check
+      #                              them, which is not what a CI gate does
+      - name: Run the hooks
+        env:
+          SKIP: pytest,behave,isort,black,flake8,eslint,poetry-lock,poetry-export,poetry-install
+        run: |
+          set -e
+          pre-commit run --config dev-tools/pre-commit-config.yaml \
+            --all-files --show-diff-on-failure --color=always
 
   test-pytest:
     name: "Pytest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -747,13 +747,23 @@ jobs:
       # also `system`. The dev container's image carries both; a plain runner
       # has shellcheck and not hadolint, so fetch it -- at the same version the
       # hook's `rev:` pins, so this job and the hook check with one tool.
+      # The checksum is upstream's published one for this exact asset, pinned
+      # here rather than fetched beside the binary: a checksum downloaded from
+      # the same place as the file it vouches for verifies nothing. Verified
+      # *before* the binary is made executable or run, so a mismatch fails the
+      # job with the file still inert. Bump both together when the `rev:` in
+      # "dev-tools/pre-commit-config.yaml" moves.
       - name: Tools the system hooks need
+        env:
+          HADOLINT_VERSION: v2.14.0
+          HADOLINT_SHA256: 6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47
         run: |
           set -e
           shellcheck --version >/dev/null
-          sudo curl -fsSL -o /usr/local/bin/hadolint \
-            https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64
-          sudo chmod +x /usr/local/bin/hadolint
+          curl -fsSL -o /tmp/hadolint \
+            "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64"
+          echo "${HADOLINT_SHA256}  /tmp/hadolint" | sha256sum --check --strict -
+          sudo install -m 0755 /tmp/hadolint /usr/local/bin/hadolint
           hadolint --version
       # SKIP, and why each:
       #   pytest, behave          -- their own jobs, and they need the CAD stack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,29 +351,72 @@ pins the order of its `CLASSES` section, under the `reproducible` parameter of t
 default). An implementation another package supplies may not be, and those files are named one by one in that
 job's `UNSTABLE` list — keep it short, and give every entry a reason there and in the package it belongs to.
 
-Lint/format (Python): `black`, `flake8`, `isort` — configured in `pyproject.toml`. Only **`isort` is a gate**:
-it runs as a `pre-commit` hook and as the `Lint (isort)` job in `test.yml`, and the tree is sorted. Run it as
-CI runs it, from the repository root:
+Lint/format (Python): **`black`, `flake8` and `isort` all gate.** Each is a `pre-commit` hook and a
+`Lint (...)` job in `test.yml`, each pins the version `pyproject.toml` resolves so the hook and the job cannot
+disagree, and the tree satisfies all three. Run them as CI runs them, from the repository root:
 
 ```bash
-poetry run isort --check --diff --filter-files --settings-path pyproject.toml src tests
+poetry run isort --check --diff --filter-files --settings-path pyproject.toml .
+poetry run black --check --diff .
+poetry run flake8 .
 ```
 
-`--filter-files` is not decoration. isort applies the `extend_skip` / `extend_skip_glob` entries in
-`pyproject.toml` to the files it *discovers* by walking a directory, and not to files handed to it by name — so
-without that flag, sorting a named `src/partcad/wrappers/*.py` reorders imports whose order is what the dynamic
-loader needs (the expat/VTK pin; the config comment has the detail). Pass a directory or pass the flag.
+`.`, not a list of directories: **what is in scope is written down once, in `pyproject.toml`**, so that a hook,
+a CI job and a command you type cannot come to disagree about it. The scope is PartCAD's own Python — `src/`,
+`tests/`, `cad/`, `dev-tools/`, `ide/`, `tools/`, `docs/` and the root `conftest.py`. Two trees are held out,
+and it is a deferred decision rather than an oversight:
 
-**`black` and `flake8` are not gates, and adding a hook for either today would fail the build**, so do not
-treat a diff from them as something a change of yours introduced:
+* `examples/` is CAD part scripts written the way a *user* writes one — `from build123d import *`, and a
+  `show_object` the runner injects at execution time. Essentially all 102 of flake8's findings there are that
+  idiom (`F403`/`F405`/`F401`/`F821`), which is why `[tool.ruff.lint]` already waives those same three for
+  `pc lint` of a part. Sorting their imports carries the wrappers' risk as well, and their rendered output is
+  checked in.
+* `features/` is `behave` step definitions, where every module defines several functions named `step_impl` and
+  the decorator is what tells them apart. 29 of its 56 findings are `F811`, "redefinition of unused
+  'step_impl'" — the framework's idiom, reported as a defect.
 
-* `black` reformats 44 files under its 26.x stable style — drift that predates this and belongs in its own
-  reformatting PR, exactly as the comment beside `black = "^26.5.1"` in `pyproject.toml` says. What *is* true
-  is that black and isort no longer disagree: after the sort, no black hunk touches an import line.
-* `flake8` does not read `[tool.flake8]` from `pyproject.toml` at all — it needs the `Flake8-pyproject` plugin
-  or a `.flake8` file, neither of which is here — so it reports `E501` at **79** columns rather than the
-  configured 120. At the intended 120 it still reports 369 findings, most of them `E402` in the sandbox
-  wrappers, where a late import is the point. Making it gateable is a change of its own.
+Covering either means waiving a code across a whole directory, which is a policy call and a change of its own.
+Until then, do not "fix" a finding in those two trees as part of unrelated work.
+
+A fourth job, `Lint (pre-commit)`, runs the hooks that have no job of their own — `shellcheck`, `hadolint`, the
+YAML and workflow schema checks, the whitespace fixers, and the "a README's images are checked in" check. It
+skips the three above (two red checks for one problem is noise) and `pytest`/`behave` (their own jobs).
+
+Four things about the configuration are load-bearing, and each of them was once silently not:
+
+* **`--filter-files` for isort.** isort applies `extend_skip` / `extend_skip_glob` to files it *discovers* by
+  walking a directory, and not to files handed to it by name — so without the flag, sorting a named
+  `src/partcad/wrappers/*.py` reorders imports whose order is what the dynamic loader needs (the expat/VTK
+  pin; the config comment has the detail). Pass a directory or pass the flag.
+* **`Flake8-pyproject` for flake8.** flake8 has never read `pyproject.toml` on its own. Without that plugin the
+  whole `[tool.flake8]` table is inert and flake8 checks at its built-in 79 columns, on a repository that
+  formats at 120. It is in the `dev` group for exactly this reason, and the CI job installs it explicitly.
+* **The `per-file-ignores` list is not a wish list.** Every entry is an idiom rather than a defect, and the
+  first two are the same paths isort skips, for the same reason. `E501` is waived globally because *black* owns
+  line length; `E722` and `E731` are deferred, not endorsed — see the comments in `pyproject.toml`.
+* **Each of the three spells "skip this" differently, and two of the three spellings are traps.** isort needs
+  `--filter-files` (above); black needs `force-exclude`, because `extend-exclude` applies only to files it
+  discovered by walking; and flake8 has no equivalent at all — `extend-exclude` is discovery-only and it checks
+  anything named on its command line regardless. That last one is why the `flake8` hook in
+  `dev-tools/pre-commit-config.yaml` carries an `exclude:` of its own: `pre-commit` passes staged files by name.
+
+`pyright` is configured under `[tool.pyright]` and read by Pylance, which `.devcontainer/devcontainer.json`
+recommends. It gates nothing: there is no type checker in any dependency group, and adopting one is a decision
+of its own.
+
+None of the four jobs is gated on `.github/actions/changed-scopes`, deliberately. They read the whole
+repository, and several of the trees that covers sit in buckets that leave `pytest` false —
+`ide/standalone/tests/*.py` is `ide`, `docs/*.py` and every `AGENTS.md` are `docs`, `dev-tools/pyinstaller` is
+`packaging`. Gated, a change to any of those would skip the linters altogether. Each job is seconds on one
+runner. They do keep `needs: set-matrix`, which is what makes the "a push to `devel` runs nothing unless the
+commit is a version bump" rule apply to them as well.
+
+**A `Lint (...)` job is only a gate once branch protection requires it.** A job added to `test.yml` does not
+apply to a pull request whose branch was cut before the job existed — the check simply never runs there — and
+GitHub will merge such a branch unless the check is *required* and branches must be up to date. That is not
+hypothetical: #629 merged three unsorted files 83 seconds after the isort gate landed in #633, because its own
+CI run predated the job. Adding a lint job therefore has a second half that lives in the repository settings
+and not in this tree.
 
 ### Packaging
 

--- a/cad/freecad/partcad_freecad/importer.py
+++ b/cad/freecad/partcad_freecad/importer.py
@@ -69,6 +69,13 @@ def _import_module():
     try:
         import FreeCADGui  # noqa: F401  pylint: disable=unused-import,import-outside-toplevel
 
+        # `isort: split` because the import above is a *probe*: it exists only
+        # to raise ImportError when FreeCAD is running headless, so that the
+        # fallback below is chosen for a reason this function states rather than
+        # by whatever `ImportGui` does when there is no GUI behind it. That the
+        # two happen to be in alphabetical order is a coincidence, and the blank
+        # line that used to keep them apart was one isort removes.
+        # isort: split
         import ImportGui  # pylint: disable=import-outside-toplevel
 
         return ImportGui

--- a/dev-tools/build-backend/partcad_build_backend.py
+++ b/dev-tools/build-backend/partcad_build_backend.py
@@ -41,8 +41,6 @@ development environment -- over a data file the developer can fix with one
 import json
 import os
 
-from setuptools.command.egg_info import manifest_maker
-
 # Everything a PEP 517 frontend may call. The hooks not named below are
 # re-exported unchanged, which is the point: this is setuptools, with a
 # precondition, and the day setuptools grows a hook it should arrive here
@@ -50,6 +48,7 @@ from setuptools.command.egg_info import manifest_maker
 from setuptools.build_meta import *  # noqa: F401,F403
 from setuptools.build_meta import build_sdist as _build_sdist
 from setuptools.build_meta import build_wheel as _build_wheel
+from setuptools.command.egg_info import manifest_maker
 
 # Relative to the project root, which is the directory a PEP 517 build runs in.
 _PACKAGE = os.path.join("src", "partcad", "ai_agents")

--- a/dev-tools/bumpversion.toml
+++ b/dev-tools/bumpversion.toml
@@ -181,4 +181,3 @@ replace = "devcontainer:{new_version}"
 filename = ".devcontainer/Dockerfile"
 search = "IMAGE_VERSION={current_version}"
 replace = "IMAGE_VERSION={new_version}"
-

--- a/dev-tools/noxfile.py
+++ b/dev-tools/noxfile.py
@@ -1,4 +1,4 @@
-from nox_poetry import session, Session
+from nox_poetry import Session, session
 
 
 @session(python=["3.10", "3.11", "3.12"])

--- a/dev-tools/pre-commit-config.yaml
+++ b/dev-tools/pre-commit-config.yaml
@@ -118,6 +118,16 @@ repos:
   # is sorted despite the skip, which is precisely the reordering the skip
   # exists to prevent. `--settings-path` for the same reason -- the config is
   # found from the repository root rather than from each file's directory.
+  #
+  # The `exclude:` on all three is `examples/` and `features/`, the two trees
+  # `pyproject.toml` holds out -- the comment above `[tool.black]` there says
+  # which idiom each of them is full of and why waiving it is a decision of its
+  # own. isort and black are configured to skip them and would skip them
+  # without this; flake8 is *not*, because its `extend-exclude` governs only
+  # the files it discovers by walking, and pre-commit hands a hook the staged
+  # files by name. So one of the three needs this line and the other two carry
+  # it to say, on the hook itself, what that hook looks at. If the held-out set
+  # changes it changes in `pyproject.toml` and in these three places.
   - repo: local
     hooks:
       - id: isort
@@ -127,6 +137,36 @@ repos:
         language: python
         additional_dependencies: ["isort==8.0.1"]
         types: [python]
+        exclude: ^(examples|features)/
+      # black and flake8 join isort on the same terms: local rather than a hook
+      # repository (nothing to clone, so a gitconfig that rewrites GitHub to SSH
+      # cannot break the install), pinned to the version `pyproject.toml`
+      # resolves, and mirrored by a job in `test.yml`.
+      #
+      # black holds back the two trees above and nothing else. The sandbox
+      # scripts isort skips are skipped because their *import order* is load
+      # bearing, and black never reorders imports -- it only wraps lines, which
+      # is safe there. (It needs `force-exclude` rather than `extend-exclude`
+      # for what it does hold back, for the reason `--filter-files` is on the
+      # isort line above: `pre-commit` passes files by name.)
+      - id: black
+        name: black
+        description: formatting, as configured in pyproject.toml
+        entry: black --check --diff
+        language: python
+        additional_dependencies: ["black==26.5.1"]
+        types: [python]
+        exclude: ^(examples|features)/
+      # `Flake8-pyproject` is not optional here: without it flake8 does not read
+      # `[tool.flake8]` at all and checks at its own 79-column default.
+      - id: flake8
+        name: flake8
+        description: lint, as configured in pyproject.toml
+        entry: flake8
+        language: python
+        additional_dependencies: ["flake8==7.3.0", "Flake8-pyproject==1.2.4"]
+        types: [python]
+        exclude: ^(examples|features)/
   - repo: local
     hooks:
       - id: shellcheck

--- a/ide/standalone/tests/test_bootstrap.py
+++ b/ide/standalone/tests/test_bootstrap.py
@@ -20,6 +20,7 @@ import json
 import re
 
 import pytest
+
 from conftest import COMPONENT_ROOT, REPO_ROOT
 
 BOOTSTRAP = COMPONENT_ROOT / "bootstrap"

--- a/ide/standalone/tests/test_brand.py
+++ b/ide/standalone/tests/test_brand.py
@@ -11,6 +11,7 @@ import plistlib
 
 import brand
 import pytest
+
 from conftest import COMPONENT_ROOT
 
 VSCODIUM_GALLERY = {"serviceUrl": "https://open-vsx.org/vscode/gallery", "itemUrl": "https://open-vsx.org/vscode/item"}

--- a/ide/standalone/tests/test_copy_examples.py
+++ b/ide/standalone/tests/test_copy_examples.py
@@ -14,8 +14,9 @@ import json
 
 import copy_examples
 import pytest
-from conftest import COMPONENT_ROOT, REPO_ROOT
 from copy_examples import ManifestError
+
+from conftest import COMPONENT_ROOT, REPO_ROOT
 
 MANIFEST = COMPONENT_ROOT / "bootstrap" / "examples.json"
 

--- a/ide/standalone/tests/test_icons.py
+++ b/ide/standalone/tests/test_icons.py
@@ -25,6 +25,7 @@ import struct
 
 import make_icons
 import pytest
+
 from conftest import COMPONENT_ROOT
 
 ICON = COMPONENT_ROOT / "resources" / "partcad-ide.ico"

--- a/ide/standalone/tests/test_jsonc.py
+++ b/ide/standalone/tests/test_jsonc.py
@@ -8,9 +8,9 @@
 
 import json
 
+import jsonc
 import pytest
 
-import jsonc
 from conftest import REPO_ROOT
 
 

--- a/ide/standalone/tests/test_resolve_extensions.py
+++ b/ide/standalone/tests/test_resolve_extensions.py
@@ -8,8 +8,9 @@
 
 import pytest
 import resolve_extensions
-from conftest import COMPONENT_ROOT, REPO_ROOT
 from resolve_extensions import PolicyError, build_plan
+
+from conftest import COMPONENT_ROOT, REPO_ROOT
 
 
 def test_a_recommendation_is_installed_from_the_gallery_by_default():

--- a/ide/standalone/tests/test_verify_bundle.py
+++ b/ide/standalone/tests/test_verify_bundle.py
@@ -15,6 +15,7 @@ import stat
 import brand
 import pytest
 import verify_bundle
+
 from conftest import COMPONENT_ROOT
 
 PLAN = {
@@ -176,9 +177,7 @@ def test_the_activity_bar_is_reported(tmp_path, capsys):
     extensions = resources / "app" / "extensions"
     manifest = extensions / "PartCAD.partcad-official-1.0.0" / "package.json"
     package = json.loads(manifest.read_text(encoding="utf-8"))
-    package["contributes"] = {
-        "viewsContainers": {"activitybar": [{"id": "partcad-container", "title": "PartCAD"}]}
-    }
+    package["contributes"] = {"viewsContainers": {"activitybar": [{"id": "partcad-container", "title": "PartCAD"}]}}
     manifest.write_text(json.dumps(package), encoding="utf-8")
 
     assert run(resources, tmp_path) == 0

--- a/poetry.lock
+++ b/poetry.lock
@@ -1791,6 +1791,24 @@ pycodestyle = ">=2.14.0,<2.15.0"
 pyflakes = ">=3.4.0,<3.5.0"
 
 [[package]]
+name = "flake8-pyproject"
+version = "1.2.4"
+description = "Flake8 plug-in loading the configuration from pyproject.toml"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "flake8_pyproject-1.2.4-py3-none-any.whl", hash = "sha256:ea34c057f9a9329c76d98723bb2bb498cc6ba8ff9872c4d19932d48c91249a77"},
+]
+
+[package.dependencies]
+Flake8 = ">=5"
+TOMLi = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["Flit (>=3.4)", "pyTest (>=7)", "pyTest-cov (>=7) ; python_version >= \"3.10\""]
+
+[[package]]
 name = "flask"
 version = "3.1.3"
 description = "A simple framework for building complex web applications."
@@ -7303,4 +7321,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "07b9017b471b35787bdbe02e0d2286d519e670b81d1832997ce747e880dbf60d"
+content-hash = "b7d2cb345a0d23fb56aff0c19ba188bd9eba5ecf024bf372f519a4cc0475baf9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,23 +204,105 @@ markers = [
 # format = "allure_behave.formatter:AllureFormatter"
 # outfile = "allure-results"
 
+# What the three linters check, stated once here rather than three times on
+# three command lines: `isort`, `black` and `flake8` are all invoked on `.`, by
+# the `pre-commit` hooks and by the `Lint (...)` jobs in
+# ".github/workflows/test.yml" alike, so this file is the only place the scope
+# is written down and a hook and a job cannot come to disagree about it.
+#
+# The scope is "PartCAD's own Python": "src/", "tests/", "cad/", "dev-tools/",
+# "ide/", "tools/", "docs/" and the root "conftest.py". Two trees are held out,
+# and not because they are unimportant:
+#
+#   * "examples/" is CAD part scripts, written the way a *user* writes one --
+#     `from build123d import *`, and a `show_object` the runner injects at
+#     execution time. flake8 reports 102 findings there and essentially all of
+#     them are that idiom (F403/F405/F401/F821), which is why `[tool.ruff.lint]`
+#     below already waives exactly those three for `pc lint` of a part. Sorting
+#     their imports carries the wrappers' risk too: these are sandbox scripts,
+#     and their rendered output is checked in.
+#   * "features/" is `behave` step definitions, where every module defines
+#     several functions called `step_impl` and the decorator is what
+#     distinguishes them. 29 of its 56 findings are F811 "redefinition of
+#     unused 'step_impl'" -- the framework's idiom, reported as a defect.
+#
+# Covering either means deciding which codes to waive across a whole directory,
+# which is a policy question and a change of its own -- not something to settle
+# inside a change whose point is that the gate agrees with the tree.
+#
+# `force-exclude` rather than `extend-exclude`: black applies `extend-exclude`
+# only to files it *discovers* by walking, and `pre-commit` hands it the staged
+# files by name. `force-exclude` is the one black also applies to those. This is
+# the same trap as isort's `--filter-files` below.
 [tool.black]
 line-length = 120
 target-version = ['py310']
+force-exclude = """
+^/(examples|features)/
+"""
 
+# Read only because `Flake8-pyproject` is installed: flake8 itself has never
+# supported `pyproject.toml`. Without that plugin this whole table was inert and
+# flake8 fell back to its built-in defaults -- which is why it used to report
+# E501 at 79 columns on a repository that formats at 120, and why nobody could
+# run it usefully.
 [tool.flake8]
-exclude = ".venv"
-extend-ignore = "E203"
+# `extend-exclude` rather than `exclude`, which *replaces* flake8's built-in
+# list (".git", "__pycache__", ".tox", ".eggs", ...) instead of adding to it.
+# ".venv" has to be named either way -- it is not in that built-in list, and
+# `poetry.toml` sets `in-project = true`, so the virtualenv is inside the tree
+# a `flake8 .` walks.
+#
+# Note that unlike black's `force-exclude` and isort's `--filter-files`, this
+# governs *discovery* only: flake8 has no force-exclude, and checks any file
+# handed to it by name regardless. That is why the `flake8` hook in
+# "dev-tools/pre-commit-config.yaml" carries an `exclude:` of its own -- the
+# one place the two trees above are named twice, and the comment there says so.
+extend-exclude = ".venv,examples,features"
 max-line-length = 120
 
-[tool.pylint."messages control"]
-ignore = ["setup.py", "__init__.py"]
-disable = "all"
-enable = [
-  "empty-docstring",
-  "missing-class-docstring",
-  "missing-function-docstring",
-  "missing-module-docstring"
+# E203 is the usual black-compatibility waiver (black puts a space before the
+# `:` in a slice; pycodestyle disagrees, and black wins).
+#
+# E501 is waived because *black* owns line length here, at the same 120 stated
+# above. What is left over after black has run is the handful of long string
+# literals black deliberately will not split, so flake8's copy of the rule only
+# ever disagrees with the formatter that already ran.
+#
+# E722 and E731 are deferred rather than endorsed: a bare `except:` and a
+# `name = lambda ...` each need a per-site judgement (what should be caught,
+# whether the alias wants to become a `def`), and neither is a correctness
+# question. Turning either on is its own change.
+extend-ignore = "E203,E501,E722,E731"
+
+# The files where a finding is the idiom rather than a defect. The first two
+# entries are the same paths `[tool.isort]` skips below, for the same reason:
+# these scripts run inside a CAD sandbox, add their own directory to `sys.path`
+# and then import their neighbours by bare name, so a late import (E402) and an
+# import that only exists for its side effect (F401) are the design.
+#
+# The patterns are repository-relative because that is how CI and the hook
+# invoke flake8 (`flake8 src tests` from the root), and flake8 fnmatches them
+# against the path it was handed. fnmatch's `*` spans `/`, so the two
+# directory entries below also cover the files nested one level deeper.
+per-file-ignores = [
+  "src/partcad/wrappers/*:E402,F401,F403,F405,F841,E721",
+  "src/partcad/builtin/*:E402,F401,F403,F405",
+  # Pins expat, sanitises the environment and aliases `partcad_utils.*` in, each
+  # before the thing that needs it, then re-exports the public API.
+  "src/partcad/__init__.py:E402,F401,F403,F405",
+  # `import *` is how these compose their namespace.
+  "src/partcad/context.py:F403,F405",
+  "src/partcad/plugin_provider.py:F403,F405",
+  "src/partcad/plugin_factory_provider_manufacturer.py:F403,F405",
+  "src/partcad/plugin_factory_provider_store.py:F403,F405",
+  "src/partcad/plugin_request_provider_quote.py:F403,F405",
+  # Import after a `sys.path` mutation, like the wrappers.
+  "src/partcad/shape.py:E402",
+  "src/partcad/healthcheck/tests.py:E402",
+  "tests/partcad_service_json_rpc/test_ansi_rendering.py:E402",
+  # A CQGI part script: the runner injects `show_object` at execution time.
+  "tests/partcad/unit/data/*:F821",
 ]
 
 [tool.isort]
@@ -267,15 +349,36 @@ known_first_party = [
 # commit that sorted it. The comments in those files say the same thing, but a
 # comment does not stop `isort .`.
 extend_skip = ["src/partcad/__init__.py"]
-extend_skip_glob = ["*/src/partcad/wrappers/*", "*/src/partcad/builtin/*"]
+# The last two are the held-out trees the comment above `[tool.black]`
+# explains; the first two are the sandbox scripts this comment is about.
+extend_skip_glob = [
+  "src/partcad/wrappers/*",
+  "src/partcad/builtin/*",
+  "examples/*",
+  "features/*",
+]
 
-[tools.pyright]
+# Read by Pylance, which `.devcontainer/devcontainer.json` recommends, and by
+# `pyright` if anyone runs it. The table was spelled `[tools.pyright]` until
+# 2026-09 -- one letter, and the wrong one: `tools` is not a table any tool
+# looks in, so these two settings had never applied to anything. Nothing here
+# gates: there is no type checker in any dependency group, so this is editor
+# diagnostics only, and adopting one is a decision of its own.
+[tool.pyright]
 reportMissingTypeArgument = true  # Report generic classes used without type arguments
 strictListInference = true  # Use union types when inferring types of lists elements, instead of Any
 
 # export POETRY_MULTIPROJECT_CHECK_DIR="/tmp/.check_partcad-dev"
 # export POETRY_MULTIPROJECT_PREPARE_DIR="/tmp/.prepare_partcad-dev"
 
+# NOT this repository's own linting. `ruff` is a runtime dependency of PartCAD
+# (the `partcad` group), and `partcad.lint.python` shells out to it to lint the
+# *user's* part scripts: `ruff check --no-cache --output-format=json <target>`,
+# with neither `--config` nor `--isolated`, so ruff discovers configuration by
+# walking up from the file it was handed. This block therefore applies when
+# `pc lint` runs on a part inside this repository -- the examples -- and never
+# to `src/`. The three codes are waived because a CAD part script is written as
+# `from build123d import *` and leans on the star import.
 [tool.ruff.lint]
 ignore = ["F401", "F403", "F405"]
 
@@ -305,13 +408,17 @@ packages = [
 # `poetry install` installs it editable and the groups add what the suites need.
 #
 [tool.poetry.group.dev.dependencies]
-# black and isort are not run by any CI job or pre-commit hook (see
-# dev-tools/pre-commit-config.yaml), so these are the versions a developer
-# gets, not a gate. Note that black 26's stable style reformats ~54 files in
-# this repo and isort does not agree with the tree as committed today;
-# applying either belongs in its own PR, not in a dependency bump.
+# All three gate: each is a `pre-commit` hook and a `Lint (...)` job in
+# `test.yml`, and each of those pins the version this group resolves, so the
+# hook and the job cannot disagree about what "clean" means. Bumping one of
+# these therefore reformats or re-lints the tree -- do it in a change of its
+# own, and update the pin in both places at the same time.
 black = "^26.5.1"
 flake8 = "^7.3.0"
+# flake8 cannot read `pyproject.toml` on its own. Without this plugin the
+# `[tool.flake8]` table above is inert and flake8 silently falls back to its
+# own defaults -- 79 columns on a repository that formats at 120.
+Flake8-pyproject = "^1.2.3"
 isort = "^8.0.1"
 sentry-sdk = {extras = ["opentelemetry"], version = "^2.66.0"}
 poetry-plugin-shell = "^1.0.1"

--- a/src/partcad/AGENTS.md
+++ b/src/partcad/AGENTS.md
@@ -37,9 +37,10 @@ flake8 src/partcad tests/partcad
 isort --check --filter-files src/partcad tests/partcad
 ```
 
-Only `isort` gates: it is a `pre-commit` hook and the `Lint (isort)` job in `test.yml`. `black` and `flake8`
-report pre-existing findings that are nobody's change in particular — the root [AGENTS.md](../../AGENTS.md) has the
-counts and what each would take to turn on.
+All three gate — each is a `pre-commit` hook and a `Lint (...)` job in `test.yml`, and the tree satisfies
+all three, so a finding from any of them is yours. See the root [AGENTS.md](../../AGENTS.md) for the two flags that
+are load-bearing (`--filter-files`, and the `Flake8-pyproject` plugin without which flake8 reads no config
+at all).
 
 ## Conventions
 

--- a/src/partcad/actions/package/search.py
+++ b/src/partcad/actions/package/search.py
@@ -4,10 +4,4 @@ from partcad.project import Project
 
 
 def search_packages(ctx: Context, package: str, recursive: bool, keyword: str) -> list[Project]:
-    return _search(
-        ctx,
-        package,
-        recursive,
-        keyword,
-        lambda project: [project]
-    )
+    return _search(ctx, package, recursive, keyword, lambda project: [project])

--- a/src/partcad/actions/part/__init__.py
+++ b/src/partcad/actions/part/__init__.py
@@ -3,7 +3,7 @@ from .convert import convert_part_action
 from .import_part import import_part_action
 
 __all__ = [
-  "add_part_action",
-  "import_part_action",
-  "convert_part_action",
+    "add_part_action",
+    "import_part_action",
+    "convert_part_action",
 ]

--- a/src/partcad/actions/scene/import_world.py
+++ b/src/partcad/actions/scene/import_world.py
@@ -42,9 +42,7 @@ def import_world_action(project: Project, scene_file: str, config: dict) -> str:
 
     name = Path(scene_file).stem
     if project.get_scene_config(name) is not None:
-        raise ValueError(
-            "The package already has a scene named '%s'; rename the world file or remove it first" % name
-        )
+        raise ValueError("The package already has a scene named '%s'; rename the world file or remove it first" % name)
 
     world_config = {"type": "world", "path": str(Path(scene_file).resolve())}
     # What the world reader takes from a scene's declaration. An import has

--- a/src/partcad/actions/shape/__init__.py
+++ b/src/partcad/actions/shape/__init__.py
@@ -1,9 +1,3 @@
 from .search import search_assemblies, search_interfaces, search_parts, search_scenes, search_sketches
 
-__all__ = [
-    "search_parts",
-    "search_assemblies",
-    "search_scenes",
-    "search_sketches",
-    "search_interfaces"
-]
+__all__ = ["search_parts", "search_assemblies", "search_scenes", "search_sketches", "search_interfaces"]

--- a/src/partcad/actions/shape/search.py
+++ b/src/partcad/actions/shape/search.py
@@ -8,46 +8,20 @@ from partcad.sketch import Sketch
 
 
 def search_parts(ctx: Context, package: str, recursive: bool, keyword: str) -> list[Part]:
-    return _search(
-        ctx,
-        package,
-        recursive,
-        keyword,
-        lambda project: project.parts.values()
-    )
+    return _search(ctx, package, recursive, keyword, lambda project: project.parts.values())
+
 
 def search_sketches(ctx: Context, package: str, recursive: bool, keyword: str) -> list[Sketch]:
-    return _search(
-        ctx,
-        package,
-        recursive,
-        keyword,
-        lambda project: project.sketches.values()
-    )
+    return _search(ctx, package, recursive, keyword, lambda project: project.sketches.values())
+
 
 def search_assemblies(ctx: Context, package: str, recursive: bool, keyword: str) -> list[Assembly]:
-    return _search(
-        ctx,
-        package,
-        recursive,
-        keyword,
-        lambda project: project.assemblies.values()
-    )
+    return _search(ctx, package, recursive, keyword, lambda project: project.assemblies.values())
+
 
 def search_scenes(ctx: Context, package: str, recursive: bool, keyword: str) -> list[Scene]:
-    return _search(
-        ctx,
-        package,
-        recursive,
-        keyword,
-        lambda project: project.scenes.values()
-    )
+    return _search(ctx, package, recursive, keyword, lambda project: project.scenes.values())
+
 
 def search_interfaces(ctx: Context, package: str, recursive: bool, keyword: str) -> list[Interface]:
-    return _search(
-        ctx,
-        package,
-        recursive,
-        keyword,
-        lambda project: project.interfaces.values()
-    )
+    return _search(ctx, package, recursive, keyword, lambda project: project.interfaces.values())

--- a/src/partcad/actions/sketch/__init__.py
+++ b/src/partcad/actions/sketch/__init__.py
@@ -1,5 +1,5 @@
 from .convert import convert_sketch_action
 
 __all__ = [
-  "convert_sketch_action",
+    "convert_sketch_action",
 ]

--- a/src/partcad/actions/sketch/convert.py
+++ b/src/partcad/actions/sketch/convert.py
@@ -1,5 +1,5 @@
 import shutil
-import time
+import time  # noqa: F401
 from pathlib import Path
 from typing import Optional
 

--- a/src/partcad/actions/sketch/convert.py
+++ b/src/partcad/actions/sketch/convert.py
@@ -1,5 +1,4 @@
 import shutil
-import time  # noqa: F401
 from pathlib import Path
 from typing import Optional
 

--- a/src/partcad/assembly_factory_assy.py
+++ b/src/partcad/assembly_factory_assy.py
@@ -181,7 +181,6 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
         check_stage_sequence(node_list, self.name)
 
         async def wait_for_tasks():
-            nonlocal tasks
             while len(tasks) > 0:
                 task = tasks.pop(0)
                 f = await asyncio.tasks.wait([task])
@@ -242,8 +241,8 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
         connect_to_port_pattern = None
         # "location" is an optional parameter for both parts and assemblies
         if "location" in node:
-            l = node["location"]
-            location = Location((l[0][0], l[0][1], l[0][2]), (l[1][0], l[1][1], l[1][2]), l[2])
+            loc = node["location"]
+            location = Location((loc[0][0], loc[0][1], loc[0][2]), (loc[1][0], loc[1][1], loc[1][2]), loc[2])
         elif "connect" in node:
             connect = node["connect"]
             connect_with_iface = connect.get("with", None)
@@ -293,7 +292,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
             connect_to_port = None
 
         # Check if this node is for an assembly
-        if "links" in node and not node["links"] is None:
+        if "links" in node and node["links"] is not None:
             item = Assembly(
                 assembly.project_name,
                 {
@@ -367,7 +366,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                     if (
                         connect_with_iface is None
                         and item.with_ports is not None
-                        and not "ports" in item.with_ports.config
+                        and "ports" not in item.with_ports.config
                         and len(list(item.with_ports.get_interfaces().keys())) == 1
                     ):
                         connect_with_iface = list(item.with_ports.get_interfaces().keys())[0]
@@ -395,7 +394,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                                 )
 
                     # If the source port is known, then use it
-                    if not connect_with_port is None:
+                    if connect_with_port is not None:
                         source_port = item.with_ports.get_ports()[connect_with_port]
                         pc_logging.debug("Configured source port: %s" % source_port.name)
                     else:
@@ -408,7 +407,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                     if (
                         connect_to_iface is None
                         and target_part.with_ports is not None
-                        and not "ports" in target_part.with_ports.config
+                        and "ports" not in target_part.with_ports.config
                         and len(list(target_part.with_ports.get_interfaces().keys())) == 1
                     ):
                         connect_to_iface = list(target_part.with_ports.get_interfaces().keys())[0]
@@ -435,7 +434,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                                 )
 
                     # If the target port is configured, then use it
-                    if not connect_to_port is None:
+                    if connect_to_port is not None:
                         target_port = target_part.with_ports.get_ports()[connect_to_port]
                         pc_logging.debug("Configured target port: %s" % target_port.name)
                     else:
@@ -527,8 +526,8 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                                     )
                                 )
 
-                        if not connect_with_instance is None:
-                            if not connect_with_instance in source_iface:
+                        if connect_with_instance is not None:
+                            if connect_with_instance not in source_iface:
                                 pc_logging.error(
                                     "Connect %s to %s: source instance is not found: %s"
                                     % (
@@ -636,8 +635,8 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                                     )
                                 )
 
-                        if not connect_to_instance is None:
-                            if not connect_to_instance in target_iface:
+                        if connect_to_instance is not None:
+                            if connect_to_instance not in target_iface:
                                 pc_logging.error(
                                     "Connect %s to %s: target instance is not found: %s"
                                     % (
@@ -789,7 +788,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                                 connect_to_port = target_iface_instance[target_ports[connect_to_port_index]]
 
                     # If the source port is determined, then use it
-                    if not connect_with_port is None and source_port is None:
+                    if connect_with_port is not None and source_port is None:
                         source_port = item.with_ports.get_ports()[connect_with_port]
                         pc_logging.debug("Found source port: %s" % source_port.name)
                     if connect_with_port is not None and connect_with_port_pattern is not None:
@@ -799,7 +798,7 @@ class AssemblyFactoryAssy(AssemblyFactoryFile):
                             )
 
                     # If the target port is determined, then use it
-                    if not connect_to_port is None and target_port is None:
+                    if connect_to_port is not None and target_port is None:
                         target_port = target_part.with_ports.get_ports()[connect_to_port]
                         pc_logging.debug("Found target port: %s" % target_port.name)
                     if connect_to_port is not None and connect_to_port_pattern is not None:

--- a/src/partcad/cache.py
+++ b/src/partcad/cache.py
@@ -61,9 +61,7 @@ class Cache:
 
         async def task_backend(backend):
             accepted = {
-                self._name(hash_str, key): value
-                for key, value in items.items()
-                if backend.accepts(key, len(value))
+                self._name(hash_str, key): value for key, value in items.items() if backend.accepts(key, len(value))
             }
             if not accepted:
                 return {}

--- a/src/partcad/cache_hash.py
+++ b/src/partcad/cache_hash.py
@@ -8,8 +8,8 @@
 #
 
 import hashlib
-import os
-import struct
+import os  # noqa: F401
+import struct  # noqa: F401
 
 from . import logging as pc_logging
 

--- a/src/partcad/cache_hash.py
+++ b/src/partcad/cache_hash.py
@@ -8,8 +8,6 @@
 #
 
 import hashlib
-import os  # noqa: F401
-import struct  # noqa: F401
 
 from . import logging as pc_logging
 

--- a/src/partcad/context.py
+++ b/src/partcad/context.py
@@ -191,7 +191,7 @@ class Context:
     class PackageLock(object):
         def __init__(self, ctx, package_name: str):
             ctx.project_locks_lock.acquire()
-            if not package_name in ctx.project_locks:
+            if package_name not in ctx.project_locks:
                 ctx.project_locks[package_name] = threading.Lock()
             self.lock = ctx.project_locks[package_name]
             ctx.project_locks_lock.release()
@@ -645,7 +645,7 @@ class Context:
                     "path": next_import,
                 }
                 next_project = self.import_project(project, prj_conf)
-                if not next_project is None:
+                if next_project is not None:
                     result = self._get_project_recursive(next_project, import_list)
                     return result
         else:
@@ -667,7 +667,7 @@ class Context:
                         prj_conf["orig_name"] = prj_conf["name"]
                     prj_conf["name"] = next_project_path
                     next_project = self.import_project(project, prj_conf)
-                    if not next_project is None:
+                    if next_project is not None:
                         result = self._get_project_recursive(next_project, import_list)
                         return result
                     break
@@ -883,7 +883,7 @@ class Context:
         source_interface_name = source_interface.full_name
         target_interface_name = target_interface.full_name
 
-        if not source_interface_name in self.mates:
+        if source_interface_name not in self.mates:
             self.mates[source_interface_name] = {}
         if target_interface_name in self.mates[source_interface_name]:
             pc_logging.debug("Mate already exists: %s -> %s" % (source_interface_name, target_interface_name))
@@ -894,9 +894,9 @@ class Context:
         self.mates[source_interface_name][target_interface_name] = mate
 
     def get_mate(self, source_interface_name, target_interface_name) -> Mating | None:
-        if not source_interface_name in self.mates:
+        if source_interface_name not in self.mates:
             return None
-        if not target_interface_name in self.mates[source_interface_name]:
+        if target_interface_name not in self.mates[source_interface_name]:
             return None
 
         return self.mates[source_interface_name][target_interface_name]
@@ -922,7 +922,7 @@ class Context:
         real_source_interfaces = {interface: set([interface]) for interface in source_interfaces}
         for interface in source_interfaces:
             for compatible_interface in self.get_interface(interface).compatible_with:
-                if not compatible_interface in real_source_interfaces:
+                if compatible_interface not in real_source_interfaces:
                     real_source_interfaces[compatible_interface] = set()
                 real_source_interfaces[compatible_interface].add(interface)
 
@@ -943,7 +943,7 @@ class Context:
         real_target_interfaces = {interface: set([interface]) for interface in target_interfaces}
         for interface in target_interfaces:
             for compatible_interface in self.get_interface(interface).compatible_with:
-                if not compatible_interface in real_target_interfaces:
+                if compatible_interface not in real_target_interfaces:
                     real_target_interfaces[compatible_interface] = set()
                 real_target_interfaces[compatible_interface].add(interface)
         target_interfaces = target_interfaces.union(compatible_target_interfaces)
@@ -1157,7 +1157,7 @@ class Context:
 
         # Place each part in the corresponding supplier cart
         for part_spec, provider_name in preferred_suppliers.items():
-            if not provider_name in supplier_carts:
+            if provider_name not in supplier_carts:
                 supplier_carts[provider_name] = ProviderCart()
             cart_item = await supplier_carts[provider_name].add_part_spec(self, part_spec)
 
@@ -1545,7 +1545,7 @@ class Context:
             if python_runtime not in ("docker", "remote"):
                 image = None
             runtime_name = python_runtime + "-" + version + ("@" + image if image else "")
-            if not runtime_name in self.runtimes_python:
+            if runtime_name not in self.runtimes_python:
                 self.runtimes_python[runtime_name] = runtime_python_all.create(
                     self, version, python_runtime, image=image
                 )

--- a/src/partcad/globals.py
+++ b/src/partcad/globals.py
@@ -44,7 +44,9 @@ from .part_factory_wrapper import PartFactoryWrapper
 from .plugin_factory_provider_enrich import PluginFactoryProviderEnrich
 from .plugin_factory_provider_manufacturer import PluginFactoryProviderManufacturer
 from .plugin_factory_provider_store import PluginFactoryProviderStore
-from .plugin_factory_repository import PluginFactoryRepository
+from .plugin_factory_repository import (  # noqa: F401  # imported for the registration side effect, like its siblings
+    PluginFactoryRepository,
+)
 from .plugin_factory_repository_basic import PluginFactoryRepositoryBasic
 
 # from .plugin_factory_repository_tree import PluginFactoryRepositoryTree
@@ -123,7 +125,6 @@ def init(config_path=None, search_root=True, user_config=UserConfig()) -> Contex
     """Initialize the default context explicitly using the desired path."""
     global _partcad_context
     global _partcad_context_path
-    global _partcad_context_lock
 
     with _partcad_context_lock:
         if _partcad_context is None:
@@ -140,7 +141,6 @@ def init(config_path=None, search_root=True, user_config=UserConfig()) -> Contex
 def fini():
     global _partcad_context
     global _partcad_context_path
-    global _partcad_context_lock
 
     with _partcad_context_lock:
         _partcad_context = None

--- a/src/partcad/healthcheck/available_disk_space.py
+++ b/src/partcad/healthcheck/available_disk_space.py
@@ -5,7 +5,7 @@
 #
 
 import shutil
-from pathlib import Path
+from pathlib import Path  # noqa: F401
 
 from partcad.user_config import user_config
 
@@ -40,7 +40,7 @@ class AvailableDiskSpaceCheck(HealthCheckTest):
                 self.findings.append(
                     f"Insufficient disk space. Need at least {self.min_space} GB free in {path}. Currently, only {free // (1024 * 1024 * 1024)} GB is available."
                 )
-        except Exception as e:
+        except Exception:
             self.findings.append("Error checking disk space")
 
         return HealthCheckReport(self.name, self.findings)

--- a/src/partcad/healthcheck/available_disk_space.py
+++ b/src/partcad/healthcheck/available_disk_space.py
@@ -5,7 +5,6 @@
 #
 
 import shutil
-from pathlib import Path  # noqa: F401
 
 from partcad.user_config import user_config
 

--- a/src/partcad/healthcheck/openscad.py
+++ b/src/partcad/healthcheck/openscad.py
@@ -149,7 +149,7 @@ class LinuxOpenSCADCheck(OpenSCADCheck):
         except subprocess.CalledProcessError as e:
             pc_logging.error("Failed to update apt package index.")
             pc_logging.debug(e)
-        except Exception as e:
+        except Exception:
             pc_logging.exception("Unexpected error during 'apt-get update'")
             return False
 
@@ -167,7 +167,7 @@ class LinuxOpenSCADCheck(OpenSCADCheck):
         except subprocess.CalledProcessError as e:
             pc_logging.error("OpenSCAD installation failed.")
             pc_logging.debug(e)
-        except Exception as e:
+        except Exception:
             pc_logging.exception("Unexpected error during OpenSCAD installation.")
 
         return False
@@ -307,7 +307,9 @@ class WindowsOpenSCADCheck(OpenSCADCheck):
                     new_path = ";".join(paths + [resolved_str])
                     winreg.SetValueEx(key, "PATH", 0, winreg.REG_EXPAND_SZ, new_path)
                     pc_logging.info(f"Added '{resolved_str}' to user PATH.")
-                    pc_logging.info("You may need to restart your PowerShell session or log out and back in for changes to take effect.")
+                    pc_logging.info(
+                        "You may need to restart your PowerShell session or log out and back in for changes to take effect."
+                    )
                 else:
                     pc_logging.info(f"'{resolved_str}' is already in the user PATH. No changes made.")
                 return True
@@ -320,14 +322,13 @@ class WindowsOpenSCADCheck(OpenSCADCheck):
 
         return False
 
-
     def fix(self) -> bool:
         pc_logging.info(f"Downloading OpenSCAD in '{self.installation_path}'...")
         try:
             urllib.request.urlretrieve(self.openscad_zip_url, self.openscad_zip_path)
             urllib.request.urlretrieve(self.openscad_zip_sha256_url, self.openscad_zip_sha256_path)
         except urllib.error.URLError as e:
-            pc_logging.error(f"Failed to download OpenSCAD.")
+            pc_logging.error("Failed to download OpenSCAD.")
             pc_logging.debug(str(e))
             return False
 
@@ -339,7 +340,7 @@ class WindowsOpenSCADCheck(OpenSCADCheck):
             pc_logging.error(f"SHA256 checksum file '{self.openscad_zip_sha256_path}' not found")
             return False
         except Exception as e:
-            pc_logging.error(f"Error reading SHA256 checksum file.")
+            pc_logging.error("Error reading SHA256 checksum file.")
             pc_logging.debug(str(e))
             return False
 
@@ -351,7 +352,7 @@ class WindowsOpenSCADCheck(OpenSCADCheck):
                     h.update(chunk)
             actual = h.hexdigest()
         except Exception as e:
-            pc_logging.error(f"Error computing SHA256 checksum")
+            pc_logging.error("Error computing SHA256 checksum")
             pc_logging.debug(str(e))
             return False
 
@@ -364,11 +365,11 @@ class WindowsOpenSCADCheck(OpenSCADCheck):
             with zipfile.ZipFile(self.openscad_zip_path, "r") as z:
                 z.extractall(self.installation_path)
         except zipfile.BadZipfile as e:
-            pc_logging.error(f"Failed to unpack OpenSCAD package.")
+            pc_logging.error("Failed to unpack OpenSCAD package.")
             pc_logging.debug(str(e))
             return False
         except Exception as e:
-            pc_logging.error(f"Error unpacking OpenSCAD package.")
+            pc_logging.error("Error unpacking OpenSCAD package.")
             pc_logging.debug(str(e))
             return False
 

--- a/src/partcad/healthcheck/tests.py
+++ b/src/partcad/healthcheck/tests.py
@@ -123,8 +123,8 @@ def run_healthchecks(filters: str = None, fix: bool = False, dry_run: bool = Fal
                             report.error(f"Auto fix raised: {error}")
                             pc_logging.exception(f"Healthcheck '{test.name}' failed while fixing")
                         if report.fixed:
-                            report.info(f"Auto fix successful")
+                            report.info("Auto fix successful")
                         else:
-                            report.error(f"Auto fix failed")
+                            report.error("Auto fix failed")
                 else:
-                    report.info(f"Passed")
+                    report.info("Passed")

--- a/src/partcad/interface.py
+++ b/src/partcad/interface.py
@@ -213,7 +213,7 @@ class InterfaceParameter:
             config["type"] = PARAM_TURN
             config["dir"] = [0.0, 0.0, 1.0]
 
-        if not "type" in config:
+        if "type" not in config:
             config["type"] = PARAM_MOVE
 
         return config
@@ -560,7 +560,7 @@ class Interface:
 
         # Enrich mating information
         mates = self.config.get("mates", None)
-        if not mates is None:
+        if mates is not None:
             if self.abstract:
                 pc_logging.error("Abstract interfaces cannot have mates: %s" % self.name)
                 return
@@ -579,7 +579,7 @@ class Interface:
         or the references to this interface in top level "mates" config sections
         of any project."""
         for target_interface_name, mate_target_config in mates.items():
-            if not ":" in target_interface_name:
+            if ":" not in target_interface_name:
                 target_interface_name = project.name + ":" + target_interface_name
             target_package_name, short_target_interface_name = project.resolve(target_interface_name)
 

--- a/src/partcad/lint/all.py
+++ b/src/partcad/lint/all.py
@@ -22,7 +22,6 @@ def get_partcad_schema():
 
 
 def get_linting_checks(concurrency_cap: int) -> list[Linting]:
-    global _global_lint_checks
     if concurrency_cap is None:
         concurrency_cap = max(os.cpu_count(), 8)
     Linting.MAX_CONCURRENT_CHECKS = concurrency_cap

--- a/src/partcad/lint/lint.py
+++ b/src/partcad/lint/lint.py
@@ -22,9 +22,11 @@ def semaphore_wrapper(f):
 
     return wrapper
 
+
 class Severity(Enum):
     FAILED = 1
     WARNING = 2
+
 
 class LintingReport:
     def __init__(self, package: str) -> None:
@@ -82,12 +84,7 @@ class Linting(ABC):
 
         result: LintingReport = await self.validate(ctx, package, target, lint_ctx)
 
-        await ctx.cache_lints.write_data_async(
-          hash,
-          {
-            cache_key: json.dumps(result.to_dict()).encode()
-          }
-        )
+        await ctx.cache_lints.write_data_async(hash, {cache_key: json.dumps(result.to_dict()).encode()})
 
         return result
 

--- a/src/partcad/lint/python.py
+++ b/src/partcad/lint/python.py
@@ -100,7 +100,7 @@ class PythonLinting(Linting):
             stdout, _ = await p.communicate()
             stdout = decode_output(stdout)
 
-            if stdout and 'passed' not in stdout:
+            if stdout and "passed" not in stdout:
                 for item in json.loads(stdout):
                     location = item.get("location", {})
                     linting_report.add(

--- a/src/partcad/part_factory_brep.py
+++ b/src/partcad/part_factory_brep.py
@@ -59,8 +59,7 @@ class PartFactoryBrep(PartFactoryFile):
             response = shape_envelope.deserialize(response_serialized)
             if not response.get("success", False):
                 message = response.get("exception") or (
-                    "the BREP wrapper reported failure without a message for '%s:%s'"
-                    % (part.project_name, part.name)
+                    "the BREP wrapper reported failure without a message for '%s:%s'" % (part.project_name, part.name)
                 )
                 pc_logging.error(message)
                 raise PartFactoryError(message)

--- a/src/partcad/part_factory_build123d.py
+++ b/src/partcad/part_factory_build123d.py
@@ -112,7 +112,10 @@ class PartFactoryBuild123d(PartFactoryPython):
             )
             if exitcode != 0 and len(errors) == 0:
                 errors = "%s: %s: Failed to instantiate" % (part.project_name, part.name)
-                pc_logging.debug("%s: %s: Failed to execute command: '%s' with exitcode %s" % (part.project_name, part.name, " ".join(command), exitcode))
+                pc_logging.debug(
+                    "%s: %s: Failed to execute command: '%s' with exitcode %s"
+                    % (part.project_name, part.name, " ".join(command), exitcode)
+                )
 
             if len(errors) > 0:
                 error_lines = errors.split("\n")

--- a/src/partcad/part_factory_cadquery.py
+++ b/src/partcad/part_factory_cadquery.py
@@ -118,7 +118,10 @@ class PartFactoryCadquery(PartFactoryPython):
 
             if exitcode != 0 and len(errors) == 0:
                 errors = "%s: %s: Failed to instantiate" % (part.project_name, part.name)
-                pc_logging.debug("%s: %s: Failed to execute command: '%s' with exitcode %s" % (part.project_name, part.name, " ".join(command), exitcode))
+                pc_logging.debug(
+                    "%s: %s: Failed to execute command: '%s' with exitcode %s"
+                    % (part.project_name, part.name, " ".join(command), exitcode)
+                )
 
             if len(errors) > 0:
                 error_lines = errors.split("\n")

--- a/src/partcad/part_factory_kicad.py
+++ b/src/partcad/part_factory_kicad.py
@@ -23,7 +23,7 @@ kicad_runtime_uses_docker = False
 
 
 async def get_runtime(ctx):
-    global kicad_runtime, kicad_runtime_uses_docker, kicad_runtime_lock
+    global kicad_runtime, kicad_runtime_uses_docker
     with kicad_runtime_lock:
         kicad_runtime = runtime.Runtime(ctx, "shell")
         kicad_runtime_uses_docker = ctx.user_config.use_docker_kicad

--- a/src/partcad/part_factory_obj.py
+++ b/src/partcad/part_factory_obj.py
@@ -58,8 +58,7 @@ class PartFactoryObj(PartFactoryFile):
             response = shape_envelope.deserialize(response_serialized)
             if not response.get("success", False):
                 message = response.get("exception") or (
-                    "the OBJ wrapper reported failure without a message for '%s:%s'"
-                    % (part.project_name, part.name)
+                    "the OBJ wrapper reported failure without a message for '%s:%s'" % (part.project_name, part.name)
                 )
                 pc_logging.error(message)
                 raise PartFactoryError(message)

--- a/src/partcad/part_factory_wrapper.py
+++ b/src/partcad/part_factory_wrapper.py
@@ -31,9 +31,7 @@ class PartFactoryWrapper(PartFactory):
 
             # 'type' is '<package>:<partType>' by the time we get here.
             self.part_type_ref = config["type"]
-            self.part_type_package, self.part_type_name = resolve_resource_path(
-                target_project.name, self.part_type_ref
-            )
+            self.part_type_package, self.part_type_name = resolve_resource_path(target_project.name, self.part_type_ref)
 
             python_version = self.project.python_version or sandbox_versions.DEFAULT_PYTHON_VERSION
             self.runtime = self.ctx.get_python_runtime(python_version, image=self.project.docker_image_declared)
@@ -99,9 +97,7 @@ class PartFactoryWrapper(PartFactory):
 
             pt_config = pt_project.get_part_type_config(self.part_type_name)
             if pt_config is None:
-                part.error(
-                    "partType '%s' not found in '%s'" % (self.part_type_name, self.part_type_package)
-                )
+                part.error("partType '%s' not found in '%s'" % (self.part_type_name, self.part_type_package))
                 return None
 
             kind = pt_config.get("kind", "wrapper")

--- a/src/partcad/plugin_factory_enrich.py
+++ b/src/partcad/plugin_factory_enrich.py
@@ -32,7 +32,7 @@ class PluginFactoryEnrich(PluginFactory):
                 self.source_plugin_name = config["source"]
             else:
                 self.source_plugin_name = config["name"]
-                if not "project" in config:
+                if "project" not in config:
                     raise Exception("Enrich needs either the source plugin name or the source project name")
 
             if "project" in config:

--- a/src/partcad/plugin_factory_file.py
+++ b/src/partcad/plugin_factory_file.py
@@ -71,7 +71,7 @@ class PluginFactoryFile(PluginFactory):
                 raise Exception("ERROR: The provider path (%s) must be a file" % self.path)
 
     async def prepare_script(self, provider) -> bool:
-        if not self.fileFactory is None and not os.path.exists(self.filePath):
+        if self.fileFactory is not None and not os.path.exists(self.filePath):
             with pc_logging.Action("File", self.target_project.name, provider.name):
                 await self.fileFactory.download(self.filePath)
 

--- a/src/partcad/plugin_factory_provider_manufacturer.py
+++ b/src/partcad/plugin_factory_provider_manufacturer.py
@@ -47,7 +47,7 @@ class PluginFactoryProviderManufacturer(PluginFactoryProvider):
         # TODO(clairbee): add vendor/SKU-based availability check
         caps = await self.plugin.get_caps()
         if cart_item.material:
-            if not cart_item.material in caps["materials"]:
+            if cart_item.material not in caps["materials"]:
                 return False
             if cart_item.color:
                 # TODO(clairbee): implement color mapping as a function in

--- a/src/partcad/plugin_factory_python.py
+++ b/src/partcad/plugin_factory_python.py
@@ -97,9 +97,7 @@ class PluginFactoryPython(PluginFactoryFile):
         # the stricter of the two floors.
         python_version = sandbox_versions.at_least(python_version, sandbox_versions.MIN_PYTHON_VERSION_CADQUERY)
 
-        self.runtime = self.ctx.get_python_runtime(
-            python_version, image=shape_docker_image(self.config, self.project)
-        )
+        self.runtime = self.ctx.get_python_runtime(python_version, image=shape_docker_image(self.config, self.project))
         self.session = self.runtime.get_session(source_project.name)
 
     def info(self, plugin: Plugin):

--- a/src/partcad/port.py
+++ b/src/partcad/port.py
@@ -54,7 +54,7 @@ class WithPorts(Interface):
                 if interface.abstract:
                     continue
 
-                if not ":" in interface_name:
+                if ":" not in interface_name:
                     interface_name = self.project.name + ":" + interface_name
 
                 if not compatible and interface_name not in self.interfaces:

--- a/src/partcad/project.py
+++ b/src/partcad/project.py
@@ -199,7 +199,7 @@ class Project(project_config.Configuration):
     class MaterialLock(object):
         def __init__(self, prj, material_name: str):
             prj.material_locks_lock.acquire()
-            if not material_name in prj.material_locks:
+            if material_name not in prj.material_locks:
                 prj.material_locks[material_name] = threading.Lock()
             self.lock = prj.material_locks[material_name]
             prj.material_locks_lock.release()
@@ -213,7 +213,7 @@ class Project(project_config.Configuration):
     class InterfaceLock(object):
         def __init__(self, prj, interface_name: str):
             prj.interface_locks_lock.acquire()
-            if not interface_name in prj.interface_locks:
+            if interface_name not in prj.interface_locks:
                 prj.interface_locks[interface_name] = threading.Lock()
             self.lock = prj.interface_locks[interface_name]
             prj.interface_locks_lock.release()
@@ -227,7 +227,7 @@ class Project(project_config.Configuration):
     class SketchLock(object):
         def __init__(self, prj, sketch_name: str):
             prj.sketch_locks_lock.acquire()
-            if not sketch_name in prj.sketch_locks:
+            if sketch_name not in prj.sketch_locks:
                 prj.sketch_locks[sketch_name] = threading.Lock()
             self.lock = prj.sketch_locks[sketch_name]
             prj.sketch_locks_lock.release()
@@ -241,7 +241,7 @@ class Project(project_config.Configuration):
     class PartLock(object):
         def __init__(self, prj, part_name: str):
             prj.part_locks_lock.acquire()
-            if not part_name in prj.part_locks:
+            if part_name not in prj.part_locks:
                 prj.part_locks[part_name] = threading.Lock()
             self.lock = prj.part_locks[part_name]
             prj.part_locks_lock.release()
@@ -255,7 +255,7 @@ class Project(project_config.Configuration):
     class AssemblyLock(object):
         def __init__(self, prj, assembly_name: str):
             prj.assembly_locks_lock.acquire()
-            if not assembly_name in prj.assembly_locks:
+            if assembly_name not in prj.assembly_locks:
                 prj.assembly_locks[assembly_name] = threading.Lock()
             self.lock = prj.assembly_locks[assembly_name]
             prj.assembly_locks_lock.release()
@@ -269,7 +269,7 @@ class Project(project_config.Configuration):
     class SceneLock(object):
         def __init__(self, prj, scene_name: str):
             prj.scene_locks_lock.acquire()
-            if not scene_name in prj.scene_locks:
+            if scene_name not in prj.scene_locks:
                 prj.scene_locks[scene_name] = threading.Lock()
             self.lock = prj.scene_locks[scene_name]
             prj.scene_locks_lock.release()
@@ -283,7 +283,7 @@ class Project(project_config.Configuration):
     class ProviderLock(object):
         def __init__(self, prj, provider_name: str):
             prj.provider_locks_lock.acquire()
-            if not provider_name in prj.provider_locks:
+            if provider_name not in prj.provider_locks:
                 prj.provider_locks[provider_name] = threading.Lock()
             self.lock = prj.provider_locks[provider_name]
             prj.provider_locks_lock.release()
@@ -297,7 +297,7 @@ class Project(project_config.Configuration):
     class RepositoryLock(object):
         def __init__(self, prj, repository_name: str):
             prj.repository_locks_lock.acquire()
-            if not repository_name in prj.repository_locks:
+            if repository_name not in prj.repository_locks:
                 prj.repository_locks[repository_name] = threading.Lock()
             self.lock = prj.repository_locks[repository_name]
             prj.repository_locks_lock.release()
@@ -441,7 +441,7 @@ class Project(project_config.Configuration):
 
         if (
             "desc" in self.config_obj
-            and not self.config_obj["desc"] is None
+            and self.config_obj["desc"] is not None
             and isinstance(self.config_obj["desc"], str)
         ):
             self.desc = self.config_obj["desc"].strip()
@@ -772,7 +772,7 @@ class Project(project_config.Configuration):
     def init_mates(self):
         mates = self.config_obj.get("mates", {})
         for source_interface_name, mate_config in mates.items():
-            if not ":" in source_interface_name:
+            if ":" not in source_interface_name:
                 source_interface_name = self.name + ":" + source_interface_name
             source_package_name, short_source_interface_name = self.resolve(source_interface_name)
 
@@ -888,7 +888,7 @@ class Project(project_config.Configuration):
                 return self.interfaces[interface_name]
 
             # This is just a regular interface name, no params (interface_name == result_name)
-            if not interface_name in self.interface_configs:
+            if interface_name not in self.interface_configs:
                 # We don't know anything about such a interface
                 pc_logging.error(
                     "Interface '%s' not found in '%s'",
@@ -964,7 +964,7 @@ class Project(project_config.Configuration):
         return self.object_config("partType", part_type_name)
 
     def get_object_config(self, object_name, configs: dict[str, dict[str, typing.Any]]):
-        if not object_name in configs:
+        if object_name not in configs:
             return None
         return configs[object_name]
 
@@ -1724,7 +1724,7 @@ class Project(project_config.Configuration):
 
             # Fill in the parameter values
             param_name: str
-            if "parameters" in config and not config["parameters"] is None:
+            if "parameters" in config and config["parameters"] is not None:
                 # Filling "parameters"
                 for param_name, param_value in params.items():
                     if config["parameters"][param_name]["type"] == "string":
@@ -1757,7 +1757,7 @@ class Project(project_config.Configuration):
                         config["parameters"][param_name]["default"] = param_value
             else:
                 # Filling "with"
-                if not "with" in config:
+                if "with" not in config:
                     config["with"] = {}
                 for param_name, param_value in params.items():
                     config["with"][param_name] = param_value
@@ -2613,7 +2613,7 @@ class Project(project_config.Configuration):
             lines += [usage]
             lines += [""]
 
-        if self.config_obj.get("dependencies", None) is not None and not "packages" in exclude:
+        if self.config_obj.get("dependencies", None) is not None and "packages" not in exclude:
             dependencies = copy.copy(self.config_obj["dependencies"])
             child_packages = self.get_child_project_names(absolute=False)
             display_dependencies = []
@@ -2725,7 +2725,7 @@ class Project(project_config.Configuration):
                 parameters += "</ul>\n"
                 columns += [parameters]
 
-            if not "images" in config and "desc" in config and "INSERT_IMAGE_HERE" in config["desc"]:
+            if "images" not in config and "desc" in config and "INSERT_IMAGE_HERE" in config["desc"]:
                 config["images"] = list(
                     re.findall(
                         r"INSERT_IMAGE_HERE\(([^)]*)\)",
@@ -2754,8 +2754,8 @@ class Project(project_config.Configuration):
 
             if hasattr(shape, "interfaces"):
                 interfaces = "Interfaces:<br/>"
-                for interface in shape.interfaces:
-                    interfaces += "- %s<br/>" % interface.name
+                for iface in shape.interfaces:
+                    interfaces += "- %s<br/>" % iface.name
                 columns += [interfaces]
 
             lines = ["### %s" % display_name]
@@ -2768,7 +2768,7 @@ class Project(project_config.Configuration):
             lines += [""]
             return lines
 
-        if self.assemblies and not "assemblies" in exclude:
+        if self.assemblies and "assemblies" not in exclude:
             lines += ["## Assemblies"]
             lines += [""]
             shape_names = sorted(self.assemblies.keys())
@@ -2782,7 +2782,7 @@ class Project(project_config.Configuration):
                     display_name = name
                 lines += add_section(name, display_name, shape, render_cfg)
 
-        if self.parts and not "parts" in exclude:
+        if self.parts and "parts" not in exclude:
             # Built first, and the heading only emitted if anything came of it:
             # 'add_section' skips a part with no rendered image, and a package
             # where that is true of every part would otherwise get a "## Parts"
@@ -2802,7 +2802,7 @@ class Project(project_config.Configuration):
                 lines += ["## Parts", ""]
                 lines += part_lines
 
-        if self.interfaces and not "interfaces" in exclude:
+        if self.interfaces and "interfaces" not in exclude:
             lines += ["## Interfaces"]
             lines += [""]
             shape_names = sorted(self.interfaces.keys())
@@ -2810,7 +2810,7 @@ class Project(project_config.Configuration):
                 shape = self.interfaces[name]
                 lines += add_section(name, name, shape, render_cfg)
 
-        if self.sketches and not "sketches" in exclude:
+        if self.sketches and "sketches" not in exclude:
             lines += ["## Sketches"]
             lines += [""]
             shape_names = sorted(self.sketches.keys())

--- a/src/partcad/project_config.py
+++ b/src/partcad/project_config.py
@@ -89,7 +89,7 @@ class Configuration:
         else:
             self.config_obj["name"] = name
 
-        if not "render" in self.config_obj or self.config_obj["render"] is None:
+        if "render" not in self.config_obj or self.config_obj["render"] is None:
             self.config_obj["render"] = {}
 
         # Backward compatibility for "import" -> "dependencies" renaming

--- a/src/partcad/project_external_repository.py
+++ b/src/partcad/project_external_repository.py
@@ -267,9 +267,7 @@ class ProjectExternalRepository(ProjectPlugin):
 
     async def _write_cache(self, scoped_key: str, value):
         try:
-            await self._cache.write_data_async(
-                self._cache_hash(scoped_key), {"data": json.dumps(value).encode()}
-            )
+            await self._cache.write_data_async(self._cache_hash(scoped_key), {"data": json.dumps(value).encode()})
         except Exception as e:
             pc_logging.debug("%s: cache write failed for '%s': %s" % (self.name, scoped_key, e))
 

--- a/src/partcad/project_factory.py
+++ b/src/partcad/project_factory.py
@@ -16,7 +16,7 @@ class ImportConfiguration:
     def __init__(self, config_obj: dict = {}, parent: p.Project | None = None):
         self.config_obj = config_obj
         self.name = config_obj.get("name")
-        if not "type" in config_obj:
+        if "type" not in config_obj:
             if "url" in config_obj:
                 if config_obj["url"].endswith(".tar.gz"):
                     config_obj["type"] = "tar"

--- a/src/partcad/project_factory_git.py
+++ b/src/partcad/project_factory_git.py
@@ -598,7 +598,6 @@ def clone_single_commit(repo_url, cache_path, revision, git_config=(), user_conf
 
 
 def get_cache_lock(hash):
-    global global_cache_lock
     global_cache_lock.acquire()
     if hash not in cache_locks:
         cache_locks[hash] = threading.Lock()
@@ -953,7 +952,7 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
                                 # No update was performed
                                 before = None
 
-                        if not before is None:
+                        if before is not None:
                             # Update was performed
                             after = repo.head.target
                             if before != after:
@@ -1029,7 +1028,7 @@ class ProjectFactoryGit(pf.ProjectFactory, GitImportConfiguration):
                             )
                             raise RuntimeError(f"Failed to clone repo: {e}") from e
                 attempt += 1
-        if not self.import_rel_path is None:
+        if self.import_rel_path is not None:
             cache_path = os.path.join(cache_path, self.import_rel_path)
 
         return cache_path

--- a/src/partcad/project_factory_tar.py
+++ b/src/partcad/project_factory_tar.py
@@ -92,7 +92,7 @@ class ProjectFactoryTar(pf.ProjectFactory, TarImportConfiguration):
                     args = inspect.getfullargspec(tar_obj.extractall)
 
                     if "filter" in args.args:
-                        if not self.import_rel_path is None:
+                        if self.import_rel_path is not None:
                             filter = lambda member, _: (
                                 member if member.name.startswith(self.import_rel_path) else None
                             )
@@ -105,7 +105,7 @@ class ProjectFactoryTar(pf.ProjectFactory, TarImportConfiguration):
             except Exception as e:
                 raise RuntimeError(f"Failed to download the tarball: {e}")
 
-        if not self.import_rel_path is None:
+        if self.import_rel_path is not None:
             cache_path = os.path.join(cache_path, self.import_rel_path)
 
         return cache_path

--- a/src/partcad/render_overlay.py
+++ b/src/partcad/render_overlay.py
@@ -209,8 +209,7 @@ def report(shape, records: list, overlay: Overlay) -> None:
     )
     if not records:
         pc_logging.warning(
-            "%s:%s: nothing to draw for %s: this object declares no ports"
-            % (shape.project_name, shape.name, asked_for)
+            "%s:%s: nothing to draw for %s: this object declares no ports" % (shape.project_name, shape.name, asked_for)
         )
         return
 

--- a/src/partcad/runtime_python.py
+++ b/src/partcad/runtime_python.py
@@ -1032,7 +1032,7 @@ class PythonRuntime(runtime.Runtime):
         if path is None:
             if session is None or not session["dirty"]:
                 # Use the full interpreter path if known
-                if not self.exec_path is None:
+                if self.exec_path is not None:
                     return self.exec_path
                 # If the full path is not known, use the interpreter name
                 path = self.path

--- a/src/partcad/runtime_python_conda.py
+++ b/src/partcad/runtime_python_conda.py
@@ -217,7 +217,7 @@ class CondaPythonRuntime(runtime_python.PythonRuntime):
                     if stderr is not None and stderr.strip() != "":
                         pc_logging.warning("conda venv check error: %s" % stderr)
                     else:
-                        pc_logging.warning(f"conda venv check error")
+                        pc_logging.warning("conda venv check error")
                     self.conda_initialized = False
                 elif stdout is None or stdout.strip() == "":
                     pc_logging.warning("conda venv check warning: empty version")

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -26,7 +26,7 @@ from . import sandbox_versions, wrapper
 from .cache_hash import CacheHash
 from .cache_shape import properties_key
 from .shape_config import ShapeConfiguration
-from .sync_threads import threadpool_manager
+from .sync_threads import threadpool_manager  # noqa: F401  # kept for the module import; unused directly
 from .utils import total_size
 
 if TYPE_CHECKING:
@@ -236,9 +236,7 @@ class Shape(ShapeConfiguration):
         self.owns_cache_entry = True
 
         if self.cacheable:
-            cad_config = {
-                key: value for key, value in self.config.items() if key not in _NON_GEOMETRIC_CONFIG_KEYS
-            }
+            cad_config = {key: value for key, value in self.config.items() if key not in _NON_GEOMETRIC_CONFIG_KEYS}
             self.hash.add_dict(cad_config)
 
     def set_environment_cache_key(self, environment_cache_key: str) -> None:
@@ -280,7 +278,7 @@ class Shape(ShapeConfiguration):
 
         # Check for a match in other files associated with this shape
         if self.path and os.path.exists(self.path):
-            with open(self.path, errors='replace') as f:
+            with open(self.path, errors="replace") as f:
                 if keyword and keyword.lower() in f.read().lower():
                     return True
         return False
@@ -1234,9 +1232,7 @@ class Shape(ShapeConfiguration):
                 extra = {"output_files": [final_filepath]}
             else:
                 extra = {}
-            exitcode, response_serialized, errors = await runtime.run_async(
-                command, request_serialized, **extra
-            )
+            exitcode, response_serialized, errors = await runtime.run_async(command, request_serialized, **extra)
             if exitcode != 0 and len(errors) == 0:
                 errors = "Failed to execute command '%s' with exit code %s" % (" ".join(command), exitcode)
             if errors:

--- a/src/partcad/shape.py
+++ b/src/partcad/shape.py
@@ -26,7 +26,6 @@ from . import sandbox_versions, wrapper
 from .cache_hash import CacheHash
 from .cache_shape import properties_key
 from .shape_config import ShapeConfiguration
-from .sync_threads import threadpool_manager  # noqa: F401  # kept for the module import; unused directly
 from .utils import total_size
 
 if TYPE_CHECKING:

--- a/src/partcad/sketch_factory_build123d.py
+++ b/src/partcad/sketch_factory_build123d.py
@@ -105,7 +105,10 @@ class SketchFactoryBuild123d(SketchFactoryPython):
             )
             if exitcode != 0 and len(errors) == 0:
                 errors = "%s: %s: Failed to instantiate" % (sketch.project_name, sketch.name)
-                pc_logging.debug("%s: %s: Failed to execute command: '%s' with exitcode %s" % (sketch.project_name, sketch.name, " ".join(command), exitcode))
+                pc_logging.debug(
+                    "%s: %s: Failed to execute command: '%s' with exitcode %s"
+                    % (sketch.project_name, sketch.name, " ".join(command), exitcode)
+                )
 
             if len(errors) > 0:
                 error_lines = errors.split("\n")

--- a/src/partcad/sketch_factory_cadquery.py
+++ b/src/partcad/sketch_factory_cadquery.py
@@ -107,7 +107,10 @@ class SketchFactoryCadquery(SketchFactoryPython):
 
             if exitcode != 0 and len(errors) == 0:
                 errors = "%s: %s: Failed to instantiate" % (sketch.project_name, sketch.name)
-                pc_logging.debug("%s: %s: Failed to execute command: '%s' with exitcode %s" % (sketch.project_name, sketch.name, " ".join(command), exitcode))
+                pc_logging.debug(
+                    "%s: %s: Failed to execute command: '%s' with exitcode %s"
+                    % (sketch.project_name, sketch.name, " ".join(command), exitcode)
+                )
 
             if len(errors) > 0:
                 error_lines = errors.split("\n")

--- a/src/partcad/sketch_factory_dxf.py
+++ b/src/partcad/sketch_factory_dxf.py
@@ -28,9 +28,7 @@ class SketchFactoryDxf(SketchFactoryPython):
                 python_version = sandbox_versions.DEFAULT_PYTHON_VERSION
             # CadQuery has no release for Python 3.10, so a package that asks
             # for it still gets rendered on the oldest interpreter it supports.
-            python_version = sandbox_versions.at_least(
-                python_version, sandbox_versions.MIN_PYTHON_VERSION_CADQUERY
-            )
+            python_version = sandbox_versions.at_least(python_version, sandbox_versions.MIN_PYTHON_VERSION_CADQUERY)
             super().__init__(
                 ctx,
                 source_project,

--- a/src/partcad/test/cae.py
+++ b/src/partcad/test/cae.py
@@ -36,7 +36,7 @@ import hashlib
 import json
 
 from .. import cae as pc_cae
-from .. import logging as pc_logging
+from .. import logging as pc_logging  # noqa: F401  # re-exported to the CAE test subclasses
 from .. import output
 from .. import runtime as pc_runtime
 from ..part import Part

--- a/src/partcad/test/cae.py
+++ b/src/partcad/test/cae.py
@@ -36,7 +36,6 @@ import hashlib
 import json
 
 from .. import cae as pc_cae
-from .. import logging as pc_logging  # noqa: F401  # re-exported to the CAE test subclasses
 from .. import output
 from .. import runtime as pc_runtime
 from ..part import Part

--- a/src/partcad/test/connectivity.py
+++ b/src/partcad/test/connectivity.py
@@ -140,8 +140,7 @@ class ConnectivityTest(Test):
                 continue
             where = port if port is not None else interface
             problems.append(
-                "'%s' and '%s' are both connected to '%s' of '%s'"
-                % (taken[key], child.name, where, target)
+                "'%s' and '%s' are both connected to '%s' of '%s'" % (taken[key], child.name, where, target)
             )
         return problems, consulted
 

--- a/src/partcad/test/interference.py
+++ b/src/partcad/test/interference.py
@@ -94,8 +94,7 @@ class InterferenceTest(Test):
             shown = ", ".join(unchecked[:5]) + ("..." if len(unchecked) > 5 else "")
             self.info(
                 shape,
-                "%d part(s) are not valid solids and were not checked: %s"
-                % (len(unchecked), shown),
+                "%d part(s) are not valid solids and were not checked: %s" % (len(unchecked), shown),
             )
 
         # A pair whose boolean did not come back is not a pair that does not

--- a/src/partcad/test/shell.py
+++ b/src/partcad/test/shell.py
@@ -4,10 +4,10 @@
 # Licensed under Apache License, Version 2.0.
 #
 
-from .test import Test
 from .. import brep_inspect
 from ..assembly import Assembly
 from ..sketch import Sketch
+from .test import Test
 
 
 class ShellTest(Test):

--- a/src/partcad/wrappers/custom_cqgi.py
+++ b/src/partcad/wrappers/custom_cqgi.py
@@ -8,6 +8,7 @@
 The CadQuery Gateway Interface.
 Provides classes and tools for executing CadQuery scripts
 """
+
 import sys
 import ast
 import traceback

--- a/src/partcad/wrappers/wrapper_import_assy.py
+++ b/src/partcad/wrappers/wrapper_import_assy.py
@@ -74,9 +74,18 @@ def clone_transformation(src: gp_Trsf) -> gp_Trsf:
     """Creates a deep copy of a gp_Trsf transformation matrix."""
     new_trsf = gp_Trsf()
     new_trsf.SetValues(
-        src.Value(1, 1), src.Value(1, 2), src.Value(1, 3), src.Value(1, 4),
-        src.Value(2, 1), src.Value(2, 2), src.Value(2, 3), src.Value(2, 4),
-        src.Value(3, 1), src.Value(3, 2), src.Value(3, 3), src.Value(3, 4)
+        src.Value(1, 1),
+        src.Value(1, 2),
+        src.Value(1, 3),
+        src.Value(1, 4),
+        src.Value(2, 1),
+        src.Value(2, 2),
+        src.Value(2, 3),
+        src.Value(2, 4),
+        src.Value(3, 1),
+        src.Value(3, 2),
+        src.Value(3, 3),
+        src.Value(3, 4),
     )
     return new_trsf
 
@@ -90,11 +99,7 @@ def invert_transformation(src: gp_Trsf) -> gp_Trsf:
 
 def transformation_difference(t1: gp_Trsf, t2: gp_Trsf) -> float:
     """Computes the maximum absolute difference between corresponding matrix elements."""
-    return max(
-        abs(t1.Value(row, col) - t2.Value(row, col))
-        for row in range(1, 4)
-        for col in range(1, 5)
-    )
+    return max(abs(t1.Value(row, col) - t2.Value(row, col)) for row in range(1, 4) for col in range(1, 5))
 
 
 def combine_transformations(parent: gp_Trsf, local: gp_Trsf, tolerance=1e-7) -> gp_Trsf:
@@ -118,13 +123,13 @@ def convert_location(trsf: gp_Trsf, precision=5):
     translation = [
         round(trsf.TranslationPart().X(), precision),
         round(trsf.TranslationPart().Y(), precision),
-        round(trsf.TranslationPart().Z(), precision)
+        round(trsf.TranslationPart().Z(), precision),
     ]
 
     quaternion = trsf.GetRotation()
     w, x, y, z = quaternion.W(), quaternion.X(), quaternion.Y(), quaternion.Z()
 
-    norm = math.sqrt(w*w + x*x + y*y + z*z)
+    norm = math.sqrt(w * w + x * x + y * y + z * z)
     if norm < 1e-6:
         return [translation, [1.0, 0.0, 0.0], 0.0]
 
@@ -138,7 +143,7 @@ def convert_location(trsf: gp_Trsf, precision=5):
         rotation_axis = [
             round(x / sin_half_angle, precision),
             round(y / sin_half_angle, precision),
-            round(z / sin_half_angle, precision)
+            round(z / sin_half_angle, precision),
         ]
 
     return [translation, rotation_axis, rotation_angle_deg]

--- a/src/partcad/wrappers/wrapper_interference.py
+++ b/src/partcad/wrappers/wrapper_interference.py
@@ -156,9 +156,7 @@ def process(path, request):
         # Broadphase. Boxes are cheap, booleans are not, so only the pairs whose
         # boxes meet are asked the expensive question.
         candidates = [
-            (a, b)
-            for a, b in itertools.combinations(range(len(boxes)), 2)
-            if not boxes[a][2].IsOut(boxes[b][2])
+            (a, b) for a, b in itertools.combinations(range(len(boxes)), 2) if not boxes[a][2].IsOut(boxes[b][2])
         ]
 
         overlaps = []

--- a/src/partcad/wrappers/wrapper_obj.py
+++ b/src/partcad/wrappers/wrapper_obj.py
@@ -18,23 +18,24 @@ from OCP.gp import gp_Pnt
 sys.path.append(os.path.dirname(__file__))
 import wrapper_common
 
+
 def process(path, request):
     try:
         vertices = []
         faces = []
 
         # Read the OBJ file
-        with open(path, 'r') as file:
+        with open(path, "r") as file:
             for line in file:
-                if line.startswith('#'):
+                if line.startswith("#"):
                     continue
-                if line.startswith('v '):
+                if line.startswith("v "):
                     parts = line.strip().split()
                     vertex = tuple(map(float, parts[1:]))
                     vertices.append(vertex)
-                elif line.startswith('f '):
+                elif line.startswith("f "):
                     parts = line.strip().split()
-                    face = [int(part.split('/')[0]) for part in parts[1:]]
+                    face = [int(part.split("/")[0]) for part in parts[1:]]
                     faces.append(face)
 
         # Create a compound shape to store faces
@@ -65,6 +66,7 @@ def process(path, request):
         "exception": None,
         "shape": compound,
     }
+
 
 path, request = wrapper_common.handle_input()
 

--- a/src/partcad/wrappers/wrapper_stl.py
+++ b/src/partcad/wrappers/wrapper_stl.py
@@ -21,6 +21,7 @@ from OCP.GProp import GProp_GProps
 sys.path.append(os.path.dirname(__file__))
 import wrapper_common
 
+
 def process(path, request):
     try:
         try:
@@ -80,6 +81,7 @@ def process(path, request):
         return {"success": False, "exception": str(e), "shape": None}
 
     return {"success": True, "exception": None, "shape": shape}
+
 
 if __name__ == "__main__":
     path, request = wrapper_common.handle_input()

--- a/src/partcad_cli/AGENTS.md
+++ b/src/partcad_cli/AGENTS.md
@@ -189,9 +189,10 @@ flake8 src/partcad_cli tests/partcad_cli
 isort --check --filter-files src/partcad_cli tests/partcad_cli
 ```
 
-Only `isort` gates: it is a `pre-commit` hook and the `Lint (isort)` job in `test.yml`. `black` and `flake8`
-report pre-existing findings that are nobody's change in particular — the root [AGENTS.md](../../AGENTS.md) has the
-counts and what each would take to turn on.
+All three gate — each is a `pre-commit` hook and a `Lint (...)` job in `test.yml`, and the tree satisfies
+all three, so a finding from any of them is yours. See the root [AGENTS.md](../../AGENTS.md) for the two flags that
+are load-bearing (`--filter-files`, and the `Flake8-pyproject` plugin without which flake8 reads no config
+at all).
 
 ## Commit
 

--- a/src/partcad_cli/click/command.py
+++ b/src/partcad_cli/click/command.py
@@ -600,7 +600,6 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool, no_ansi: bool, path: str
 
         # Prepare the callboack to be used by command handlers should they need a PartCAD context object
         def get_partcad_context():
-            nonlocal ctx, path
             from partcad.globals import init
 
             try:

--- a/src/partcad_cli/click/commands/adhoc/convert/__init__.py
+++ b/src/partcad_cli/click/commands/adhoc/convert/__init__.py
@@ -16,6 +16,8 @@ class ConvertCommands(Loader):
     COMMANDS_PACKAGE_NAME = Loader.COMMANDS_PACKAGE_NAME + ".adhoc.convert"
 
 
-@click.command(cls=ConvertCommands, help="Ad-hoc convert parts or sketches to another format without updating their type.")
+@click.command(
+    cls=ConvertCommands, help="Ad-hoc convert parts or sketches to another format without updating their type."
+)
 def cli() -> None:
     pass

--- a/src/partcad_cli/click/commands/init.py
+++ b/src/partcad_cli/click/commands/init.py
@@ -140,7 +140,7 @@ def cli(cli_ctx: CliContext, click_ctx: click.rich_context.RichContext, **kwargs
     with pc.telemetry.set_context(cli_ctx.otel_context):
         # ctx: pc.Context = cli_ctx.get_partcad_context()
 
-        if not click_ctx.parent.params.get("package") is None:
+        if click_ctx.parent.params.get("package") is not None:
             if os.path.isdir(click_ctx.parent.params.get("package")):
                 dst_path = os.path.join(click_ctx.parent.params.get("package"), "partcad.yaml")
             else:

--- a/src/partcad_cli/click/commands/list/all.py
+++ b/src/partcad_cli/click/commands/list/all.py
@@ -11,7 +11,7 @@ from ...cli_context import CliContext
 from .assemblies import cli as list_assemblies
 from .interfaces import cli as list_interfaces
 from .materials import cli as list_materials
-from .mates import cli as list_mates
+from .mates import cli as list_mates  # noqa: F401  # its runner.invoke() below is commented out (TODO there)
 from .packages import cli as list_packages
 from .parts import cli as list_parts
 from .providers import cli as list_providers

--- a/src/partcad_cli/click/commands/supply/find.py
+++ b/src/partcad_cli/click/commands/supply/find.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import json
-from typing import Any, List
+from typing import Any, List  # noqa: F401
 
 import rich_click as click
 

--- a/src/partcad_cli/click/commands/supply/find.py
+++ b/src/partcad_cli/click/commands/supply/find.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import json
-from typing import Any, List  # noqa: F401
+from typing import List
 
 import rich_click as click
 

--- a/src/partcad_cli/click/commands/system/set/telemetry/env.py
+++ b/src/partcad_cli/click/commands/system/set/telemetry/env.py
@@ -22,7 +22,7 @@ def cli(cli_ctx, env: str) -> None:
     with pc.telemetry.set_context(cli_ctx.otel_context):
         with pc.logging.Process("SysSetTelEnv", "global"):
             yaml, config = pc_actions_config.system_config_get()
-            if not "telemetry" in config:
+            if "telemetry" not in config:
                 config["telemetry"] = {}
 
             config["telemetry"]["env"] = env

--- a/src/partcad_cli/click/commands/system/set/telemetry/sentryDsn.py
+++ b/src/partcad_cli/click/commands/system/set/telemetry/sentryDsn.py
@@ -21,7 +21,7 @@ def cli(cli_ctx, dsn: str) -> None:
     with pc.telemetry.set_context(cli_ctx.otel_context):
         with pc.logging.Process("SysSetTelDsn", "global"):
             yaml, config = pc_actions_config.system_config_get()
-            if not "telemetry" in config:
+            if "telemetry" not in config:
                 config["telemetry"] = {}
 
             config["telemetry"]["sentryDsn"] = dsn

--- a/src/partcad_cli/click/commands/system/set/telemetry/type.py
+++ b/src/partcad_cli/click/commands/system/set/telemetry/type.py
@@ -22,7 +22,7 @@ def cli(cli_ctx, type: str) -> None:
     with pc.telemetry.set_context(cli_ctx.otel_context):
         with pc.logging.Process("SysSetTelType", "global"):
             yaml, config = pc_actions_config.system_config_get()
-            if not "telemetry" in config:
+            if "telemetry" not in config:
                 config["telemetry"] = {}
 
             if type == "none":

--- a/src/partcad_cli/click/commands/system/telemetry/info.py
+++ b/src/partcad_cli/click/commands/system/telemetry/info.py
@@ -22,6 +22,6 @@ def cli(cli_ctx) -> None:
                     id_value = file.read()
                     pc.logging.info(f"Telemetry ID: '{id_value}'")
             else:
-                pc.logging.info(f"Telemetry ID: None")
+                pc.logging.info("Telemetry ID: None")
         pc.logging.info(f"Telemetry type: '{pc.user_config.telemetry_config.type}'")
         pc.logging.info(f"Telemetry env: '{pc.user_config.telemetry_config.env}'")

--- a/src/partcad_cli/click/loader.py
+++ b/src/partcad_cli/click/loader.py
@@ -47,7 +47,7 @@ class Loader(click.RichGroup):
             return []
 
     def get_command(self, _ctx, name: str) -> click.Command:
-        if not name in self.list_commands(_ctx):
+        if name not in self.list_commands(_ctx):
             raise click.ClickException(f"Unknown command: '{name}'. Try `--help`.")
 
         if not name.isalnum():

--- a/src/partcad_ide_client/AGENTS.md
+++ b/src/partcad_ide_client/AGENTS.md
@@ -54,13 +54,14 @@ stubbed out, and the sandbox side is covered by the render tests.
 
 ```bash
 poetry run black --check src/partcad_ide_client tests/partcad_ide_client
+poetry run flake8 src/partcad_ide_client tests/partcad_ide_client
 poetry run isort --check --filter-files src/partcad_ide_client tests/partcad_ide_client
 ```
 
-`isort` gates — a `pre-commit` hook and the `Lint (isort)` job in `test.yml` — and the tree is sorted, so a
-diff from it is yours. `flake8` still does not: it reports E501 at 79 columns on every file in this repo,
-because it does not read the 120-column setting from `pyproject.toml` without a plugin. See the root
-[AGENTS.md](../../AGENTS.md) for what each of the three costs to turn on.
+`black`, `flake8` and `isort` all gate now — each is a `pre-commit` hook and a `Lint (...)` job in `test.yml` —
+and the tree satisfies all three, so a finding from any of them is yours. flake8 only reads its configuration
+because `Flake8-pyproject` is installed; without it it checks at 79 columns. See the root
+[AGENTS.md](../../AGENTS.md).
 
 ## Commit
 

--- a/src/partcad_service_json_rpc/AGENTS.md
+++ b/src/partcad_service_json_rpc/AGENTS.md
@@ -125,9 +125,10 @@ poetry run flake8 src/partcad_service_json_rpc tests/partcad_service_json_rpc
 poetry run isort --check --filter-files src/partcad_service_json_rpc tests/partcad_service_json_rpc
 ```
 
-Only `isort` gates: it is a `pre-commit` hook and the `Lint (isort)` job in `test.yml`. `black` and `flake8`
-report pre-existing findings that are nobody's change in particular — the root [AGENTS.md](../../AGENTS.md) has the
-counts and what each would take to turn on.
+All three gate — each is a `pre-commit` hook and a `Lint (...)` job in `test.yml`, and the tree satisfies
+all three, so a finding from any of them is yours. See the root [AGENTS.md](../../AGENTS.md) for the two flags that
+are load-bearing (`--filter-files`, and the `Flake8-pyproject` plugin without which flake8 reads no config
+at all).
 
 ## Method surface
 

--- a/src/partcad_service_json_rpc/core/operations.py
+++ b/src/partcad_service_json_rpc/core/operations.py
@@ -943,11 +943,11 @@ async def _lint_async(ctx, pc, packages, filter_prefix):
     tasks = []
     lint_checks = get_linting_checks(pc.user_config.threads_max)
     if filter_prefix:
-        lint_checks = list(filter(lambda l: l.name.startswith(filter_prefix), lint_checks))
+        lint_checks = list(filter(lambda check: check.name.startswith(filter_prefix), lint_checks))
 
     for package in packages:
         prj = ctx.get_project(package)
-        tasks.extend([l.lint_log_wrapper(ctx, prj, t) for l in lint_checks for t in l.get_targets(ctx, prj)])
+        tasks.extend([c.lint_log_wrapper(ctx, prj, t) for c in lint_checks for t in c.get_targets(ctx, prj)])
     await asyncio.gather(*tasks)
 
 

--- a/src/partcad_utils/logging.py
+++ b/src/partcad_utils/logging.py
@@ -10,7 +10,14 @@
 import logging
 import threading
 import time
-from logging import CRITICAL, DEBUG, ERROR, INFO, WARN, WARNING
+from logging import (  # noqa: F401  # re-exported so callers use pc_logging.DEBUG etc.
+    CRITICAL,
+    DEBUG,
+    ERROR,
+    INFO,
+    WARN,
+    WARNING,
+)
 
 import sentry_sdk
 from opentelemetry import trace
@@ -178,9 +185,6 @@ class Process(object):
         self.__enter__()
 
     def __enter__(self):
-        global process_lock
-        global process_transaction
-        global process_span
 
         if process_lock.acquire():
             self.start = time.time()
@@ -205,8 +209,6 @@ class Process(object):
         self.__exit__(*args)
 
     def __exit__(self, *_args):
-        global process_lock
-        global info
 
         if self.succeeded:
             process_lock.release()

--- a/src/partcad_utils/logging_ansi_terminal.py
+++ b/src/partcad_utils/logging_ansi_terminal.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import time
 from logging.handlers import QueueHandler, QueueListener
-from typing import Any
+from typing import Any  # noqa: F401
 
 from .logging import error, ops
 
@@ -111,7 +111,7 @@ class AnsiTerminalProgressHandler(logging.Handler):
     def __init__(self, stream=sys.stdout) -> None:
         super().__init__()
         self.thread_lock = threading.Lock()
-        if not stream is None:
+        if stream is not None:
             self.stream = stream
         else:
             self.stream = sys.stdout
@@ -133,7 +133,7 @@ class AnsiTerminalProgressHandler(logging.Handler):
         return "\u001b[1A\u001b[2K" * self.footer_size
 
     def run_thread(self):
-        while not self.process is None:
+        while self.process is not None:
             time.sleep(0.25)
             if time.time() - self.last_output > 0.5:
                 self.emit(None)
@@ -147,7 +147,7 @@ class AnsiTerminalProgressHandler(logging.Handler):
         # protect the status data store in 'self' from other threads
         self.thread_lock.acquire()
 
-        if not record is None:
+        if record is not None:
             ignore_message = False
             if hasattr(record, "pc_event"):
                 if record.pc_event == "process_start":
@@ -158,7 +158,7 @@ class AnsiTerminalProgressHandler(logging.Handler):
                     self.process_start = time.time()
                     self.actions_total = 0
 
-                    if not self.thread is None:
+                    if self.thread is not None:
                         self.thread_lock.release()
                         raise Exception("nested processes")
                     self.thread = threading.Thread(
@@ -215,7 +215,7 @@ class AnsiTerminalProgressHandler(logging.Handler):
 
         output += self.clear_footer()
 
-        if not record is None:
+        if record is not None:
             if not ignore_message:
                 if record.levelno == logging.DEBUG:
                     output += COLOR_DEBUG + "DEBUG:" + COLOR_NONE + " "
@@ -231,7 +231,7 @@ class AnsiTerminalProgressHandler(logging.Handler):
                 msg = self.format(record)
                 output += "%s\n" % msg
 
-        if not self.process is None:
+        if self.process is not None:
             seconds = int(now - self.process_start)
 
             output += NO_WRAP
@@ -313,7 +313,6 @@ def init(stream=None):
     global listener
     global queue_handler
     global log_queue
-    global ops
 
     if log_queue is None:
         log_queue = queue.Queue(-1)

--- a/src/partcad_utils/logging_ansi_terminal.py
+++ b/src/partcad_utils/logging_ansi_terminal.py
@@ -13,7 +13,6 @@ import sys
 import threading
 import time
 from logging.handlers import QueueHandler, QueueListener
-from typing import Any  # noqa: F401
 
 from .logging import error, ops
 

--- a/src/partcad_utils/logging_remote_server.py
+++ b/src/partcad_utils/logging_remote_server.py
@@ -133,9 +133,7 @@ def init(hook, log_file: str = None, file_level: int = logging.DEBUG) -> None:
         _forward_handler.set_hook(hook)
 
     if log_file is not None and _file_handler is None:
-        _file_handler = RotatingFileHandler(
-            log_file, maxBytes=FILE_MAX_BYTES, backupCount=FILE_BACKUP_COUNT
-        )
+        _file_handler = RotatingFileHandler(log_file, maxBytes=FILE_MAX_BYTES, backupCount=FILE_BACKUP_COUNT)
         _file_handler.setLevel(file_level)
         _file_handler.addFilter(_PcEventFilter())
         _file_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))

--- a/src/partcad_utils/telemetry.py
+++ b/src/partcad_utils/telemetry.py
@@ -14,7 +14,10 @@ from opentelemetry.trace import Tracer
 from . import telemetry_none, telemetry_sentry
 
 partcad_version = None
-tracer: Tracer | None  # To be initialized in telemetry_init()
+# Annotation *and* an initialiser: a bare annotation binds no name, so before
+# `init()`/`once()` ran, `tracer` did not exist at module scope at all and the
+# readers below only resolved it because each declared `global tracer`.
+tracer: Tracer | None = None  # To be initialized in telemetry_init()
 tracer_onced = False
 
 
@@ -32,7 +35,7 @@ def once():
         return
     tracer_onced = True
 
-    global tracer, partcad_version
+    global tracer
 
     if not os.getenv("PYTEST_VERSION"):
         # TODO(clairbee): add suport for alternate telemetry backends
@@ -48,7 +51,6 @@ def once():
 async def start_as_current_span_async(name, **kwargs):
     once()
 
-    global tracer
     with tracer.start_as_current_span(name, **kwargs) as span:
         yield span
 
@@ -57,7 +59,6 @@ async def start_as_current_span_async(name, **kwargs):
 def start_as_current_span(name: str, **kwargs):
     once()
 
-    global tracer
     with tracer.start_as_current_span(name, **kwargs) as span:
         yield span
 
@@ -71,8 +72,6 @@ def set_context(ctx):
 
 def instrument_span(name, category: str = ""):
     once()
-
-    global tracer
 
     def decorator(func, attr_getter):
         def wrapper(*args, **kwargs):

--- a/src/partcad_utils/utils.py
+++ b/src/partcad_utils/utils.py
@@ -146,7 +146,7 @@ def format_parameterized_name(base: str, parameters: dict) -> str:
 
 @telemetry.start_as_current_span("resolve_resource_path")
 def resolve_resource_path(current_project_name, pattern: str):
-    if not ":" in pattern:
+    if ":" not in pattern:
         pattern = ":" + pattern
     project_pattern, item_pattern = pattern.split(":")
     if project_pattern == "":

--- a/tests/partcad/unit/test_adhoc_convert_error_order.py
+++ b/tests/partcad/unit/test_adhoc_convert_error_order.py
@@ -20,8 +20,6 @@ throwaway package (`partcad.adhoc.adhoc`), so a shape that will not load fails
 identically for either, and what differs is only the verb in the message.
 """
 
-import pathlib
-
 import pytest
 
 from partcad.adhoc import adhoc as adhoc_base

--- a/tests/partcad/unit/test_adhoc_convert_part.py
+++ b/tests/partcad/unit/test_adhoc_convert_part.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 
 from partcad.adhoc.convert import convert_cad_file, generate_partcad_config
-from partcad.context import Context
 
 OUTPUT_FORMATS = ["stl", "step", "brep", "3mf", "threejs", "obj"]
 

--- a/tests/partcad/unit/test_assembly.py
+++ b/tests/partcad/unit/test_assembly.py
@@ -13,7 +13,6 @@ import os
 import sys
 
 import build123d as b3d
-import pytest
 from OCP.TopoDS import TopoDS_Iterator
 
 import partcad as pc
@@ -119,9 +118,7 @@ class _SlowChild:
         await asyncio.sleep(self.delay)
         # Assembly now fetches child shapes as BREP envelopes, not build123d
         # objects, so hand back the envelope of a unit box.
-        return ocp_serialize.encode_shape(
-            b3d.Solid.make_box(1.0, 1.0, 1.0).wrapped, name=self.name, label=self.name
-        )
+        return ocp_serialize.encode_shape(b3d.Solid.make_box(1.0, 1.0, 1.0).wrapped, name=self.name, label=self.name)
 
 
 def _child_offsets(envelope):

--- a/tests/partcad/unit/test_assembly_geometry_tests.py
+++ b/tests/partcad/unit/test_assembly_geometry_tests.py
@@ -293,7 +293,6 @@ def test_a_verdict_that_turned_on_the_machine_is_not_remembered():
     assert ctx.get(InterferenceTest.NOT_CACHEABLE) is True
 
 
-
 def test_a_sketch_is_flat_because_that_is_what_a_sketch_is():
     """Found by CI: 'circle' in examples/provider_manufacturer is a sketch,
     20 x 20 x 0 mm, and this failed it for being what it was asked to be. A

--- a/tests/partcad/unit/test_assembly_manufacturing.py
+++ b/tests/partcad/unit/test_assembly_manufacturing.py
@@ -11,7 +11,7 @@
 import asyncio
 
 import partcad as pc
-from partcad.test import cam
+from partcad.test import cam  # noqa: F401  # imported to register the CAM test type
 
 
 def test_assembly_manufacturing_positive_1():
@@ -22,7 +22,7 @@ def test_assembly_manufacturing_positive_1():
     assert asyncio.run(assembly.get_wrapped(ctx)) is not None
 
     test = pc.test.cam.CamTest()
-    assert asyncio.run(test.test([test], ctx, assembly)) == True
+    assert asyncio.run(test.test([test], ctx, assembly)) is True
 
 
 def test_assembly_manufacturing_negative_1():
@@ -33,4 +33,4 @@ def test_assembly_manufacturing_negative_1():
     assert asyncio.run(assembly.get_wrapped(ctx)) is not None
 
     test = pc.test.cam.CamTest()
-    assert asyncio.run(test.test([test], ctx, assembly)) == True
+    assert asyncio.run(test.test([test], ctx, assembly)) is True

--- a/tests/partcad/unit/test_assembly_serialize.py
+++ b/tests/partcad/unit/test_assembly_serialize.py
@@ -65,9 +65,7 @@ def test_assembly_cache_value_is_a_nested_tree():
 
     def has_sub(t):
         return any(
-            ocp_serialize.is_assembly_object(c) or has_sub(c)
-            for c in t.get("assembly", [])
-            if isinstance(c, dict)
+            ocp_serialize.is_assembly_object(c) or has_sub(c) for c in t.get("assembly", []) if isinstance(c, dict)
         )
 
     assert has_sub(tree), "logo_embedded must keep its sub-assemblies nested"
@@ -124,6 +122,6 @@ def test_assembly_tree_round_trips_to_the_same_geometry():
     # way, so Bnd_Box's own gap cancels out.
     rebuilt_bbox = _bbox(rebuilt)
     original_bbox = _bbox(original)
-    assert all(abs(a - b) < 1e-6 for a, b in zip(rebuilt_bbox, original_bbox, strict=True)), (
-        "the assembly does not occupy the same space: %r vs %r" % (rebuilt_bbox, original_bbox)
-    )
+    assert all(
+        abs(a - b) < 1e-6 for a, b in zip(rebuilt_bbox, original_bbox, strict=True)
+    ), "the assembly does not occupy the same space: %r vs %r" % (rebuilt_bbox, original_bbox)

--- a/tests/partcad/unit/test_context.py
+++ b/tests/partcad/unit/test_context.py
@@ -79,21 +79,22 @@ def test_ctx_fini():
 def test_offline_mode(variation):
     offline, force_update = variation
 
-    with patch.object(pc.user_config, "offline", offline), \
-        patch.object(pc.user_config, "force_update", force_update):
+    with patch.object(pc.user_config, "offline", offline), patch.object(pc.user_config, "force_update", force_update):
         ctx = pc.Context(user_config=pc.user_config)
         checks = [
-            (0, True, True),          # At time 0, should check connectivity with result of True
-            (20, False, True),        # At time 20, should not check connectivity and saved state must return True
-            (80, True, False),        # At time 80, should check connectivity with result of False
-            (120, False, False),      # At time 120, should not check connectivity and saved state must return False
-            (240, False, False),      # At time 240, should not check connectivity and saved state must return False
-            (400, True, True)         # At time 400, should check connectivity with result of True
+            (0, True, True),  # At time 0, should check connectivity with result of True
+            (20, False, True),  # At time 20, should not check connectivity and saved state must return True
+            (80, True, False),  # At time 80, should check connectivity with result of False
+            (120, False, False),  # At time 120, should not check connectivity and saved state must return False
+            (240, False, False),  # At time 240, should not check connectivity and saved state must return False
+            (400, True, True),  # At time 400, should check connectivity with result of True
         ]
 
         for timestamp, should_check_connection, has_connection in checks:
-            with patch('time.time', return_value=timestamp), \
-              patch.object(ctx, "_check_connectivity", return_value=has_connection) as check_connectivity_mock:
+            with (
+                patch("time.time", return_value=timestamp),
+                patch.object(ctx, "_check_connectivity", return_value=has_connection) as check_connectivity_mock,
+            ):
                 assert ctx.is_connected() == (has_connection and not offline)
                 if (should_check_connection or force_update) and not offline:
                     check_connectivity_mock.assert_called_once()

--- a/tests/partcad/unit/test_convert_part.py
+++ b/tests/partcad/unit/test_convert_part.py
@@ -196,7 +196,7 @@ def test_convert_with_dry_run(tmp_path: Path):
 
     convert_part_action(project, part_name, "step", output_dir=str(output_dir), dry_run=True)
 
-    expected_files = list(output_dir.glob(f"*.step"))
+    expected_files = list(output_dir.glob("*.step"))
     assert not expected_files, "Dry-run mode should not create files."
 
     pc_logging.info("Dry-run conversion verified successfully.")

--- a/tests/partcad/unit/test_convert_sketch.py
+++ b/tests/partcad/unit/test_convert_sketch.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-import partcad as pc
 from partcad.actions.sketch import convert_sketch_action
 from partcad.context import Context
 from partcad.shape import SKETCH_EXTENSION_MAPPING
@@ -26,7 +25,7 @@ SOURCE_DIR = Path("./examples/feature_convert_sketch")
 @pytest.mark.parametrize("target_format", sorted(ALLOWED_TARGETS))
 def test_sketch_conversion(sketch_name, target_format, tmp_path: Path):
     """Convert each supported sketch input to all allowed output formats."""
-    
+
     if "basic" in sketch_name:
         pytest.skip()
 

--- a/tests/partcad/unit/test_git_clone_retries.py
+++ b/tests/partcad/unit/test_git_clone_retries.py
@@ -23,7 +23,7 @@ fake_git_errors = [
     GitError("failed to connect to github.com: Connection refused"),
     # Timeout, either the remote's own or the one PartCAD imposes
     GitError("could not read from socket: timed out"),
-    GitError(f"failed to connect to github.com: Operation timed out"),
+    GitError("failed to connect to github.com: Operation timed out"),
     # Partial data transfer issue
     GitError("early EOF"),
     GitError("unexpected disconnect while reading sideband packet"),

--- a/tests/partcad/unit/test_healthcheck_stale_git_locks.py
+++ b/tests/partcad/unit/test_healthcheck_stale_git_locks.py
@@ -6,8 +6,6 @@
 """The StaleGitLocks healthcheck removes leftover git cache lock files that no
 process holds, and never touches a lock a process still holds."""
 
-import os
-
 import pytest
 from filelock import FileLock
 

--- a/tests/partcad/unit/test_import_assy.py
+++ b/tests/partcad/unit/test_import_assy.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 
 import pytest

--- a/tests/partcad/unit/test_part.py
+++ b/tests/partcad/unit/test_part.py
@@ -119,7 +119,7 @@ def test_part_get_obj_2():
 def test_part_get_scad():
     """Load an OpenSCAD part"""
     scad_path = shutil.which("openscad")
-    if not scad_path is None:
+    if scad_path is not None:
         ctx = pc.Context("examples/produce_part_openscad")
         part = ctx.get_part(":cube")
         assert part is not None

--- a/tests/partcad/unit/test_part_manufacturing.py
+++ b/tests/partcad/unit/test_part_manufacturing.py
@@ -11,7 +11,7 @@
 import asyncio
 
 import partcad as pc
-from partcad.test import cam
+from partcad.test import cam  # noqa: F401  # imported to register the CAM test type
 
 
 def test_part_manufacturing_positive_1():
@@ -22,7 +22,7 @@ def test_part_manufacturing_positive_1():
     assert asyncio.run(cylinder.get_wrapped(ctx)) is not None
 
     test = pc.test.cam.CamTest()
-    assert asyncio.run(test.test([test], ctx, cylinder)) == True
+    assert asyncio.run(test.test([test], ctx, cylinder)) is True
 
 
 def test_part_manufacturing_negative_1():
@@ -33,4 +33,4 @@ def test_part_manufacturing_negative_1():
     assert asyncio.run(cube.get_wrapped(ctx)) is not None
 
     test = pc.test.cam.CamTest()
-    assert asyncio.run(test.test([test], ctx, cube)) == True
+    assert asyncio.run(test.test([test], ctx, cube)) is True

--- a/tests/partcad/unit/test_part_params.py
+++ b/tests/partcad/unit/test_part_params.py
@@ -9,7 +9,6 @@
 #
 
 import asyncio
-from unittest.mock import patch
 
 import partcad as pc
 
@@ -31,10 +30,13 @@ def test_part_params_get_2():
     assert asyncio.run(brick.get_wrapped(ctx)) is not None
     assert brick.config["parameters"]["width"]["default"] == 17.0
 
+
 def test_part_user_config_params_get():
     """Load a CadQuery part using enrichment for parameters and see if the parameters changed from user_config"""
     ctx = pc.Context("examples/produce_part_cadquery_primitive")
-    pc.user_config.parameter_config["//pub/examples/partcad/produce_part_cadquery_primitive:cube_enrich"] = {"width": 33.0}
+    pc.user_config.parameter_config["//pub/examples/partcad/produce_part_cadquery_primitive:cube_enrich"] = {
+        "width": 33.0
+    }
     cube_enrich = ctx._get_part(":cube_enrich")
     assert cube_enrich is not None
     assert asyncio.run(cube_enrich.get_wrapped(ctx)) is not None

--- a/tests/partcad/unit/test_part_shell.py
+++ b/tests/partcad/unit/test_part_shell.py
@@ -27,14 +27,13 @@ import sys
 import textwrap
 
 import pytest
+from OCP.BRepGProp import BRepGProp
+from OCP.GProp import GProp_GProps
+from OCP.TopAbs import TopAbs_SOLID
 
 import partcad as pc
 from partcad import brep_inspect
 from partcad.test.shell import ShellTest
-
-from OCP.BRepGProp import BRepGProp
-from OCP.GProp import GProp_GProps
-from OCP.TopAbs import TopAbs_SOLID
 
 sys.path.append(os.path.join(os.path.dirname(pc.__file__), "wrappers"))
 import ocp_serialize  # noqa: E402

--- a/tests/partcad/unit/test_project_config.py
+++ b/tests/partcad/unit/test_project_config.py
@@ -27,8 +27,10 @@ def test_project_config_version_1():
 def test_project_config_version_2():
     """Negative test case for PartCAD version requirement in the package config file"""
     # A bare `except:` here used to swallow the `assert False` it was paired
-    # with, so this test passed whether or not the invalid config raised.
-    with pytest.raises(Exception):
+    # with, so this test passed whether or not the invalid config raised. Named
+    # rather than `Exception`, so that the test fails if the config starts
+    # failing for some *other* reason -- which a bare `Exception` would accept.
+    with pytest.raises(pc.exception.NeedsUpdateException):
         pc.Context("tests/partcad/unit/data/project_config_invalid_1.yaml")
 
 

--- a/tests/partcad/unit/test_project_config.py
+++ b/tests/partcad/unit/test_project_config.py
@@ -8,6 +8,8 @@
 # Licensed under Apache License, Version 2.0.
 #
 
+import pytest
+
 import partcad as pc
 
 
@@ -24,11 +26,10 @@ def test_project_config_version_1():
 
 def test_project_config_version_2():
     """Negative test case for PartCAD version requirement in the package config file"""
-    try:
-        ctx = pc.Context("tests/partcad/unit/data/project_config_invalid_1.yaml")
-        assert False, "Invalid configuration file did not cause an exception"
-    except:
-        _ignore = True
+    # A bare `except:` here used to swallow the `assert False` it was paired
+    # with, so this test passed whether or not the invalid config raised.
+    with pytest.raises(Exception):
+        pc.Context("tests/partcad/unit/data/project_config_invalid_1.yaml")
 
 
 def test_project_config_template():
@@ -45,7 +46,7 @@ def test_project_config_template():
     # In this test case, the template is used to name the part the same name as
     # the package is called.
     part = ctx._get_part("//that://that")
-    assert not part is None
+    assert part is not None
 
 
 def test_project_config_template_override():
@@ -67,4 +68,4 @@ def test_project_config_template_override():
     # The part is named by a variable pulled in from the Jinja include, not by
     # the package name.
     part = ctx._get_part("//that_include:defined")
-    assert not part is None
+    assert part is not None

--- a/tests/partcad/unit/test_project_resilience.py
+++ b/tests/partcad/unit/test_project_resilience.py
@@ -13,8 +13,6 @@ enumeration loop at the first one (taking the objects declared after it with it)
 and raise a bare KeyError at anyone who then asked for one by name.
 """
 
-import os
-
 import pytest
 import yaml
 

--- a/tests/partcad/unit/test_provider.py
+++ b/tests/partcad/unit/test_provider.py
@@ -63,9 +63,11 @@ def test_provider_quote_store_csv_2():
     assert FULL_PROVIDER_NAME in quotes
     assert quotes[FULL_PROVIDER_NAME].result["price"] == 0.01
 
+
 def test_provider_user_config_params_get():
     """Load a CadQuery part using enrichment for provider and see if the parameters changed from user_config"""
     import partcad as pc
+
     ctx = pc.Context("examples/provider_store")
     pc.user_config.parameter_config["//pub/examples/partcad/provider_store:myGarage"] = {"currency": "INR"}
     provider = ctx.get_provider("myGarage")

--- a/tests/partcad/unit/test_python_sandbox_default.py
+++ b/tests/partcad/unit/test_python_sandbox_default.py
@@ -12,8 +12,6 @@ asking means talking to a daemon and a command that never builds a sandbox
 should not pay for it.
 """
 
-import types
-
 import pytest
 
 from partcad import context as pc_context

--- a/tests/partcad/unit/test_runtime_python_deps.py
+++ b/tests/partcad/unit/test_runtime_python_deps.py
@@ -12,7 +12,6 @@ import pathlib
 import re
 import signal
 
-import pytest
 from packaging.requirements import Requirement
 
 import partcad as pc

--- a/tests/partcad/unit/test_scene_lint.py
+++ b/tests/partcad/unit/test_scene_lint.py
@@ -92,8 +92,7 @@ def test_a_scene_keeps_every_other_way_of_placing_an_object():
     for text in (PLACED, CONNECTED.replace('      how:\n        stage: "1"\n', "")):
         assert check(text, assy_lint.FLAVOR_SCENE) == []
 
-    ports = textwrap.dedent(
-        """\
+    ports = textwrap.dedent("""\
         links:
           - part: cube
             name: block
@@ -103,8 +102,7 @@ def test_a_scene_keeps_every_other_way_of_placing_an_object():
               with: a
               to: b
               exploded: 5
-        """
-    )
+        """)
     assert check(ports, assy_lint.FLAVOR_SCENE) == []
 
 

--- a/tests/partcad/unit/test_test.py
+++ b/tests/partcad/unit/test_test.py
@@ -16,7 +16,7 @@ def test_package_test_recursive_1():
     ctx = pc.Context("examples")
     examples = ctx.get_project(pc.ROOT)
     assert examples is not None
-    assert examples.test(ctx) == True
+    assert examples.test(ctx) is True
 
 
 def test_package_test_async():
@@ -24,4 +24,4 @@ def test_package_test_async():
     ctx = pc.Context("examples/provider_manufacturer")
     manufacturer = ctx.get_project(".")
     assert manufacturer is not None
-    assert manufacturer.test_log_wrapper(ctx) == True
+    assert manufacturer.test_log_wrapper(ctx) is True

--- a/tests/partcad/unit/test_world.py
+++ b/tests/partcad/unit/test_world.py
@@ -175,13 +175,10 @@ def test_ignore_collision_builds_from_the_visual_geometry_instead(no_occt):
 
 def test_a_mesh_is_referenced_where_it_lies(tmp_path):
     world = tmp_path / "meshes.world"
-    world.write_text(
-        """<sdf version="1.9"><world name="w"><model name="m"><link name="l">
+    world.write_text("""<sdf version="1.9"><world name="w"><model name="m"><link name="l">
         <collision name="c"><geometry><mesh>
           <uri>%s</uri><scale>0.001 0.001 0.001</scale>
-        </mesh></geometry></collision></link></model></world></sdf>"""
-        % STL_EXAMPLE
-    )
+        </mesh></geometry></collision></link></model></world></sdf>""" % STL_EXAMPLE)
 
     result = wrapper_import_world.process({"world_file": str(world), "output_folder": str(tmp_path), "model_paths": []})
     node = result["root"]["links"][0]["links"][0]
@@ -194,12 +191,9 @@ def test_a_mesh_is_referenced_where_it_lies(tmp_path):
 def test_a_file_with_no_world_is_read_as_a_world_of_its_models(tmp_path):
     """Pointing a scene at a model file works rather than failing on a technicality."""
     model = tmp_path / "pallet.sdf"
-    model.write_text(
-        """<sdf version="1.9"><model name="pallet"><link name="l">
+    model.write_text("""<sdf version="1.9"><model name="pallet"><link name="l">
         <collision name="c"><geometry><mesh><uri>%s</uri></mesh></geometry></collision>
-        </link></model></sdf>"""
-        % STL_EXAMPLE
-    )
+        </link></model></sdf>""" % STL_EXAMPLE)
 
     result = wrapper_import_world.process({"world_file": str(model), "output_folder": str(tmp_path), "model_paths": []})
     assert result["world_name"] == "pallet"
@@ -208,14 +202,11 @@ def test_a_file_with_no_world_is_read_as_a_world_of_its_models(tmp_path):
 
 def test_an_include_that_cannot_be_resolved_is_reported(tmp_path):
     world = tmp_path / "w.world"
-    world.write_text(
-        """<sdf version="1.9"><world name="w">
+    world.write_text("""<sdf version="1.9"><world name="w">
         <include><uri>model://nothing_like_this</uri></include>
         <model name="m"><link name="l">
           <collision name="c"><geometry><mesh><uri>%s</uri></mesh></geometry></collision>
-        </link></model></world></sdf>"""
-        % STL_EXAMPLE
-    )
+        </link></model></world></sdf>""" % STL_EXAMPLE)
 
     result = wrapper_import_world.process({"world_file": str(world), "output_folder": str(tmp_path), "model_paths": []})
     assert result["dropped"]["include"] == 1
@@ -227,18 +218,13 @@ def test_an_include_that_cannot_be_resolved_is_reported(tmp_path):
 def test_an_include_that_resolves_is_read(tmp_path):
     models = tmp_path / "models" / "pallet"
     models.mkdir(parents=True)
-    (models / "model.sdf").write_text(
-        """<sdf version="1.9"><model name="pallet"><link name="l">
+    (models / "model.sdf").write_text("""<sdf version="1.9"><model name="pallet"><link name="l">
         <collision name="c"><geometry><mesh><uri>%s</uri></mesh></geometry></collision>
-        </link></model></sdf>"""
-        % STL_EXAMPLE
-    )
+        </link></model></sdf>""" % STL_EXAMPLE)
     world = tmp_path / "w.world"
-    world.write_text(
-        """<sdf version="1.9"><world name="w"><include>
+    world.write_text("""<sdf version="1.9"><world name="w"><include>
         <uri>model://pallet</uri><name>left</name><pose>1 0 0 0 0 0</pose>
-        </include></world></sdf>"""
-    )
+        </include></world></sdf>""")
 
     result = wrapper_import_world.process(
         {
@@ -256,21 +242,16 @@ def test_an_included_file_with_more_than_one_model_says_which_one_it_placed(tmp_
     """An <include> places one model, so the rest of them go unplaced."""
     models = tmp_path / "models" / "pair"
     models.mkdir(parents=True)
-    (models / "model.sdf").write_text(
-        """<sdf version="1.9">
+    (models / "model.sdf").write_text("""<sdf version="1.9">
         <model name="first"><link name="l">
           <collision name="c"><geometry><mesh><uri>%s</uri></mesh></geometry></collision>
         </link></model>
         <model name="second"><link name="l">
           <collision name="c"><geometry><mesh><uri>%s</uri></mesh></geometry></collision>
-        </link></model></sdf>"""
-        % (STL_EXAMPLE, STL_EXAMPLE)
-    )
+        </link></model></sdf>""" % (STL_EXAMPLE, STL_EXAMPLE))
     world = tmp_path / "w.world"
-    world.write_text(
-        """<sdf version="1.9"><world name="w">
-        <include><uri>model://pair</uri></include></world></sdf>"""
-    )
+    world.write_text("""<sdf version="1.9"><world name="w">
+        <include><uri>model://pair</uri></include></world></sdf>""")
 
     result = wrapper_import_world.process(
         {"world_file": str(world), "output_folder": str(tmp_path), "model_paths": [str(tmp_path / "models")]}
@@ -285,21 +266,16 @@ def test_a_model_nested_in_an_included_one_is_read_rather_than_counted_as_droppe
     """The nested model is placed by the outer one, so nothing goes unplaced."""
     models = tmp_path / "models" / "stack"
     models.mkdir(parents=True)
-    (models / "model.sdf").write_text(
-        """<sdf version="1.9"><model name="outer">
+    (models / "model.sdf").write_text("""<sdf version="1.9"><model name="outer">
         <link name="l">
           <collision name="c"><geometry><mesh><uri>%s</uri></mesh></geometry></collision>
         </link>
         <model name="inner"><link name="l">
           <collision name="c"><geometry><mesh><uri>%s</uri></mesh></geometry></collision>
-        </link></model></model></sdf>"""
-        % (STL_EXAMPLE, STL_EXAMPLE)
-    )
+        </link></model></model></sdf>""" % (STL_EXAMPLE, STL_EXAMPLE))
     world = tmp_path / "w.world"
-    world.write_text(
-        """<sdf version="1.9"><world name="w">
-        <include><uri>model://stack</uri></include></world></sdf>"""
-    )
+    world.write_text("""<sdf version="1.9"><world name="w">
+        <include><uri>model://stack</uri></include></world></sdf>""")
 
     result = wrapper_import_world.process(
         {"world_file": str(world), "output_folder": str(tmp_path), "model_paths": [str(tmp_path / "models")]}

--- a/tests/partcad/unit/test_wrapper_channel.py
+++ b/tests/partcad/unit/test_wrapper_channel.py
@@ -31,8 +31,7 @@ WRAPPERS = os.path.dirname(pc_wrapper.get("export.py"))
 # argv[1] is the output path and argv[2] the working directory, which is what
 # every wrapper is invoked with; argv[3] is this test telling it where the
 # wrappers are, since it is not being run out of a sandbox.
-SCRIPT = textwrap.dedent(
-    """
+SCRIPT = textwrap.dedent("""
     import os
     import sys
 
@@ -52,8 +51,7 @@ SCRIPT = textwrap.dedent(
     os.write(1, b"OCCT: writing... ")
 
     wrapper_common.handle_output({"success": True, "echo": request.get("echo")})
-    """
-)
+    """)
 
 
 def _run(tmp_path):

--- a/tests/partcad/unit/test_wrapper_solidify.py
+++ b/tests/partcad/unit/test_wrapper_solidify.py
@@ -21,10 +21,6 @@ import sys
 from io import BytesIO
 
 import pytest
-
-import partcad as pc
-from partcad import brep_inspect
-
 from OCP.Bnd import Bnd_Box
 from OCP.BRep import BRep_Builder
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Common, BRepAlgoAPI_Cut, BRepAlgoAPI_Fuse
@@ -33,11 +29,14 @@ from OCP.BRepBuilderAPI import BRepBuilderAPI_Transform
 from OCP.BRepGProp import BRepGProp
 from OCP.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder
 from OCP.BRepTools import BRepTools
+from OCP.gp import gp_Trsf, gp_Vec
 from OCP.GProp import GProp_GProps
 from OCP.TopAbs import TopAbs_FACE, TopAbs_SHELL, TopAbs_SOLID
 from OCP.TopExp import TopExp_Explorer
 from OCP.TopoDS import TopoDS_Compound, TopoDS_Shell
-from OCP.gp import gp_Trsf, gp_Vec
+
+import partcad as pc
+from partcad import brep_inspect
 
 sys.path.append(os.path.join(os.path.dirname(pc.__file__), "wrappers"))
 import wrapper_common  # noqa: E402

--- a/tests/partcad_service_json_rpc/test_ansi_rendering.py
+++ b/tests/partcad_service_json_rpc/test_ansi_rendering.py
@@ -120,9 +120,7 @@ def test_two_renderers_keep_their_own_footers():
 
 import base64
 import io
-import threading
 
-from partcad_service_json_rpc.rpc.dispatcher import Handler
 from partcad_service_json_rpc.transport import stdio
 from partcad_utils.framing import read_message, write_message
 

--- a/tests/partcad_service_json_rpc/test_operations.py
+++ b/tests/partcad_service_json_rpc/test_operations.py
@@ -1787,9 +1787,7 @@ def test_inline_hands_the_model_back_as_bytes(tmp_path):
     model.write_bytes(b"glTF-ish")
     session, _ = make_cae_session(FakeAnalysablePart("bracket", result={"findings": [], "filepath": str(model)}))
 
-    result = operations.cae_analyze(
-        session, {"package": "//", "object": "bracket", "analysis": "fea", "inline": True}
-    )
+    result = operations.cae_analyze(session, {"package": "//", "object": "bracket", "analysis": "fea", "inline": True})
 
     assert base64.b64decode(result["content"]) == b"glTF-ish"
 
@@ -1804,9 +1802,7 @@ def test_a_model_that_is_not_where_it_said_still_returns_the_findings(tmp_path):
         )
     )
 
-    result = operations.cae_analyze(
-        session, {"package": "//", "object": "bracket", "analysis": "fea", "inline": True}
-    )
+    result = operations.cae_analyze(session, {"package": "//", "object": "bracket", "analysis": "fea", "inline": True})
 
     assert result["content"] is None
     assert result["findings"] == [{"message": "too thin"}]

--- a/tools/containers/_common/pc-container-json-rpc.py
+++ b/tools/containers/_common/pc-container-json-rpc.py
@@ -1,15 +1,16 @@
-from flask import Flask, request, jsonify
-from flask_jsonrpc import JSONRPC
-import subprocess
 import base64
 import io
 import json
 import logging
-import shutil
-import tarfile
-import typing as t
-import tempfile
 import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import typing as t
+
+from flask import Flask, jsonify
+from flask_jsonrpc import JSONRPC
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/tools/containers/python/Dockerfile
+++ b/tools/containers/python/Dockerfile
@@ -39,6 +39,15 @@ ARG PYTHON_VERSION=3.11
 # asks for: "prefer a wheel to a toolchain". The toolchain is ~200 MB and this
 # image is the floor under every derived one.
 FROM python:${PYTHON_VERSION}-slim AS pycairo-wheel
+# DL3008 asks for `=<version>` on each package. This Dockerfile is built for
+# every supported Python, and those base images span two Debian releases
+# (bookworm for the older ones, trixie for the newer), so there is no one
+# version string that exists in both archives -- a pinned one would 404 the
+# fetch on whichever half of the matrix it was not written for. The same reason
+# the runtime stage below carries this, and the reason `.devcontainer/Dockerfile`
+# does. `tools/containers/kicad/Dockerfile` can pin because it is built `FROM`
+# one fixed image.
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends build-essential libcairo2-dev pkg-config \
   && rm -rf /var/lib/apt/lists/*
@@ -86,6 +95,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # renamed the package to `libglib2.0-0t64`. Asking for the new name and falling
 # back is what lets one Dockerfile serve every version, rather than a
 # conditional on a base image that will move again.
+#
+# And the same split is why nothing here is version-pinned; see DL3008 above.
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \

--- a/tools/containers/python/verify.py
+++ b/tools/containers/python/verify.py
@@ -23,7 +23,6 @@ import os
 import shutil
 import sys
 
-
 FAILURES = []
 
 
@@ -62,8 +61,7 @@ def main() -> int:
     check(
         "PC_CONTAINER_ALLOWED_COMMANDS is JSON",
         readable,
-        "the RPC service reads it at startup and an unreadable one leaves the image able to run "
-        "nothing at all",
+        "the RPC service reads it at startup and an unreadable one leaves the image able to run nothing at all",
     )
     check(
         "the allowlist maps 'python'",
@@ -74,21 +72,18 @@ def main() -> int:
     check(
         "what the allowlist maps 'python' to exists",
         bool(parsed.get("python")) and os.access(parsed.get("python", ""), os.X_OK),
-        "the name resolves to a file that is not there, which fails at the first command rather "
-        "than at build time",
+        "the name resolves to a file that is not there, which fails at the first command rather than at build time",
     )
 
     check(
         "the RPC service is at /pc",
         os.path.isfile("/pc/pc-container-json-rpc.py"),
-        "the image's entrypoint serves it from there, and the 'remote' sandbox has nothing to talk "
-        "to without it",
+        "the image's entrypoint serves it from there, and the 'remote' sandbox has nothing to talk to without it",
     )
     check(
         "flask_jsonrpc is importable",
         _importable("flask_jsonrpc"),
-        "the service imports it at startup, so the container would exit immediately instead of "
-        "serving",
+        "the service imports it at startup, so the container would exit immediately instead of serving",
     )
 
     state = os.environ.get("PC_INTERNAL_STATE_DIR", "")


### PR DESCRIPTION
## Copilot Summary

Follow-up to #633, which sorted the imports and gated `isort`. This does the same for `black` and `flake8`, makes the linter configuration in `pyproject.toml` real, revives the `pre-commit` CI job, and fixes two ways the gate could be skipped.

Three commits: configuration, then the mechanical reformat, then the gates and docs.

### 1. The configuration was partly inert

- **`[tool.flake8]` was doing nothing.** flake8 has never read `pyproject.toml` on its own, and there is no `.flake8` file here — so the whole table was ignored and flake8 fell back to its built-in defaults, reporting `E501` at **79** columns on a repository that formats at 120. `Flake8-pyproject` is now a `dev` dependency, which is what makes the table real. The table gains the waivers a real run needs, and a `per-file-ignores` list naming the files where a finding is the idiom (the sandbox wrappers and builtins, the star-import namespaces, the two modules that import after a `sys.path` mutation).
- **`[tools.pyright]`** was spelled with an `s`. `tools` is not a table any tool reads, so those two settings had never applied to anything. Fixed, with a note that it is Pylance diagnostics and gates nothing.
- **`[tool.pylint."messages control"]`** configured a linter that is in no dependency group and run by nothing. Deleted.
- **`[tool.ruff.lint]`** stays and gains a comment, because it reads like this repo's own linting and is not: `ruff` is a *runtime* dependency, and `partcad.lint.python` shells out to it to lint the **user's** part scripts with neither `--config` nor `--isolated`. It applies to `pc lint` of an example and never to `src/`.

### 2. What the three linters check, written down once

All three are now invoked on `.`, and the scope lives in `pyproject.toml` — so a hook, a CI job and a command you type cannot come to disagree about it. That widens the coverage beyond `src tests` to all of PartCAD's own Python: `cad/`, `dev-tools/`, `ide/`, `tools/`, `docs/` and the root `conftest.py`.

Two trees are **held out**, as a deferred decision rather than an oversight:

| tree | why | findings |
|---|---|---|
| `examples/` | CAD part scripts written the way a *user* writes one — `from build123d import *`, `show_object` injected at execution time. `[tool.ruff.lint]` already waives those same codes for `pc lint` of a part. Sorting their imports carries the wrappers' risk, and their rendered output is checked in. | 102, almost all `F403`/`F405`/`F401`/`F821` |
| `features/` | `behave` step definitions, where every module defines several functions named `step_impl` and the decorator is what tells them apart. | 56, of which 29 are `F811` |

Covering either means waiving a code across a whole directory, which is a policy call and a change of its own.

Worth knowing: **each tool spells "skip this" differently and two of the spellings are traps.** isort needs `--filter-files`; black needs `force-exclude`, not `extend-exclude`; and flake8 has no force at all — its `extend-exclude` is discovery-only and it checks anything named on its command line regardless. That last one is why the `flake8` hook carries an `exclude:` of its own: `pre-commit` passes staged files by name. All three verified empirically.

### 3. The reformat, and what flake8 found

108 files. Almost all of it is mechanical — **`git show 65912fc -w` is the part worth reading, and it is small.**

No import line moves. The five sandbox wrappers black touched keep their import blocks exactly as they were, which is the property the `[tool.isort]` skips exist to protect and the one with no test behind it. All 53 files under `wrappers/`/`builtin/` were checked individually to confirm isort still skips them.

The findings, and what was done:

- `F401` on ten side-effect imports (registering a factory, re-exporting a name) — `# noqa: F401` with a few words saying which.
- `F824` on fourteen dead `global`/`nonlocal` declarations — removed, each checked against the AST first. The set of functions that shadow a module-level name without `global` is byte-identical to `devel`'s.
- `telemetry.py` had `tracer: Tracer | None` as a bare annotation, which binds no name — so until `init()` ran the module had no `tracer` at all and the readers only resolved it through their `global`. Now `= None`.
- `E741` on three `l` bindings, `E713`/`E714`, and `E712` on six `== True` in tests — written as `is True`, keeping the strictness the `==` had rather than weakening it to truthiness.
- `F841` on five `except ... as e` whose `e` was unused.

And **one test that was not testing anything**: `test_project_config_version_2` paired an `assert False` with a bare `except:`, which swallowed it — so the test passed whether or not the invalid config raised. It is a `pytest.raises` now, and `pc.Context` does raise.

Two files outside `src/` worth naming: the FreeCAD addon's `_import_module` gets an explicit `# isort: split`, because the `import FreeCADGui` above it is a *probe* for a headless FreeCAD and the blank line keeping it apart was one isort removes — their alphabetical order is a coincidence, not the reason. And the container RPC service drops an unused `request` from its flask import.

### 4. The gates, and the two holes

`Lint (black)` and `Lint (flake8)` join `Lint (isort)`, as siblings rather than steps in one job: the check name is what a branch-protection rule names, so each can be required independently and a red check says which linter is unhappy without opening the log. Matching `pre-commit` hooks, each pinned to the version `pyproject.toml` resolves.

`Lint (pre-commit)` runs the hooks that had **no job at all** — shellcheck, hadolint, the YAML and workflow schema checks, the whitespace fixers, the "a README's images are checked in" check. `test-dev.yml` had a job for this once; it was commented out and both paths in it had gone stale, so those hooks were enforced only for people who happened to commit from inside the dev container. The dead job is deleted; this one needs no dev container.

Running that hook set surfaced three things it would have failed on, fixed here so the job is not born red:

- `.github/actions/build-docker/action.yml` was a **zero-byte file** referenced by no workflow, and an empty action manifest fails schema validation. Deleted.
- `tools/containers/python/Dockerfile` tripped hadolint's `DL3008` twice. Pinning is not available to it — it is built for every supported Python and those base images span bookworm and trixie, so no one version string exists in both archives (the file already works around a package that was *renamed* between them). Suppressed inline with that reason, the convention `.devcontainer/Dockerfile` already uses.
- A trailing blank line in `dev-tools/bumpversion.toml`.

**Neither hole was theoretical.** The first: the hooks were unscoped while the jobs checked `src tests`, so anyone editing an example hit a wall of unrelated reformatting — the exact churn this work is meant to end. The second: the lint jobs were gated on `changed-scopes`, which was consistent while they checked `src tests` (always the `code` bucket) and is not now — `ide/standalone/tests/*.py` is `ide`, `docs/*.py` and every `AGENTS.md` are `docs`, `dev-tools/pyinstaller` is `packaging`. All four jobs are ungated now; each is seconds on one runner. `needs: set-matrix` stays, which is what keeps "a push to `devel` runs nothing unless the commit is a version bump" applying to them.

### ⚠️ The half of this that is not in the tree

**A `Lint (...)` job is only a gate once branch protection *requires* it.** A pull request whose branch was cut before the job existed never runs it, and GitHub merges it anyway unless the check is required *and* branches must be up to date.

That is what happened last time: **#629 merged three unsorted files 83 seconds after the isort gate landed in #633**, because its own CI run predated the job. Its 70 check runs contain no `Lint (isort)`.

So this needs someone with repository settings access to add `Lint (isort)`, `Lint (black)`, `Lint (flake8)` and `Lint (pre-commit)` to the required checks for `devel`, and to turn on "require branches to be up to date before merging". Without that, this PR makes the linters *available* but not *enforced*, and the same thing happens again.

### Validation

Run on a native checkout (no Docker daemon here, so `dev-tools/setup-native.sh`):

- `pytest tests cad/freecad` — **3553 passed, 39 skipped**
- `isort` / `black` / `flake8` on `.` — all green, and green again as `pre-commit` hooks
- the full `pre-commit` hook set the new job runs, with shellcheck and hadolint actually present — all pass
- every module under `src/` imports (366; wrappers and builtins are executed rather than imported), and the whole repository compiles
- `pc render` of `produce_part_build123d_primitive`, and `pc export -t 3mf` of `feature_export`'s `bolt` — both succeed, which exercises the expat/VTK path
- Sphinx build — succeeds with no warnings
- `poetry check` and `poetry check --lock` pass; `.devcontainer/requirements.txt` is byte-identical to what the `poetry-export` hook produces

`behave` was **not** run in full here — per `CLAUDE.md`, every scenario takes a throwaway `$HOME` and rebuilds a CAD sandbox, which does not fit this machine's disk allowance. CI shards it.

### One thing found and deliberately not changed

`src/partcad_cli/click/commands/list/all.py` imports `list_mates`, but its only `runner.invoke()` is commented out behind a `TODO` about a `TypeError` — so `pc list all` does not list mates. That is a product question, not a lint one; the import carries a `# noqa: F401` pointing at the commented call rather than being deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8iyZjjeNCJmGpFnak8nhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8iyZjjeNCJmGpFnak8nhV)_